### PR TITLE
SEC: getTenantFromAuth trusts x-alga-tenant header from session-less callers

### DIFF
--- a/docs/plans/2026-08-14-tenant-header-auth-plan.md
+++ b/docs/plans/2026-08-14-tenant-header-auth-plan.md
@@ -1,0 +1,351 @@
+# Authenticated tenant-header resolution for extension gateways
+
+**Date:** 2026-08-14
+**Card:** `acd7e949-bc3b-46a8-817c-fae52916f8f1`
+**Status:** implementation design
+**Scope:** extension gateway tenant resolution only; no implementation is included in this commit
+
+## Problem and security objective
+
+`server/src/lib/extensions/gateway/auth.ts` currently treats a non-empty
+`x-alga-tenant` or legacy `x-tenant-id` header as sufficient tenant authority whenever
+`getSession()` returns no tenant. `DEV_TENANT_ID` is a final implicit authority source.
+The comment calling this an internal-caller path is not enforced by code.
+
+The currently exposed server routes happen to add session/user checks around this
+helper, but the helper's contract is unsafe: a new caller, or a guard-order change,
+could resolve an attacker-selected tenant and then load that tenant's extension install
+configuration, secret envelope, and provider configuration.
+
+The implementation must make these invariants local to the authentication helper:
+
+1. A browser/session flow derives its tenant only from a complete authenticated
+   session. Tenant headers may be checked for consistency during compatibility, but
+   never select the tenant.
+2. A service flow derives its tenant from a header only after authenticating an
+   explicit service credential with a constant-time comparison.
+3. Session and service modes are separate APIs. A caller must choose one; there is no
+   generic helper that silently falls from a partial session into service headers.
+4. Conflicting identity evidence fails closed. No source wins by precedence.
+5. `DEV_TENANT_ID` is not an authentication mechanism and is removed from this path in
+   every environment.
+
+## Repository findings and caller audit
+
+The following is grounded in the repository as inspected on this branch.
+
+| Code path | Current behavior | Required disposition |
+| --- | --- | --- |
+| `server/src/lib/extensions/gateway/auth.ts` | `getTenantFromAuth()` prefers a session tenant, then accepts either tenant header without service authentication, then accepts `DEV_TENANT_ID`. | Replace the ambiguous API with explicitly named session and service resolvers. Remove the development fallback. |
+| `server/src/lib/extensions/gateway/auth.test.ts` | Covers session success/mismatch and positively asserts that a session-less header is accepted. | Replace the unsafe assertion with a complete fail-closed matrix. |
+| `server/src/app/api/ext/[extensionId]/[[...path]]/route.ts` | `assertSessionProductAccess()` runs before `getTenantFromAuth()`. The route then loads install config and may forward secrets to the runner. CORS advertises `x-alga-tenant`. | Keep it session-only, call the session resolver, retain guard-before-resolution ordering, and stop advertising tenant selection in browser CORS. |
+| `server/src/app/ext-ui/[extensionId]/[contentHash]/[...path]/route.ts` | In legacy `EXT_UI_HOST_MODE=nextjs`, calls the helper and converts auth/lookup failures to 404; default Rust mode returns/redirects before tenant resolution. | Use the session resolver. Forged headers, `DEV_TENANT_ID`, and partial sessions must remain indistinguishable 404s and must not reach install/cache lookups. |
+| `server/src/app/api/ext-debug/stream/route.ts` | `getCurrentUser()` gates access, then `getTenantFromAuth()` is used as a fallback before `currentUser.tenant`; `tenantId` query selection is intentionally allowed for authorized MSP debugging. | Remove tenant-header resolution from this route. Select the normalized query tenant when supplied, otherwise `currentUser.tenant`, after the existing user/RBAC gate. Ignore tenant headers as authority. |
+| `server/src/app/api/ext-proxy/[extensionId]/[[...path]]/route.ts` | Every verb calls `assertSessionProductAccess()` before the EE package handler. | Keep the public delegator session-only and verify behaviorally that denial occurs before the package handler. |
+| `packages/product-ext-proxy/ee/gateway/auth.ts` | Contains a second, drifting copy of unsafe `getTenantFromAuth()` and `DEV_TENANT_ID`. `getUserInfoFromAuth()` also treats the mere presence of `x-alga-tenant` as proof of an internal caller and drops user context. | Delete the copied tenant resolver and import the central session resolver in the handler. Make user-info lookup session-driven, not header-driven. |
+| `packages/product-ext-proxy/ee/handler.ts` | Calls the package-local resolver directly, but its exposed server route is currently session-gated. CORS advertises `x-alga-tenant`. | Import the central session resolver, preserve the outer session gate, and remove the tenant header from allowed browser CORS headers. |
+| `ee/server/src/lib/extensions/runnerAuth.ts` | Centralizes constant-time `x-runner-auth` verification for `/api/internal/ext-*`, rejects absent configuration, and rejects known development defaults in production. | Move the environment-neutral implementation to shared server code and keep an EE re-export so existing internal routes retain one implementation and stable imports. |
+
+Additional header producers were audited and do not call these tenant resolvers:
+
+- `packages/jobs/src/lib/handlers/extensionScheduledInvocationHandler.ts` sends
+  `x-alga-tenant` to the runner execution API, not to a server tenant resolver.
+- `packages/product-ext-proxy/shared/gateway-utils.ts` and
+  `ee/server/src/lib/extensions/lib/gateway-utils.ts` construct runner-bound headers
+  after tenant resolution.
+- `ee/runner/src/engine/host_api.rs` sends `x-alga-tenant` from an already constructed
+  execution context. Its `UI_PROXY_AUTH_KEY`/`x-runner-auth` behavior is a separate
+  outbound-proxy concern; no current `getTenantFromServiceAuth` route consumes it.
+- General API-key paths using `x-tenant-id` in API controllers/middleware have their
+  own API-key-to-tenant validation contracts and are not users of this extension
+  helper.
+
+There is therefore no current production caller that needs session-less resolution
+through this helper. Service support should be safe and explicit for a future internal
+route, without weakening any current browser route to make the new helper appear used.
+
+## Target design
+
+### 1. Separate session and service contracts
+
+In `server/src/lib/extensions/gateway/auth.ts`, remove `getTenantFromAuth` and export
+two intentionally narrow functions:
+
+```ts
+getTenantFromSessionAuth(req: NextRequest): Promise<string>
+getTenantFromServiceAuth(req: NextRequest): Promise<string>
+```
+
+Do not retain a backward-compatible alias. Renaming makes all current and future
+callers make an authentication-mode decision and makes missed call sites fail at
+compile time.
+
+`getTenantFromSessionAuth` algorithm:
+
+1. Call `getSession()`.
+2. If no session exists, throw a typed tenant-auth error with code
+   `unauthenticated`.
+3. If a session exists but `session.user.tenant` is absent, blank, or not a string,
+   throw `invalid_session`. This check occurs before considering any header.
+4. Normalize `x-alga-tenant` and `x-tenant-id`. If either non-empty header differs
+   from the session tenant, or if the two supplied headers differ from each other,
+   throw `tenant_mismatch`.
+5. Return the session tenant. Matching headers are tolerated only as transitional
+   compatibility; they are not authority.
+
+`getTenantFromServiceAuth` algorithm:
+
+1. Call `getSession()`. If any session object is present, reject with `mixed_auth`;
+   a partial session must not be reinterpreted as a service caller.
+2. Authenticate `req.headers.get('x-runner-auth')` against
+   `process.env.RUNNER_SERVICE_TOKEN` through the shared constant-time runner-auth
+   verifier. Do not accept `RUNNER_STORAGE_API_TOKEN` here: a storage-scoped token
+   must not silently become generic tenant-selection authority.
+3. Normalize `x-alga-tenant` and `x-tenant-id`. Require at least one. When both are
+   present, require exact agreement; otherwise throw `tenant_mismatch` rather than
+   assigning precedence.
+4. Return the authenticated header tenant. Keep `x-tenant-id` only as a documented
+   legacy compatibility input under service authentication; new callers send
+   `x-alga-tenant`.
+
+Neither function reads `DEV_TENANT_ID`. Local calls use a real seeded session or set a
+non-default `RUNNER_SERVICE_TOKEN` and matching `x-runner-auth` header. This is simpler
+and safer than a `NODE_ENV !== 'production'` gate, which still makes environment
+classification an identity source.
+
+### 2. Typed, non-leaking failures
+
+Add a small `TenantAuthError` in `server/src/lib/extensions/gateway/auth.ts` (or a
+sibling `errors.ts` if it improves readability) with stable internal codes:
+
+- `unauthenticated`
+- `invalid_session`
+- `invalid_service_auth`
+- `missing_tenant`
+- `mixed_auth`
+- `tenant_mismatch`
+
+Route boundaries return generic 401 for missing/invalid authentication and 403 for a
+tenant mismatch. Legacy UI assets continue returning 404 for every auth/lookup
+failure. Logs may include the error code but must not include the runner token, cookie,
+or tenant headers. Service-token misconfiguration must fail as 401, not fall through
+to another tenant source.
+
+### 3. One runner-auth implementation
+
+Create `server/src/lib/extensions/runnerAuth.ts` by moving the pure Node token
+verification from `ee/server/src/lib/extensions/runnerAuth.ts`. Preserve:
+
+- constant-time comparison for equal-length values;
+- failure on missing configured secrets;
+- production rejection of `local-runner-key`, `changeme`, `change-me`, and `secret`;
+- `assertRunnerAuth` and `isValidRunnerToken` behavior used by existing internal
+  extension APIs.
+
+Change `ee/server/src/lib/extensions/runnerAuth.ts` to a compatibility re-export from
+the shared module. This avoids a broad import churn while ensuring internal EE routes
+and the new service resolver execute exactly the same security logic. Add shared unit
+coverage before converting the EE file to the re-export.
+
+### 4. Keep browser routes browser-authenticated
+
+Update these call sites to `getTenantFromSessionAuth`:
+
+- `server/src/app/api/ext/[extensionId]/[[...path]]/route.ts`
+- `server/src/app/ext-ui/[extensionId]/[contentHash]/[...path]/route.ts`
+- `packages/product-ext-proxy/ee/handler.ts`
+
+For the package handler, import the central resolver directly and remove the duplicate
+function from `packages/product-ext-proxy/ee/gateway/auth.ts`. Also remove its
+header-presence shortcut in `getUserInfoFromAuth`: a matching tenant header on a
+session request must not suppress the authenticated user passed to the runner.
+
+Do not make `/api/ext` or `/api/ext-proxy` accept service auth as an alternative to
+`assertSessionProductAccess`. A future internal service endpoint must call
+`getTenantFromServiceAuth` explicitly and perform any install/capability authorization
+appropriate to that endpoint.
+
+Remove `x-alga-tenant` from `ALLOWED_HEADERS` in the browser-facing `/api/ext` and EE
+proxy CORS responses. Same-origin compatibility remains, and matching tenant headers
+remain tolerated by the session resolver temporarily, but cross-origin browser code is
+no longer encouraged to send a tenant selector. Do not add `x-runner-auth` to any
+browser CORS allow-list.
+
+### 5. Align public API metadata
+
+Update `server/src/lib/api/openapi/routes/extensionGateway.ts` so the public extension
+gateway is documented as session-authenticated and tenant-scoped by the session. Remove
+`x-alga-tenant`, `x-tenant-id`, and `DEV_TENANT_ID` as advertised tenant-selection
+mechanisms, and document 401/403 outcomes.
+
+Regenerate, rather than hand-edit, the derived OpenAPI and registry artifacts with the
+repository generators (`sdk/scripts/generate-openapi.ts` for CE and EE, followed by
+`ee/scripts/generate-chat-registry.mjs`). Review the generated diff specifically for
+the extension gateway entries under:
+
+- `sdk/docs/openapi/alga-openapi.{ce,ee}.{json,yaml}` and compatibility copies emitted
+  by the generator;
+- `server/src/lib/mcp/registry.generated.ts`;
+- `ee/server/src/chat/registry/apiRegistry.generated.ts`.
+
+## Ordered implementation sequence
+
+1. Move runner-token verification into `server/src/lib/extensions/runnerAuth.ts`, add
+   focused tests, and make the EE module a re-export. Run existing internal extension
+   API auth tests to prove no behavior change.
+2. Replace the generic resolver in `server/src/lib/extensions/gateway/auth.ts` with
+   the typed session/service APIs and remove `DEV_TENANT_ID` resolution.
+3. Rewrite `server/src/lib/extensions/gateway/auth.test.ts` around the full behavior
+   matrix below before migrating callers.
+4. Migrate `/api/ext` and legacy `/ext-ui` to the session resolver; remove tenant CORS
+   advertisement and add route-boundary tests that prove downstream work is not
+   reached on auth failure.
+5. Consolidate the EE product proxy on the central session resolver, remove its
+   duplicate resolver/fallback, fix header-based user suppression, and add delegator
+   and package-handler regression tests.
+6. Remove tenant-header interpretation from `ext-debug/stream`; preserve its explicit
+   query-tenant behavior behind current-user and RBAC checks.
+7. Update the canonical OpenAPI route metadata, regenerate derived files, and confirm
+   no generated description still advertises `DEV_TENANT_ID` or unauthenticated tenant
+   headers for the extension gateway.
+8. Run targeted tests, both server and EE typechecks, and a repository-wide caller
+   audit for the removed symbol before requesting review.
+
+## Behavioral test plan
+
+These tests must execute functions/routes with controlled session and downstream
+spies. Source-string assertions alone do not prove the security boundary.
+
+### Resolver tests (`server/src/lib/extensions/gateway/auth.test.ts`)
+
+| Case | Expected behavior |
+| --- | --- |
+| Complete session, no tenant headers | Session tenant is returned. |
+| Complete session, matching canonical and/or legacy header | Session tenant is returned; the header is not treated as authority. |
+| Complete session, either header differs | `tenant_mismatch`; no fallback. |
+| Complete session, canonical and legacy headers disagree | `tenant_mismatch`, even if one matches the session. |
+| No session, forged tenant header, no token | Session resolver rejects `unauthenticated`. |
+| No session, forged tenant header plus valid service token | Session resolver still rejects; auth modes cannot be smuggled into browser callers. |
+| Session object/user exists but tenant is missing or blank, with any headers/token | `invalid_session`; it never falls into service mode. |
+| No session, service resolver, missing/incorrect token | `invalid_service_auth`; no tenant is returned. |
+| No session, service resolver, valid token plus canonical header | Header tenant is returned. |
+| No session, service resolver, valid token plus legacy header | Header tenant is returned for compatibility. |
+| No session, service resolver, valid token but no tenant header | `missing_tenant`. |
+| No session, service resolver, valid token and conflicting tenant headers | `tenant_mismatch`. |
+| Any session plus otherwise valid service credentials | `mixed_auth`. |
+| Production with a known default service token | Rejected by runner-auth validation. |
+| Development/test with only `DEV_TENANT_ID` set | Both resolvers reject; the variable has no effect. |
+
+Ensure every test restores `NODE_ENV`, `RUNNER_SERVICE_TOKEN`, and `DEV_TENANT_ID` to
+avoid order-dependent security results.
+
+### Route and package tests
+
+- Add a direct `/api/ext` route test: no session plus forged `x-alga-tenant` returns
+  401 from `assertSessionProductAccess`; spies for tenant resolution, install lookup,
+  and runner fetch remain untouched. A partial session also stops before install
+  lookup. Preserve a valid-session happy path and the 403 mismatch response.
+- Add a direct `/api/ext-proxy` delegator test for every exported verb through a
+  representative table: a denied session response is returned and the EE handler is
+  not invoked. One allowed case proves delegation still occurs.
+- Extend `ee/server/src/__tests__/integration/extensionProxyFlow.test.ts` (or split a
+  focused unit test) to mock the central resolver actually imported by the package.
+  Prove a session request with a matching tenant header still carries user info to the
+  runner, while a mismatched header stops before `loadInstallConfigCached` and
+  `backend.execute`.
+- Add legacy `/ext-ui` tests: no session, partial session, forged headers, and
+  `DEV_TENANT_ID` all return the existing 404 and do not call `getTenantInstall`,
+  `resolveVersion`, `ensureUiCached`, or `serveFrom`. A complete-session/hash-match
+  case remains successful.
+- Add `ext-debug/stream` tests showing that forged tenant headers cannot change the
+  stream key; absent query selection uses `currentUser.tenant`, explicit query
+  selection remains available only after `getCurrentUser` and `hasPermission` pass,
+  and denial does not open Redis.
+- Keep shared runner-auth tests for correct token, incorrect token, unequal-length
+  token, missing configuration, and production default rejection; retain existing EE
+  internal API tests as compatibility coverage through the re-export.
+
+Suggested targeted validation commands during implementation:
+
+```bash
+cd server && npx vitest run src/lib/extensions/gateway/auth.test.ts <new-route-test-files>
+cd ee/server && npx vitest run src/__tests__/integration/extensionProxyFlow.test.ts <new-focused-tests>
+cd server && npm run typecheck
+cd ee/server && npm run typecheck
+rg -n "getTenantFromAuth|DEV_TENANT_ID" server/src packages/product-ext-proxy/ee
+rg -n "x-alga-tenant.*tenant resolution|DEV_TENANT_ID" server/src/lib/api/openapi sdk/docs/openapi server/src/lib/mcp ee/server/src/chat/registry
+```
+
+The final `rg` audit should find no removed generic resolver and no extension-gateway
+documentation claiming `DEV_TENANT_ID` or a bare tenant header authenticates a caller.
+
+## Migration and compatibility considerations
+
+- **Current browser traffic:** `/api/ext` and `/api/ext-proxy` already require a
+  session through `assertSessionProductAccess`, so legitimate traffic continues to
+  resolve the same tenant. Matching headers remain temporarily accepted but become
+  redundant and are removed from CORS advertisement.
+- **Legacy UI mode:** deployments using `EXT_UI_HOST_MODE=nextjs` must have a valid
+  session cookie when serving assets. Header-only and `DEV_TENANT_ID` access will stop
+  working and should be treated as an unsafe undocumented dependency, not preserved.
+- **Service integrations:** no current resolver caller needs session-less operation.
+  Before a future service route ships, provision a non-default `RUNNER_SERVICE_TOKEN`
+  to the server and the same secret to its producer, send it as `x-runner-auth`, and
+  use `x-alga-tenant`. Never expose that token to browser code or CORS.
+- **Local development:** remove reliance on `DEV_TENANT_ID` for extension routes.
+  Browser testing uses the seeded dev session. Service tests use an explicit test
+  token. `scripts/dev-uninstall-extension.mjs` has a separate use of
+  `DEV_TENANT_ID` and is unaffected.
+- **Token scope:** only `RUNNER_SERVICE_TOKEN` authorizes generic service tenant
+  selection. Existing storage/config tokens remain limited to their established
+  internal endpoints.
+- **Error compatibility:** unauthenticated service or partial-session failures become
+  401 instead of accidental downstream 500s. The legacy asset route intentionally
+  preserves 404 masking. Tenant mismatch remains 403 on JSON gateway routes.
+- **Generated docs:** generated OpenAPI/registry changes may be large; regenerate from
+  the canonical source and review only expected extension-gateway semantic changes.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Hidden header-only local or legacy consumer breaks. | Repository audit found none. Make the break explicit, document session/service setup, and do not preserve unsafe fallback behavior. |
+| A future route imports the wrong resolver. | Remove the ambiguous symbol, expose separately named functions, keep service auth out of browser CORS, and add route tests that assert downstream calls never occur after denial. |
+| Duplicate EE proxy logic drifts again. | Delete the package tenant resolver and import the shared implementation; align its existing integration test mock with the real import. |
+| Partial session is treated as session-less. | Test `session !== null` separately from tenant presence and reject before checking service credentials or headers. |
+| Conflicting canonical/legacy headers select by precedence. | Normalize both and require agreement in both auth modes. |
+| Timing or default-secret weakness is reintroduced. | Reuse one constant-time runner-auth implementation and preserve production insecure-default rejection tests. |
+| Security fix accidentally suppresses valid MSP debug selection. | Make the existing query parameter the only explicit selection mechanism in that RBAC-gated route and test it independently from headers. |
+| Public docs continue teaching unsafe usage. | Update the canonical OpenAPI source, regenerate all editions/registries, and audit generated text. |
+
+## Explicitly out of scope
+
+- Implementing the existing no-op extension `assertAccess()` / per-extension RBAC;
+  that is tracked separately and must not be bundled into this authentication fix.
+- Changing API-key tenant selection in general v1 API controllers, MCP connector
+  headers, mobile headers, webhook tenant resolution, or middleware tenant context.
+- Redesigning runner execution authentication, secret envelopes, install lookup, or
+  capability enforcement.
+- Adding a new service-facing extension route merely to consume
+  `getTenantFromServiceAuth`.
+- Rotating or distributing production secrets as part of the code change; deployment
+  owners must configure a future service producer and server before that path is used.
+- Removing the legacy `x-tenant-id` header from unrelated APIs. Within this design it
+  remains a service-authenticated compatibility alias only.
+- Changing Rust runner `UI_PROXY_AUTH_KEY` behavior unless a concrete route adopting
+  `getTenantFromServiceAuth` is added in a separately reviewed change.
+- Database schema changes, migrations, UI changes, feature flags, or broad auth-system
+  refactors.
+
+## Definition of done
+
+- No extension gateway resolver returns a tenant from an unauthenticated header or
+  `DEV_TENANT_ID`.
+- Partial sessions and mixed session/service credentials fail closed.
+- Current browser routes use the session-only API; a service route can opt into the
+  separately authenticated service API without caller-discipline assumptions.
+- The product proxy no longer contains a duplicate resolver or treats header presence
+  as internal-caller proof.
+- All behavior tests above pass, downstream spies prove denials stop before tenant data
+  or runner work, CE and EE typechecks pass, and generated public metadata describes
+  the hardened contract.

--- a/ee/server/src/__tests__/integration/extensionProxyFlow.test.ts
+++ b/ee/server/src/__tests__/integration/extensionProxyFlow.test.ts
@@ -13,8 +13,22 @@ vi.mock('@alga-psa/user-composition/actions', () => ({
 vi.mock('server/src/lib/auth/rbac', () => ({
   hasPermission: vi.fn(),
 }));
-vi.mock('server/src/lib/extensions/gateway/auth', () => ({
-  getTenantFromAuth: vi.fn(),
+// The handler imports the central session resolver from server/; keep the
+// real TenantAuthError so the handler's typed error handling is exercised.
+vi.mock('server/src/lib/extensions/gateway/auth', async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...original,
+    getTenantFromSessionAuth: vi.fn(),
+  };
+});
+vi.mock('@alga-psa/auth', () => ({
+  getSession: vi.fn(),
+}));
+vi.mock('@alga-psa/db/admin', () => ({
+  getAdminConnection: vi.fn(async () => {
+    throw new Error('no database in extension proxy unit tests');
+  }),
 }));
 vi.mock('../../../../../packages/product-ext-proxy/ee/install-config-cache', () => ({
   loadInstallConfigCached: vi.fn(),
@@ -226,14 +240,14 @@ describe('Extension Proxy Flow Integration', () => {
       const { GET } = await import('../../../../../packages/product-ext-proxy/ee/handler');
       const { getCurrentUser } = await import('@alga-psa/user-composition/actions');
       const { hasPermission } = await import('server/src/lib/auth/rbac');
-      const { getTenantFromAuth } = await import('server/src/lib/extensions/gateway/auth');
+      const { getTenantFromSessionAuth } = await import('server/src/lib/extensions/gateway/auth');
       const { loadInstallConfigCached } = await import('../../../../../packages/product-ext-proxy/ee/install-config-cache');
       const { getRunnerBackend } = await import('../../../../../packages/product-ext-proxy/ee/runner-backend');
 
       // Setup mocks
       const tenantId = 'tenant-1';
       const installId = 'install-1';
-      vi.mocked(getTenantFromAuth).mockResolvedValue(tenantId);
+      vi.mocked(getTenantFromSessionAuth).mockResolvedValue(tenantId);
       vi.mocked(getCurrentUser).mockResolvedValue({ id: 'user-1', tenant: tenantId } as any);
       vi.mocked(hasPermission).mockResolvedValue(true);
       vi.mocked(loadInstallConfigCached).mockResolvedValue({
@@ -251,7 +265,9 @@ describe('Extension Proxy Flow Integration', () => {
         body: mockBody,
       });
       vi.mocked(getRunnerBackend).mockReturnValue({
+        kind: 'docker',
         execute: mockExecute,
+        getPublicBase: () => null,
       } as any);
 
       // Construct Request
@@ -293,13 +309,13 @@ describe('Extension Proxy Flow Integration', () => {
       const { getRunnerBackend, RunnerRequestError } = await import('../../../../../packages/product-ext-proxy/ee/runner-backend');
       const { getCurrentUser } = await import('@alga-psa/user-composition/actions');
       const { hasPermission } = await import('server/src/lib/auth/rbac');
-      const { getTenantFromAuth } = await import('server/src/lib/extensions/gateway/auth');
+      const { getTenantFromSessionAuth } = await import('server/src/lib/extensions/gateway/auth');
       const { loadInstallConfigCached } = await import('../../../../../packages/product-ext-proxy/ee/install-config-cache');
 
       // Setup Auth & Config Mocks
       const tenantId = 'tenant-1';
       const installId = 'install-1';
-      vi.mocked(getTenantFromAuth).mockResolvedValue(tenantId);
+      vi.mocked(getTenantFromSessionAuth).mockResolvedValue(tenantId);
       vi.mocked(getCurrentUser).mockResolvedValue({ id: 'user-1', tenant: tenantId } as any);
       vi.mocked(hasPermission).mockResolvedValue(true);
       vi.mocked(loadInstallConfigCached).mockResolvedValue({
@@ -313,7 +329,9 @@ describe('Extension Proxy Flow Integration', () => {
       // Mock Runner error
       const mockExecute = vi.fn().mockRejectedValue(new RunnerRequestError('Runner failed', 'docker', 502));
       vi.mocked(getRunnerBackend).mockReturnValue({
+        kind: 'docker',
         execute: mockExecute,
+        getPublicBase: () => null,
       } as any);
 
       // Construct Request
@@ -334,13 +352,13 @@ describe('Extension Proxy Flow Integration', () => {
       const { POST } = await import('../../../../../packages/product-ext-proxy/ee/handler');
       const { getCurrentUser } = await import('@alga-psa/user-composition/actions');
       const { hasPermission } = await import('server/src/lib/auth/rbac');
-      const { getTenantFromAuth } = await import('server/src/lib/extensions/gateway/auth');
+      const { getTenantFromSessionAuth } = await import('server/src/lib/extensions/gateway/auth');
       const { loadInstallConfigCached } = await import('../../../../../packages/product-ext-proxy/ee/install-config-cache');
       const { getRunnerBackend } = await import('../../../../../packages/product-ext-proxy/ee/runner-backend');
 
       const tenantId = 'tenant-1';
       const installId = 'install-1';
-      vi.mocked(getTenantFromAuth).mockResolvedValue(tenantId);
+      vi.mocked(getTenantFromSessionAuth).mockResolvedValue(tenantId);
       vi.mocked(getCurrentUser).mockResolvedValue({ id: 'user-1', tenant: tenantId } as any);
       vi.mocked(hasPermission).mockResolvedValue(true);
       vi.mocked(loadInstallConfigCached).mockResolvedValue({
@@ -357,7 +375,9 @@ describe('Extension Proxy Flow Integration', () => {
         body: Buffer.from('{}'),
       });
       vi.mocked(getRunnerBackend).mockReturnValue({
+        kind: 'docker',
         execute: mockExecute,
+        getPublicBase: () => null,
       } as any);
 
       const req = new Request(`http://localhost:3000/api/ext-proxy/${extensionId}/tickets?__method=DELETE&limit=10`, {
@@ -390,6 +410,90 @@ describe('Extension Proxy Flow Integration', () => {
         : '';
       expect(forwardedBodyRaw).toContain('"reason":"cleanup"');
       expect(forwardedBodyRaw).not.toContain('__method');
+    });
+
+    it('carries session user info to the runner on a session request with a matching tenant header', async () => {
+      const { GET } = await import('../../../../../packages/product-ext-proxy/ee/handler');
+      const { getTenantFromSessionAuth, TenantAuthError } = await import('server/src/lib/extensions/gateway/auth');
+      const { getSession } = await import('@alga-psa/auth');
+      const { loadInstallConfigCached } = await import('../../../../../packages/product-ext-proxy/ee/install-config-cache');
+      const { getRunnerBackend } = await import('../../../../../packages/product-ext-proxy/ee/runner-backend');
+
+      const tenantId = 'tenant-1';
+      vi.mocked(getTenantFromSessionAuth).mockResolvedValue(tenantId);
+      vi.mocked(getSession).mockResolvedValue({
+        user: {
+          tenant: tenantId,
+          user_id: 'user-1',
+          email: 'agent@example.com',
+          name: 'Agent One',
+          user_type: 'internal',
+        },
+      } as any);
+      vi.mocked(loadInstallConfigCached).mockResolvedValue({
+        installId: 'install-1',
+        versionId: 'v1',
+        contentHash: 'hash',
+        config: {},
+        providers: [],
+      });
+
+      const mockExecute = vi.fn().mockResolvedValue({
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+        body: Buffer.from('{}'),
+      });
+      vi.mocked(getRunnerBackend).mockReturnValue({ kind: 'docker', execute: mockExecute, getPublicBase: () => null } as any);
+
+      // Matching tenant header on a session request must not suppress user info.
+      const req = new Request(`http://localhost:3000/api/ext-proxy/${extensionId}/tickets`, {
+        method: 'GET',
+        headers: { 'x-alga-tenant': tenantId, 'x-request-id': 'req-user' },
+      });
+      const response = await GET(req as any, { params: Promise.resolve({ extensionId, path: ['tickets'] }) });
+
+      expect(response.status).toBe(200);
+      expect(mockExecute).toHaveBeenCalledTimes(1);
+      const executePayload = mockExecute.mock.calls[0]?.[0] as {
+        user?: { user_id: string; user_email: string; user_name: string };
+      };
+      expect(executePayload.user).toEqual(
+        expect.objectContaining({
+          user_id: 'user-1',
+          user_email: 'agent@example.com',
+          user_name: 'Agent One',
+          user_type: 'internal',
+        }),
+      );
+      expect(TenantAuthError).toBeDefined();
+    });
+
+    it('stops before install lookup and runner execution on a mismatched tenant header', async () => {
+      const { GET } = await import('../../../../../packages/product-ext-proxy/ee/handler');
+      const { getTenantFromSessionAuth, TenantAuthError } = await import('server/src/lib/extensions/gateway/auth');
+      const { getSession } = await import('@alga-psa/auth');
+      const { loadInstallConfigCached } = await import('../../../../../packages/product-ext-proxy/ee/install-config-cache');
+      const { getRunnerBackend } = await import('../../../../../packages/product-ext-proxy/ee/runner-backend');
+
+      // The central resolver fails closed on a header/session mismatch.
+      vi.mocked(getTenantFromSessionAuth).mockRejectedValue(
+        new TenantAuthError('tenant_mismatch', 'x-alga-tenant header does not match the session tenant'),
+      );
+      vi.mocked(getSession).mockResolvedValue({ user: { tenant: 'tenant-1' } } as any);
+
+      const mockExecute = vi.fn();
+      vi.mocked(getRunnerBackend).mockReturnValue({ kind: 'docker', execute: mockExecute, getPublicBase: () => null } as any);
+
+      const req = new Request(`http://localhost:3000/api/ext-proxy/${extensionId}/tickets`, {
+        method: 'GET',
+        headers: { 'x-alga-tenant': 'tenant-evil', 'x-request-id': 'req-mismatch' },
+      });
+      const response = await GET(req as any, { params: Promise.resolve({ extensionId, path: ['tickets'] }) });
+
+      expect(response.status).toBe(403);
+      expect(await response.json()).toEqual(expect.objectContaining({ error: 'tenant_mismatch' }));
+      expect(loadInstallConfigCached).not.toHaveBeenCalled();
+      expect(mockExecute).not.toHaveBeenCalled();
     });
   });
 });

--- a/ee/server/src/__tests__/integration/extensionProxyFlow.test.ts
+++ b/ee/server/src/__tests__/integration/extensionProxyFlow.test.ts
@@ -13,9 +13,11 @@ vi.mock('@alga-psa/user-composition/actions', () => ({
 vi.mock('server/src/lib/auth/rbac', () => ({
   hasPermission: vi.fn(),
 }));
-// The handler imports the central session resolver from server/; keep the
-// real TenantAuthError so the handler's typed error handling is exercised.
-vi.mock('server/src/lib/extensions/gateway/auth', async (importOriginal) => {
+// The handler imports the session resolver from the package's own gateway/auth
+// (importing `server` here would cycle the project graph). Keep the real
+// TenantAuthError and getUserInfoFromAuth so the handler's typed error handling
+// is exercised.
+vi.mock('../../../../../packages/product-ext-proxy/ee/gateway/auth', async (importOriginal) => {
   const original = (await importOriginal()) as Record<string, unknown>;
   return {
     ...original,
@@ -240,7 +242,7 @@ describe('Extension Proxy Flow Integration', () => {
       const { GET } = await import('../../../../../packages/product-ext-proxy/ee/handler');
       const { getCurrentUser } = await import('@alga-psa/user-composition/actions');
       const { hasPermission } = await import('server/src/lib/auth/rbac');
-      const { getTenantFromSessionAuth } = await import('server/src/lib/extensions/gateway/auth');
+      const { getTenantFromSessionAuth } = await import('../../../../../packages/product-ext-proxy/ee/gateway/auth');
       const { loadInstallConfigCached } = await import('../../../../../packages/product-ext-proxy/ee/install-config-cache');
       const { getRunnerBackend } = await import('../../../../../packages/product-ext-proxy/ee/runner-backend');
 
@@ -309,7 +311,7 @@ describe('Extension Proxy Flow Integration', () => {
       const { getRunnerBackend, RunnerRequestError } = await import('../../../../../packages/product-ext-proxy/ee/runner-backend');
       const { getCurrentUser } = await import('@alga-psa/user-composition/actions');
       const { hasPermission } = await import('server/src/lib/auth/rbac');
-      const { getTenantFromSessionAuth } = await import('server/src/lib/extensions/gateway/auth');
+      const { getTenantFromSessionAuth } = await import('../../../../../packages/product-ext-proxy/ee/gateway/auth');
       const { loadInstallConfigCached } = await import('../../../../../packages/product-ext-proxy/ee/install-config-cache');
 
       // Setup Auth & Config Mocks
@@ -352,7 +354,7 @@ describe('Extension Proxy Flow Integration', () => {
       const { POST } = await import('../../../../../packages/product-ext-proxy/ee/handler');
       const { getCurrentUser } = await import('@alga-psa/user-composition/actions');
       const { hasPermission } = await import('server/src/lib/auth/rbac');
-      const { getTenantFromSessionAuth } = await import('server/src/lib/extensions/gateway/auth');
+      const { getTenantFromSessionAuth } = await import('../../../../../packages/product-ext-proxy/ee/gateway/auth');
       const { loadInstallConfigCached } = await import('../../../../../packages/product-ext-proxy/ee/install-config-cache');
       const { getRunnerBackend } = await import('../../../../../packages/product-ext-proxy/ee/runner-backend');
 
@@ -414,7 +416,7 @@ describe('Extension Proxy Flow Integration', () => {
 
     it('carries session user info to the runner on a session request with a matching tenant header', async () => {
       const { GET } = await import('../../../../../packages/product-ext-proxy/ee/handler');
-      const { getTenantFromSessionAuth, TenantAuthError } = await import('server/src/lib/extensions/gateway/auth');
+      const { getTenantFromSessionAuth, TenantAuthError } = await import('../../../../../packages/product-ext-proxy/ee/gateway/auth');
       const { getSession } = await import('@alga-psa/auth');
       const { loadInstallConfigCached } = await import('../../../../../packages/product-ext-proxy/ee/install-config-cache');
       const { getRunnerBackend } = await import('../../../../../packages/product-ext-proxy/ee/runner-backend');
@@ -470,7 +472,7 @@ describe('Extension Proxy Flow Integration', () => {
 
     it('stops before install lookup and runner execution on a mismatched tenant header', async () => {
       const { GET } = await import('../../../../../packages/product-ext-proxy/ee/handler');
-      const { getTenantFromSessionAuth, TenantAuthError } = await import('server/src/lib/extensions/gateway/auth');
+      const { getTenantFromSessionAuth, TenantAuthError } = await import('../../../../../packages/product-ext-proxy/ee/gateway/auth');
       const { getSession } = await import('@alga-psa/auth');
       const { loadInstallConfigCached } = await import('../../../../../packages/product-ext-proxy/ee/install-config-cache');
       const { getRunnerBackend } = await import('../../../../../packages/product-ext-proxy/ee/runner-backend');

--- a/ee/server/src/chat/registry/apiRegistry.generated.ts
+++ b/ee/server/src/chat/registry/apiRegistry.generated.ts
@@ -15557,7 +15557,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/email/oauth/initiate",
     "displayName": "Initiate email OAuth flow",
     "summary": "Initiate email OAuth flow",
-    "description": "Starts the OAuth 2.0 authorization flow for a Google or Microsoft email provider. Requires a valid Auth.js session cookie. The handler builds secure OAuth state containing tenant, user, providerId, redirect URI, timestamp, and nonce, resolves the provider client ID from configured secrets, and returns the authorization URL for the browser to visit.",
+    "description": "Starts the OAuth 2.0 authorization flow for a Google email provider. Requires a valid Auth.js session cookie. The handler builds secure OAuth state containing tenant, user, providerId, redirect URI, timestamp, and nonce, resolves the provider client ID from configured secrets, and returns the authorization URL for the browser to visit. Microsoft mailbox OAuth is not served by this unsigned route: it must be initiated from the mailbox form with an explicit application selection so the callback receives a signed state token.",
     "tags": [
       "Email"
     ],
@@ -15884,7 +15884,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/ext/{extensionId}/{path}",
     "displayName": "Forward GET request to extension runner",
     "summary": "Forward GET request to extension runner",
-    "description": "Tenant-scoped extension gateway endpoint that forwards GET requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers and all query parameters to RUNNER_BASE_URL /v1/execute; and relays the runner response. GET requests do not read a body and do not generate an idempotency key. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
+    "description": "Tenant-scoped extension gateway endpoint that forwards GET requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers and all query parameters to RUNNER_BASE_URL /v1/execute; and relays the runner response. GET requests do not read a body and do not generate an idempotency key. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
     "tags": [
       "Extension Gateway"
     ],
@@ -15930,26 +15930,6 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "schema": {
           "type": "string",
           "description": "Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner."
-        }
-      },
-      {
-        "name": "x-alga-tenant",
-        "in": "header",
-        "required": false,
-        "description": "Internal tenant header used for tenant resolution before session fallback.",
-        "schema": {
-          "type": "string",
-          "description": "Internal tenant header used for tenant resolution before session fallback."
-        }
-      },
-      {
-        "name": "x-tenant-id",
-        "in": "header",
-        "required": false,
-        "description": "Legacy tenant header accepted for tenant resolution before session fallback.",
-        "schema": {
-          "type": "string",
-          "description": "Legacy tenant header accepted for tenant resolution before session fallback."
         }
       }
     ],
@@ -15965,7 +15945,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/ext/{extensionId}/{path}",
     "displayName": "Forward POST request to extension runner",
     "summary": "Forward POST request to extension runner",
-    "description": "Tenant-scoped extension gateway endpoint that forwards POST requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For POST requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. An x-idempotency-key header is forwarded when supplied, otherwise the generated x-request-id is used as the non-GET idempotency fallback. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
+    "description": "Tenant-scoped extension gateway endpoint that forwards POST requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For POST requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. An x-idempotency-key header is forwarded when supplied, otherwise the generated x-request-id is used as the non-GET idempotency fallback. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
     "tags": [
       "Extension Gateway"
     ],
@@ -16011,26 +15991,6 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "schema": {
           "type": "string",
           "description": "Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner."
-        }
-      },
-      {
-        "name": "x-alga-tenant",
-        "in": "header",
-        "required": false,
-        "description": "Internal tenant header used for tenant resolution before session fallback.",
-        "schema": {
-          "type": "string",
-          "description": "Internal tenant header used for tenant resolution before session fallback."
-        }
-      },
-      {
-        "name": "x-tenant-id",
-        "in": "header",
-        "required": false,
-        "description": "Legacy tenant header accepted for tenant resolution before session fallback.",
-        "schema": {
-          "type": "string",
-          "description": "Legacy tenant header accepted for tenant resolution before session fallback."
         }
       }
     ],
@@ -16051,7 +16011,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/ext/{extensionId}/{path}",
     "displayName": "Forward PUT request to extension runner",
     "summary": "Forward PUT request to extension runner",
-    "description": "Tenant-scoped extension gateway endpoint that forwards PUT requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For PUT requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Clients should provide x-idempotency-key for safe retries; otherwise the gateway falls back to a generated request ID. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
+    "description": "Tenant-scoped extension gateway endpoint that forwards PUT requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For PUT requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Clients should provide x-idempotency-key for safe retries; otherwise the gateway falls back to a generated request ID. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
     "tags": [
       "Extension Gateway"
     ],
@@ -16097,26 +16057,6 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "schema": {
           "type": "string",
           "description": "Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner."
-        }
-      },
-      {
-        "name": "x-alga-tenant",
-        "in": "header",
-        "required": false,
-        "description": "Internal tenant header used for tenant resolution before session fallback.",
-        "schema": {
-          "type": "string",
-          "description": "Internal tenant header used for tenant resolution before session fallback."
-        }
-      },
-      {
-        "name": "x-tenant-id",
-        "in": "header",
-        "required": false,
-        "description": "Legacy tenant header accepted for tenant resolution before session fallback.",
-        "schema": {
-          "type": "string",
-          "description": "Legacy tenant header accepted for tenant resolution before session fallback."
         }
       }
     ],
@@ -16137,7 +16077,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/ext/{extensionId}/{path}",
     "displayName": "Forward PATCH request to extension runner",
     "summary": "Forward PATCH request to extension runner",
-    "description": "Tenant-scoped extension gateway endpoint that forwards PATCH requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For PATCH requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Clients should provide x-idempotency-key for safe retries; otherwise the gateway falls back to a generated request ID. The gateway does not interpret PATCH semantics; partial-update behavior is extension-defined.",
+    "description": "Tenant-scoped extension gateway endpoint that forwards PATCH requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For PATCH requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Clients should provide x-idempotency-key for safe retries; otherwise the gateway falls back to a generated request ID. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway does not interpret PATCH semantics; partial-update behavior is extension-defined.",
     "tags": [
       "Extension Gateway"
     ],
@@ -16183,26 +16123,6 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "schema": {
           "type": "string",
           "description": "Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner."
-        }
-      },
-      {
-        "name": "x-alga-tenant",
-        "in": "header",
-        "required": false,
-        "description": "Internal tenant header used for tenant resolution before session fallback.",
-        "schema": {
-          "type": "string",
-          "description": "Internal tenant header used for tenant resolution before session fallback."
-        }
-      },
-      {
-        "name": "x-tenant-id",
-        "in": "header",
-        "required": false,
-        "description": "Legacy tenant header accepted for tenant resolution before session fallback.",
-        "schema": {
-          "type": "string",
-          "description": "Legacy tenant header accepted for tenant resolution before session fallback."
         }
       }
     ],
@@ -16223,7 +16143,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/ext/{extensionId}/{path}",
     "displayName": "Forward DELETE request to extension runner",
     "summary": "Forward DELETE request to extension runner",
-    "description": "Tenant-scoped extension gateway endpoint that forwards DELETE requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For DELETE requests the body, if present, is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
+    "description": "Tenant-scoped extension gateway endpoint that forwards DELETE requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For DELETE requests the body, if present, is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
     "tags": [
       "Extension Gateway"
     ],
@@ -16269,26 +16189,6 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "schema": {
           "type": "string",
           "description": "Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner."
-        }
-      },
-      {
-        "name": "x-alga-tenant",
-        "in": "header",
-        "required": false,
-        "description": "Internal tenant header used for tenant resolution before session fallback.",
-        "schema": {
-          "type": "string",
-          "description": "Internal tenant header used for tenant resolution before session fallback."
-        }
-      },
-      {
-        "name": "x-tenant-id",
-        "in": "header",
-        "required": false,
-        "description": "Legacy tenant header accepted for tenant resolution before session fallback.",
-        "schema": {
-          "type": "string",
-          "description": "Legacy tenant header accepted for tenant resolution before session fallback."
         }
       }
     ],
@@ -51841,14 +51741,6 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
             "null"
           ],
           "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-        },
-        "next_action": {
-          "type": "string",
-          "minLength": 1
-        },
-        "next_action_due": {
-          "type": "string",
-          "format": "date-time"
         },
         "generator_key": {
           "type": [

--- a/ee/server/src/lib/extensions/runnerAuth.ts
+++ b/ee/server/src/lib/extensions/runnerAuth.ts
@@ -1,91 +1,15 @@
-import crypto from 'crypto';
-
 /**
- * Shared verification for the internal extension-runner host APIs
- * (`/api/internal/ext-*`).
+ * Compatibility re-export of the shared runner-auth verification.
  *
- * These endpoints are reachable without an API key (they are in the middleware
- * skip-list) and are authenticated solely by a shared `x-runner-auth` token.
- * Verification is centralized here so that every host API:
- *   1. compares the token in constant time (no timing side-channel), and
- *   2. refuses to accept a well-known development default in production
- *      (so a deployment that forgot to rotate the secret fails closed instead
- *      of running with a publicly documented token).
+ * The environment-neutral implementation lives in the shared server package at
+ * `server/src/lib/extensions/runnerAuth.ts`. Keeping a re-export here preserves
+ * the stable `@ee/lib/extensions/runnerAuth` import used by the internal
+ * extension-runner host APIs while guaranteeing those routes and the extension
+ * gateway execute exactly the same security logic.
  */
-
-export class RunnerAuthError extends Error {
-  readonly status = 401;
-  constructor(message = 'unauthorized') {
-    super(message);
-    this.name = 'RunnerAuthError';
-  }
-}
-
-// Tokens that ship in example/compose files for local development. They must
-// never be accepted in production.
-const INSECURE_DEFAULT_TOKENS = new Set([
-  'local-runner-key',
-  'changeme',
-  'change-me',
-  'secret',
-]);
-
-function timingSafeEqual(provided: string, expected: string): boolean {
-  const a = Buffer.from(provided, 'utf8');
-  const b = Buffer.from(expected, 'utf8');
-  if (a.length !== b.length) {
-    return false;
-  }
-  return crypto.timingSafeEqual(a, b);
-}
-
-/**
- * Resolve the configured runner token from the supplied env values (in
- * precedence order). Throws if none is set, or if a known-insecure default is
- * configured while running in production.
- */
-export function resolveRunnerToken(...candidates: Array<string | undefined | null>): string {
-  const expected = candidates.find(
-    (value): value is string => typeof value === 'string' && value.trim().length > 0,
-  );
-  if (!expected) {
-    throw new RunnerAuthError('runner auth token not configured');
-  }
-  if (process.env.NODE_ENV === 'production' && INSECURE_DEFAULT_TOKENS.has(expected)) {
-    throw new RunnerAuthError('runner auth token is set to an insecure default value');
-  }
-  return expected;
-}
-
-/**
- * Assert that the request-provided `x-runner-auth` value matches the configured
- * token, using a constant-time comparison. Throws {@link RunnerAuthError}
- * (status 401) on any mismatch or misconfiguration.
- */
-export function assertRunnerAuth(
-  provided: string | null | undefined,
-  ...candidates: Array<string | undefined | null>
-): void {
-  const expected = resolveRunnerToken(...candidates);
-  if (!provided || !timingSafeEqual(provided, expected)) {
-    throw new RunnerAuthError('unauthorized');
-  }
-}
-
-/**
- * Boolean variant for call sites that need to throw their own error type.
- * Returns false when the token is missing/mismatched, or when the token is
- * unset / left at a known-insecure default in production.
- */
-export function isValidRunnerToken(
-  provided: string | null | undefined,
-  ...candidates: Array<string | undefined | null>
-): boolean {
-  let expected: string;
-  try {
-    expected = resolveRunnerToken(...candidates);
-  } catch {
-    return false;
-  }
-  return !!provided && timingSafeEqual(provided, expected);
-}
+export {
+  RunnerAuthError,
+  assertRunnerAuth,
+  isValidRunnerToken,
+  resolveRunnerToken,
+} from 'server/src/lib/extensions/runnerAuth';

--- a/packages/product-ext-proxy/ee/gateway/auth.ts
+++ b/packages/product-ext-proxy/ee/gateway/auth.ts
@@ -96,25 +96,13 @@ async function getUserClientId(userId: string, tenantId: string): Promise<string
 /**
  * Get full user info from session for passing to runner.
  * Returns null if no valid session exists.
+ *
+ * User context is session-driven. A tenant header's presence is not treated as
+ * internal-caller proof and never suppresses the authenticated user.
  */
 export async function getUserInfoFromAuth(req: NextRequest): Promise<ExtProxyUserInfo | null> {
-  // Check for internal header first (not typically used for user info)
-  const headerTenant = req.headers.get('x-alga-tenant');
-  if (headerTenant) {
-    // When using header-based auth, we don't have user info
-    console.log('[ext-proxy auth] Skipping user info - x-alga-tenant header present');
-    return null;
-  }
-
   const session = await getSession();
   const user = session?.user as any;
-
-  console.log('[ext-proxy auth] Session check', {
-    hasSession: !!session,
-    hasUser: !!user,
-    userId: user?.user_id || user?.id,
-    userEmail: user?.email,
-  });
 
   if (!user) {
     return null;
@@ -149,40 +137,7 @@ export async function getUserInfoFromAuth(req: NextRequest): Promise<ExtProxyUse
     additional_fields: extractAdditionalFields(user as Record<string, unknown>),
   };
 
-  console.log('[ext-proxy auth] Returning user info', {
-    userId: userInfo.user_id,
-    userEmail: userInfo.user_email,
-    userName: userInfo.user_name,
-    userType: userInfo.user_type,
-    clientId: userInfo.client_id,
-  });
-
   return userInfo;
-}
-
-export async function getTenantFromAuth(req: NextRequest): Promise<string> {
-  const session = await getSession();
-  const sessionTenant = (session?.user as any)?.tenant;
-  const h = req.headers.get('x-alga-tenant')?.trim();
-  const legacy = req.headers.get('x-tenant-id')?.trim();
-
-  if (sessionTenant && String(sessionTenant).trim()) {
-    const tenant = String(sessionTenant).trim();
-    if ((h && h !== tenant) || (legacy && legacy !== tenant)) {
-      throw new Error('tenant_mismatch');
-    }
-    return tenant;
-  }
-
-  // Header-based tenant selection is only allowed for non-browser/internal callers
-  // that do not already have a session tenant. A browser user must never be able
-  // to switch tenants by supplying x-alga-tenant/x-tenant-id.
-  if (h) return h;
-  if (legacy) return legacy;
-
-  const dev = process.env.DEV_TENANT_ID;
-  if (dev && dev.trim()) return dev.trim();
-  throw new Error('unauthenticated');
 }
 
 export async function assertAccess(_tenantId: string, _extensionId: string, _method: string, _path: string): Promise<void> {

--- a/packages/product-ext-proxy/ee/gateway/auth.ts
+++ b/packages/product-ext-proxy/ee/gateway/auth.ts
@@ -140,6 +140,79 @@ export async function getUserInfoFromAuth(req: NextRequest): Promise<ExtProxyUse
   return userInfo;
 }
 
+export type TenantAuthErrorCode =
+  | 'unauthenticated'
+  | 'invalid_session'
+  | 'invalid_service_auth'
+  | 'missing_tenant'
+  | 'mixed_auth'
+  | 'tenant_mismatch';
+
+/**
+ * Typed tenant-resolution failure. Route boundaries map this to a generic 401
+ * (missing/invalid authentication) or 403 (conflicting tenant evidence). The
+ * internal `code` is stable and may be logged; request credentials (runner
+ * token, cookies, tenant header values) must never be included in logs.
+ *
+ * Mirrors server/src/lib/extensions/gateway/auth.ts. It is duplicated here so
+ * this package does not import the `server` app (which depends on this
+ * package), which would create a build/project-graph cycle.
+ */
+// LEVERAGE: friction ext-proxy-tenant-auth — session tenant resolver + error
+// type are duplicated between server/src/lib/extensions/gateway/auth.ts and
+// this package because the only shared home would be a `server` import that
+// cycles the project graph; a shared low-layer package would remove the copy.
+export class TenantAuthError extends Error {
+  readonly code: TenantAuthErrorCode;
+  readonly status: number;
+
+  constructor(code: TenantAuthErrorCode, message: string) {
+    super(message);
+    this.name = 'TenantAuthError';
+    this.code = code;
+    this.status = code === 'tenant_mismatch' ? 403 : 401;
+  }
+}
+
+/**
+ * Resolve the tenant for a browser/session flow.
+ *
+ * The session is the only tenant authority. `x-alga-tenant` and `x-tenant-id`
+ * are normalized and checked only for consistency during compatibility; they
+ * can never select a tenant, and a header that disagrees with the session
+ * fails closed with `tenant_mismatch`. A partial session (session object with
+ * a missing/blank tenant) throws `invalid_session` before any header is
+ * considered, and never falls through to service authentication.
+ */
+export async function getTenantFromSessionAuth(req: NextRequest): Promise<string> {
+  const session = await getSession();
+
+  if (!session) {
+    throw new TenantAuthError('unauthenticated', 'No authenticated session found');
+  }
+
+  const rawTenant = (session.user as { tenant?: unknown } | null | undefined)?.tenant;
+  if (typeof rawTenant !== 'string' || !rawTenant.trim()) {
+    throw new TenantAuthError('invalid_session', 'Session is missing a tenant');
+  }
+  const tenant = rawTenant.trim();
+
+  const canonical = toNonEmptyString(req.headers.get('x-alga-tenant'));
+  const legacy = toNonEmptyString(req.headers.get('x-tenant-id'));
+
+  if (canonical && canonical !== tenant) {
+    throw new TenantAuthError('tenant_mismatch', 'x-alga-tenant header does not match the session tenant');
+  }
+  if (legacy && legacy !== tenant) {
+    throw new TenantAuthError('tenant_mismatch', 'x-tenant-id header does not match the session tenant');
+  }
+  if (canonical && legacy && canonical !== legacy) {
+    throw new TenantAuthError('tenant_mismatch', 'Conflicting tenant headers supplied');
+  }
+
+  return tenant;
+}
+
 export async function assertAccess(_tenantId: string, _extensionId: string, _method: string, _path: string): Promise<void> {
   // TODO: implement RBAC and per-tenant endpoint checks
   return;

--- a/packages/product-ext-proxy/ee/handler.ts
+++ b/packages/product-ext-proxy/ee/handler.ts
@@ -8,8 +8,9 @@ import { getRunnerBackend, RunnerConfigError, RunnerRequestError } from './runne
 import {
   getTenantFromSessionAuth,
   TenantAuthError,
-} from 'server/src/lib/extensions/gateway/auth';
-import { getUserInfoFromAuth, assertAccess } from './gateway/auth';
+  getUserInfoFromAuth,
+  assertAccess,
+} from './gateway/auth';
 
 type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS';
 type ProxyMethod = Exclude<Method, 'OPTIONS'>;

--- a/packages/product-ext-proxy/ee/handler.ts
+++ b/packages/product-ext-proxy/ee/handler.ts
@@ -5,7 +5,11 @@ import path from 'node:path';
 import { filterRequestHeaders, getTimeoutMs, pathnameFromParts } from '../shared/gateway-utils';
 import { loadInstallConfigCached } from './install-config-cache';
 import { getRunnerBackend, RunnerConfigError, RunnerRequestError } from './runner-backend';
-import { getTenantFromAuth, getUserInfoFromAuth, assertAccess } from './gateway/auth';
+import {
+  getTenantFromSessionAuth,
+  TenantAuthError,
+} from 'server/src/lib/extensions/gateway/auth';
+import { getUserInfoFromAuth, assertAccess } from './gateway/auth';
 
 type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS';
 type ProxyMethod = Exclude<Method, 'OPTIONS'>;
@@ -116,7 +120,7 @@ function corsPreflight(origin: string | null): NextResponse {
     headers.set('access-control-allow-credentials', 'true');
   }
   headers.set('access-control-allow-methods', 'GET,POST,PUT,PATCH,DELETE,OPTIONS');
-  headers.set('access-control-allow-headers', 'content-type,x-request-id,x-alga-tenant');
+  headers.set('access-control-allow-headers', 'content-type,x-request-id');
   headers.set('access-control-max-age', '120');
   headers.set('vary', 'Origin, Access-Control-Request-Headers');
   return new NextResponse(null, { status: 204, headers });
@@ -229,7 +233,7 @@ async function handle(
       methodOverrideSource,
     } = resolveMethodAndBody(rawMethod as ProxyMethod, url, initialBodyBuf);
 
-    const tenantId = await getTenantFromAuth(req);
+    const tenantId = await getTenantFromSessionAuth(req);
     const userInfo = await getUserInfoFromAuth(req);
     logDebug('ext-proxy:start', {
       tenantId,
@@ -356,8 +360,8 @@ async function handle(
     if (error instanceof AccessError) {
       return applyCorsHeaders(json(error.status, { error: error.message }), corsOrigin);
     }
-    if (error?.message === 'tenant_mismatch') {
-      return applyCorsHeaders(json(403, { error: 'tenant_mismatch' }), corsOrigin);
+    if (error instanceof TenantAuthError) {
+      return applyCorsHeaders(json(error.status, { error: error.code }), corsOrigin);
     }
     if (error instanceof RunnerConfigError) {
       console.error('[ext-proxy] Runner configuration error:', error.message);

--- a/sdk/docs/openapi/alga-openapi.ce.json
+++ b/sdk/docs/openapi/alga-openapi.ce.json
@@ -239,9 +239,6 @@
       "name": "ext-proxy"
     },
     {
-      "name": "financial"
-    },
-    {
       "name": "import"
     },
     {
@@ -252,6 +249,12 @@
     },
     {
       "name": "internal"
+    },
+    {
+      "name": "inventory"
+    },
+    {
+      "name": "marketing"
     },
     {
       "name": "mcp"
@@ -266,6 +269,9 @@
       "name": "online-meetings"
     },
     {
+      "name": "opportunities"
+    },
+    {
       "name": "platform-feature-flags"
     },
     {
@@ -276,6 +282,9 @@
     },
     {
       "name": "public"
+    },
+    {
+      "name": "scim"
     },
     {
       "name": "secrets"
@@ -10490,14 +10499,6 @@
           "x-idempotency-key": {
             "type": "string",
             "description": "Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner."
-          },
-          "x-alga-tenant": {
-            "type": "string",
-            "description": "Internal tenant header used for tenant resolution before session fallback."
-          },
-          "x-tenant-id": {
-            "type": "string",
-            "description": "Legacy tenant header accepted for tenant resolution before session fallback."
           }
         }
       },
@@ -10517,6 +10518,9 @@
           "error": {
             "type": "string",
             "enum": [
+              "unauthenticated",
+              "invalid_session",
+              "tenant_mismatch",
               "not_installed",
               "payload_too_large",
               "install_context_missing",
@@ -22022,14 +22026,6 @@
               "null"
             ],
             "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-          },
-          "next_action": {
-            "type": "string",
-            "minLength": 1
-          },
-          "next_action_due": {
-            "type": "string",
-            "format": "date-time"
           },
           "generator_key": {
             "type": [
@@ -44614,7 +44610,7 @@
     "/api/email/oauth/initiate": {
       "post": {
         "summary": "Initiate email OAuth flow",
-        "description": "Starts the OAuth 2.0 authorization flow for a Google or Microsoft email provider. Requires a valid Auth.js session cookie. The handler builds secure OAuth state containing tenant, user, providerId, redirect URI, timestamp, and nonce, resolves the provider client ID from configured secrets, and returns the authorization URL for the browser to visit.",
+        "description": "Starts the OAuth 2.0 authorization flow for a Google email provider. Requires a valid Auth.js session cookie. The handler builds secure OAuth state containing tenant, user, providerId, redirect URI, timestamp, and nonce, resolves the provider client ID from configured secrets, and returns the authorization URL for the browser to visit. Microsoft mailbox OAuth is not served by this unsigned route: it must be initiated from the mailbox form with an explicit application selection so the callback receives a signed state token.",
         "tags": [
           "Email"
         ],
@@ -45107,7 +45103,7 @@
     "/api/ext/{extensionId}/{path}": {
       "get": {
         "summary": "Forward GET request to extension runner",
-        "description": "Tenant-scoped extension gateway endpoint that forwards GET requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers and all query parameters to RUNNER_BASE_URL /v1/execute; and relays the runner response. GET requests do not read a body and do not generate an idempotency key. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
+        "description": "Tenant-scoped extension gateway endpoint that forwards GET requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers and all query parameters to RUNNER_BASE_URL /v1/execute; and relays the runner response. GET requests do not read a body and do not generate an idempotency key. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
         "tags": [
           "Extension Gateway"
         ],
@@ -45167,26 +45163,6 @@
             "description": "Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner.",
             "name": "x-idempotency-key",
             "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Internal tenant header used for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Internal tenant header used for tenant resolution before session fallback.",
-            "name": "x-alga-tenant",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Legacy tenant header accepted for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Legacy tenant header accepted for tenant resolution before session fallback.",
-            "name": "x-tenant-id",
-            "in": "header"
           }
         ],
         "responses": {
@@ -45203,8 +45179,28 @@
           "204": {
             "description": "Runner returned no content, or CORS preflight for OPTIONS requests on this gateway path."
           },
+          "401": {
+            "description": "No authenticated session, or the session is missing a tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "A tenant header conflicts with the authenticated session tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
           "404": {
-            "description": "Extension is not installed or not enabled for the resolved tenant.",
+            "description": "Extension is not installed or not enabled for the session tenant.",
             "content": {
               "application/json": {
                 "schema": {
@@ -45214,7 +45210,7 @@
             }
           },
           "500": {
-            "description": "Tenant could not be resolved or another internal gateway error occurred.",
+            "description": "Another internal gateway error occurred.",
             "content": {
               "application/json": {
                 "schema": {
@@ -45237,7 +45233,7 @@
       },
       "post": {
         "summary": "Forward POST request to extension runner",
-        "description": "Tenant-scoped extension gateway endpoint that forwards POST requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For POST requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. An x-idempotency-key header is forwarded when supplied, otherwise the generated x-request-id is used as the non-GET idempotency fallback. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
+        "description": "Tenant-scoped extension gateway endpoint that forwards POST requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For POST requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. An x-idempotency-key header is forwarded when supplied, otherwise the generated x-request-id is used as the non-GET idempotency fallback. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
         "tags": [
           "Extension Gateway"
         ],
@@ -45298,26 +45294,6 @@
             "required": false,
             "description": "Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner.",
             "name": "x-idempotency-key",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Internal tenant header used for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Internal tenant header used for tenant resolution before session fallback.",
-            "name": "x-alga-tenant",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Legacy tenant header accepted for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Legacy tenant header accepted for tenant resolution before session fallback.",
-            "name": "x-tenant-id",
             "in": "header"
           }
         ],
@@ -45347,8 +45323,28 @@
           "204": {
             "description": "Runner returned no content, or CORS preflight for OPTIONS requests on this gateway path."
           },
+          "401": {
+            "description": "No authenticated session, or the session is missing a tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "A tenant header conflicts with the authenticated session tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
           "404": {
-            "description": "Extension is not installed or not enabled for the resolved tenant.",
+            "description": "Extension is not installed or not enabled for the session tenant.",
             "content": {
               "application/json": {
                 "schema": {
@@ -45368,7 +45364,7 @@
             }
           },
           "500": {
-            "description": "Tenant could not be resolved or another internal gateway error occurred.",
+            "description": "Another internal gateway error occurred.",
             "content": {
               "application/json": {
                 "schema": {
@@ -45391,7 +45387,7 @@
       },
       "put": {
         "summary": "Forward PUT request to extension runner",
-        "description": "Tenant-scoped extension gateway endpoint that forwards PUT requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For PUT requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Clients should provide x-idempotency-key for safe retries; otherwise the gateway falls back to a generated request ID. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
+        "description": "Tenant-scoped extension gateway endpoint that forwards PUT requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For PUT requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Clients should provide x-idempotency-key for safe retries; otherwise the gateway falls back to a generated request ID. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
         "tags": [
           "Extension Gateway"
         ],
@@ -45452,26 +45448,6 @@
             "required": false,
             "description": "Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner.",
             "name": "x-idempotency-key",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Internal tenant header used for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Internal tenant header used for tenant resolution before session fallback.",
-            "name": "x-alga-tenant",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Legacy tenant header accepted for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Legacy tenant header accepted for tenant resolution before session fallback.",
-            "name": "x-tenant-id",
             "in": "header"
           }
         ],
@@ -45501,8 +45477,28 @@
           "204": {
             "description": "Runner returned no content, or CORS preflight for OPTIONS requests on this gateway path."
           },
+          "401": {
+            "description": "No authenticated session, or the session is missing a tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "A tenant header conflicts with the authenticated session tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
           "404": {
-            "description": "Extension is not installed or not enabled for the resolved tenant.",
+            "description": "Extension is not installed or not enabled for the session tenant.",
             "content": {
               "application/json": {
                 "schema": {
@@ -45522,7 +45518,7 @@
             }
           },
           "500": {
-            "description": "Tenant could not be resolved or another internal gateway error occurred.",
+            "description": "Another internal gateway error occurred.",
             "content": {
               "application/json": {
                 "schema": {
@@ -45545,7 +45541,7 @@
       },
       "patch": {
         "summary": "Forward PATCH request to extension runner",
-        "description": "Tenant-scoped extension gateway endpoint that forwards PATCH requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For PATCH requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Clients should provide x-idempotency-key for safe retries; otherwise the gateway falls back to a generated request ID. The gateway does not interpret PATCH semantics; partial-update behavior is extension-defined.",
+        "description": "Tenant-scoped extension gateway endpoint that forwards PATCH requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For PATCH requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Clients should provide x-idempotency-key for safe retries; otherwise the gateway falls back to a generated request ID. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway does not interpret PATCH semantics; partial-update behavior is extension-defined.",
         "tags": [
           "Extension Gateway"
         ],
@@ -45606,26 +45602,6 @@
             "required": false,
             "description": "Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner.",
             "name": "x-idempotency-key",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Internal tenant header used for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Internal tenant header used for tenant resolution before session fallback.",
-            "name": "x-alga-tenant",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Legacy tenant header accepted for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Legacy tenant header accepted for tenant resolution before session fallback.",
-            "name": "x-tenant-id",
             "in": "header"
           }
         ],
@@ -45655,8 +45631,28 @@
           "204": {
             "description": "Runner returned no content, or CORS preflight for OPTIONS requests on this gateway path."
           },
+          "401": {
+            "description": "No authenticated session, or the session is missing a tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "A tenant header conflicts with the authenticated session tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
           "404": {
-            "description": "Extension is not installed or not enabled for the resolved tenant.",
+            "description": "Extension is not installed or not enabled for the session tenant.",
             "content": {
               "application/json": {
                 "schema": {
@@ -45676,7 +45672,7 @@
             }
           },
           "500": {
-            "description": "Tenant could not be resolved or another internal gateway error occurred.",
+            "description": "Another internal gateway error occurred.",
             "content": {
               "application/json": {
                 "schema": {
@@ -45699,7 +45695,7 @@
       },
       "delete": {
         "summary": "Forward DELETE request to extension runner",
-        "description": "Tenant-scoped extension gateway endpoint that forwards DELETE requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For DELETE requests the body, if present, is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
+        "description": "Tenant-scoped extension gateway endpoint that forwards DELETE requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For DELETE requests the body, if present, is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
         "tags": [
           "Extension Gateway"
         ],
@@ -45761,26 +45757,6 @@
             "description": "Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner.",
             "name": "x-idempotency-key",
             "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Internal tenant header used for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Internal tenant header used for tenant resolution before session fallback.",
-            "name": "x-alga-tenant",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Legacy tenant header accepted for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Legacy tenant header accepted for tenant resolution before session fallback.",
-            "name": "x-tenant-id",
-            "in": "header"
           }
         ],
         "requestBody": {
@@ -45809,8 +45785,28 @@
           "204": {
             "description": "Runner returned no content, or CORS preflight for OPTIONS requests on this gateway path."
           },
+          "401": {
+            "description": "No authenticated session, or the session is missing a tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "A tenant header conflicts with the authenticated session tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
           "404": {
-            "description": "Extension is not installed or not enabled for the resolved tenant.",
+            "description": "Extension is not installed or not enabled for the session tenant.",
             "content": {
               "application/json": {
                 "schema": {
@@ -45830,7 +45826,7 @@
             }
           },
           "500": {
-            "description": "Tenant could not be resolved or another internal gateway error occurred.",
+            "description": "Another internal gateway error occurred.",
             "content": {
               "application/json": {
                 "schema": {
@@ -110468,6 +110464,126 @@
         }
       }
     },
+    "/api/auth/client-portal/sso/discover": {
+      "post": {
+        "summary": "POST auth",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "auth"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/client-portal/sso/resolve": {
+      "post": {
+        "summary": "POST auth",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "auth"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/auth/e2e/google/authorize": {
       "get": {
         "summary": "GET auth",
@@ -115630,6 +115746,366 @@
         }
       }
     },
+    "/api/inventory/sales-orders/{id}/document": {
+      "get": {
+        "summary": "GET inventory",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "inventory"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/inventory/sales-orders/{id}/email-confirmation": {
+      "post": {
+        "summary": "POST inventory",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "inventory"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/marketing/capture/{tenant}/{slug}": {
+      "post": {
+        "summary": "POST marketing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "marketing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/marketing/track/click/{tenant}/{enrollmentId}/{stepId}": {
+      "get": {
+        "summary": "GET marketing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "marketing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/marketing/track/open/{tenant}/{enrollmentId}/{stepId}": {
+      "get": {
+        "summary": "GET marketing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "marketing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/marketing/unsubscribe/{tenant}/{enrollmentId}": {
+      "get": {
+        "summary": "GET marketing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "marketing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST marketing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "marketing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/mcp": {
       "get": {
         "summary": "GET mcp",
@@ -116180,6 +116656,308 @@
         "x-alga-products": [
           "psa"
         ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/scim/v2/{connectionId}/{scimPath}": {
+      "delete": {
+        "summary": "DELETE scim",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "scim"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "responses": {
+          "204": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "GET scim",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "scim"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "options": {
+        "summary": "OPTIONS scim",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "scim"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "PATCH scim",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "scim"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST scim",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "scim"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "PUT scim",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "scim"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Placeholder success response",
@@ -117954,72 +118732,12 @@
         }
       }
     },
-    "/api/v1/financial/reconciliation/run": {
+    "/api/v1/inventory/counts/{sessionId}/cancel": {
       "post": {
         "summary": "POST v1",
         "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
         "tags": [
-          "financial"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "requestBody": {
-          "description": "Placeholder request body",
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlaceholderObject"
-              },
-              "description": "Placeholder request body"
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/financial/reconciliation/{id}/resolve": {
-      "post": {
-        "summary": "POST v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "financial"
+          "inventory"
         ],
         "extensions": {
           "x-generated-from": "docs/openapi/route-inventory.json",
@@ -119899,6 +120617,686 @@
         "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
         "tags": [
           "mobile"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/calibration": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "opportunities"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/forecast": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "opportunities"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/meeting-sessions": {
+      "post": {
+        "summary": "POST v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "opportunities"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/meeting-sessions/active": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "opportunities"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/meeting-sessions/{sessionId}/reviews": {
+      "post": {
+        "summary": "POST v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "opportunities"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/qbr/yield": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "opportunities"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/qbr/{clientId}": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "opportunities"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/qbr/{clientId}/opportunities": {
+      "post": {
+        "summary": "POST v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "opportunities"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/rollups": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "opportunities"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/{id}/commitments": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "opportunities"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "opportunities"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/{id}/commitments/{commitmentId}": {
+      "delete": {
+        "summary": "DELETE v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "opportunities"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "204": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "PUT v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "opportunities"
         ],
         "extensions": {
           "x-generated-from": "docs/openapi/route-inventory.json",
@@ -123204,6 +124602,112 @@
         "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
         "tags": [
           "tenant-management"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/webhooks/ai-gateway": {
+      "options": {
+        "summary": "OPTIONS webhooks",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "webhooks"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST webhooks",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "webhooks"
         ],
         "extensions": {
           "x-generated-from": "docs/openapi/route-inventory.json",

--- a/sdk/docs/openapi/alga-openapi.ce.yaml
+++ b/sdk/docs/openapi/alga-openapi.ce.yaml
@@ -83,19 +83,22 @@ tags:
   - name: ext-bundles
   - name: ext-debug
   - name: ext-proxy
-  - name: financial
   - name: import
   - name: inbound
   - name: integrations
   - name: internal
+  - name: inventory
+  - name: marketing
   - name: mcp
   - name: meta
   - name: mobile
   - name: online-meetings
+  - name: opportunities
   - name: platform-feature-flags
   - name: platform-notifications
   - name: platform-reports
   - name: public
+  - name: scim
   - name: secrets
   - name: share
   - name: storage
@@ -7431,14 +7434,6 @@ components:
           type: string
           description: Optional idempotency key for non-GET methods. The gateway falls
             back to x-request-id when absent and forwards the key to the runner.
-        x-alga-tenant:
-          type: string
-          description: Internal tenant header used for tenant resolution before session
-            fallback.
-        x-tenant-id:
-          type: string
-          description: Legacy tenant header accepted for tenant resolution before session
-            fallback.
     ExtensionOpaqueRequest:
       type: object
       properties: {}
@@ -7456,6 +7451,9 @@ components:
         error:
           type: string
           enum:
+            - unauthenticated
+            - invalid_session
+            - tenant_mismatch
             - not_installed
             - payload_too_large
             - install_context_missing
@@ -15631,12 +15629,6 @@ components:
             - string
             - "null"
           pattern: ^\d{4}-\d{2}-\d{2}$
-        next_action:
-          type: string
-          minLength: 1
-        next_action_due:
-          type: string
-          format: date-time
         generator_key:
           type:
             - string
@@ -30852,12 +30844,14 @@ paths:
   /api/email/oauth/initiate:
     post:
       summary: Initiate email OAuth flow
-      description: Starts the OAuth 2.0 authorization flow for a Google or Microsoft
-        email provider. Requires a valid Auth.js session cookie. The handler
-        builds secure OAuth state containing tenant, user, providerId, redirect
-        URI, timestamp, and nonce, resolves the provider client ID from
-        configured secrets, and returns the authorization URL for the browser to
-        visit.
+      description: "Starts the OAuth 2.0 authorization flow for a Google email
+        provider. Requires a valid Auth.js session cookie. The handler builds
+        secure OAuth state containing tenant, user, providerId, redirect URI,
+        timestamp, and nonce, resolves the provider client ID from configured
+        secrets, and returns the authorization URL for the browser to visit.
+        Microsoft mailbox OAuth is not served by this unsigned route: it must be
+        initiated from the mailbox form with an explicit application selection
+        so the callback receives a signed state token."
       tags:
         - Email
       security:
@@ -31209,14 +31203,15 @@ paths:
     get:
       summary: Forward GET request to extension runner
       description: Tenant-scoped extension gateway endpoint that forwards GET requests
-        to an installed extension runner. The gateway resolves the tenant from
-        x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in
-        development; verifies the extension is installed and enabled for that
-        tenant; forwards selected headers and all query parameters to
-        RUNNER_BASE_URL /v1/execute; and relays the runner response. GET
-        requests do not read a body and do not generate an idempotency key. The
-        gateway currently has a placeholder access check and does not enforce
-        per-extension RBAC beyond tenant install resolution.
+        to an installed extension runner. The gateway requires an authenticated
+        session and derives the tenant from that session; verifies the extension
+        is installed and enabled for the session tenant; forwards selected
+        headers and all query parameters to RUNNER_BASE_URL /v1/execute; and
+        relays the runner response. GET requests do not read a body and do not
+        generate an idempotency key. Tenant-selection headers are not accepted
+        as authentication and a header that disagrees with the session tenant
+        fails closed. The gateway currently has a placeholder access check and
+        does not enforce per-extension RBAC beyond tenant install resolution.
       tags:
         - Extension Gateway
       security:
@@ -31268,24 +31263,6 @@ paths:
             back to x-request-id when absent and forwards the key to the runner.
           name: x-idempotency-key
           in: header
-        - schema:
-            type: string
-            description: Internal tenant header used for tenant resolution before session
-              fallback.
-          required: false
-          description: Internal tenant header used for tenant resolution before session
-            fallback.
-          name: x-alga-tenant
-          in: header
-        - schema:
-            type: string
-            description: Legacy tenant header accepted for tenant resolution before session
-              fallback.
-          required: false
-          description: Legacy tenant header accepted for tenant resolution before session
-            fallback.
-          name: x-tenant-id
-          in: header
       responses:
         "200":
           description: Runner response relayed by the gateway. The actual status can vary
@@ -31297,15 +31274,26 @@ paths:
         "204":
           description: Runner returned no content, or CORS preflight for OPTIONS requests
             on this gateway path.
+        "401":
+          description: No authenticated session, or the session is missing a tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
+        "403":
+          description: A tenant header conflicts with the authenticated session tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "404":
-          description: Extension is not installed or not enabled for the resolved tenant.
+          description: Extension is not installed or not enabled for the session tenant.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "500":
-          description: Tenant could not be resolved or another internal gateway error
-            occurred.
+          description: Another internal gateway error occurred.
           content:
             application/json:
               schema:
@@ -31320,17 +31308,18 @@ paths:
     post:
       summary: Forward POST request to extension runner
       description: Tenant-scoped extension gateway endpoint that forwards POST
-        requests to an installed extension runner. The gateway resolves the
-        tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID
-        in development; verifies the extension is installed and enabled for that
-        tenant; forwards selected headers, query parameters, and an optional
-        opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner
-        response. For POST requests the body is limited to 10 MB,
-        base64-encoded, and forwarded as http.body_b64. An x-idempotency-key
-        header is forwarded when supplied, otherwise the generated x-request-id
-        is used as the non-GET idempotency fallback. The gateway currently has a
-        placeholder access check and does not enforce per-extension RBAC beyond
-        tenant install resolution.
+        requests to an installed extension runner. The gateway requires an
+        authenticated session and derives the tenant from that session; verifies
+        the extension is installed and enabled for the session tenant; forwards
+        selected headers, query parameters, and an optional opaque body to
+        RUNNER_BASE_URL /v1/execute; and relays the runner response. For POST
+        requests the body is limited to 10 MB, base64-encoded, and forwarded as
+        http.body_b64. An x-idempotency-key header is forwarded when supplied,
+        otherwise the generated x-request-id is used as the non-GET idempotency
+        fallback. Tenant-selection headers are not accepted as authentication
+        and a header that disagrees with the session tenant fails closed. The
+        gateway currently has a placeholder access check and does not enforce
+        per-extension RBAC beyond tenant install resolution.
       tags:
         - Extension Gateway
       security:
@@ -31383,24 +31372,6 @@ paths:
           description: Optional idempotency key for non-GET methods. The gateway falls
             back to x-request-id when absent and forwards the key to the runner.
           name: x-idempotency-key
-          in: header
-        - schema:
-            type: string
-            description: Internal tenant header used for tenant resolution before session
-              fallback.
-          required: false
-          description: Internal tenant header used for tenant resolution before session
-            fallback.
-          name: x-alga-tenant
-          in: header
-        - schema:
-            type: string
-            description: Legacy tenant header accepted for tenant resolution before session
-              fallback.
-          required: false
-          description: Legacy tenant header accepted for tenant resolution before session
-            fallback.
-          name: x-tenant-id
           in: header
       requestBody:
         description: Optional extension-specific POST body. The gateway accepts any
@@ -31423,8 +31394,20 @@ paths:
         "204":
           description: Runner returned no content, or CORS preflight for OPTIONS requests
             on this gateway path.
+        "401":
+          description: No authenticated session, or the session is missing a tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
+        "403":
+          description: A tenant header conflicts with the authenticated session tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "404":
-          description: Extension is not installed or not enabled for the resolved tenant.
+          description: Extension is not installed or not enabled for the session tenant.
           content:
             application/json:
               schema:
@@ -31436,8 +31419,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "500":
-          description: Tenant could not be resolved or another internal gateway error
-            occurred.
+          description: Another internal gateway error occurred.
           content:
             application/json:
               schema:
@@ -31452,16 +31434,18 @@ paths:
     put:
       summary: Forward PUT request to extension runner
       description: Tenant-scoped extension gateway endpoint that forwards PUT requests
-        to an installed extension runner. The gateway resolves the tenant from
-        x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in
-        development; verifies the extension is installed and enabled for that
-        tenant; forwards selected headers, query parameters, and an optional
-        opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner
-        response. For PUT requests the body is limited to 10 MB, base64-encoded,
-        and forwarded as http.body_b64. Clients should provide x-idempotency-key
-        for safe retries; otherwise the gateway falls back to a generated
-        request ID. The gateway currently has a placeholder access check and
-        does not enforce per-extension RBAC beyond tenant install resolution.
+        to an installed extension runner. The gateway requires an authenticated
+        session and derives the tenant from that session; verifies the extension
+        is installed and enabled for the session tenant; forwards selected
+        headers, query parameters, and an optional opaque body to
+        RUNNER_BASE_URL /v1/execute; and relays the runner response. For PUT
+        requests the body is limited to 10 MB, base64-encoded, and forwarded as
+        http.body_b64. Clients should provide x-idempotency-key for safe
+        retries; otherwise the gateway falls back to a generated request ID.
+        Tenant-selection headers are not accepted as authentication and a header
+        that disagrees with the session tenant fails closed. The gateway
+        currently has a placeholder access check and does not enforce
+        per-extension RBAC beyond tenant install resolution.
       tags:
         - Extension Gateway
       security:
@@ -31514,24 +31498,6 @@ paths:
           description: Optional idempotency key for non-GET methods. The gateway falls
             back to x-request-id when absent and forwards the key to the runner.
           name: x-idempotency-key
-          in: header
-        - schema:
-            type: string
-            description: Internal tenant header used for tenant resolution before session
-              fallback.
-          required: false
-          description: Internal tenant header used for tenant resolution before session
-            fallback.
-          name: x-alga-tenant
-          in: header
-        - schema:
-            type: string
-            description: Legacy tenant header accepted for tenant resolution before session
-              fallback.
-          required: false
-          description: Legacy tenant header accepted for tenant resolution before session
-            fallback.
-          name: x-tenant-id
           in: header
       requestBody:
         description: Optional extension-specific PUT body. The gateway accepts any
@@ -31554,8 +31520,20 @@ paths:
         "204":
           description: Runner returned no content, or CORS preflight for OPTIONS requests
             on this gateway path.
+        "401":
+          description: No authenticated session, or the session is missing a tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
+        "403":
+          description: A tenant header conflicts with the authenticated session tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "404":
-          description: Extension is not installed or not enabled for the resolved tenant.
+          description: Extension is not installed or not enabled for the session tenant.
           content:
             application/json:
               schema:
@@ -31567,8 +31545,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "500":
-          description: Tenant could not be resolved or another internal gateway error
-            occurred.
+          description: Another internal gateway error occurred.
           content:
             application/json:
               schema:
@@ -31583,16 +31560,18 @@ paths:
     patch:
       summary: Forward PATCH request to extension runner
       description: Tenant-scoped extension gateway endpoint that forwards PATCH
-        requests to an installed extension runner. The gateway resolves the
-        tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID
-        in development; verifies the extension is installed and enabled for that
-        tenant; forwards selected headers, query parameters, and an optional
-        opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner
-        response. For PATCH requests the body is limited to 10 MB,
-        base64-encoded, and forwarded as http.body_b64. Clients should provide
-        x-idempotency-key for safe retries; otherwise the gateway falls back to
-        a generated request ID. The gateway does not interpret PATCH semantics;
-        partial-update behavior is extension-defined.
+        requests to an installed extension runner. The gateway requires an
+        authenticated session and derives the tenant from that session; verifies
+        the extension is installed and enabled for the session tenant; forwards
+        selected headers, query parameters, and an optional opaque body to
+        RUNNER_BASE_URL /v1/execute; and relays the runner response. For PATCH
+        requests the body is limited to 10 MB, base64-encoded, and forwarded as
+        http.body_b64. Clients should provide x-idempotency-key for safe
+        retries; otherwise the gateway falls back to a generated request ID.
+        Tenant-selection headers are not accepted as authentication and a header
+        that disagrees with the session tenant fails closed. The gateway does
+        not interpret PATCH semantics; partial-update behavior is
+        extension-defined.
       tags:
         - Extension Gateway
       security:
@@ -31645,24 +31624,6 @@ paths:
           description: Optional idempotency key for non-GET methods. The gateway falls
             back to x-request-id when absent and forwards the key to the runner.
           name: x-idempotency-key
-          in: header
-        - schema:
-            type: string
-            description: Internal tenant header used for tenant resolution before session
-              fallback.
-          required: false
-          description: Internal tenant header used for tenant resolution before session
-            fallback.
-          name: x-alga-tenant
-          in: header
-        - schema:
-            type: string
-            description: Legacy tenant header accepted for tenant resolution before session
-              fallback.
-          required: false
-          description: Legacy tenant header accepted for tenant resolution before session
-            fallback.
-          name: x-tenant-id
           in: header
       requestBody:
         description: Optional extension-specific PATCH body. The gateway accepts any
@@ -31685,8 +31646,20 @@ paths:
         "204":
           description: Runner returned no content, or CORS preflight for OPTIONS requests
             on this gateway path.
+        "401":
+          description: No authenticated session, or the session is missing a tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
+        "403":
+          description: A tenant header conflicts with the authenticated session tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "404":
-          description: Extension is not installed or not enabled for the resolved tenant.
+          description: Extension is not installed or not enabled for the session tenant.
           content:
             application/json:
               schema:
@@ -31698,8 +31671,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "500":
-          description: Tenant could not be resolved or another internal gateway error
-            occurred.
+          description: Another internal gateway error occurred.
           content:
             application/json:
               schema:
@@ -31714,15 +31686,16 @@ paths:
     delete:
       summary: Forward DELETE request to extension runner
       description: Tenant-scoped extension gateway endpoint that forwards DELETE
-        requests to an installed extension runner. The gateway resolves the
-        tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID
-        in development; verifies the extension is installed and enabled for that
-        tenant; forwards selected headers, query parameters, and an optional
-        opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner
-        response. For DELETE requests the body, if present, is limited to 10 MB,
-        base64-encoded, and forwarded as http.body_b64. The gateway currently
-        has a placeholder access check and does not enforce per-extension RBAC
-        beyond tenant install resolution.
+        requests to an installed extension runner. The gateway requires an
+        authenticated session and derives the tenant from that session; verifies
+        the extension is installed and enabled for the session tenant; forwards
+        selected headers, query parameters, and an optional opaque body to
+        RUNNER_BASE_URL /v1/execute; and relays the runner response. For DELETE
+        requests the body, if present, is limited to 10 MB, base64-encoded, and
+        forwarded as http.body_b64. Tenant-selection headers are not accepted as
+        authentication and a header that disagrees with the session tenant fails
+        closed. The gateway currently has a placeholder access check and does
+        not enforce per-extension RBAC beyond tenant install resolution.
       tags:
         - Extension Gateway
       security:
@@ -31776,24 +31749,6 @@ paths:
             back to x-request-id when absent and forwards the key to the runner.
           name: x-idempotency-key
           in: header
-        - schema:
-            type: string
-            description: Internal tenant header used for tenant resolution before session
-              fallback.
-          required: false
-          description: Internal tenant header used for tenant resolution before session
-            fallback.
-          name: x-alga-tenant
-          in: header
-        - schema:
-            type: string
-            description: Legacy tenant header accepted for tenant resolution before session
-              fallback.
-          required: false
-          description: Legacy tenant header accepted for tenant resolution before session
-            fallback.
-          name: x-tenant-id
-          in: header
       requestBody:
         description: Optional extension-specific DELETE body. The gateway accepts any
           content type up to 10 MB and forwards it as base64.
@@ -31815,8 +31770,20 @@ paths:
         "204":
           description: Runner returned no content, or CORS preflight for OPTIONS requests
             on this gateway path.
+        "401":
+          description: No authenticated session, or the session is missing a tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
+        "403":
+          description: A tenant header conflicts with the authenticated session tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "404":
-          description: Extension is not installed or not enabled for the resolved tenant.
+          description: Extension is not installed or not enabled for the session tenant.
           content:
             application/json:
               schema:
@@ -31828,8 +31795,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "500":
-          description: Tenant could not be resolved or another internal gateway error
-            occurred.
+          description: Another internal gateway error occurred.
           content:
             application/json:
               schema:
@@ -73366,6 +73332,84 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /api/auth/client-portal/sso/discover:
+    post:
+      summary: POST auth
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - auth
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/auth/client-portal/sso/resolve:
+    post:
+      summary: POST auth
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - auth
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /api/auth/e2e/google/authorize:
     get:
       summary: GET auth
@@ -76720,6 +76764,241 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /api/inventory/sales-orders/{id}/document:
+    get:
+      summary: GET inventory
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - inventory
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/inventory/sales-orders/{id}/email-confirmation:
+    post:
+      summary: POST inventory
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - inventory
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/marketing/capture/{tenant}/{slug}:
+    post:
+      summary: POST marketing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - marketing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/marketing/track/click/{tenant}/{enrollmentId}/{stepId}:
+    get:
+      summary: GET marketing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - marketing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/marketing/track/open/{tenant}/{enrollmentId}/{stepId}:
+    get:
+      summary: GET marketing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - marketing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/marketing/unsubscribe/{tenant}/{enrollmentId}:
+    get:
+      summary: GET marketing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - marketing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST marketing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - marketing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /api/mcp:
     get:
       summary: GET mcp
@@ -77080,6 +77359,205 @@ paths:
         x-placeholder: true
       x-alga-products:
         - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/scim/v2/{connectionId}/{scimPath}:
+    delete:
+      summary: DELETE scim
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - scim
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      responses:
+        "204":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    get:
+      summary: GET scim
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - scim
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    options:
+      summary: OPTIONS scim
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - scim
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    patch:
+      summary: PATCH scim
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - scim
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST scim
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - scim
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    put:
+      summary: PUT scim
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - scim
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
       responses:
         "200":
           description: Placeholder success response
@@ -78230,52 +78708,13 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/financial/reconciliation/run:
+  /api/v1/inventory/counts/{sessionId}/cancel:
     post:
       summary: POST v1
       description: This operation was generated automatically from the route
         inventory. Replace with canonical OpenAPI metadata.
       tags:
-        - financial
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      requestBody:
-        description: Placeholder request body
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PlaceholderObject"
-            description: Placeholder request body
-      responses:
-        "201":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/financial/reconciliation/{id}/resolve:
-    post:
-      summary: POST v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - financial
+        - inventory
       extensions:
         x-generated-from: docs/openapi/route-inventory.json
         x-placeholder: true
@@ -79497,6 +79936,447 @@ paths:
         inventory. Replace with canonical OpenAPI metadata.
       tags:
         - mobile
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/opportunities/calibration:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - opportunities
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/opportunities/forecast:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - opportunities
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/opportunities/meeting-sessions:
+    post:
+      summary: POST v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - opportunities
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/opportunities/meeting-sessions/active:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - opportunities
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/opportunities/meeting-sessions/{sessionId}/reviews:
+    post:
+      summary: POST v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - opportunities
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/opportunities/qbr/yield:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - opportunities
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/opportunities/qbr/{clientId}:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - opportunities
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/opportunities/qbr/{clientId}/opportunities:
+    post:
+      summary: POST v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - opportunities
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/opportunities/rollups:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - opportunities
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/opportunities/{id}/commitments:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - opportunities
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - opportunities
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/opportunities/{id}/commitments/{commitmentId}:
+    delete:
+      summary: DELETE v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - opportunities
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "204":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    put:
+      summary: PUT v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - opportunities
       extensions:
         x-generated-from: docs/openapi/route-inventory.json
         x-placeholder: true
@@ -81637,6 +82517,75 @@ paths:
         inventory. Replace with canonical OpenAPI metadata.
       tags:
         - tenant-management
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/webhooks/ai-gateway:
+    options:
+      summary: OPTIONS webhooks
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - webhooks
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST webhooks
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - webhooks
       extensions:
         x-generated-from: docs/openapi/route-inventory.json
         x-placeholder: true

--- a/sdk/docs/openapi/alga-openapi.ee.json
+++ b/sdk/docs/openapi/alga-openapi.ee.json
@@ -242,9 +242,6 @@
       "name": "extensions"
     },
     {
-      "name": "financial"
-    },
-    {
       "name": "import"
     },
     {
@@ -255,6 +252,12 @@
     },
     {
       "name": "internal"
+    },
+    {
+      "name": "inventory"
+    },
+    {
+      "name": "marketing"
     },
     {
       "name": "mcp"
@@ -279,6 +282,9 @@
     },
     {
       "name": "public"
+    },
+    {
+      "name": "scim"
     },
     {
       "name": "secrets"
@@ -10493,14 +10499,6 @@
           "x-idempotency-key": {
             "type": "string",
             "description": "Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner."
-          },
-          "x-alga-tenant": {
-            "type": "string",
-            "description": "Internal tenant header used for tenant resolution before session fallback."
-          },
-          "x-tenant-id": {
-            "type": "string",
-            "description": "Legacy tenant header accepted for tenant resolution before session fallback."
           }
         }
       },
@@ -10520,6 +10518,9 @@
           "error": {
             "type": "string",
             "enum": [
+              "unauthenticated",
+              "invalid_session",
+              "tenant_mismatch",
               "not_installed",
               "payload_too_large",
               "install_context_missing",
@@ -22025,14 +22026,6 @@
               "null"
             ],
             "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-          },
-          "next_action": {
-            "type": "string",
-            "minLength": 1
-          },
-          "next_action_due": {
-            "type": "string",
-            "format": "date-time"
           },
           "generator_key": {
             "type": [
@@ -44617,7 +44610,7 @@
     "/api/email/oauth/initiate": {
       "post": {
         "summary": "Initiate email OAuth flow",
-        "description": "Starts the OAuth 2.0 authorization flow for a Google or Microsoft email provider. Requires a valid Auth.js session cookie. The handler builds secure OAuth state containing tenant, user, providerId, redirect URI, timestamp, and nonce, resolves the provider client ID from configured secrets, and returns the authorization URL for the browser to visit.",
+        "description": "Starts the OAuth 2.0 authorization flow for a Google email provider. Requires a valid Auth.js session cookie. The handler builds secure OAuth state containing tenant, user, providerId, redirect URI, timestamp, and nonce, resolves the provider client ID from configured secrets, and returns the authorization URL for the browser to visit. Microsoft mailbox OAuth is not served by this unsigned route: it must be initiated from the mailbox form with an explicit application selection so the callback receives a signed state token.",
         "tags": [
           "Email"
         ],
@@ -45110,7 +45103,7 @@
     "/api/ext/{extensionId}/{path}": {
       "get": {
         "summary": "Forward GET request to extension runner",
-        "description": "Tenant-scoped extension gateway endpoint that forwards GET requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers and all query parameters to RUNNER_BASE_URL /v1/execute; and relays the runner response. GET requests do not read a body and do not generate an idempotency key. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
+        "description": "Tenant-scoped extension gateway endpoint that forwards GET requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers and all query parameters to RUNNER_BASE_URL /v1/execute; and relays the runner response. GET requests do not read a body and do not generate an idempotency key. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
         "tags": [
           "Extension Gateway"
         ],
@@ -45170,26 +45163,6 @@
             "description": "Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner.",
             "name": "x-idempotency-key",
             "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Internal tenant header used for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Internal tenant header used for tenant resolution before session fallback.",
-            "name": "x-alga-tenant",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Legacy tenant header accepted for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Legacy tenant header accepted for tenant resolution before session fallback.",
-            "name": "x-tenant-id",
-            "in": "header"
           }
         ],
         "responses": {
@@ -45206,8 +45179,28 @@
           "204": {
             "description": "Runner returned no content, or CORS preflight for OPTIONS requests on this gateway path."
           },
+          "401": {
+            "description": "No authenticated session, or the session is missing a tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "A tenant header conflicts with the authenticated session tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
           "404": {
-            "description": "Extension is not installed or not enabled for the resolved tenant.",
+            "description": "Extension is not installed or not enabled for the session tenant.",
             "content": {
               "application/json": {
                 "schema": {
@@ -45217,7 +45210,7 @@
             }
           },
           "500": {
-            "description": "Tenant could not be resolved or another internal gateway error occurred.",
+            "description": "Another internal gateway error occurred.",
             "content": {
               "application/json": {
                 "schema": {
@@ -45240,7 +45233,7 @@
       },
       "post": {
         "summary": "Forward POST request to extension runner",
-        "description": "Tenant-scoped extension gateway endpoint that forwards POST requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For POST requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. An x-idempotency-key header is forwarded when supplied, otherwise the generated x-request-id is used as the non-GET idempotency fallback. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
+        "description": "Tenant-scoped extension gateway endpoint that forwards POST requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For POST requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. An x-idempotency-key header is forwarded when supplied, otherwise the generated x-request-id is used as the non-GET idempotency fallback. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
         "tags": [
           "Extension Gateway"
         ],
@@ -45301,26 +45294,6 @@
             "required": false,
             "description": "Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner.",
             "name": "x-idempotency-key",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Internal tenant header used for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Internal tenant header used for tenant resolution before session fallback.",
-            "name": "x-alga-tenant",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Legacy tenant header accepted for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Legacy tenant header accepted for tenant resolution before session fallback.",
-            "name": "x-tenant-id",
             "in": "header"
           }
         ],
@@ -45350,8 +45323,28 @@
           "204": {
             "description": "Runner returned no content, or CORS preflight for OPTIONS requests on this gateway path."
           },
+          "401": {
+            "description": "No authenticated session, or the session is missing a tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "A tenant header conflicts with the authenticated session tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
           "404": {
-            "description": "Extension is not installed or not enabled for the resolved tenant.",
+            "description": "Extension is not installed or not enabled for the session tenant.",
             "content": {
               "application/json": {
                 "schema": {
@@ -45371,7 +45364,7 @@
             }
           },
           "500": {
-            "description": "Tenant could not be resolved or another internal gateway error occurred.",
+            "description": "Another internal gateway error occurred.",
             "content": {
               "application/json": {
                 "schema": {
@@ -45394,7 +45387,7 @@
       },
       "put": {
         "summary": "Forward PUT request to extension runner",
-        "description": "Tenant-scoped extension gateway endpoint that forwards PUT requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For PUT requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Clients should provide x-idempotency-key for safe retries; otherwise the gateway falls back to a generated request ID. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
+        "description": "Tenant-scoped extension gateway endpoint that forwards PUT requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For PUT requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Clients should provide x-idempotency-key for safe retries; otherwise the gateway falls back to a generated request ID. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
         "tags": [
           "Extension Gateway"
         ],
@@ -45455,26 +45448,6 @@
             "required": false,
             "description": "Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner.",
             "name": "x-idempotency-key",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Internal tenant header used for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Internal tenant header used for tenant resolution before session fallback.",
-            "name": "x-alga-tenant",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Legacy tenant header accepted for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Legacy tenant header accepted for tenant resolution before session fallback.",
-            "name": "x-tenant-id",
             "in": "header"
           }
         ],
@@ -45504,8 +45477,28 @@
           "204": {
             "description": "Runner returned no content, or CORS preflight for OPTIONS requests on this gateway path."
           },
+          "401": {
+            "description": "No authenticated session, or the session is missing a tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "A tenant header conflicts with the authenticated session tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
           "404": {
-            "description": "Extension is not installed or not enabled for the resolved tenant.",
+            "description": "Extension is not installed or not enabled for the session tenant.",
             "content": {
               "application/json": {
                 "schema": {
@@ -45525,7 +45518,7 @@
             }
           },
           "500": {
-            "description": "Tenant could not be resolved or another internal gateway error occurred.",
+            "description": "Another internal gateway error occurred.",
             "content": {
               "application/json": {
                 "schema": {
@@ -45548,7 +45541,7 @@
       },
       "patch": {
         "summary": "Forward PATCH request to extension runner",
-        "description": "Tenant-scoped extension gateway endpoint that forwards PATCH requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For PATCH requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Clients should provide x-idempotency-key for safe retries; otherwise the gateway falls back to a generated request ID. The gateway does not interpret PATCH semantics; partial-update behavior is extension-defined.",
+        "description": "Tenant-scoped extension gateway endpoint that forwards PATCH requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For PATCH requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Clients should provide x-idempotency-key for safe retries; otherwise the gateway falls back to a generated request ID. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway does not interpret PATCH semantics; partial-update behavior is extension-defined.",
         "tags": [
           "Extension Gateway"
         ],
@@ -45609,26 +45602,6 @@
             "required": false,
             "description": "Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner.",
             "name": "x-idempotency-key",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Internal tenant header used for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Internal tenant header used for tenant resolution before session fallback.",
-            "name": "x-alga-tenant",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Legacy tenant header accepted for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Legacy tenant header accepted for tenant resolution before session fallback.",
-            "name": "x-tenant-id",
             "in": "header"
           }
         ],
@@ -45658,8 +45631,28 @@
           "204": {
             "description": "Runner returned no content, or CORS preflight for OPTIONS requests on this gateway path."
           },
+          "401": {
+            "description": "No authenticated session, or the session is missing a tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "A tenant header conflicts with the authenticated session tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
           "404": {
-            "description": "Extension is not installed or not enabled for the resolved tenant.",
+            "description": "Extension is not installed or not enabled for the session tenant.",
             "content": {
               "application/json": {
                 "schema": {
@@ -45679,7 +45672,7 @@
             }
           },
           "500": {
-            "description": "Tenant could not be resolved or another internal gateway error occurred.",
+            "description": "Another internal gateway error occurred.",
             "content": {
               "application/json": {
                 "schema": {
@@ -45702,7 +45695,7 @@
       },
       "delete": {
         "summary": "Forward DELETE request to extension runner",
-        "description": "Tenant-scoped extension gateway endpoint that forwards DELETE requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For DELETE requests the body, if present, is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
+        "description": "Tenant-scoped extension gateway endpoint that forwards DELETE requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For DELETE requests the body, if present, is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
         "tags": [
           "Extension Gateway"
         ],
@@ -45764,26 +45757,6 @@
             "description": "Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner.",
             "name": "x-idempotency-key",
             "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Internal tenant header used for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Internal tenant header used for tenant resolution before session fallback.",
-            "name": "x-alga-tenant",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Legacy tenant header accepted for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Legacy tenant header accepted for tenant resolution before session fallback.",
-            "name": "x-tenant-id",
-            "in": "header"
           }
         ],
         "requestBody": {
@@ -45812,8 +45785,28 @@
           "204": {
             "description": "Runner returned no content, or CORS preflight for OPTIONS requests on this gateway path."
           },
+          "401": {
+            "description": "No authenticated session, or the session is missing a tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "A tenant header conflicts with the authenticated session tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
           "404": {
-            "description": "Extension is not installed or not enabled for the resolved tenant.",
+            "description": "Extension is not installed or not enabled for the session tenant.",
             "content": {
               "application/json": {
                 "schema": {
@@ -45833,7 +45826,7 @@
             }
           },
           "500": {
-            "description": "Tenant could not be resolved or another internal gateway error occurred.",
+            "description": "Another internal gateway error occurred.",
             "content": {
               "application/json": {
                 "schema": {
@@ -112252,6 +112245,126 @@
         }
       }
     },
+    "/api/auth/client-portal/sso/discover": {
+      "post": {
+        "summary": "POST auth",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "auth"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/client-portal/sso/resolve": {
+      "post": {
+        "summary": "POST auth",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "auth"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/auth/e2e/google/authorize": {
       "get": {
         "summary": "GET auth",
@@ -117234,6 +117347,366 @@
         }
       }
     },
+    "/api/inventory/sales-orders/{id}/document": {
+      "get": {
+        "summary": "GET inventory",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "inventory"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/inventory/sales-orders/{id}/email-confirmation": {
+      "post": {
+        "summary": "POST inventory",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "inventory"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/marketing/capture/{tenant}/{slug}": {
+      "post": {
+        "summary": "POST marketing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "marketing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/marketing/track/click/{tenant}/{enrollmentId}/{stepId}": {
+      "get": {
+        "summary": "GET marketing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "marketing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/marketing/track/open/{tenant}/{enrollmentId}/{stepId}": {
+      "get": {
+        "summary": "GET marketing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "marketing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/marketing/unsubscribe/{tenant}/{enrollmentId}": {
+      "get": {
+        "summary": "GET marketing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "marketing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST marketing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "marketing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/mcp": {
       "get": {
         "summary": "GET mcp",
@@ -117784,6 +118257,308 @@
         "x-alga-products": [
           "psa"
         ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/scim/v2/{connectionId}/{scimPath}": {
+      "delete": {
+        "summary": "DELETE scim",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "scim"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "responses": {
+          "204": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "GET scim",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "scim"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "options": {
+        "summary": "OPTIONS scim",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "scim"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "PATCH scim",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "scim"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST scim",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "scim"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "PUT scim",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "scim"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Placeholder success response",
@@ -119558,72 +120333,12 @@
         }
       }
     },
-    "/api/v1/financial/reconciliation/run": {
+    "/api/v1/inventory/counts/{sessionId}/cancel": {
       "post": {
         "summary": "POST v1",
         "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
         "tags": [
-          "financial"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "requestBody": {
-          "description": "Placeholder request body",
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlaceholderObject"
-              },
-              "description": "Placeholder request body"
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/financial/reconciliation/{id}/resolve": {
-      "post": {
-        "summary": "POST v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "financial"
+          "inventory"
         ],
         "extensions": {
           "x-generated-from": "docs/openapi/route-inventory.json",
@@ -124559,6 +125274,112 @@
         }
       }
     },
+    "/api/webhooks/ai-gateway": {
+      "options": {
+        "summary": "OPTIONS webhooks",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "webhooks"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST webhooks",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "webhooks"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/webhooks/alternative-payments": {
       "get": {
         "summary": "GET webhooks",
@@ -125785,6 +126606,104 @@
         }
       }
     },
+    "/api/integrations/entra/mappings": {
+      "get": {
+        "summary": "GET integrations",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "integrations"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true,
+          "x-edition": "EE"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/integrations/entra/mappings/groups": {
+      "get": {
+        "summary": "GET integrations",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "integrations"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true,
+          "x-edition": "EE"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/integrations/entra/reconciliation-queue": {
       "get": {
         "summary": "GET integrations",
@@ -125802,6 +126721,67 @@
         ],
         "responses": {
           "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/integrations/entra/reconciliation-queue/dismiss": {
+      "post": {
+        "summary": "POST integrations",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "integrations"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true,
+          "x-edition": "EE"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
             "description": "Placeholder success response",
             "content": {
               "application/json": {
@@ -125896,6 +126876,175 @@
       }
     },
     "/api/integrations/entra/reconciliation-queue/resolve-new": {
+      "post": {
+        "summary": "POST integrations",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "integrations"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true,
+          "x-edition": "EE"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/integrations/entra/schedule": {
+      "get": {
+        "summary": "GET integrations",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "integrations"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true,
+          "x-edition": "EE"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST integrations",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "integrations"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true,
+          "x-edition": "EE"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/integrations/entra/sync/preflight": {
       "post": {
         "summary": "POST integrations",
         "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",

--- a/sdk/docs/openapi/alga-openapi.ee.yaml
+++ b/sdk/docs/openapi/alga-openapi.ee.yaml
@@ -84,11 +84,12 @@ tags:
   - name: ext-proxy
   - name: ext-storage
   - name: extensions
-  - name: financial
   - name: import
   - name: inbound
   - name: integrations
   - name: internal
+  - name: inventory
+  - name: marketing
   - name: mcp
   - name: meta
   - name: mobile
@@ -97,6 +98,7 @@ tags:
   - name: platform-notifications
   - name: platform-reports
   - name: public
+  - name: scim
   - name: secrets
   - name: share
   - name: storage
@@ -7432,14 +7434,6 @@ components:
           type: string
           description: Optional idempotency key for non-GET methods. The gateway falls
             back to x-request-id when absent and forwards the key to the runner.
-        x-alga-tenant:
-          type: string
-          description: Internal tenant header used for tenant resolution before session
-            fallback.
-        x-tenant-id:
-          type: string
-          description: Legacy tenant header accepted for tenant resolution before session
-            fallback.
     ExtensionOpaqueRequest:
       type: object
       properties: {}
@@ -7457,6 +7451,9 @@ components:
         error:
           type: string
           enum:
+            - unauthenticated
+            - invalid_session
+            - tenant_mismatch
             - not_installed
             - payload_too_large
             - install_context_missing
@@ -15632,12 +15629,6 @@ components:
             - string
             - "null"
           pattern: ^\d{4}-\d{2}-\d{2}$
-        next_action:
-          type: string
-          minLength: 1
-        next_action_due:
-          type: string
-          format: date-time
         generator_key:
           type:
             - string
@@ -30853,12 +30844,14 @@ paths:
   /api/email/oauth/initiate:
     post:
       summary: Initiate email OAuth flow
-      description: Starts the OAuth 2.0 authorization flow for a Google or Microsoft
-        email provider. Requires a valid Auth.js session cookie. The handler
-        builds secure OAuth state containing tenant, user, providerId, redirect
-        URI, timestamp, and nonce, resolves the provider client ID from
-        configured secrets, and returns the authorization URL for the browser to
-        visit.
+      description: "Starts the OAuth 2.0 authorization flow for a Google email
+        provider. Requires a valid Auth.js session cookie. The handler builds
+        secure OAuth state containing tenant, user, providerId, redirect URI,
+        timestamp, and nonce, resolves the provider client ID from configured
+        secrets, and returns the authorization URL for the browser to visit.
+        Microsoft mailbox OAuth is not served by this unsigned route: it must be
+        initiated from the mailbox form with an explicit application selection
+        so the callback receives a signed state token."
       tags:
         - Email
       security:
@@ -31210,14 +31203,15 @@ paths:
     get:
       summary: Forward GET request to extension runner
       description: Tenant-scoped extension gateway endpoint that forwards GET requests
-        to an installed extension runner. The gateway resolves the tenant from
-        x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in
-        development; verifies the extension is installed and enabled for that
-        tenant; forwards selected headers and all query parameters to
-        RUNNER_BASE_URL /v1/execute; and relays the runner response. GET
-        requests do not read a body and do not generate an idempotency key. The
-        gateway currently has a placeholder access check and does not enforce
-        per-extension RBAC beyond tenant install resolution.
+        to an installed extension runner. The gateway requires an authenticated
+        session and derives the tenant from that session; verifies the extension
+        is installed and enabled for the session tenant; forwards selected
+        headers and all query parameters to RUNNER_BASE_URL /v1/execute; and
+        relays the runner response. GET requests do not read a body and do not
+        generate an idempotency key. Tenant-selection headers are not accepted
+        as authentication and a header that disagrees with the session tenant
+        fails closed. The gateway currently has a placeholder access check and
+        does not enforce per-extension RBAC beyond tenant install resolution.
       tags:
         - Extension Gateway
       security:
@@ -31269,24 +31263,6 @@ paths:
             back to x-request-id when absent and forwards the key to the runner.
           name: x-idempotency-key
           in: header
-        - schema:
-            type: string
-            description: Internal tenant header used for tenant resolution before session
-              fallback.
-          required: false
-          description: Internal tenant header used for tenant resolution before session
-            fallback.
-          name: x-alga-tenant
-          in: header
-        - schema:
-            type: string
-            description: Legacy tenant header accepted for tenant resolution before session
-              fallback.
-          required: false
-          description: Legacy tenant header accepted for tenant resolution before session
-            fallback.
-          name: x-tenant-id
-          in: header
       responses:
         "200":
           description: Runner response relayed by the gateway. The actual status can vary
@@ -31298,15 +31274,26 @@ paths:
         "204":
           description: Runner returned no content, or CORS preflight for OPTIONS requests
             on this gateway path.
+        "401":
+          description: No authenticated session, or the session is missing a tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
+        "403":
+          description: A tenant header conflicts with the authenticated session tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "404":
-          description: Extension is not installed or not enabled for the resolved tenant.
+          description: Extension is not installed or not enabled for the session tenant.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "500":
-          description: Tenant could not be resolved or another internal gateway error
-            occurred.
+          description: Another internal gateway error occurred.
           content:
             application/json:
               schema:
@@ -31321,17 +31308,18 @@ paths:
     post:
       summary: Forward POST request to extension runner
       description: Tenant-scoped extension gateway endpoint that forwards POST
-        requests to an installed extension runner. The gateway resolves the
-        tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID
-        in development; verifies the extension is installed and enabled for that
-        tenant; forwards selected headers, query parameters, and an optional
-        opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner
-        response. For POST requests the body is limited to 10 MB,
-        base64-encoded, and forwarded as http.body_b64. An x-idempotency-key
-        header is forwarded when supplied, otherwise the generated x-request-id
-        is used as the non-GET idempotency fallback. The gateway currently has a
-        placeholder access check and does not enforce per-extension RBAC beyond
-        tenant install resolution.
+        requests to an installed extension runner. The gateway requires an
+        authenticated session and derives the tenant from that session; verifies
+        the extension is installed and enabled for the session tenant; forwards
+        selected headers, query parameters, and an optional opaque body to
+        RUNNER_BASE_URL /v1/execute; and relays the runner response. For POST
+        requests the body is limited to 10 MB, base64-encoded, and forwarded as
+        http.body_b64. An x-idempotency-key header is forwarded when supplied,
+        otherwise the generated x-request-id is used as the non-GET idempotency
+        fallback. Tenant-selection headers are not accepted as authentication
+        and a header that disagrees with the session tenant fails closed. The
+        gateway currently has a placeholder access check and does not enforce
+        per-extension RBAC beyond tenant install resolution.
       tags:
         - Extension Gateway
       security:
@@ -31384,24 +31372,6 @@ paths:
           description: Optional idempotency key for non-GET methods. The gateway falls
             back to x-request-id when absent and forwards the key to the runner.
           name: x-idempotency-key
-          in: header
-        - schema:
-            type: string
-            description: Internal tenant header used for tenant resolution before session
-              fallback.
-          required: false
-          description: Internal tenant header used for tenant resolution before session
-            fallback.
-          name: x-alga-tenant
-          in: header
-        - schema:
-            type: string
-            description: Legacy tenant header accepted for tenant resolution before session
-              fallback.
-          required: false
-          description: Legacy tenant header accepted for tenant resolution before session
-            fallback.
-          name: x-tenant-id
           in: header
       requestBody:
         description: Optional extension-specific POST body. The gateway accepts any
@@ -31424,8 +31394,20 @@ paths:
         "204":
           description: Runner returned no content, or CORS preflight for OPTIONS requests
             on this gateway path.
+        "401":
+          description: No authenticated session, or the session is missing a tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
+        "403":
+          description: A tenant header conflicts with the authenticated session tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "404":
-          description: Extension is not installed or not enabled for the resolved tenant.
+          description: Extension is not installed or not enabled for the session tenant.
           content:
             application/json:
               schema:
@@ -31437,8 +31419,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "500":
-          description: Tenant could not be resolved or another internal gateway error
-            occurred.
+          description: Another internal gateway error occurred.
           content:
             application/json:
               schema:
@@ -31453,16 +31434,18 @@ paths:
     put:
       summary: Forward PUT request to extension runner
       description: Tenant-scoped extension gateway endpoint that forwards PUT requests
-        to an installed extension runner. The gateway resolves the tenant from
-        x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in
-        development; verifies the extension is installed and enabled for that
-        tenant; forwards selected headers, query parameters, and an optional
-        opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner
-        response. For PUT requests the body is limited to 10 MB, base64-encoded,
-        and forwarded as http.body_b64. Clients should provide x-idempotency-key
-        for safe retries; otherwise the gateway falls back to a generated
-        request ID. The gateway currently has a placeholder access check and
-        does not enforce per-extension RBAC beyond tenant install resolution.
+        to an installed extension runner. The gateway requires an authenticated
+        session and derives the tenant from that session; verifies the extension
+        is installed and enabled for the session tenant; forwards selected
+        headers, query parameters, and an optional opaque body to
+        RUNNER_BASE_URL /v1/execute; and relays the runner response. For PUT
+        requests the body is limited to 10 MB, base64-encoded, and forwarded as
+        http.body_b64. Clients should provide x-idempotency-key for safe
+        retries; otherwise the gateway falls back to a generated request ID.
+        Tenant-selection headers are not accepted as authentication and a header
+        that disagrees with the session tenant fails closed. The gateway
+        currently has a placeholder access check and does not enforce
+        per-extension RBAC beyond tenant install resolution.
       tags:
         - Extension Gateway
       security:
@@ -31515,24 +31498,6 @@ paths:
           description: Optional idempotency key for non-GET methods. The gateway falls
             back to x-request-id when absent and forwards the key to the runner.
           name: x-idempotency-key
-          in: header
-        - schema:
-            type: string
-            description: Internal tenant header used for tenant resolution before session
-              fallback.
-          required: false
-          description: Internal tenant header used for tenant resolution before session
-            fallback.
-          name: x-alga-tenant
-          in: header
-        - schema:
-            type: string
-            description: Legacy tenant header accepted for tenant resolution before session
-              fallback.
-          required: false
-          description: Legacy tenant header accepted for tenant resolution before session
-            fallback.
-          name: x-tenant-id
           in: header
       requestBody:
         description: Optional extension-specific PUT body. The gateway accepts any
@@ -31555,8 +31520,20 @@ paths:
         "204":
           description: Runner returned no content, or CORS preflight for OPTIONS requests
             on this gateway path.
+        "401":
+          description: No authenticated session, or the session is missing a tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
+        "403":
+          description: A tenant header conflicts with the authenticated session tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "404":
-          description: Extension is not installed or not enabled for the resolved tenant.
+          description: Extension is not installed or not enabled for the session tenant.
           content:
             application/json:
               schema:
@@ -31568,8 +31545,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "500":
-          description: Tenant could not be resolved or another internal gateway error
-            occurred.
+          description: Another internal gateway error occurred.
           content:
             application/json:
               schema:
@@ -31584,16 +31560,18 @@ paths:
     patch:
       summary: Forward PATCH request to extension runner
       description: Tenant-scoped extension gateway endpoint that forwards PATCH
-        requests to an installed extension runner. The gateway resolves the
-        tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID
-        in development; verifies the extension is installed and enabled for that
-        tenant; forwards selected headers, query parameters, and an optional
-        opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner
-        response. For PATCH requests the body is limited to 10 MB,
-        base64-encoded, and forwarded as http.body_b64. Clients should provide
-        x-idempotency-key for safe retries; otherwise the gateway falls back to
-        a generated request ID. The gateway does not interpret PATCH semantics;
-        partial-update behavior is extension-defined.
+        requests to an installed extension runner. The gateway requires an
+        authenticated session and derives the tenant from that session; verifies
+        the extension is installed and enabled for the session tenant; forwards
+        selected headers, query parameters, and an optional opaque body to
+        RUNNER_BASE_URL /v1/execute; and relays the runner response. For PATCH
+        requests the body is limited to 10 MB, base64-encoded, and forwarded as
+        http.body_b64. Clients should provide x-idempotency-key for safe
+        retries; otherwise the gateway falls back to a generated request ID.
+        Tenant-selection headers are not accepted as authentication and a header
+        that disagrees with the session tenant fails closed. The gateway does
+        not interpret PATCH semantics; partial-update behavior is
+        extension-defined.
       tags:
         - Extension Gateway
       security:
@@ -31646,24 +31624,6 @@ paths:
           description: Optional idempotency key for non-GET methods. The gateway falls
             back to x-request-id when absent and forwards the key to the runner.
           name: x-idempotency-key
-          in: header
-        - schema:
-            type: string
-            description: Internal tenant header used for tenant resolution before session
-              fallback.
-          required: false
-          description: Internal tenant header used for tenant resolution before session
-            fallback.
-          name: x-alga-tenant
-          in: header
-        - schema:
-            type: string
-            description: Legacy tenant header accepted for tenant resolution before session
-              fallback.
-          required: false
-          description: Legacy tenant header accepted for tenant resolution before session
-            fallback.
-          name: x-tenant-id
           in: header
       requestBody:
         description: Optional extension-specific PATCH body. The gateway accepts any
@@ -31686,8 +31646,20 @@ paths:
         "204":
           description: Runner returned no content, or CORS preflight for OPTIONS requests
             on this gateway path.
+        "401":
+          description: No authenticated session, or the session is missing a tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
+        "403":
+          description: A tenant header conflicts with the authenticated session tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "404":
-          description: Extension is not installed or not enabled for the resolved tenant.
+          description: Extension is not installed or not enabled for the session tenant.
           content:
             application/json:
               schema:
@@ -31699,8 +31671,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "500":
-          description: Tenant could not be resolved or another internal gateway error
-            occurred.
+          description: Another internal gateway error occurred.
           content:
             application/json:
               schema:
@@ -31715,15 +31686,16 @@ paths:
     delete:
       summary: Forward DELETE request to extension runner
       description: Tenant-scoped extension gateway endpoint that forwards DELETE
-        requests to an installed extension runner. The gateway resolves the
-        tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID
-        in development; verifies the extension is installed and enabled for that
-        tenant; forwards selected headers, query parameters, and an optional
-        opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner
-        response. For DELETE requests the body, if present, is limited to 10 MB,
-        base64-encoded, and forwarded as http.body_b64. The gateway currently
-        has a placeholder access check and does not enforce per-extension RBAC
-        beyond tenant install resolution.
+        requests to an installed extension runner. The gateway requires an
+        authenticated session and derives the tenant from that session; verifies
+        the extension is installed and enabled for the session tenant; forwards
+        selected headers, query parameters, and an optional opaque body to
+        RUNNER_BASE_URL /v1/execute; and relays the runner response. For DELETE
+        requests the body, if present, is limited to 10 MB, base64-encoded, and
+        forwarded as http.body_b64. Tenant-selection headers are not accepted as
+        authentication and a header that disagrees with the session tenant fails
+        closed. The gateway currently has a placeholder access check and does
+        not enforce per-extension RBAC beyond tenant install resolution.
       tags:
         - Extension Gateway
       security:
@@ -31777,24 +31749,6 @@ paths:
             back to x-request-id when absent and forwards the key to the runner.
           name: x-idempotency-key
           in: header
-        - schema:
-            type: string
-            description: Internal tenant header used for tenant resolution before session
-              fallback.
-          required: false
-          description: Internal tenant header used for tenant resolution before session
-            fallback.
-          name: x-alga-tenant
-          in: header
-        - schema:
-            type: string
-            description: Legacy tenant header accepted for tenant resolution before session
-              fallback.
-          required: false
-          description: Legacy tenant header accepted for tenant resolution before session
-            fallback.
-          name: x-tenant-id
-          in: header
       requestBody:
         description: Optional extension-specific DELETE body. The gateway accepts any
           content type up to 10 MB and forwards it as base64.
@@ -31816,8 +31770,20 @@ paths:
         "204":
           description: Runner returned no content, or CORS preflight for OPTIONS requests
             on this gateway path.
+        "401":
+          description: No authenticated session, or the session is missing a tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
+        "403":
+          description: A tenant header conflicts with the authenticated session tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "404":
-          description: Extension is not installed or not enabled for the resolved tenant.
+          description: Extension is not installed or not enabled for the session tenant.
           content:
             application/json:
               schema:
@@ -31829,8 +31795,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "500":
-          description: Tenant could not be resolved or another internal gateway error
-            occurred.
+          description: Another internal gateway error occurred.
           content:
             application/json:
               schema:
@@ -74508,6 +74473,84 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /api/auth/client-portal/sso/discover:
+    post:
+      summary: POST auth
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - auth
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/auth/client-portal/sso/resolve:
+    post:
+      summary: POST auth
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - auth
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /api/auth/e2e/google/authorize:
     get:
       summary: GET auth
@@ -77745,6 +77788,241 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /api/inventory/sales-orders/{id}/document:
+    get:
+      summary: GET inventory
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - inventory
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/inventory/sales-orders/{id}/email-confirmation:
+    post:
+      summary: POST inventory
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - inventory
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/marketing/capture/{tenant}/{slug}:
+    post:
+      summary: POST marketing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - marketing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/marketing/track/click/{tenant}/{enrollmentId}/{stepId}:
+    get:
+      summary: GET marketing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - marketing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/marketing/track/open/{tenant}/{enrollmentId}/{stepId}:
+    get:
+      summary: GET marketing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - marketing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/marketing/unsubscribe/{tenant}/{enrollmentId}:
+    get:
+      summary: GET marketing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - marketing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST marketing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - marketing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /api/mcp:
     get:
       summary: GET mcp
@@ -78105,6 +78383,205 @@ paths:
         x-placeholder: true
       x-alga-products:
         - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/scim/v2/{connectionId}/{scimPath}:
+    delete:
+      summary: DELETE scim
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - scim
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      responses:
+        "204":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    get:
+      summary: GET scim
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - scim
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    options:
+      summary: OPTIONS scim
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - scim
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    patch:
+      summary: PATCH scim
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - scim
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST scim
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - scim
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    put:
+      summary: PUT scim
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - scim
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
       responses:
         "200":
           description: Placeholder success response
@@ -79255,52 +79732,13 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/financial/reconciliation/run:
+  /api/v1/inventory/counts/{sessionId}/cancel:
     post:
       summary: POST v1
       description: This operation was generated automatically from the route
         inventory. Replace with canonical OpenAPI metadata.
       tags:
-        - financial
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      requestBody:
-        description: Placeholder request body
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PlaceholderObject"
-            description: Placeholder request body
-      responses:
-        "201":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/financial/reconciliation/{id}/resolve:
-    post:
-      summary: POST v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - financial
+        - inventory
       extensions:
         x-generated-from: docs/openapi/route-inventory.json
         x-placeholder: true
@@ -82507,6 +82945,75 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /api/webhooks/ai-gateway:
+    options:
+      summary: OPTIONS webhooks
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - webhooks
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST webhooks
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - webhooks
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /api/webhooks/alternative-payments:
     get:
       summary: GET webhooks
@@ -83309,6 +83816,70 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /api/integrations/entra/mappings:
+    get:
+      summary: GET integrations
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - integrations
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+        x-edition: EE
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/integrations/entra/mappings/groups:
+    get:
+      summary: GET integrations
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - integrations
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+        x-edition: EE
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /api/integrations/entra/reconciliation-queue:
     get:
       summary: GET integrations
@@ -83324,6 +83895,46 @@ paths:
         - psa
       responses:
         "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/integrations/entra/reconciliation-queue/dismiss:
+    post:
+      summary: POST integrations
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - integrations
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+        x-edition: EE
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
           description: Placeholder success response
           content:
             application/json:
@@ -83382,6 +83993,117 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
   /api/integrations/entra/reconciliation-queue/resolve-new:
+    post:
+      summary: POST integrations
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - integrations
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+        x-edition: EE
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/integrations/entra/schedule:
+    get:
+      summary: GET integrations
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - integrations
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+        x-edition: EE
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST integrations
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - integrations
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+        x-edition: EE
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/integrations/entra/sync/preflight:
     post:
       summary: POST integrations
       description: This operation was generated automatically from the route

--- a/sdk/docs/openapi/alga-openapi.json
+++ b/sdk/docs/openapi/alga-openapi.json
@@ -239,9 +239,6 @@
       "name": "ext-proxy"
     },
     {
-      "name": "financial"
-    },
-    {
       "name": "import"
     },
     {
@@ -252,6 +249,12 @@
     },
     {
       "name": "internal"
+    },
+    {
+      "name": "inventory"
+    },
+    {
+      "name": "marketing"
     },
     {
       "name": "mcp"
@@ -266,6 +269,9 @@
       "name": "online-meetings"
     },
     {
+      "name": "opportunities"
+    },
+    {
       "name": "platform-feature-flags"
     },
     {
@@ -276,6 +282,9 @@
     },
     {
       "name": "public"
+    },
+    {
+      "name": "scim"
     },
     {
       "name": "secrets"
@@ -10490,14 +10499,6 @@
           "x-idempotency-key": {
             "type": "string",
             "description": "Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner."
-          },
-          "x-alga-tenant": {
-            "type": "string",
-            "description": "Internal tenant header used for tenant resolution before session fallback."
-          },
-          "x-tenant-id": {
-            "type": "string",
-            "description": "Legacy tenant header accepted for tenant resolution before session fallback."
           }
         }
       },
@@ -10517,6 +10518,9 @@
           "error": {
             "type": "string",
             "enum": [
+              "unauthenticated",
+              "invalid_session",
+              "tenant_mismatch",
               "not_installed",
               "payload_too_large",
               "install_context_missing",
@@ -22022,14 +22026,6 @@
               "null"
             ],
             "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-          },
-          "next_action": {
-            "type": "string",
-            "minLength": 1
-          },
-          "next_action_due": {
-            "type": "string",
-            "format": "date-time"
           },
           "generator_key": {
             "type": [
@@ -44614,7 +44610,7 @@
     "/api/email/oauth/initiate": {
       "post": {
         "summary": "Initiate email OAuth flow",
-        "description": "Starts the OAuth 2.0 authorization flow for a Google or Microsoft email provider. Requires a valid Auth.js session cookie. The handler builds secure OAuth state containing tenant, user, providerId, redirect URI, timestamp, and nonce, resolves the provider client ID from configured secrets, and returns the authorization URL for the browser to visit.",
+        "description": "Starts the OAuth 2.0 authorization flow for a Google email provider. Requires a valid Auth.js session cookie. The handler builds secure OAuth state containing tenant, user, providerId, redirect URI, timestamp, and nonce, resolves the provider client ID from configured secrets, and returns the authorization URL for the browser to visit. Microsoft mailbox OAuth is not served by this unsigned route: it must be initiated from the mailbox form with an explicit application selection so the callback receives a signed state token.",
         "tags": [
           "Email"
         ],
@@ -45107,7 +45103,7 @@
     "/api/ext/{extensionId}/{path}": {
       "get": {
         "summary": "Forward GET request to extension runner",
-        "description": "Tenant-scoped extension gateway endpoint that forwards GET requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers and all query parameters to RUNNER_BASE_URL /v1/execute; and relays the runner response. GET requests do not read a body and do not generate an idempotency key. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
+        "description": "Tenant-scoped extension gateway endpoint that forwards GET requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers and all query parameters to RUNNER_BASE_URL /v1/execute; and relays the runner response. GET requests do not read a body and do not generate an idempotency key. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
         "tags": [
           "Extension Gateway"
         ],
@@ -45167,26 +45163,6 @@
             "description": "Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner.",
             "name": "x-idempotency-key",
             "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Internal tenant header used for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Internal tenant header used for tenant resolution before session fallback.",
-            "name": "x-alga-tenant",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Legacy tenant header accepted for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Legacy tenant header accepted for tenant resolution before session fallback.",
-            "name": "x-tenant-id",
-            "in": "header"
           }
         ],
         "responses": {
@@ -45203,8 +45179,28 @@
           "204": {
             "description": "Runner returned no content, or CORS preflight for OPTIONS requests on this gateway path."
           },
+          "401": {
+            "description": "No authenticated session, or the session is missing a tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "A tenant header conflicts with the authenticated session tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
           "404": {
-            "description": "Extension is not installed or not enabled for the resolved tenant.",
+            "description": "Extension is not installed or not enabled for the session tenant.",
             "content": {
               "application/json": {
                 "schema": {
@@ -45214,7 +45210,7 @@
             }
           },
           "500": {
-            "description": "Tenant could not be resolved or another internal gateway error occurred.",
+            "description": "Another internal gateway error occurred.",
             "content": {
               "application/json": {
                 "schema": {
@@ -45237,7 +45233,7 @@
       },
       "post": {
         "summary": "Forward POST request to extension runner",
-        "description": "Tenant-scoped extension gateway endpoint that forwards POST requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For POST requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. An x-idempotency-key header is forwarded when supplied, otherwise the generated x-request-id is used as the non-GET idempotency fallback. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
+        "description": "Tenant-scoped extension gateway endpoint that forwards POST requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For POST requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. An x-idempotency-key header is forwarded when supplied, otherwise the generated x-request-id is used as the non-GET idempotency fallback. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
         "tags": [
           "Extension Gateway"
         ],
@@ -45298,26 +45294,6 @@
             "required": false,
             "description": "Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner.",
             "name": "x-idempotency-key",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Internal tenant header used for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Internal tenant header used for tenant resolution before session fallback.",
-            "name": "x-alga-tenant",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Legacy tenant header accepted for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Legacy tenant header accepted for tenant resolution before session fallback.",
-            "name": "x-tenant-id",
             "in": "header"
           }
         ],
@@ -45347,8 +45323,28 @@
           "204": {
             "description": "Runner returned no content, or CORS preflight for OPTIONS requests on this gateway path."
           },
+          "401": {
+            "description": "No authenticated session, or the session is missing a tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "A tenant header conflicts with the authenticated session tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
           "404": {
-            "description": "Extension is not installed or not enabled for the resolved tenant.",
+            "description": "Extension is not installed or not enabled for the session tenant.",
             "content": {
               "application/json": {
                 "schema": {
@@ -45368,7 +45364,7 @@
             }
           },
           "500": {
-            "description": "Tenant could not be resolved or another internal gateway error occurred.",
+            "description": "Another internal gateway error occurred.",
             "content": {
               "application/json": {
                 "schema": {
@@ -45391,7 +45387,7 @@
       },
       "put": {
         "summary": "Forward PUT request to extension runner",
-        "description": "Tenant-scoped extension gateway endpoint that forwards PUT requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For PUT requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Clients should provide x-idempotency-key for safe retries; otherwise the gateway falls back to a generated request ID. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
+        "description": "Tenant-scoped extension gateway endpoint that forwards PUT requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For PUT requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Clients should provide x-idempotency-key for safe retries; otherwise the gateway falls back to a generated request ID. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
         "tags": [
           "Extension Gateway"
         ],
@@ -45452,26 +45448,6 @@
             "required": false,
             "description": "Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner.",
             "name": "x-idempotency-key",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Internal tenant header used for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Internal tenant header used for tenant resolution before session fallback.",
-            "name": "x-alga-tenant",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Legacy tenant header accepted for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Legacy tenant header accepted for tenant resolution before session fallback.",
-            "name": "x-tenant-id",
             "in": "header"
           }
         ],
@@ -45501,8 +45477,28 @@
           "204": {
             "description": "Runner returned no content, or CORS preflight for OPTIONS requests on this gateway path."
           },
+          "401": {
+            "description": "No authenticated session, or the session is missing a tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "A tenant header conflicts with the authenticated session tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
           "404": {
-            "description": "Extension is not installed or not enabled for the resolved tenant.",
+            "description": "Extension is not installed or not enabled for the session tenant.",
             "content": {
               "application/json": {
                 "schema": {
@@ -45522,7 +45518,7 @@
             }
           },
           "500": {
-            "description": "Tenant could not be resolved or another internal gateway error occurred.",
+            "description": "Another internal gateway error occurred.",
             "content": {
               "application/json": {
                 "schema": {
@@ -45545,7 +45541,7 @@
       },
       "patch": {
         "summary": "Forward PATCH request to extension runner",
-        "description": "Tenant-scoped extension gateway endpoint that forwards PATCH requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For PATCH requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Clients should provide x-idempotency-key for safe retries; otherwise the gateway falls back to a generated request ID. The gateway does not interpret PATCH semantics; partial-update behavior is extension-defined.",
+        "description": "Tenant-scoped extension gateway endpoint that forwards PATCH requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For PATCH requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Clients should provide x-idempotency-key for safe retries; otherwise the gateway falls back to a generated request ID. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway does not interpret PATCH semantics; partial-update behavior is extension-defined.",
         "tags": [
           "Extension Gateway"
         ],
@@ -45606,26 +45602,6 @@
             "required": false,
             "description": "Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner.",
             "name": "x-idempotency-key",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Internal tenant header used for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Internal tenant header used for tenant resolution before session fallback.",
-            "name": "x-alga-tenant",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Legacy tenant header accepted for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Legacy tenant header accepted for tenant resolution before session fallback.",
-            "name": "x-tenant-id",
             "in": "header"
           }
         ],
@@ -45655,8 +45631,28 @@
           "204": {
             "description": "Runner returned no content, or CORS preflight for OPTIONS requests on this gateway path."
           },
+          "401": {
+            "description": "No authenticated session, or the session is missing a tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "A tenant header conflicts with the authenticated session tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
           "404": {
-            "description": "Extension is not installed or not enabled for the resolved tenant.",
+            "description": "Extension is not installed or not enabled for the session tenant.",
             "content": {
               "application/json": {
                 "schema": {
@@ -45676,7 +45672,7 @@
             }
           },
           "500": {
-            "description": "Tenant could not be resolved or another internal gateway error occurred.",
+            "description": "Another internal gateway error occurred.",
             "content": {
               "application/json": {
                 "schema": {
@@ -45699,7 +45695,7 @@
       },
       "delete": {
         "summary": "Forward DELETE request to extension runner",
-        "description": "Tenant-scoped extension gateway endpoint that forwards DELETE requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For DELETE requests the body, if present, is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
+        "description": "Tenant-scoped extension gateway endpoint that forwards DELETE requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For DELETE requests the body, if present, is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
         "tags": [
           "Extension Gateway"
         ],
@@ -45761,26 +45757,6 @@
             "description": "Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner.",
             "name": "x-idempotency-key",
             "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Internal tenant header used for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Internal tenant header used for tenant resolution before session fallback.",
-            "name": "x-alga-tenant",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Legacy tenant header accepted for tenant resolution before session fallback."
-            },
-            "required": false,
-            "description": "Legacy tenant header accepted for tenant resolution before session fallback.",
-            "name": "x-tenant-id",
-            "in": "header"
           }
         ],
         "requestBody": {
@@ -45809,8 +45785,28 @@
           "204": {
             "description": "Runner returned no content, or CORS preflight for OPTIONS requests on this gateway path."
           },
+          "401": {
+            "description": "No authenticated session, or the session is missing a tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "A tenant header conflicts with the authenticated session tenant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtensionGatewayErrorResponse"
+                }
+              }
+            }
+          },
           "404": {
-            "description": "Extension is not installed or not enabled for the resolved tenant.",
+            "description": "Extension is not installed or not enabled for the session tenant.",
             "content": {
               "application/json": {
                 "schema": {
@@ -45830,7 +45826,7 @@
             }
           },
           "500": {
-            "description": "Tenant could not be resolved or another internal gateway error occurred.",
+            "description": "Another internal gateway error occurred.",
             "content": {
               "application/json": {
                 "schema": {
@@ -110468,6 +110464,126 @@
         }
       }
     },
+    "/api/auth/client-portal/sso/discover": {
+      "post": {
+        "summary": "POST auth",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "auth"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/client-portal/sso/resolve": {
+      "post": {
+        "summary": "POST auth",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "auth"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/auth/e2e/google/authorize": {
       "get": {
         "summary": "GET auth",
@@ -115630,6 +115746,366 @@
         }
       }
     },
+    "/api/inventory/sales-orders/{id}/document": {
+      "get": {
+        "summary": "GET inventory",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "inventory"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/inventory/sales-orders/{id}/email-confirmation": {
+      "post": {
+        "summary": "POST inventory",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "inventory"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/marketing/capture/{tenant}/{slug}": {
+      "post": {
+        "summary": "POST marketing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "marketing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/marketing/track/click/{tenant}/{enrollmentId}/{stepId}": {
+      "get": {
+        "summary": "GET marketing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "marketing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/marketing/track/open/{tenant}/{enrollmentId}/{stepId}": {
+      "get": {
+        "summary": "GET marketing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "marketing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/marketing/unsubscribe/{tenant}/{enrollmentId}": {
+      "get": {
+        "summary": "GET marketing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "marketing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST marketing",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "marketing"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/mcp": {
       "get": {
         "summary": "GET mcp",
@@ -116180,6 +116656,308 @@
         "x-alga-products": [
           "psa"
         ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/scim/v2/{connectionId}/{scimPath}": {
+      "delete": {
+        "summary": "DELETE scim",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "scim"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "responses": {
+          "204": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "GET scim",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "scim"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "options": {
+        "summary": "OPTIONS scim",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "scim"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "PATCH scim",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "scim"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST scim",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "scim"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "PUT scim",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "scim"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Placeholder success response",
@@ -117954,72 +118732,12 @@
         }
       }
     },
-    "/api/v1/financial/reconciliation/run": {
+    "/api/v1/inventory/counts/{sessionId}/cancel": {
       "post": {
         "summary": "POST v1",
         "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
         "tags": [
-          "financial"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "requestBody": {
-          "description": "Placeholder request body",
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlaceholderObject"
-              },
-              "description": "Placeholder request body"
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/financial/reconciliation/{id}/resolve": {
-      "post": {
-        "summary": "POST v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "financial"
+          "inventory"
         ],
         "extensions": {
           "x-generated-from": "docs/openapi/route-inventory.json",
@@ -119899,6 +120617,686 @@
         "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
         "tags": [
           "mobile"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/calibration": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "opportunities"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/forecast": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "opportunities"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/meeting-sessions": {
+      "post": {
+        "summary": "POST v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "opportunities"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/meeting-sessions/active": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "opportunities"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/meeting-sessions/{sessionId}/reviews": {
+      "post": {
+        "summary": "POST v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "opportunities"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/qbr/yield": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "opportunities"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/qbr/{clientId}": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "opportunities"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/qbr/{clientId}/opportunities": {
+      "post": {
+        "summary": "POST v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "opportunities"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/rollups": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "opportunities"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/{id}/commitments": {
+      "get": {
+        "summary": "GET v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "opportunities"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "opportunities"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/{id}/commitments/{commitmentId}": {
+      "delete": {
+        "summary": "DELETE v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "opportunities"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "204": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "PUT v1",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "opportunities"
         ],
         "extensions": {
           "x-generated-from": "docs/openapi/route-inventory.json",
@@ -123204,6 +124602,112 @@
         "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
         "tags": [
           "tenant-management"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "requestBody": {
+          "description": "Placeholder request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceholderObject"
+              },
+              "description": "Placeholder request body"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/webhooks/ai-gateway": {
+      "options": {
+        "summary": "OPTIONS webhooks",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "webhooks"
+        ],
+        "extensions": {
+          "x-generated-from": "docs/openapi/route-inventory.json",
+          "x-placeholder": true
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Placeholder success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceholderObject"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "POST webhooks",
+        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
+        "tags": [
+          "webhooks"
         ],
         "extensions": {
           "x-generated-from": "docs/openapi/route-inventory.json",

--- a/sdk/docs/openapi/alga-openapi.yaml
+++ b/sdk/docs/openapi/alga-openapi.yaml
@@ -83,19 +83,22 @@ tags:
   - name: ext-bundles
   - name: ext-debug
   - name: ext-proxy
-  - name: financial
   - name: import
   - name: inbound
   - name: integrations
   - name: internal
+  - name: inventory
+  - name: marketing
   - name: mcp
   - name: meta
   - name: mobile
   - name: online-meetings
+  - name: opportunities
   - name: platform-feature-flags
   - name: platform-notifications
   - name: platform-reports
   - name: public
+  - name: scim
   - name: secrets
   - name: share
   - name: storage
@@ -7431,14 +7434,6 @@ components:
           type: string
           description: Optional idempotency key for non-GET methods. The gateway falls
             back to x-request-id when absent and forwards the key to the runner.
-        x-alga-tenant:
-          type: string
-          description: Internal tenant header used for tenant resolution before session
-            fallback.
-        x-tenant-id:
-          type: string
-          description: Legacy tenant header accepted for tenant resolution before session
-            fallback.
     ExtensionOpaqueRequest:
       type: object
       properties: {}
@@ -7456,6 +7451,9 @@ components:
         error:
           type: string
           enum:
+            - unauthenticated
+            - invalid_session
+            - tenant_mismatch
             - not_installed
             - payload_too_large
             - install_context_missing
@@ -15631,12 +15629,6 @@ components:
             - string
             - "null"
           pattern: ^\d{4}-\d{2}-\d{2}$
-        next_action:
-          type: string
-          minLength: 1
-        next_action_due:
-          type: string
-          format: date-time
         generator_key:
           type:
             - string
@@ -30852,12 +30844,14 @@ paths:
   /api/email/oauth/initiate:
     post:
       summary: Initiate email OAuth flow
-      description: Starts the OAuth 2.0 authorization flow for a Google or Microsoft
-        email provider. Requires a valid Auth.js session cookie. The handler
-        builds secure OAuth state containing tenant, user, providerId, redirect
-        URI, timestamp, and nonce, resolves the provider client ID from
-        configured secrets, and returns the authorization URL for the browser to
-        visit.
+      description: "Starts the OAuth 2.0 authorization flow for a Google email
+        provider. Requires a valid Auth.js session cookie. The handler builds
+        secure OAuth state containing tenant, user, providerId, redirect URI,
+        timestamp, and nonce, resolves the provider client ID from configured
+        secrets, and returns the authorization URL for the browser to visit.
+        Microsoft mailbox OAuth is not served by this unsigned route: it must be
+        initiated from the mailbox form with an explicit application selection
+        so the callback receives a signed state token."
       tags:
         - Email
       security:
@@ -31209,14 +31203,15 @@ paths:
     get:
       summary: Forward GET request to extension runner
       description: Tenant-scoped extension gateway endpoint that forwards GET requests
-        to an installed extension runner. The gateway resolves the tenant from
-        x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in
-        development; verifies the extension is installed and enabled for that
-        tenant; forwards selected headers and all query parameters to
-        RUNNER_BASE_URL /v1/execute; and relays the runner response. GET
-        requests do not read a body and do not generate an idempotency key. The
-        gateway currently has a placeholder access check and does not enforce
-        per-extension RBAC beyond tenant install resolution.
+        to an installed extension runner. The gateway requires an authenticated
+        session and derives the tenant from that session; verifies the extension
+        is installed and enabled for the session tenant; forwards selected
+        headers and all query parameters to RUNNER_BASE_URL /v1/execute; and
+        relays the runner response. GET requests do not read a body and do not
+        generate an idempotency key. Tenant-selection headers are not accepted
+        as authentication and a header that disagrees with the session tenant
+        fails closed. The gateway currently has a placeholder access check and
+        does not enforce per-extension RBAC beyond tenant install resolution.
       tags:
         - Extension Gateway
       security:
@@ -31268,24 +31263,6 @@ paths:
             back to x-request-id when absent and forwards the key to the runner.
           name: x-idempotency-key
           in: header
-        - schema:
-            type: string
-            description: Internal tenant header used for tenant resolution before session
-              fallback.
-          required: false
-          description: Internal tenant header used for tenant resolution before session
-            fallback.
-          name: x-alga-tenant
-          in: header
-        - schema:
-            type: string
-            description: Legacy tenant header accepted for tenant resolution before session
-              fallback.
-          required: false
-          description: Legacy tenant header accepted for tenant resolution before session
-            fallback.
-          name: x-tenant-id
-          in: header
       responses:
         "200":
           description: Runner response relayed by the gateway. The actual status can vary
@@ -31297,15 +31274,26 @@ paths:
         "204":
           description: Runner returned no content, or CORS preflight for OPTIONS requests
             on this gateway path.
+        "401":
+          description: No authenticated session, or the session is missing a tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
+        "403":
+          description: A tenant header conflicts with the authenticated session tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "404":
-          description: Extension is not installed or not enabled for the resolved tenant.
+          description: Extension is not installed or not enabled for the session tenant.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "500":
-          description: Tenant could not be resolved or another internal gateway error
-            occurred.
+          description: Another internal gateway error occurred.
           content:
             application/json:
               schema:
@@ -31320,17 +31308,18 @@ paths:
     post:
       summary: Forward POST request to extension runner
       description: Tenant-scoped extension gateway endpoint that forwards POST
-        requests to an installed extension runner. The gateway resolves the
-        tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID
-        in development; verifies the extension is installed and enabled for that
-        tenant; forwards selected headers, query parameters, and an optional
-        opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner
-        response. For POST requests the body is limited to 10 MB,
-        base64-encoded, and forwarded as http.body_b64. An x-idempotency-key
-        header is forwarded when supplied, otherwise the generated x-request-id
-        is used as the non-GET idempotency fallback. The gateway currently has a
-        placeholder access check and does not enforce per-extension RBAC beyond
-        tenant install resolution.
+        requests to an installed extension runner. The gateway requires an
+        authenticated session and derives the tenant from that session; verifies
+        the extension is installed and enabled for the session tenant; forwards
+        selected headers, query parameters, and an optional opaque body to
+        RUNNER_BASE_URL /v1/execute; and relays the runner response. For POST
+        requests the body is limited to 10 MB, base64-encoded, and forwarded as
+        http.body_b64. An x-idempotency-key header is forwarded when supplied,
+        otherwise the generated x-request-id is used as the non-GET idempotency
+        fallback. Tenant-selection headers are not accepted as authentication
+        and a header that disagrees with the session tenant fails closed. The
+        gateway currently has a placeholder access check and does not enforce
+        per-extension RBAC beyond tenant install resolution.
       tags:
         - Extension Gateway
       security:
@@ -31383,24 +31372,6 @@ paths:
           description: Optional idempotency key for non-GET methods. The gateway falls
             back to x-request-id when absent and forwards the key to the runner.
           name: x-idempotency-key
-          in: header
-        - schema:
-            type: string
-            description: Internal tenant header used for tenant resolution before session
-              fallback.
-          required: false
-          description: Internal tenant header used for tenant resolution before session
-            fallback.
-          name: x-alga-tenant
-          in: header
-        - schema:
-            type: string
-            description: Legacy tenant header accepted for tenant resolution before session
-              fallback.
-          required: false
-          description: Legacy tenant header accepted for tenant resolution before session
-            fallback.
-          name: x-tenant-id
           in: header
       requestBody:
         description: Optional extension-specific POST body. The gateway accepts any
@@ -31423,8 +31394,20 @@ paths:
         "204":
           description: Runner returned no content, or CORS preflight for OPTIONS requests
             on this gateway path.
+        "401":
+          description: No authenticated session, or the session is missing a tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
+        "403":
+          description: A tenant header conflicts with the authenticated session tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "404":
-          description: Extension is not installed or not enabled for the resolved tenant.
+          description: Extension is not installed or not enabled for the session tenant.
           content:
             application/json:
               schema:
@@ -31436,8 +31419,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "500":
-          description: Tenant could not be resolved or another internal gateway error
-            occurred.
+          description: Another internal gateway error occurred.
           content:
             application/json:
               schema:
@@ -31452,16 +31434,18 @@ paths:
     put:
       summary: Forward PUT request to extension runner
       description: Tenant-scoped extension gateway endpoint that forwards PUT requests
-        to an installed extension runner. The gateway resolves the tenant from
-        x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in
-        development; verifies the extension is installed and enabled for that
-        tenant; forwards selected headers, query parameters, and an optional
-        opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner
-        response. For PUT requests the body is limited to 10 MB, base64-encoded,
-        and forwarded as http.body_b64. Clients should provide x-idempotency-key
-        for safe retries; otherwise the gateway falls back to a generated
-        request ID. The gateway currently has a placeholder access check and
-        does not enforce per-extension RBAC beyond tenant install resolution.
+        to an installed extension runner. The gateway requires an authenticated
+        session and derives the tenant from that session; verifies the extension
+        is installed and enabled for the session tenant; forwards selected
+        headers, query parameters, and an optional opaque body to
+        RUNNER_BASE_URL /v1/execute; and relays the runner response. For PUT
+        requests the body is limited to 10 MB, base64-encoded, and forwarded as
+        http.body_b64. Clients should provide x-idempotency-key for safe
+        retries; otherwise the gateway falls back to a generated request ID.
+        Tenant-selection headers are not accepted as authentication and a header
+        that disagrees with the session tenant fails closed. The gateway
+        currently has a placeholder access check and does not enforce
+        per-extension RBAC beyond tenant install resolution.
       tags:
         - Extension Gateway
       security:
@@ -31514,24 +31498,6 @@ paths:
           description: Optional idempotency key for non-GET methods. The gateway falls
             back to x-request-id when absent and forwards the key to the runner.
           name: x-idempotency-key
-          in: header
-        - schema:
-            type: string
-            description: Internal tenant header used for tenant resolution before session
-              fallback.
-          required: false
-          description: Internal tenant header used for tenant resolution before session
-            fallback.
-          name: x-alga-tenant
-          in: header
-        - schema:
-            type: string
-            description: Legacy tenant header accepted for tenant resolution before session
-              fallback.
-          required: false
-          description: Legacy tenant header accepted for tenant resolution before session
-            fallback.
-          name: x-tenant-id
           in: header
       requestBody:
         description: Optional extension-specific PUT body. The gateway accepts any
@@ -31554,8 +31520,20 @@ paths:
         "204":
           description: Runner returned no content, or CORS preflight for OPTIONS requests
             on this gateway path.
+        "401":
+          description: No authenticated session, or the session is missing a tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
+        "403":
+          description: A tenant header conflicts with the authenticated session tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "404":
-          description: Extension is not installed or not enabled for the resolved tenant.
+          description: Extension is not installed or not enabled for the session tenant.
           content:
             application/json:
               schema:
@@ -31567,8 +31545,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "500":
-          description: Tenant could not be resolved or another internal gateway error
-            occurred.
+          description: Another internal gateway error occurred.
           content:
             application/json:
               schema:
@@ -31583,16 +31560,18 @@ paths:
     patch:
       summary: Forward PATCH request to extension runner
       description: Tenant-scoped extension gateway endpoint that forwards PATCH
-        requests to an installed extension runner. The gateway resolves the
-        tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID
-        in development; verifies the extension is installed and enabled for that
-        tenant; forwards selected headers, query parameters, and an optional
-        opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner
-        response. For PATCH requests the body is limited to 10 MB,
-        base64-encoded, and forwarded as http.body_b64. Clients should provide
-        x-idempotency-key for safe retries; otherwise the gateway falls back to
-        a generated request ID. The gateway does not interpret PATCH semantics;
-        partial-update behavior is extension-defined.
+        requests to an installed extension runner. The gateway requires an
+        authenticated session and derives the tenant from that session; verifies
+        the extension is installed and enabled for the session tenant; forwards
+        selected headers, query parameters, and an optional opaque body to
+        RUNNER_BASE_URL /v1/execute; and relays the runner response. For PATCH
+        requests the body is limited to 10 MB, base64-encoded, and forwarded as
+        http.body_b64. Clients should provide x-idempotency-key for safe
+        retries; otherwise the gateway falls back to a generated request ID.
+        Tenant-selection headers are not accepted as authentication and a header
+        that disagrees with the session tenant fails closed. The gateway does
+        not interpret PATCH semantics; partial-update behavior is
+        extension-defined.
       tags:
         - Extension Gateway
       security:
@@ -31645,24 +31624,6 @@ paths:
           description: Optional idempotency key for non-GET methods. The gateway falls
             back to x-request-id when absent and forwards the key to the runner.
           name: x-idempotency-key
-          in: header
-        - schema:
-            type: string
-            description: Internal tenant header used for tenant resolution before session
-              fallback.
-          required: false
-          description: Internal tenant header used for tenant resolution before session
-            fallback.
-          name: x-alga-tenant
-          in: header
-        - schema:
-            type: string
-            description: Legacy tenant header accepted for tenant resolution before session
-              fallback.
-          required: false
-          description: Legacy tenant header accepted for tenant resolution before session
-            fallback.
-          name: x-tenant-id
           in: header
       requestBody:
         description: Optional extension-specific PATCH body. The gateway accepts any
@@ -31685,8 +31646,20 @@ paths:
         "204":
           description: Runner returned no content, or CORS preflight for OPTIONS requests
             on this gateway path.
+        "401":
+          description: No authenticated session, or the session is missing a tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
+        "403":
+          description: A tenant header conflicts with the authenticated session tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "404":
-          description: Extension is not installed or not enabled for the resolved tenant.
+          description: Extension is not installed or not enabled for the session tenant.
           content:
             application/json:
               schema:
@@ -31698,8 +31671,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "500":
-          description: Tenant could not be resolved or another internal gateway error
-            occurred.
+          description: Another internal gateway error occurred.
           content:
             application/json:
               schema:
@@ -31714,15 +31686,16 @@ paths:
     delete:
       summary: Forward DELETE request to extension runner
       description: Tenant-scoped extension gateway endpoint that forwards DELETE
-        requests to an installed extension runner. The gateway resolves the
-        tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID
-        in development; verifies the extension is installed and enabled for that
-        tenant; forwards selected headers, query parameters, and an optional
-        opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner
-        response. For DELETE requests the body, if present, is limited to 10 MB,
-        base64-encoded, and forwarded as http.body_b64. The gateway currently
-        has a placeholder access check and does not enforce per-extension RBAC
-        beyond tenant install resolution.
+        requests to an installed extension runner. The gateway requires an
+        authenticated session and derives the tenant from that session; verifies
+        the extension is installed and enabled for the session tenant; forwards
+        selected headers, query parameters, and an optional opaque body to
+        RUNNER_BASE_URL /v1/execute; and relays the runner response. For DELETE
+        requests the body, if present, is limited to 10 MB, base64-encoded, and
+        forwarded as http.body_b64. Tenant-selection headers are not accepted as
+        authentication and a header that disagrees with the session tenant fails
+        closed. The gateway currently has a placeholder access check and does
+        not enforce per-extension RBAC beyond tenant install resolution.
       tags:
         - Extension Gateway
       security:
@@ -31776,24 +31749,6 @@ paths:
             back to x-request-id when absent and forwards the key to the runner.
           name: x-idempotency-key
           in: header
-        - schema:
-            type: string
-            description: Internal tenant header used for tenant resolution before session
-              fallback.
-          required: false
-          description: Internal tenant header used for tenant resolution before session
-            fallback.
-          name: x-alga-tenant
-          in: header
-        - schema:
-            type: string
-            description: Legacy tenant header accepted for tenant resolution before session
-              fallback.
-          required: false
-          description: Legacy tenant header accepted for tenant resolution before session
-            fallback.
-          name: x-tenant-id
-          in: header
       requestBody:
         description: Optional extension-specific DELETE body. The gateway accepts any
           content type up to 10 MB and forwards it as base64.
@@ -31815,8 +31770,20 @@ paths:
         "204":
           description: Runner returned no content, or CORS preflight for OPTIONS requests
             on this gateway path.
+        "401":
+          description: No authenticated session, or the session is missing a tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
+        "403":
+          description: A tenant header conflicts with the authenticated session tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "404":
-          description: Extension is not installed or not enabled for the resolved tenant.
+          description: Extension is not installed or not enabled for the session tenant.
           content:
             application/json:
               schema:
@@ -31828,8 +31795,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ExtensionGatewayErrorResponse"
         "500":
-          description: Tenant could not be resolved or another internal gateway error
-            occurred.
+          description: Another internal gateway error occurred.
           content:
             application/json:
               schema:
@@ -73366,6 +73332,84 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /api/auth/client-portal/sso/discover:
+    post:
+      summary: POST auth
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - auth
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/auth/client-portal/sso/resolve:
+    post:
+      summary: POST auth
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - auth
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /api/auth/e2e/google/authorize:
     get:
       summary: GET auth
@@ -76720,6 +76764,241 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /api/inventory/sales-orders/{id}/document:
+    get:
+      summary: GET inventory
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - inventory
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/inventory/sales-orders/{id}/email-confirmation:
+    post:
+      summary: POST inventory
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - inventory
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/marketing/capture/{tenant}/{slug}:
+    post:
+      summary: POST marketing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - marketing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/marketing/track/click/{tenant}/{enrollmentId}/{stepId}:
+    get:
+      summary: GET marketing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - marketing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/marketing/track/open/{tenant}/{enrollmentId}/{stepId}:
+    get:
+      summary: GET marketing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - marketing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/marketing/unsubscribe/{tenant}/{enrollmentId}:
+    get:
+      summary: GET marketing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - marketing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST marketing
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - marketing
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /api/mcp:
     get:
       summary: GET mcp
@@ -77080,6 +77359,205 @@ paths:
         x-placeholder: true
       x-alga-products:
         - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/scim/v2/{connectionId}/{scimPath}:
+    delete:
+      summary: DELETE scim
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - scim
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      responses:
+        "204":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    get:
+      summary: GET scim
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - scim
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    options:
+      summary: OPTIONS scim
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - scim
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    patch:
+      summary: PATCH scim
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - scim
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST scim
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - scim
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    put:
+      summary: PUT scim
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - scim
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products: []
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
       responses:
         "200":
           description: Placeholder success response
@@ -78230,52 +78708,13 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/financial/reconciliation/run:
+  /api/v1/inventory/counts/{sessionId}/cancel:
     post:
       summary: POST v1
       description: This operation was generated automatically from the route
         inventory. Replace with canonical OpenAPI metadata.
       tags:
-        - financial
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      requestBody:
-        description: Placeholder request body
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PlaceholderObject"
-            description: Placeholder request body
-      responses:
-        "201":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/financial/reconciliation/{id}/resolve:
-    post:
-      summary: POST v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - financial
+        - inventory
       extensions:
         x-generated-from: docs/openapi/route-inventory.json
         x-placeholder: true
@@ -79497,6 +79936,447 @@ paths:
         inventory. Replace with canonical OpenAPI metadata.
       tags:
         - mobile
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/opportunities/calibration:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - opportunities
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/opportunities/forecast:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - opportunities
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/opportunities/meeting-sessions:
+    post:
+      summary: POST v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - opportunities
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/opportunities/meeting-sessions/active:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - opportunities
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/opportunities/meeting-sessions/{sessionId}/reviews:
+    post:
+      summary: POST v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - opportunities
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/opportunities/qbr/yield:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - opportunities
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/opportunities/qbr/{clientId}:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - opportunities
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/opportunities/qbr/{clientId}/opportunities:
+    post:
+      summary: POST v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - opportunities
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/opportunities/rollups:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - opportunities
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/opportunities/{id}/commitments:
+    get:
+      summary: GET v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - opportunities
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - opportunities
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/opportunities/{id}/commitments/{commitmentId}:
+    delete:
+      summary: DELETE v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - opportunities
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "204":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    put:
+      summary: PUT v1
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - opportunities
       extensions:
         x-generated-from: docs/openapi/route-inventory.json
         x-placeholder: true
@@ -81637,6 +82517,75 @@ paths:
         inventory. Replace with canonical OpenAPI metadata.
       tags:
         - tenant-management
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      requestBody:
+        description: Placeholder request body
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaceholderObject"
+            description: Placeholder request body
+      responses:
+        "201":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/webhooks/ai-gateway:
+    options:
+      summary: OPTIONS webhooks
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - webhooks
+      extensions:
+        x-generated-from: docs/openapi/route-inventory.json
+        x-placeholder: true
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Placeholder success response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlaceholderObject"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: POST webhooks
+      description: This operation was generated automatically from the route
+        inventory. Replace with canonical OpenAPI metadata.
+      tags:
+        - webhooks
       extensions:
         x-generated-from: docs/openapi/route-inventory.json
         x-placeholder: true

--- a/server/src/app/api/ext-debug/stream/route.test.ts
+++ b/server/src/app/api/ext-debug/stream/route.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const getCurrentUserMock = vi.fn();
+const hasPermissionMock = vi.fn();
+const createDebugStreamClientMock = vi.fn();
+
+vi.mock('@alga-psa/user-composition/actions', () => ({
+  getCurrentUser: (...args: unknown[]) => getCurrentUserMock(...args),
+}));
+
+vi.mock('server/src/lib/auth/rbac', () => ({
+  hasPermission: (...args: unknown[]) => hasPermissionMock(...args),
+}));
+
+vi.mock('server/src/lib/extensions/debugStream/redis', () => ({
+  createDebugStreamClient: (...args: unknown[]) => createDebugStreamClientMock(...args),
+  getDebugStreamPrefix: () => 'ext-debug:',
+}));
+
+const { GET, POST } = await import('./route');
+
+function buildRequest(url: string, headers: Record<string, string> = {}) {
+  return new NextRequest(url, { headers });
+}
+
+function buildRedisClient() {
+  const xRevRange = vi.fn().mockResolvedValue([]);
+  const xRead = vi.fn().mockRejectedValue(new Error('stop polling in test'));
+  return {
+    xRevRange,
+    xRead,
+    quit: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn(),
+  };
+}
+
+describe('/api/ext-debug/stream', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('ignores forged tenant headers when selecting the stream key from the session tenant', async () => {
+    getCurrentUserMock.mockResolvedValue({ user_id: 'u1', tenant: 'session-tenant', user_type: 'internal' });
+    hasPermissionMock.mockResolvedValue(true);
+    const client = buildRedisClient();
+    createDebugStreamClientMock.mockResolvedValue(client);
+
+    const response = await GET(
+      buildRequest('https://example.test/api/ext-debug/stream?extensionId=testext', {
+        'x-alga-tenant': 'attacker-tenant',
+        'x-tenant-id': 'attacker-legacy',
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await vi.waitFor(() => expect(client.xRevRange).toHaveBeenCalled());
+    expect(client.xRevRange.mock.calls[0][0]).toBe('ext-debug:session-tenant:testext');
+  });
+
+  it('uses currentUser.tenant when no tenant query is supplied', async () => {
+    getCurrentUserMock.mockResolvedValue({ user_id: 'u1', tenant: 'session-tenant', user_type: 'internal' });
+    hasPermissionMock.mockResolvedValue(true);
+    const client = buildRedisClient();
+    createDebugStreamClientMock.mockResolvedValue(client);
+
+    const response = await GET(
+      buildRequest('https://example.test/api/ext-debug/stream?extensionId=testext'),
+    );
+
+    expect(response.status).toBe(200);
+    await vi.waitFor(() => expect(client.xRevRange).toHaveBeenCalled());
+    expect(client.xRevRange.mock.calls[0][0]).toBe('ext-debug:session-tenant:testext');
+  });
+
+  it('honors the explicit tenant query selection after the user and RBAC gates pass', async () => {
+    getCurrentUserMock.mockResolvedValue({ user_id: 'u1', tenant: 'session-tenant', user_type: 'internal' });
+    hasPermissionMock.mockResolvedValue(true);
+    const client = buildRedisClient();
+    createDebugStreamClientMock.mockResolvedValue(client);
+
+    const response = await GET(
+      buildRequest(
+        'https://example.test/api/ext-debug/stream?extensionId=testext&tenantId=query-tenant',
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    await vi.waitFor(() => expect(client.xRevRange).toHaveBeenCalled());
+    expect(client.xRevRange.mock.calls[0][0]).toBe('ext-debug:query-tenant:testext');
+  });
+
+  it('denies with 401 without opening Redis when there is no current user', async () => {
+    getCurrentUserMock.mockResolvedValue(null);
+
+    const response = await GET(
+      buildRequest('https://example.test/api/ext-debug/stream?extensionId=testext'),
+    );
+
+    expect(response.status).toBe(401);
+    expect(createDebugStreamClientMock).not.toHaveBeenCalled();
+  });
+
+  it('denies with 403 without opening Redis when the RBAC gate fails', async () => {
+    getCurrentUserMock.mockResolvedValue({ user_id: 'u1', tenant: 'session-tenant', user_type: 'internal' });
+    hasPermissionMock.mockResolvedValue(false);
+
+    const response = await GET(
+      buildRequest('https://example.test/api/ext-debug/stream?extensionId=testext'),
+    );
+
+    expect(response.status).toBe(403);
+    expect(createDebugStreamClientMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps POST polling behind the same user/RBAC gates', async () => {
+    getCurrentUserMock.mockResolvedValue(null);
+
+    const response = await POST(
+      buildRequest('https://example.test/api/ext-debug/stream?extensionId=testext'),
+    );
+
+    expect(response.status).toBe(401);
+    expect(createDebugStreamClientMock).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/app/api/ext-debug/stream/route.ts
+++ b/server/src/app/api/ext-debug/stream/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getCurrentUser } from '@alga-psa/user-composition/actions';
 import { hasPermission } from 'server/src/lib/auth/rbac';
-import { getTenantFromAuth } from 'server/src/lib/extensions/gateway/auth';
 import {
   createDebugStreamClient,
   getDebugStreamPrefix,
@@ -39,7 +38,6 @@ class HttpResponseError extends Error {
 }
 
 async function assertAccess(
-  req: NextRequest,
   tenantIdFromQuery: string | null,
 ): Promise<{ tenantId: string | null }> {
   const currentUser = await getCurrentUser();
@@ -48,29 +46,14 @@ async function assertAccess(
     throw new HttpResponseError(json(401, { error: 'Unauthorized' }));
   }
 
-  let tenantFromAuth: string | null = null;
-  try {
-    tenantFromAuth = await getTenantFromAuth(req);
-  } catch (err: unknown) {
-    // For end-user initiated requests we often won't have x-alga-tenant headers.
-    // Treat missing tenant header as null and fall back to the session tenant.
-    if (!(err instanceof Error && err.message === 'unauthenticated')) {
-      throw err;
-    }
-  }
-  const effectiveTenant =
-    tenantIdFromQuery || tenantFromAuth || currentUser.tenant || null;
+  // Tenant headers are not authority on this route. The explicit query
+  // parameter is the only selection mechanism, and it remains gated behind the
+  // current-user and RBAC checks below.
+  const effectiveTenant = tenantIdFromQuery?.trim() || currentUser.tenant || null;
 
   if (!effectiveTenant) {
     throw new HttpResponseError(json(401, { error: 'Unauthorized' }));
   }
-
-  // Allow cross-tenant debugging if the user has permission.
-  // The strict check (currentUser.tenant !== effectiveTenant) prevented MSP admins
-  // from debugging customer tenants.
-  // if (currentUser.tenant && currentUser.tenant !== effectiveTenant) {
-  //   throw new HttpResponseError(json(401, { error: 'Unauthorized' }));
-  // }
 
   // Require extension read permission within tenant context
   const allowed = await hasPermission(currentUser, 'extension', 'read');
@@ -96,7 +79,7 @@ export async function GET(req: NextRequest): Promise<Response> {
       return json(400, { error: 'extensionId is required' });
     }
 
-    const { tenantId } = await assertAccess(req, tenantIdParam);
+    const { tenantId } = await assertAccess(tenantIdParam);
     const normalizedInstall = installId?.trim().toLowerCase() || null;
     const normalizedRequest = requestId?.trim().toLowerCase() || null;
     const streamKeys = buildStreamKeys(extensionId, tenantId);
@@ -394,7 +377,7 @@ export async function POST(req: NextRequest): Promise<Response> {
       return json(400, { error: 'extensionId is required' });
     }
 
-    const { tenantId } = await assertAccess(req, tenantIdParam);
+    const { tenantId } = await assertAccess(tenantIdParam);
     const normalizedInstall = installId?.trim().toLowerCase() || null;
     const normalizedRequest = requestId?.trim().toLowerCase() || null;
     const streamKeys = buildStreamKeys(extensionId, tenantId);

--- a/server/src/app/api/ext-proxy/[extensionId]/[[...path]]/route.test.ts
+++ b/server/src/app/api/ext-proxy/[extensionId]/[[...path]]/route.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const assertSessionProductAccessMock = vi.fn();
+const handlerSpies: Record<string, ReturnType<typeof vi.fn>> = {
+  GET: vi.fn(),
+  POST: vi.fn(),
+  PUT: vi.fn(),
+  PATCH: vi.fn(),
+  DELETE: vi.fn(),
+};
+
+vi.mock('@/lib/api/standaloneProductGuards', () => ({
+  assertSessionProductAccess: (...args: unknown[]) => assertSessionProductAccessMock(...args),
+}));
+
+vi.mock('@product/ext-proxy/ee/handler', () => ({
+  GET: (...args: unknown[]) => handlerSpies.GET(...args),
+  POST: (...args: unknown[]) => handlerSpies.POST(...args),
+  PUT: (...args: unknown[]) => handlerSpies.PUT(...args),
+  PATCH: (...args: unknown[]) => handlerSpies.PATCH(...args),
+  DELETE: (...args: unknown[]) => handlerSpies.DELETE(...args),
+}));
+
+const route = await import('./route');
+
+function buildRequest(method: string, headers: Record<string, string> = {}) {
+  return new NextRequest('https://example.test/api/ext-proxy/demo/tickets', {
+    method,
+    headers,
+  });
+}
+
+function buildContext() {
+  return { params: Promise.resolve({ extensionId: 'demo', path: ['tickets'] }) };
+}
+
+function deniedResponse(status: number) {
+  return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+const VERBS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'] as const;
+
+describe('/api/ext-proxy delegator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+    it.each(VERBS)(
+      'returns the denied session response without invoking the EE handler for %s',
+      async (verb) => {
+        assertSessionProductAccessMock.mockResolvedValue(deniedResponse(401));
+
+        const handler = route[verb] as typeof route.GET;
+        const response = await handler(
+          buildRequest(verb, { 'x-alga-tenant': 'attacker-tenant' }),
+          buildContext(),
+        );
+
+      expect(response.status).toBe(401);
+      expect(handlerSpies[verb]).not.toHaveBeenCalled();
+      for (const other of VERBS) {
+        if (other !== verb) {
+          expect(handlerSpies[other]).not.toHaveBeenCalled();
+        }
+      }
+    },
+  );
+
+  it('delegates to the EE handler when the session guard passes', async () => {
+    assertSessionProductAccessMock.mockResolvedValue(null);
+    handlerSpies.GET.mockResolvedValue(
+      new Response('proxied', { status: 200, headers: { 'content-type': 'text/plain' } }),
+    );
+
+    const response = await route.GET(buildRequest('GET'), buildContext());
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('proxied');
+    expect(handlerSpies.GET).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/src/app/api/ext/[extensionId]/[[...path]]/route.test.ts
+++ b/server/src/app/api/ext/[extensionId]/[[...path]]/route.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const assertSessionProductAccessMock = vi.fn();
+const getTenantFromSessionAuthMock = vi.fn();
+const getTenantInstallMock = vi.fn();
+const resolveVersionMock = vi.fn();
+const getCurrentUserMock = vi.fn();
+const createTenantKnexMock = vi.fn();
+
+vi.mock('@/lib/api/standaloneProductGuards', () => ({
+  assertSessionProductAccess: (...args: unknown[]) => assertSessionProductAccessMock(...args),
+}));
+
+vi.mock('server/src/lib/extensions/gateway/auth', async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...original,
+    getTenantFromSessionAuth: (...args: unknown[]) => getTenantFromSessionAuthMock(...args),
+  };
+});
+
+vi.mock('server/src/lib/extensions/gateway/registry', () => ({
+  getTenantInstall: (...args: unknown[]) => getTenantInstallMock(...args),
+  resolveVersion: (...args: unknown[]) => resolveVersionMock(...args),
+}));
+
+vi.mock('@alga-psa/user-composition/actions', () => ({
+  getCurrentUser: (...args: unknown[]) => getCurrentUserMock(...args),
+}));
+
+vi.mock('server/src/lib/db', () => ({
+  createTenantKnex: (...args: unknown[]) => createTenantKnexMock(...args),
+}));
+
+const { GET, OPTIONS } = await import('./route');
+
+function buildRequest(headers: Record<string, string> = {}) {
+  return new NextRequest('https://example.test/api/ext/demo/ext/action', { headers });
+}
+
+function buildContext() {
+  return { params: Promise.resolve({ extensionId: 'demo', path: ['ext', 'action'] }) };
+}
+
+function deniedResponse(status: number) {
+  return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('GET /api/ext/{extensionId}/{path}', () => {
+  const fetchSpy = vi.spyOn(global, 'fetch');
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createTenantKnexMock.mockRejectedValue(new Error('no database in route test'));
+  });
+
+  it('returns 401 before tenant resolution/install lookup/runner fetch when there is no session', async () => {
+    assertSessionProductAccessMock.mockResolvedValue(deniedResponse(401));
+
+    const response = await GET(buildRequest({ 'x-alga-tenant': 'attacker-tenant' }), buildContext());
+
+    expect(response.status).toBe(401);
+    expect(getTenantFromSessionAuthMock).not.toHaveBeenCalled();
+    expect(getTenantInstallMock).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('stops before install lookup when the session is partial (guard rejects)', async () => {
+    assertSessionProductAccessMock.mockResolvedValue(deniedResponse(401));
+
+    const response = await GET(buildRequest(), buildContext());
+
+    expect(response.status).toBe(401);
+    expect(getTenantFromSessionAuthMock).not.toHaveBeenCalled();
+    expect(getTenantInstallMock).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 and stops downstream on a tenant mismatch', async () => {
+    const { TenantAuthError } = await import('server/src/lib/extensions/gateway/auth');
+    assertSessionProductAccessMock.mockResolvedValue(null);
+    getTenantFromSessionAuthMock.mockRejectedValue(
+      new TenantAuthError('tenant_mismatch', 'x-alga-tenant header does not match the session tenant'),
+    );
+
+    const response = await GET(buildRequest({ 'x-alga-tenant': 'tenant-b' }), buildContext());
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: 'tenant_mismatch' });
+    expect(getTenantInstallMock).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('forwards a valid session request to the runner', async () => {
+    const { TenantAuthError } = await import('server/src/lib/extensions/gateway/auth');
+    assertSessionProductAccessMock.mockResolvedValue(null);
+    getTenantFromSessionAuthMock.mockResolvedValue('tenant-a');
+    getTenantInstallMock.mockResolvedValue({
+      install_id: 'install-1',
+      version_id: 'version-1',
+      tenant_id: 'tenant-a',
+    });
+    resolveVersionMock.mockResolvedValue({
+      install_id: 'install-1',
+      version_id: 'version-1',
+      content_hash: 'sha256:abc123',
+    });
+    getCurrentUserMock.mockResolvedValue({
+      user_id: 'user-1',
+      email: 'u@example.com',
+      first_name: 'Unit',
+      last_name: 'Tester',
+      tenant: 'tenant-a',
+      user_type: 'internal',
+    });
+    fetchSpy.mockResolvedValue(
+      new Response(
+        JSON.stringify({ body_b64: Buffer.from('runner-ok').toString('base64'), status: 200 }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+
+    const response = await GET(buildRequest(), buildContext());
+
+    expect(TenantAuthError).toBeDefined();
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('runner-ok');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toContain('/v1/execute');
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.context.tenant_id).toBe('tenant-a');
+    expect(body.user.user_id).toBe('user-1');
+  });
+
+  it('does not advertise x-alga-tenant in the CORS allow-list', async () => {
+    const preflight = new NextRequest('https://example.test/api/ext/demo/ext/action', {
+      method: 'OPTIONS',
+      headers: { origin: 'https://example.test' },
+    });
+
+    const response = await OPTIONS(preflight, buildContext());
+
+    expect(response.status).toBe(204);
+    const allowHeaders = response.headers.get('access-control-allow-headers') ?? '';
+    expect(allowHeaders.toLowerCase()).not.toContain('x-alga-tenant');
+  });
+});

--- a/server/src/app/api/ext/[extensionId]/[[...path]]/route.ts
+++ b/server/src/app/api/ext/[extensionId]/[[...path]]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import crypto from 'node:crypto';
 
-import { getTenantFromAuth, assertAccess } from 'server/src/lib/extensions/gateway/auth';
+import { getTenantFromSessionAuth, TenantAuthError, assertAccess } from 'server/src/lib/extensions/gateway/auth';
 import { getTenantInstall, resolveVersion } from 'server/src/lib/extensions/gateway/registry';
 import { filterRequestHeaders, filterResponseHeaders } from 'server/src/lib/extensions/gateway/headers';
 import { getCurrentUser } from '@alga-psa/user-composition/actions';
@@ -13,7 +13,7 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 const ALLOWED_METHODS = 'GET,POST,PUT,PATCH,DELETE,OPTIONS';
-const ALLOWED_HEADERS = 'content-type,x-request-id,x-idempotency-key,x-alga-tenant';
+const ALLOWED_HEADERS = 'content-type,x-request-id,x-idempotency-key';
 
 const isEnterpriseEdition =
   (process.env.EDITION ?? '').toLowerCase() === 'ee' ||
@@ -224,7 +224,6 @@ async function handle(req: NextRequest, ctx: { params: Promise<{ extensionId: st
     headers: {
       origin: req.headers.get('origin'),
       host: req.headers.get('host'),
-      'x-alga-tenant': req.headers.get('x-alga-tenant'),
     },
   });
   const corsOrigin = pickCorsOrigin(req);
@@ -247,7 +246,7 @@ async function handle(req: NextRequest, ctx: { params: Promise<{ extensionId: st
       return deniedResponse;
     }
 
-    const tenantId = await getTenantFromAuth(req);
+    const tenantId = await getTenantFromSessionAuth(req);
     console.log('[api/ext] tenant resolved', { tenantId, extensionId, method, elapsed: Date.now() - start });
     await assertAccess(tenantId, extensionId, method, path);
 
@@ -397,9 +396,9 @@ async function handle(req: NextRequest, ctx: { params: Promise<{ extensionId: st
       );
     }
   } catch (err) {
-    if (err instanceof Error && err.message === 'tenant_mismatch') {
+    if (err instanceof TenantAuthError) {
       return applyCorsHeaders(
-        NextResponse.json({ error: 'tenant_mismatch' }, { status: 403 }),
+        NextResponse.json({ error: err.code }, { status: err.status }),
         corsOrigin
       );
     }

--- a/server/src/app/ext-ui/[extensionId]/[contentHash]/[...path]/route.test.ts
+++ b/server/src/app/ext-ui/[extensionId]/[contentHash]/[...path]/route.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const getTenantFromSessionAuthMock = vi.fn();
+const getTenantInstallMock = vi.fn();
+const resolveVersionMock = vi.fn();
+const ensureUiCachedMock = vi.fn();
+const serveFromMock = vi.fn();
+
+vi.mock('server/src/lib/extensions/gateway/auth', async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...original,
+    getTenantFromSessionAuth: (...args: unknown[]) => getTenantFromSessionAuthMock(...args),
+  };
+});
+
+vi.mock('server/src/lib/extensions/gateway/registry', () => ({
+  getTenantInstall: (...args: unknown[]) => getTenantInstallMock(...args),
+  resolveVersion: (...args: unknown[]) => resolveVersionMock(...args),
+}));
+
+vi.mock('server/src/lib/extensions/assets/cache', () => ({
+  ensureUiCached: (...args: unknown[]) => ensureUiCachedMock(...args),
+}));
+
+vi.mock('server/src/lib/extensions/assets/serve', () => ({
+  serveFrom: (...args: unknown[]) => serveFromMock(...args),
+}));
+
+const { GET } = await import('./route');
+
+const ORIGINAL_EXT_UI_HOST_MODE = process.env.EXT_UI_HOST_MODE;
+
+function buildRequest(headers: Record<string, string> = {}) {
+  return new NextRequest('https://example.test/ext-ui/demo/sha256:abc123/index.html', {
+    headers,
+  });
+}
+
+function buildContext() {
+  return {
+    params: Promise.resolve({
+      extensionId: 'demo',
+      contentHash: 'sha256:abc123',
+      path: ['index.html'],
+    }),
+  };
+}
+
+describe('GET /ext-ui/{extensionId}/{contentHash}/{path} (legacy nextjs mode)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.EXT_UI_HOST_MODE = 'nextjs';
+    delete process.env.DEV_TENANT_ID;
+    serveFromMock.mockResolvedValue(new Response('ui-asset', { status: 200 }));
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_EXT_UI_HOST_MODE === undefined) {
+      delete process.env.EXT_UI_HOST_MODE;
+    } else {
+      process.env.EXT_UI_HOST_MODE = ORIGINAL_EXT_UI_HOST_MODE;
+    }
+    delete process.env.DEV_TENANT_ID;
+  });
+
+  it('returns an indistinguishable 404 with no session and a forged tenant header', async () => {
+    const { TenantAuthError } = await import('server/src/lib/extensions/gateway/auth');
+    getTenantFromSessionAuthMock.mockRejectedValue(
+      new TenantAuthError('unauthenticated', 'No authenticated session found'),
+    );
+
+    const response = await GET(
+      buildRequest({ 'x-alga-tenant': 'attacker-tenant' }),
+      buildContext(),
+    );
+
+    expect(response.status).toBe(404);
+    expect(getTenantInstallMock).not.toHaveBeenCalled();
+    expect(resolveVersionMock).not.toHaveBeenCalled();
+    expect(ensureUiCachedMock).not.toHaveBeenCalled();
+    expect(serveFromMock).not.toHaveBeenCalled();
+  });
+
+  it('returns a 404 for a partial session without reaching install/cache lookups', async () => {
+    const { TenantAuthError } = await import('server/src/lib/extensions/gateway/auth');
+    getTenantFromSessionAuthMock.mockRejectedValue(
+      new TenantAuthError('invalid_session', 'Session is missing a tenant'),
+    );
+
+    const response = await GET(buildRequest(), buildContext());
+
+    expect(response.status).toBe(404);
+    expect(getTenantInstallMock).not.toHaveBeenCalled();
+    expect(resolveVersionMock).not.toHaveBeenCalled();
+    expect(ensureUiCachedMock).not.toHaveBeenCalled();
+    expect(serveFromMock).not.toHaveBeenCalled();
+  });
+
+  it('returns a 404 when only DEV_TENANT_ID is set', async () => {
+    const { TenantAuthError } = await import('server/src/lib/extensions/gateway/auth');
+    process.env.DEV_TENANT_ID = 'dev-tenant';
+    getTenantFromSessionAuthMock.mockRejectedValue(
+      new TenantAuthError('unauthenticated', 'No authenticated session found'),
+    );
+
+    const response = await GET(buildRequest(), buildContext());
+
+    expect(response.status).toBe(404);
+    expect(getTenantInstallMock).not.toHaveBeenCalled();
+    expect(ensureUiCachedMock).not.toHaveBeenCalled();
+    expect(serveFromMock).not.toHaveBeenCalled();
+  });
+
+  it('serves the asset for a complete session with a matching content hash', async () => {
+    getTenantFromSessionAuthMock.mockResolvedValue('tenant-a');
+    getTenantInstallMock.mockResolvedValue({
+      install_id: 'install-1',
+      version_id: 'version-1',
+      tenant_id: 'tenant-a',
+    });
+    resolveVersionMock.mockResolvedValue({
+      install_id: 'install-1',
+      version_id: 'version-1',
+      content_hash: 'sha256:abc123',
+    });
+    ensureUiCachedMock.mockResolvedValue('/tmp/ui-cache/abc123');
+
+    const response = await GET(buildRequest(), buildContext());
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('ui-asset');
+    expect(serveFromMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a 404 when the content hash does not match the active install', async () => {
+    getTenantFromSessionAuthMock.mockResolvedValue('tenant-a');
+    getTenantInstallMock.mockResolvedValue({
+      install_id: 'install-1',
+      version_id: 'version-1',
+      tenant_id: 'tenant-a',
+    });
+    resolveVersionMock.mockResolvedValue({
+      install_id: 'install-1',
+      version_id: 'version-1',
+      content_hash: 'sha256:def456',
+    });
+
+    const response = await GET(buildRequest(), buildContext());
+
+    expect(response.status).toBe(404);
+    expect(ensureUiCachedMock).not.toHaveBeenCalled();
+    expect(serveFromMock).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/app/ext-ui/[extensionId]/[contentHash]/[...path]/route.ts
+++ b/server/src/app/ext-ui/[extensionId]/[contentHash]/[...path]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { ensureUiCached } from 'server/src/lib/extensions/assets/cache';
 import { serveFrom } from 'server/src/lib/extensions/assets/serve';
-import { getTenantFromAuth } from 'server/src/lib/extensions/gateway/auth';
+import { getTenantFromSessionAuth } from 'server/src/lib/extensions/gateway/auth';
 import { getTenantInstall, resolveVersion } from 'server/src/lib/extensions/gateway/registry';
 
 /**
@@ -83,7 +83,7 @@ export async function GET(
   // Legacy nextjs mode: retain existing validation and serving behavior
   // Validate that this contentHash matches the caller's active install for this extension.
   try {
-    const tenantId = await getTenantFromAuth(req);
+    const tenantId = await getTenantFromSessionAuth(req);
     const install = await getTenantInstall(tenantId, extensionId);
     if (!install) {
       console.warn(JSON.stringify({ ...logCtx, action: 'legacy_not_installed_404' }));

--- a/server/src/lib/api/openapi/routes/extensionGateway.ts
+++ b/server/src/lib/api/openapi/routes/extensionGateway.ts
@@ -29,14 +29,6 @@ export function registerExtensionGatewayRoutes(registry: ApiOpenApiRegistry) {
         .string()
         .optional()
         .describe('Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner.'),
-      'x-alga-tenant': zOpenApi
-        .string()
-        .optional()
-        .describe('Internal tenant header used for tenant resolution before session fallback.'),
-      'x-tenant-id': zOpenApi
-        .string()
-        .optional()
-        .describe('Legacy tenant header accepted for tenant resolution before session fallback.'),
     }),
   );
 
@@ -61,6 +53,9 @@ export function registerExtensionGatewayRoutes(registry: ApiOpenApiRegistry) {
     zOpenApi.object({
       error: zOpenApi
         .enum([
+          'unauthenticated',
+          'invalid_session',
+          'tenant_mismatch',
           'not_installed',
           'payload_too_large',
           'install_context_missing',
@@ -88,12 +83,20 @@ export function registerExtensionGatewayRoutes(registry: ApiOpenApiRegistry) {
         description: 'Runner returned no content, or CORS preflight for OPTIONS requests on this gateway path.',
         emptyBody: true,
       },
+      401: {
+        description: 'No authenticated session, or the session is missing a tenant.',
+        schema: ExtensionGatewayErrorResponse,
+      },
+      403: {
+        description: 'A tenant header conflicts with the authenticated session tenant.',
+        schema: ExtensionGatewayErrorResponse,
+      },
       404: {
-        description: 'Extension is not installed or not enabled for the resolved tenant.',
+        description: 'Extension is not installed or not enabled for the session tenant.',
         schema: ExtensionGatewayErrorResponse,
       },
       500: {
-        description: 'Tenant could not be resolved or another internal gateway error occurred.',
+        description: 'Another internal gateway error occurred.',
         schema: ExtensionGatewayErrorResponse,
       },
       502: {
@@ -149,30 +152,30 @@ export function registerExtensionGatewayRoutes(registry: ApiOpenApiRegistry) {
   registerGatewayMethod(
     'get',
     'Forward GET request to extension runner',
-    'Tenant-scoped extension gateway endpoint that forwards GET requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers and all query parameters to RUNNER_BASE_URL /v1/execute; and relays the runner response. GET requests do not read a body and do not generate an idempotency key. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.',
+    'Tenant-scoped extension gateway endpoint that forwards GET requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers and all query parameters to RUNNER_BASE_URL /v1/execute; and relays the runner response. GET requests do not read a body and do not generate an idempotency key. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.',
   );
 
   registerGatewayMethod(
     'post',
     'Forward POST request to extension runner',
-    'Tenant-scoped extension gateway endpoint that forwards POST requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For POST requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. An x-idempotency-key header is forwarded when supplied, otherwise the generated x-request-id is used as the non-GET idempotency fallback. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.',
+    'Tenant-scoped extension gateway endpoint that forwards POST requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For POST requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. An x-idempotency-key header is forwarded when supplied, otherwise the generated x-request-id is used as the non-GET idempotency fallback. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.',
   );
 
   registerGatewayMethod(
     'put',
     'Forward PUT request to extension runner',
-    'Tenant-scoped extension gateway endpoint that forwards PUT requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For PUT requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Clients should provide x-idempotency-key for safe retries; otherwise the gateway falls back to a generated request ID. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.',
+    'Tenant-scoped extension gateway endpoint that forwards PUT requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For PUT requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Clients should provide x-idempotency-key for safe retries; otherwise the gateway falls back to a generated request ID. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.',
   );
 
   registerGatewayMethod(
     'patch',
     'Forward PATCH request to extension runner',
-    'Tenant-scoped extension gateway endpoint that forwards PATCH requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For PATCH requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Clients should provide x-idempotency-key for safe retries; otherwise the gateway falls back to a generated request ID. The gateway does not interpret PATCH semantics; partial-update behavior is extension-defined.',
+    'Tenant-scoped extension gateway endpoint that forwards PATCH requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For PATCH requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Clients should provide x-idempotency-key for safe retries; otherwise the gateway falls back to a generated request ID. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway does not interpret PATCH semantics; partial-update behavior is extension-defined.',
   );
 
   registerGatewayMethod(
     'delete',
     'Forward DELETE request to extension runner',
-    'Tenant-scoped extension gateway endpoint that forwards DELETE requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For DELETE requests the body, if present, is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.',
+    'Tenant-scoped extension gateway endpoint that forwards DELETE requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For DELETE requests the body, if present, is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.',
   );
 }

--- a/server/src/lib/extensions/gateway/auth.test.ts
+++ b/server/src/lib/extensions/gateway/auth.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { NextRequest } from 'next/server';
 
-import { getTenantFromAuth } from './auth';
+import {
+  TenantAuthError,
+  getTenantFromSessionAuth,
+  getTenantFromServiceAuth,
+} from './auth';
 
 const getSessionMock = vi.fn();
 
@@ -13,39 +17,305 @@ function request(headers: Record<string, string> = {}) {
   return new NextRequest('https://example.test/api/ext/demo', { headers });
 }
 
+function expectTenantAuthError(
+  promise: Promise<unknown>,
+  code: string,
+) {
+  return expect(promise).rejects.toMatchObject({ code });
+}
+
 describe('extension gateway tenant resolution', () => {
   beforeEach(() => {
     getSessionMock.mockReset();
-    delete process.env.DEV_TENANT_ID;
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('RUNNER_SERVICE_TOKEN', '');
+    vi.stubEnv('DEV_TENANT_ID', '');
   });
 
-  it('uses the authenticated session tenant even when no tenant header is present', async () => {
-    getSessionMock.mockResolvedValue({ user: { tenant: 'tenant-a' } });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });  describe('getTenantFromSessionAuth', () => {
+    it('returns the session tenant when no tenant header is present', async () => {
+      getSessionMock.mockResolvedValue({ user: { tenant: 'tenant-a' } });
 
-    await expect(getTenantFromAuth(request())).resolves.toBe('tenant-a');
+      await expect(getTenantFromSessionAuth(request())).resolves.toBe('tenant-a');
+    });
+
+    it('returns the session tenant when a matching canonical header is present', async () => {
+      getSessionMock.mockResolvedValue({ user: { tenant: 'tenant-a' } });
+
+      await expect(
+        getTenantFromSessionAuth(request({ 'x-alga-tenant': 'tenant-a' })),
+      ).resolves.toBe('tenant-a');
+    });
+
+    it('returns the session tenant when a matching legacy header is present', async () => {
+      getSessionMock.mockResolvedValue({ user: { tenant: 'tenant-a' } });
+
+      await expect(
+        getTenantFromSessionAuth(request({ 'x-tenant-id': 'tenant-a' })),
+      ).resolves.toBe('tenant-a');
+    });
+
+    it('returns the session tenant when canonical and legacy headers both match', async () => {
+      getSessionMock.mockResolvedValue({ user: { tenant: 'tenant-a' } });
+
+      await expect(
+        getTenantFromSessionAuth(
+          request({ 'x-alga-tenant': 'tenant-a', 'x-tenant-id': 'tenant-a' }),
+        ),
+      ).resolves.toBe('tenant-a');
+    });
+
+    it('rejects with tenant_mismatch when the canonical header differs from the session', async () => {
+      getSessionMock.mockResolvedValue({ user: { tenant: 'tenant-a' } });
+
+      await expectTenantAuthError(
+        getTenantFromSessionAuth(request({ 'x-alga-tenant': 'tenant-b' })),
+        'tenant_mismatch',
+      );
+    });
+
+    it('rejects with tenant_mismatch when the legacy header differs from the session', async () => {
+      getSessionMock.mockResolvedValue({ user: { tenant: 'tenant-a' } });
+
+      await expectTenantAuthError(
+        getTenantFromSessionAuth(request({ 'x-tenant-id': 'tenant-b' })),
+        'tenant_mismatch',
+      );
+    });
+
+    it('rejects with tenant_mismatch when canonical and legacy headers disagree even if one matches the session', async () => {
+      getSessionMock.mockResolvedValue({ user: { tenant: 'tenant-a' } });
+
+      await expectTenantAuthError(
+        getTenantFromSessionAuth(
+          request({ 'x-alga-tenant': 'tenant-a', 'x-tenant-id': 'tenant-b' }),
+        ),
+        'tenant_mismatch',
+      );
+    });
+
+    it('rejects with tenant_mismatch when both supplied headers disagree with the session', async () => {
+      getSessionMock.mockResolvedValue({ user: { tenant: 'tenant-a' } });
+
+      await expectTenantAuthError(
+        getTenantFromSessionAuth(
+          request({ 'x-alga-tenant': 'tenant-b', 'x-tenant-id': 'tenant-c' }),
+        ),
+        'tenant_mismatch',
+      );
+    });
+
+    it('rejects with unauthenticated when there is no session even with a forged tenant header', async () => {
+      getSessionMock.mockResolvedValue(null);
+
+      await expectTenantAuthError(
+        getTenantFromSessionAuth(request({ 'x-alga-tenant': 'attacker-tenant' })),
+        'unauthenticated',
+      );
+    });
+
+    it('rejects with unauthenticated even when a valid service token accompanies a forged header', async () => {
+      getSessionMock.mockResolvedValue(null);
+      vi.stubEnv('RUNNER_SERVICE_TOKEN', 'service-secret');
+
+      await expectTenantAuthError(
+        getTenantFromSessionAuth(
+          request({
+            'x-alga-tenant': 'attacker-tenant',
+            'x-runner-auth': 'service-secret',
+          }),
+        ),
+        'unauthenticated',
+      );
+    });
+
+    it('rejects with invalid_session when the session user has no tenant, regardless of headers/token', async () => {
+      getSessionMock.mockResolvedValue({ user: { tenant: undefined } });
+
+      await expectTenantAuthError(
+        getTenantFromSessionAuth(request({ 'x-alga-tenant': 'tenant-b' })),
+        'invalid_session',
+      );
+    });
+
+    it('rejects with invalid_session when the session tenant is blank, regardless of headers/token', async () => {
+      getSessionMock.mockResolvedValue({ user: { tenant: '   ' } });
+
+      await expectTenantAuthError(
+        getTenantFromSessionAuth(
+          request({
+            'x-alga-tenant': 'tenant-b',
+            'x-runner-auth': 'service-secret',
+          }),
+        ),
+        'invalid_session',
+      );
+    });
+
+    it('rejects with invalid_session when the session user is absent, never falling into service mode', async () => {
+      getSessionMock.mockResolvedValue({});
+
+      await expectTenantAuthError(
+        getTenantFromSessionAuth(request()),
+        'invalid_session',
+      );
+    });
   });
 
-  it('rejects a tenant header that attempts to switch away from the session tenant', async () => {
-    getSessionMock.mockResolvedValue({ user: { tenant: 'tenant-a' } });
+  describe('getTenantFromServiceAuth', () => {
+    it('rejects with invalid_service_auth when no token is supplied', async () => {
+      getSessionMock.mockResolvedValue(null);
+      vi.stubEnv('RUNNER_SERVICE_TOKEN', 'service-secret');
 
-    await expect(
-      getTenantFromAuth(request({ 'x-alga-tenant': 'tenant-b' }))
-    ).rejects.toThrow('tenant_mismatch');
+      await expectTenantAuthError(
+        getTenantFromServiceAuth(request({ 'x-alga-tenant': 'tenant-svc' })),
+        'invalid_service_auth',
+      );
+    });
+
+    it('rejects with invalid_service_auth when the token is incorrect', async () => {
+      getSessionMock.mockResolvedValue(null);
+      vi.stubEnv('RUNNER_SERVICE_TOKEN', 'service-secret');
+
+      await expectTenantAuthError(
+        getTenantFromServiceAuth(
+          request({ 'x-alga-tenant': 'tenant-svc', 'x-runner-auth': 'wrong-token' }),
+        ),
+        'invalid_service_auth',
+      );
+    });
+
+    it('rejects with invalid_service_auth when the token is unconfigured', async () => {
+      getSessionMock.mockResolvedValue(null);
+
+      await expectTenantAuthError(
+        getTenantFromServiceAuth(
+          request({ 'x-alga-tenant': 'tenant-svc', 'x-runner-auth': 'service-secret' }),
+        ),
+        'invalid_service_auth',
+      );
+    });
+
+    it('returns the canonical header tenant with a valid token', async () => {
+      getSessionMock.mockResolvedValue(null);
+      vi.stubEnv('RUNNER_SERVICE_TOKEN', 'service-secret');
+
+      await expect(
+        getTenantFromServiceAuth(
+          request({ 'x-alga-tenant': 'tenant-svc', 'x-runner-auth': 'service-secret' }),
+        ),
+      ).resolves.toBe('tenant-svc');
+    });
+
+    it('returns the legacy header tenant for compatibility with a valid token', async () => {
+      getSessionMock.mockResolvedValue(null);
+      vi.stubEnv('RUNNER_SERVICE_TOKEN', 'service-secret');
+
+      await expect(
+        getTenantFromServiceAuth(
+          request({ 'x-tenant-id': 'tenant-legacy', 'x-runner-auth': 'service-secret' }),
+        ),
+      ).resolves.toBe('tenant-legacy');
+    });
+
+    it('rejects with missing_tenant when no tenant header is present', async () => {
+      getSessionMock.mockResolvedValue(null);
+      vi.stubEnv('RUNNER_SERVICE_TOKEN', 'service-secret');
+
+      await expectTenantAuthError(
+        getTenantFromServiceAuth(request({ 'x-runner-auth': 'service-secret' })),
+        'missing_tenant',
+      );
+    });
+
+    it('rejects with tenant_mismatch when canonical and legacy headers conflict', async () => {
+      getSessionMock.mockResolvedValue(null);
+      vi.stubEnv('RUNNER_SERVICE_TOKEN', 'service-secret');
+
+      await expectTenantAuthError(
+        getTenantFromServiceAuth(
+          request({
+            'x-alga-tenant': 'tenant-a',
+            'x-tenant-id': 'tenant-b',
+            'x-runner-auth': 'service-secret',
+          }),
+        ),
+        'tenant_mismatch',
+      );
+    });
+
+    it('rejects with mixed_auth when any session is present with otherwise valid service credentials', async () => {
+      getSessionMock.mockResolvedValue({ user: { tenant: 'tenant-a' } });
+      vi.stubEnv('RUNNER_SERVICE_TOKEN', 'service-secret');
+
+      await expectTenantAuthError(
+        getTenantFromServiceAuth(
+          request({
+            'x-alga-tenant': 'tenant-svc',
+            'x-runner-auth': 'service-secret',
+          }),
+        ),
+        'mixed_auth',
+      );
+    });
+
+    it('rejects with mixed_auth when a partial session is present', async () => {
+      getSessionMock.mockResolvedValue({ user: {} });
+      vi.stubEnv('RUNNER_SERVICE_TOKEN', 'service-secret');
+
+      await expectTenantAuthError(
+        getTenantFromServiceAuth(
+          request({ 'x-alga-tenant': 'tenant-svc', 'x-runner-auth': 'service-secret' }),
+        ),
+        'mixed_auth',
+      );
+    });
+
+    it('rejects a known default service token in production via runner-auth validation', async () => {
+      getSessionMock.mockResolvedValue(null);
+      vi.stubEnv('NODE_ENV', 'production');
+      vi.stubEnv('RUNNER_SERVICE_TOKEN', 'local-runner-key');
+
+      await expectTenantAuthError(
+        getTenantFromServiceAuth(
+          request({ 'x-alga-tenant': 'tenant-svc', 'x-runner-auth': 'local-runner-key' }),
+        ),
+        'invalid_service_auth',
+      );
+    });
   });
 
-  it('allows matching tenant headers for callers with a session tenant', async () => {
-    getSessionMock.mockResolvedValue({ user: { tenant: 'tenant-a' } });
+  describe('DEV_TENANT_ID has no effect', () => {
+    it('does not resolve a tenant from DEV_TENANT_ID for the session resolver', async () => {
+      getSessionMock.mockResolvedValue(null);
+      vi.stubEnv('DEV_TENANT_ID', 'dev-tenant');
 
-    await expect(
-      getTenantFromAuth(request({ 'x-tenant-id': 'tenant-a' }))
-    ).resolves.toBe('tenant-a');
+      await expectTenantAuthError(
+        getTenantFromSessionAuth(request()),
+        'unauthenticated',
+      );
+    });
+
+    it('does not resolve a tenant from DEV_TENANT_ID for the service resolver', async () => {
+      getSessionMock.mockResolvedValue(null);
+      vi.stubEnv('DEV_TENANT_ID', 'dev-tenant');
+      vi.stubEnv('RUNNER_SERVICE_TOKEN', 'service-secret');
+
+      await expectTenantAuthError(
+        getTenantFromServiceAuth(request({ 'x-runner-auth': 'service-secret' })),
+        'missing_tenant',
+      );
+    });
   });
 
-  it('still supports header-only tenant resolution for internal callers without a session', async () => {
-    getSessionMock.mockResolvedValue(null);
-
-    await expect(
-      getTenantFromAuth(request({ 'x-alga-tenant': 'tenant-internal' }))
-    ).resolves.toBe('tenant-internal');
+  it('TenantAuthError carries the expected status codes', () => {
+    expect(new TenantAuthError('tenant_mismatch', 'x').status).toBe(403);
+    expect(new TenantAuthError('unauthenticated', 'x').status).toBe(401);
+    expect(new TenantAuthError('invalid_session', 'x').status).toBe(401);
+    expect(new TenantAuthError('invalid_service_auth', 'x').status).toBe(401);
+    expect(new TenantAuthError('missing_tenant', 'x').status).toBe(401);
+    expect(new TenantAuthError('mixed_auth', 'x').status).toBe(401);
   });
 });

--- a/server/src/lib/extensions/gateway/auth.ts
+++ b/server/src/lib/extensions/gateway/auth.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server';
 import { getSession } from '@alga-psa/auth';
 import { tenantDb } from '@alga-psa/db';
 import { getAdminConnection } from '@alga-psa/db/admin';
+import { assertRunnerAuth, RunnerAuthError } from '../runnerAuth';
 
 export interface ExtProxyUserInfo {
   user_id: string;
@@ -11,6 +12,32 @@ export interface ExtProxyUserInfo {
   client_name: string;
   /** For client portal users, the client_id they are associated with */
   client_id?: string;
+}
+
+export type TenantAuthErrorCode =
+  | 'unauthenticated'
+  | 'invalid_session'
+  | 'invalid_service_auth'
+  | 'missing_tenant'
+  | 'mixed_auth'
+  | 'tenant_mismatch';
+
+/**
+ * Typed tenant-resolution failure. Route boundaries map this to a generic 401
+ * (missing/invalid authentication) or 403 (conflicting tenant evidence). The
+ * internal `code` is stable and may be logged; request credentials (runner
+ * token, cookies, tenant header values) must never be included in logs.
+ */
+export class TenantAuthError extends Error {
+  readonly code: TenantAuthErrorCode;
+  readonly status: number;
+
+  constructor(code: TenantAuthErrorCode, message: string) {
+    super(message);
+    this.name = 'TenantAuthError';
+    this.code = code;
+    this.status = code === 'tenant_mismatch' ? 403 : 401;
+  }
 }
 
 /**
@@ -47,28 +74,18 @@ async function getUserClientId(userId: string, tenantId: string): Promise<string
   return result?.client_id || undefined;
 }
 
+function normalizeHeaderValue(value: string | null): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
 /**
  * Get full user info from session for passing to runner.
  * Returns null if no valid session exists.
  */
 export async function getUserInfoFromAuth(req: NextRequest): Promise<ExtProxyUserInfo | null> {
-  // Check for internal header first (not typically used for user info)
-  const headerTenant = req.headers.get('x-alga-tenant');
-  if (headerTenant) {
-    // When using header-based auth, we don't have user info
-    console.log('[ext-proxy auth] Skipping user info - x-alga-tenant header present');
-    return null;
-  }
-
   const session = await getSession();
   const user = session?.user as any;
-
-  console.log('[ext-proxy auth] Session check', {
-    hasSession: !!session,
-    hasUser: !!user,
-    userId: user?.user_id || user?.id,
-    userEmail: user?.email,
-  });
 
   if (!user) {
     return null;
@@ -94,40 +111,87 @@ export async function getUserInfoFromAuth(req: NextRequest): Promise<ExtProxyUse
     client_id: clientId,
   };
 
-  console.log('[ext-proxy auth] Returning user info', {
-    userId: userInfo.user_id,
-    userEmail: userInfo.user_email,
-    userName: userInfo.user_name,
-    userType: userInfo.user_type,
-    clientId: userInfo.client_id,
-  });
-
   return userInfo;
 }
 
-export async function getTenantFromAuth(req: NextRequest): Promise<string> {
+/**
+ * Resolve the tenant for a browser/session flow.
+ *
+ * The session is the only tenant authority. `x-alga-tenant` and `x-tenant-id`
+ * are normalized and checked only for consistency during compatibility; they
+ * can never select a tenant, and a header that disagrees with the session
+ * fails closed with `tenant_mismatch`. A partial session (session object with
+ * a missing/blank tenant) throws `invalid_session` before any header is
+ * considered, and never falls through to service authentication.
+ */
+export async function getTenantFromSessionAuth(req: NextRequest): Promise<string> {
   const session = await getSession();
-  const sessionTenant = (session?.user as any)?.tenant;
-  const h = req.headers.get('x-alga-tenant')?.trim();
-  const legacy = req.headers.get('x-tenant-id')?.trim();
 
-  if (sessionTenant && String(sessionTenant).trim()) {
-    const tenant = String(sessionTenant).trim();
-    if ((h && h !== tenant) || (legacy && legacy !== tenant)) {
-      throw new Error('tenant_mismatch');
-    }
-    return tenant;
+  if (!session) {
+    throw new TenantAuthError('unauthenticated', 'No authenticated session found');
   }
 
-  // Header-based tenant selection is only allowed for non-browser/internal callers
-  // that do not already have a session tenant. A browser user must never be able
-  // to switch tenants by supplying x-alga-tenant/x-tenant-id.
-  if (h) return h;
-  if (legacy) return legacy;
+  const rawTenant = (session.user as { tenant?: unknown } | null | undefined)?.tenant;
+  if (typeof rawTenant !== 'string' || !rawTenant.trim()) {
+    throw new TenantAuthError('invalid_session', 'Session is missing a tenant');
+  }
+  const tenant = rawTenant.trim();
 
-  const dev = process.env.DEV_TENANT_ID;
-  if (dev && dev.trim()) return dev.trim();
-  throw new Error('unauthenticated');
+  const canonical = normalizeHeaderValue(req.headers.get('x-alga-tenant'));
+  const legacy = normalizeHeaderValue(req.headers.get('x-tenant-id'));
+
+  if (canonical && canonical !== tenant) {
+    throw new TenantAuthError('tenant_mismatch', 'x-alga-tenant header does not match the session tenant');
+  }
+  if (legacy && legacy !== tenant) {
+    throw new TenantAuthError('tenant_mismatch', 'x-tenant-id header does not match the session tenant');
+  }
+  if (canonical && legacy && canonical !== legacy) {
+    throw new TenantAuthError('tenant_mismatch', 'Conflicting tenant headers supplied');
+  }
+
+  return tenant;
+}
+
+/**
+ * Resolve the tenant for a service flow.
+ *
+ * A tenant header is honored only after an explicit service credential
+ * (`x-runner-auth` matching `RUNNER_SERVICE_TOKEN`) is verified with a
+ * constant-time comparison. `RUNNER_STORAGE_API_TOKEN` is deliberately not
+ * accepted here. Any session object — even a partial one — rejects with
+ * `mixed_auth` so partial sessions are never reinterpreted as service callers.
+ * `x-tenant-id` remains a documented legacy alias under service
+ * authentication; when both headers are supplied they must agree exactly.
+ */
+export async function getTenantFromServiceAuth(req: NextRequest): Promise<string> {
+  const session = await getSession();
+
+  if (session) {
+    throw new TenantAuthError('mixed_auth', 'Session must not be combined with service authentication');
+  }
+
+  try {
+    assertRunnerAuth(req.headers.get('x-runner-auth'), process.env.RUNNER_SERVICE_TOKEN);
+  } catch (error) {
+    if (error instanceof RunnerAuthError) {
+      throw new TenantAuthError('invalid_service_auth', 'Invalid or unconfigured service token');
+    }
+    throw error;
+  }
+
+  const canonical = normalizeHeaderValue(req.headers.get('x-alga-tenant'));
+  const legacy = normalizeHeaderValue(req.headers.get('x-tenant-id'));
+
+  const tenant = canonical || legacy;
+  if (!tenant) {
+    throw new TenantAuthError('missing_tenant', 'Service request is missing a tenant header');
+  }
+  if (canonical && legacy && canonical !== legacy) {
+    throw new TenantAuthError('tenant_mismatch', 'Conflicting tenant headers supplied');
+  }
+
+  return tenant;
 }
 
 export async function assertAccess(_tenantId: string, _extensionId: string, _method: string, _path: string): Promise<void> {

--- a/server/src/lib/extensions/runnerAuth.test.ts
+++ b/server/src/lib/extensions/runnerAuth.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  RunnerAuthError,
+  assertRunnerAuth,
+  isValidRunnerToken,
+  resolveRunnerToken,
+} from './runnerAuth';
+
+describe('shared extension runner auth verification', () => {
+  beforeEach(() => {
+    vi.stubEnv('NODE_ENV', 'test');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('resolveRunnerToken', () => {
+    it('returns the first non-empty configured token', () => {
+      expect(resolveRunnerToken(undefined, ' ', 'configured-token')).toBe('configured-token');
+    });
+
+    it('throws when no token is configured', () => {
+      expect(() => resolveRunnerToken(undefined, null, '  ')).toThrow(RunnerAuthError);
+      expect(() => resolveRunnerToken()).toThrow('runner auth token not configured');
+    });
+
+    it('rejects known development defaults in production', () => {
+      vi.stubEnv('NODE_ENV', 'production');
+      for (const insecure of ['local-runner-key', 'changeme', 'change-me', 'secret']) {
+        expect(() => resolveRunnerToken(insecure)).toThrow(RunnerAuthError);
+      }
+    });
+
+    it('accepts a known development default outside production', () => {
+      vi.stubEnv('NODE_ENV', 'test');
+      expect(resolveRunnerToken('local-runner-key')).toBe('local-runner-key');
+    });
+
+    it('accepts a non-default token in production', () => {
+      vi.stubEnv('NODE_ENV', 'production');
+      expect(resolveRunnerToken('a-real-secret')).toBe('a-real-secret');
+    });
+  });
+
+  describe('assertRunnerAuth', () => {
+    it('accepts a correct token with a constant-time comparison', () => {
+      expect(() => assertRunnerAuth('correct-token', 'correct-token')).not.toThrow();
+    });
+
+    it('rejects an incorrect token of the same length', () => {
+      expect(() => assertRunnerAuth('correct-token', 'wrong-token-00')).toThrow(
+        RunnerAuthError,
+      );
+    });
+
+    it('rejects an unequal-length token without comparing', () => {
+      expect(() => assertRunnerAuth('short', 'a-much-longer-configured-token')).toThrow(
+        RunnerAuthError,
+      );
+    });
+
+    it('rejects a missing token', () => {
+      expect(() => assertRunnerAuth(null, 'configured-token')).toThrow(RunnerAuthError);
+      expect(() => assertRunnerAuth(undefined, 'configured-token')).toThrow(RunnerAuthError);
+      expect(() => assertRunnerAuth('', 'configured-token')).toThrow(RunnerAuthError);
+    });
+
+    it('throws when configuration is missing entirely', () => {
+      expect(() => assertRunnerAuth('any-token', undefined, null)).toThrow(
+        'runner auth token not configured',
+      );
+    });
+
+    it('throws when production is configured with a known default', () => {
+      vi.stubEnv('NODE_ENV', 'production');
+      expect(() => assertRunnerAuth('local-runner-key', 'local-runner-key')).toThrow(
+        RunnerAuthError,
+      );
+    });
+
+    it('picks the first configured candidate in precedence order', () => {
+      expect(() =>
+        assertRunnerAuth('primary', 'primary', 'fallback')
+      ).not.toThrow();
+      expect(() =>
+        assertRunnerAuth('fallback', undefined, 'fallback')
+      ).not.toThrow();
+      expect(() =>
+        assertRunnerAuth('fallback', 'primary', 'fallback')
+      ).toThrow(RunnerAuthError);
+    });
+  });
+
+  describe('isValidRunnerToken', () => {
+    it('returns true for a correct token', () => {
+      expect(isValidRunnerToken('correct-token', 'correct-token')).toBe(true);
+    });
+
+    it('returns false for an incorrect token', () => {
+      expect(isValidRunnerToken('nope', 'correct-token')).toBe(false);
+    });
+
+    it('returns false for an unequal-length token', () => {
+      expect(isValidRunnerToken('x', 'correct-token')).toBe(false);
+    });
+
+    it('returns false when configuration is missing', () => {
+      expect(isValidRunnerToken('anything', undefined, null)).toBe(false);
+    });
+
+    it('returns false for a known default in production', () => {
+      vi.stubEnv('NODE_ENV', 'production');
+      expect(isValidRunnerToken('secret', 'secret')).toBe(false);
+    });
+  });
+});

--- a/server/src/lib/extensions/runnerAuth.ts
+++ b/server/src/lib/extensions/runnerAuth.ts
@@ -1,0 +1,96 @@
+import crypto from 'crypto';
+
+/**
+ * Shared verification for `x-runner-auth` credentials.
+ *
+ * Used by the internal extension-runner host APIs (`/api/internal/ext-*`) and
+ * by service-authenticated tenant resolution in the extension gateway
+ * (`getTenantFromServiceAuth`). These endpoints are reachable without an API
+ * key (they are in the middleware skip-list) and are authenticated solely by a
+ * shared token. Verification is centralized here so that every consumer:
+ *   1. compares the token in constant time (no timing side-channel), and
+ *   2. refuses to accept a well-known development default in production
+ *      (so a deployment that forgot to rotate the secret fails closed instead
+ *      of running with a publicly documented token).
+ *
+ * This module is environment-neutral. EE keeps a compatibility re-export at
+ * `ee/server/src/lib/extensions/runnerAuth.ts` so existing internal routes
+ * retain stable imports while executing exactly the same security logic.
+ */
+
+export class RunnerAuthError extends Error {
+  readonly status = 401;
+  constructor(message = 'unauthorized') {
+    super(message);
+    this.name = 'RunnerAuthError';
+  }
+}
+
+// Tokens that ship in example/compose files for local development. They must
+// never be accepted in production.
+const INSECURE_DEFAULT_TOKENS = new Set([
+  'local-runner-key',
+  'changeme',
+  'change-me',
+  'secret',
+]);
+
+function timingSafeEqual(provided: string, expected: string): boolean {
+  const a = Buffer.from(provided, 'utf8');
+  const b = Buffer.from(expected, 'utf8');
+  if (a.length !== b.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(a, b);
+}
+
+/**
+ * Resolve the configured runner token from the supplied env values (in
+ * precedence order). Throws if none is set, or if a known-insecure default is
+ * configured while running in production.
+ */
+export function resolveRunnerToken(...candidates: Array<string | undefined | null>): string {
+  const expected = candidates.find(
+    (value): value is string => typeof value === 'string' && value.trim().length > 0,
+  );
+  if (!expected) {
+    throw new RunnerAuthError('runner auth token not configured');
+  }
+  if (process.env.NODE_ENV === 'production' && INSECURE_DEFAULT_TOKENS.has(expected)) {
+    throw new RunnerAuthError('runner auth token is set to an insecure default value');
+  }
+  return expected;
+}
+
+/**
+ * Assert that the request-provided `x-runner-auth` value matches the configured
+ * token, using a constant-time comparison. Throws {@link RunnerAuthError}
+ * (status 401) on any mismatch or misconfiguration.
+ */
+export function assertRunnerAuth(
+  provided: string | null | undefined,
+  ...candidates: Array<string | undefined | null>
+): void {
+  const expected = resolveRunnerToken(...candidates);
+  if (!provided || !timingSafeEqual(provided, expected)) {
+    throw new RunnerAuthError('unauthorized');
+  }
+}
+
+/**
+ * Boolean variant for call sites that need to throw their own error type.
+ * Returns false when the token is missing/mismatched, or when the token is
+ * unset / left at a known-insecure default in production.
+ */
+export function isValidRunnerToken(
+  provided: string | null | undefined,
+  ...candidates: Array<string | undefined | null>
+): boolean {
+  let expected: string;
+  try {
+    expected = resolveRunnerToken(...candidates);
+  } catch {
+    return false;
+  }
+  return !!provided && timingSafeEqual(provided, expected);
+}

--- a/server/src/lib/mcp/registry.generated.ts
+++ b/server/src/lib/mcp/registry.generated.ts
@@ -15557,7 +15557,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/email/oauth/initiate",
     "displayName": "Initiate email OAuth flow",
     "summary": "Initiate email OAuth flow",
-    "description": "Starts the OAuth 2.0 authorization flow for a Google or Microsoft email provider. Requires a valid Auth.js session cookie. The handler builds secure OAuth state containing tenant, user, providerId, redirect URI, timestamp, and nonce, resolves the provider client ID from configured secrets, and returns the authorization URL for the browser to visit.",
+    "description": "Starts the OAuth 2.0 authorization flow for a Google email provider. Requires a valid Auth.js session cookie. The handler builds secure OAuth state containing tenant, user, providerId, redirect URI, timestamp, and nonce, resolves the provider client ID from configured secrets, and returns the authorization URL for the browser to visit. Microsoft mailbox OAuth is not served by this unsigned route: it must be initiated from the mailbox form with an explicit application selection so the callback receives a signed state token.",
     "tags": [
       "Email"
     ],
@@ -15884,7 +15884,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/ext/{extensionId}/{path}",
     "displayName": "Forward GET request to extension runner",
     "summary": "Forward GET request to extension runner",
-    "description": "Tenant-scoped extension gateway endpoint that forwards GET requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers and all query parameters to RUNNER_BASE_URL /v1/execute; and relays the runner response. GET requests do not read a body and do not generate an idempotency key. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
+    "description": "Tenant-scoped extension gateway endpoint that forwards GET requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers and all query parameters to RUNNER_BASE_URL /v1/execute; and relays the runner response. GET requests do not read a body and do not generate an idempotency key. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
     "tags": [
       "Extension Gateway"
     ],
@@ -15930,26 +15930,6 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "schema": {
           "type": "string",
           "description": "Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner."
-        }
-      },
-      {
-        "name": "x-alga-tenant",
-        "in": "header",
-        "required": false,
-        "description": "Internal tenant header used for tenant resolution before session fallback.",
-        "schema": {
-          "type": "string",
-          "description": "Internal tenant header used for tenant resolution before session fallback."
-        }
-      },
-      {
-        "name": "x-tenant-id",
-        "in": "header",
-        "required": false,
-        "description": "Legacy tenant header accepted for tenant resolution before session fallback.",
-        "schema": {
-          "type": "string",
-          "description": "Legacy tenant header accepted for tenant resolution before session fallback."
         }
       }
     ],
@@ -15965,7 +15945,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/ext/{extensionId}/{path}",
     "displayName": "Forward POST request to extension runner",
     "summary": "Forward POST request to extension runner",
-    "description": "Tenant-scoped extension gateway endpoint that forwards POST requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For POST requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. An x-idempotency-key header is forwarded when supplied, otherwise the generated x-request-id is used as the non-GET idempotency fallback. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
+    "description": "Tenant-scoped extension gateway endpoint that forwards POST requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For POST requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. An x-idempotency-key header is forwarded when supplied, otherwise the generated x-request-id is used as the non-GET idempotency fallback. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
     "tags": [
       "Extension Gateway"
     ],
@@ -16011,26 +15991,6 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "schema": {
           "type": "string",
           "description": "Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner."
-        }
-      },
-      {
-        "name": "x-alga-tenant",
-        "in": "header",
-        "required": false,
-        "description": "Internal tenant header used for tenant resolution before session fallback.",
-        "schema": {
-          "type": "string",
-          "description": "Internal tenant header used for tenant resolution before session fallback."
-        }
-      },
-      {
-        "name": "x-tenant-id",
-        "in": "header",
-        "required": false,
-        "description": "Legacy tenant header accepted for tenant resolution before session fallback.",
-        "schema": {
-          "type": "string",
-          "description": "Legacy tenant header accepted for tenant resolution before session fallback."
         }
       }
     ],
@@ -16051,7 +16011,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/ext/{extensionId}/{path}",
     "displayName": "Forward PUT request to extension runner",
     "summary": "Forward PUT request to extension runner",
-    "description": "Tenant-scoped extension gateway endpoint that forwards PUT requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For PUT requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Clients should provide x-idempotency-key for safe retries; otherwise the gateway falls back to a generated request ID. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
+    "description": "Tenant-scoped extension gateway endpoint that forwards PUT requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For PUT requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Clients should provide x-idempotency-key for safe retries; otherwise the gateway falls back to a generated request ID. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
     "tags": [
       "Extension Gateway"
     ],
@@ -16097,26 +16057,6 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "schema": {
           "type": "string",
           "description": "Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner."
-        }
-      },
-      {
-        "name": "x-alga-tenant",
-        "in": "header",
-        "required": false,
-        "description": "Internal tenant header used for tenant resolution before session fallback.",
-        "schema": {
-          "type": "string",
-          "description": "Internal tenant header used for tenant resolution before session fallback."
-        }
-      },
-      {
-        "name": "x-tenant-id",
-        "in": "header",
-        "required": false,
-        "description": "Legacy tenant header accepted for tenant resolution before session fallback.",
-        "schema": {
-          "type": "string",
-          "description": "Legacy tenant header accepted for tenant resolution before session fallback."
         }
       }
     ],
@@ -16137,7 +16077,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/ext/{extensionId}/{path}",
     "displayName": "Forward PATCH request to extension runner",
     "summary": "Forward PATCH request to extension runner",
-    "description": "Tenant-scoped extension gateway endpoint that forwards PATCH requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For PATCH requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Clients should provide x-idempotency-key for safe retries; otherwise the gateway falls back to a generated request ID. The gateway does not interpret PATCH semantics; partial-update behavior is extension-defined.",
+    "description": "Tenant-scoped extension gateway endpoint that forwards PATCH requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For PATCH requests the body is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Clients should provide x-idempotency-key for safe retries; otherwise the gateway falls back to a generated request ID. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway does not interpret PATCH semantics; partial-update behavior is extension-defined.",
     "tags": [
       "Extension Gateway"
     ],
@@ -16183,26 +16123,6 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "schema": {
           "type": "string",
           "description": "Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner."
-        }
-      },
-      {
-        "name": "x-alga-tenant",
-        "in": "header",
-        "required": false,
-        "description": "Internal tenant header used for tenant resolution before session fallback.",
-        "schema": {
-          "type": "string",
-          "description": "Internal tenant header used for tenant resolution before session fallback."
-        }
-      },
-      {
-        "name": "x-tenant-id",
-        "in": "header",
-        "required": false,
-        "description": "Legacy tenant header accepted for tenant resolution before session fallback.",
-        "schema": {
-          "type": "string",
-          "description": "Legacy tenant header accepted for tenant resolution before session fallback."
         }
       }
     ],
@@ -16223,7 +16143,7 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
     "path": "/api/ext/{extensionId}/{path}",
     "displayName": "Forward DELETE request to extension runner",
     "summary": "Forward DELETE request to extension runner",
-    "description": "Tenant-scoped extension gateway endpoint that forwards DELETE requests to an installed extension runner. The gateway resolves the tenant from x-alga-tenant, x-tenant-id, session cookie, or DEV_TENANT_ID in development; verifies the extension is installed and enabled for that tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For DELETE requests the body, if present, is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
+    "description": "Tenant-scoped extension gateway endpoint that forwards DELETE requests to an installed extension runner. The gateway requires an authenticated session and derives the tenant from that session; verifies the extension is installed and enabled for the session tenant; forwards selected headers, query parameters, and an optional opaque body to RUNNER_BASE_URL /v1/execute; and relays the runner response. For DELETE requests the body, if present, is limited to 10 MB, base64-encoded, and forwarded as http.body_b64. Tenant-selection headers are not accepted as authentication and a header that disagrees with the session tenant fails closed. The gateway currently has a placeholder access check and does not enforce per-extension RBAC beyond tenant install resolution.",
     "tags": [
       "Extension Gateway"
     ],
@@ -16269,26 +16189,6 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
         "schema": {
           "type": "string",
           "description": "Optional idempotency key for non-GET methods. The gateway falls back to x-request-id when absent and forwards the key to the runner."
-        }
-      },
-      {
-        "name": "x-alga-tenant",
-        "in": "header",
-        "required": false,
-        "description": "Internal tenant header used for tenant resolution before session fallback.",
-        "schema": {
-          "type": "string",
-          "description": "Internal tenant header used for tenant resolution before session fallback."
-        }
-      },
-      {
-        "name": "x-tenant-id",
-        "in": "header",
-        "required": false,
-        "description": "Legacy tenant header accepted for tenant resolution before session fallback.",
-        "schema": {
-          "type": "string",
-          "description": "Legacy tenant header accepted for tenant resolution before session fallback."
         }
       }
     ],
@@ -51841,14 +51741,6 @@ export const chatApiRegistry: ChatApiRegistryEntry[] = [
             "null"
           ],
           "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-        },
-        "next_action": {
-          "type": "string",
-          "minLength": 1
-        },
-        "next_action_due": {
-          "type": "string",
-          "format": "date-time"
         },
         "generator_key": {
           "type": [


### PR DESCRIPTION
## SEC: getTenantFromAuth trusts x-alga-tenant header from session-less callers

### Problem

The extension gateway's `getTenantFromAuth` resolved a caller's tenant from the
`x-alga-tenant` / `x-tenant-id` request headers whenever no session tenant was
present. A session-less (anonymous) caller could therefore forge a header and
have the gateway operate against **any** tenant. `getUserInfoFromAuth`
compounded this by treating the mere presence of `x-alga-tenant` as proof of an
"internal caller" and suppressing the authenticated user. A `DEV_TENANT_ID`
fallback provided a further implicit-tenant path.

### Fix

`getTenantFromAuth` is removed entirely (zero compile-time survivors) and split
into two resolvers that force each caller to declare its authentication mode:

- **`getTenantFromSessionAuth`** (browser/session flows) — the session is the
  only tenant authority. `x-alga-tenant` / `x-tenant-id` are normalized and
  checked *for consistency only*; they can never select a tenant. A header that
  disagrees with the session fails closed with `tenant_mismatch` (403). A
  partial session (session object with a missing/blank tenant) throws
  `invalid_session` (401) before any header is considered and never falls
  through to service auth.
- **`getTenantFromServiceAuth`** (service flows) — a tenant header is honored
  only after an explicit `x-runner-auth` credential is verified against
  `RUNNER_SERVICE_TOKEN` with a **constant-time** comparison. `RUNNER_STORAGE_API_TOKEN`
  is deliberately not accepted. Any session object present — even a partial one —
  rejects with `mixed_auth` so a partial session can never be reinterpreted as a
  service caller. Conflicting `x-alga-tenant` / `x-tenant-id` values fail closed.

Supporting changes:

- New typed `TenantAuthError` with a stable, loggable `code`
  (`unauthenticated` / `invalid_session` / `invalid_service_auth` /
  `missing_tenant` / `mixed_auth` / `tenant_mismatch`) mapping to 401 or 403.
  Request credentials (tokens, cookies, header values) are never logged.
- `DEV_TENANT_ID` is removed from the extension tenant-resolution path entirely.
- Runner-auth verification is extracted to a shared
  `server/src/lib/extensions/runnerAuth.ts` (constant-time compare,
  missing-config failure, production insecure-default rejection preserved);
  `ee/server/src/lib/extensions/runnerAuth.ts` becomes a compatibility
  re-export. 17 new shared unit tests.
- `packages/product-ext-proxy/ee/gateway/auth.ts` drops its old unsafe
  `getTenantFromAuth` and defines the safe session-only `getTenantFromSessionAuth`
  + `TenantAuthError` package-locally (using the shared `@alga-psa/auth`
  `getSession`); the EE handler imports them package-locally and maps
  `TenantAuthError` to `error.status`/`error.code`. The resolver is kept in the
  package rather than imported from the `server` app because `server` already
  depends on this package — a `server` import would create a project-graph cycle
  (caught by the circular-dependency guard and the EE build-deps ordering). A
  `// LEVERAGE: friction` marker notes the resolver is now mirrored between
  `server` and this package and would collapse into one if hoisted to a shared
  low-layer module.
- `x-alga-tenant` removed from CORS `access-control-allow-headers` in the EE
  handler and the `api/ext` route; noisy `console.log` of header/session
  contents removed.
- `api/ext-debug/stream` no longer consults tenant headers — the explicit query
  parameter is the only selection mechanism and stays gated behind current-user +
  RBAC checks; dead cross-tenant-comment code removed.
- Extension gateway routes updated to the new resolver and error mapping.
- OpenAPI specs (CE/EE + compatibility copies) and the generated MCP/chat
  registries regenerated to reflect the semantic change; audit of the
  regenerated specs is clean of `DEV_TENANT_ID` and header-as-auth wording.

### Tests

New/updated route and resolver unit tests cover: anonymous forged headers → 401,
matching session headers → pass, conflicting headers → 403, service-auth
constant-time token check, `mixed_auth`, and fail-closed behavior. The EE
`extensionProxyFlow` integration test mock now targets the module the handler
actually imports, adding user-info and fail-closed coverage.

### Smoke-test results — PASS (one optional UI check inconclusive)

Live browser/API flows against the worktree server on port 3410 (real in-browser
fetches, no mocked responses):

- Anonymous forged `x-alga-tenant` and legacy `x-tenant-id` → **401 Unauthorized**.
- Authenticated request without a tenant header → expected downstream **404 `not_installed`**.
- Matching authenticated tenant headers → expected downstream **404**.
- Conflicting `x-alga-tenant` or `x-tenant-id` → **403 `tenant_mismatch`**.
- CORS preflight omitted `X-Alga-Tenant` → **204**.
- `/api/ext-debug/stream` ignored a forged tenant header → **200** with an empty event stream.
- Real credential login and authenticated dashboard session succeeded.

Notes:
- The browser used the host's Tailscale address for the same port 3410 (the card
  browser runs on the hub machine). Normal click/Enter did not submit the
  off-screen login form, so `requestSubmit()` was invoked after filling it; the
  real Auth.js credential flow then completed normally.
- **Fidelity compromise:** compose Postgres/PgBouncer were used, but compose
  Redis had a stale/deleted secret mount, so a temporary **real** Redis 8.0.5 on
  port 6391 was used — no simulator or mock. The server remained live on 3410.
- Not directly live-tested: `getTenantFromServiceAuth` / `x-runner-auth`, because
  no current production route calls that service-only resolver.
- Concerns: global API CORS still advertises legacy `X-Tenant-ID`, although the
  gateway now rejects it for session-less callers. Direct Extensions settings
  navigation returned HTTP 200 and the correct title but rendered an empty body
  amid remote-dev HMR/router errors, so that optional adjacent check is
  **inconclusive**.

Evidence directory: `/tmp/alga-smoke-evidence/sec-gettenantfromauth-20260814T212800Z`

Worktree status remains only the pre-existing `package-lock.json` modification
(unrelated dependency drift, intentionally not part of this PR).
