### PR TITLE
29.8.42 — "Custom Rate" in Pricing Schedule for Contracts needs to be multi-currency

### DIFF
--- a/packages/billing/src/actions/contractPricingScheduleActions.customRate.test.ts
+++ b/packages/billing/src/actions/contractPricingScheduleActions.customRate.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@alga-psa/auth', () => ({
+  withAuth: (fn: any) => fn,
+}));
+
+vi.mock('@alga-psa/auth/rbac', () => ({
+  hasPermission: vi.fn(),
+}));
+
+const tableMock = vi.fn();
+
+vi.mock('@alga-psa/db', () => ({
+  createTenantKnex: vi.fn(async () => ({ knex: { fn: { now: () => 'now()' } } })),
+  tenantDb: vi.fn(() => ({ table: tableMock })),
+}));
+
+import { hasPermission } from '@alga-psa/auth/rbac';
+import {
+  createPricingSchedule,
+  updatePricingSchedule,
+} from './contractPricingScheduleActions';
+
+const callCreatePricingSchedule = createPricingSchedule as any;
+const callUpdatePricingSchedule = updatePricingSchedule as any;
+
+const CUSTOM_RATE_ERROR = {
+  actionError: "Custom rate must be a non-negative integer amount in the currency's minor units",
+};
+
+const user = { user_id: 'user-1' };
+const ctx = { tenant: 'tenant-1' };
+
+const existingSchedule = {
+  tenant: 'tenant-1',
+  schedule_id: 'schedule-1',
+  contract_id: 'contract-1',
+  effective_date: '2026-01-01T00:00:00.000Z',
+  custom_rate: 12345,
+};
+
+/**
+ * The overlap builders pass callbacks to where/orWhere; a returnThis mock never
+ * invokes them, so the chain collapses to the queued first() results.
+ */
+function makeSchedulesQuery(firstResults: unknown[], row: Record<string, unknown>) {
+  const queued = [...firstResults];
+  const returning = vi.fn(async () => [row]);
+  const query: any = {
+    where: vi.fn().mockReturnThis(),
+    whereNot: vi.fn().mockReturnThis(),
+    whereNull: vi.fn().mockReturnThis(),
+    orWhere: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    first: vi.fn(async () => queued.shift()),
+    insert: vi.fn(() => ({ returning })),
+    update: vi.fn(() => ({ returning })),
+  };
+  return query;
+}
+
+function seedTables(schedulesFirstResults: unknown[], row: Record<string, unknown> = existingSchedule) {
+  const schedulesQuery = makeSchedulesQuery(schedulesFirstResults, row);
+  const contractsQuery = {
+    where: vi.fn().mockReturnThis(),
+    first: vi.fn(async () => ({ is_system_managed_default: false })),
+  };
+  tableMock.mockImplementation((tableName: string) => (
+    tableName === 'contracts' ? contractsQuery : schedulesQuery
+  ));
+  return { schedulesQuery, contractsQuery };
+}
+
+function createData(customRate: unknown) {
+  return {
+    contract_id: 'contract-1',
+    effective_date: '2026-01-01T00:00:00.000Z',
+    end_date: null,
+    custom_rate: customRate,
+  };
+}
+
+describe('pricing schedule actions: custom_rate validation and null reset', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(hasPermission).mockResolvedValue(true);
+  });
+
+  it.each([
+    ['a negative amount', -100],
+    ['a fractional amount', 123.45],
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+    ['a string amount', '100'],
+  ])('create rejects %s before touching the table', async (_label, customRate) => {
+    const { schedulesQuery } = seedTables([undefined]);
+
+    await expect(callCreatePricingSchedule(user, ctx, createData(customRate)))
+      .resolves.toEqual(CUSTOM_RATE_ERROR);
+    expect(schedulesQuery.insert).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['null (use the default rate)', null],
+    ['zero minor units', 0],
+    ['an integer minor-unit amount', 12345],
+  ])('create accepts %s', async (_label, customRate) => {
+    // First result: the overlap probe finds nothing.
+    const { schedulesQuery } = seedTables([undefined]);
+
+    await expect(callCreatePricingSchedule(user, ctx, createData(customRate)))
+      .resolves.toEqual(existingSchedule);
+    expect(schedulesQuery.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ custom_rate: customRate })
+    );
+  });
+
+  it.each([
+    ['a negative amount', -1],
+    ['a fractional amount', 0.5],
+    ['NaN', Number.NaN],
+    ['a string amount', 'abc'],
+  ])('update rejects %s before touching the row', async (_label, customRate) => {
+    // First result: the existing schedule lookup.
+    const { schedulesQuery } = seedTables([existingSchedule]);
+
+    await expect(callUpdatePricingSchedule(user, ctx, 'schedule-1', { custom_rate: customRate }))
+      .resolves.toEqual(CUSTOM_RATE_ERROR);
+    expect(schedulesQuery.update).not.toHaveBeenCalled();
+  });
+
+  it('update persists an explicit custom_rate null so the reset actually clears the stored rate', async () => {
+    // Existing schedule lookup, then the overlap probe finds nothing.
+    const { schedulesQuery } = seedTables([existingSchedule, undefined]);
+
+    await expect(callUpdatePricingSchedule(user, ctx, 'schedule-1', { custom_rate: null }))
+      .resolves.toEqual(existingSchedule);
+    expect(schedulesQuery.update).toHaveBeenCalledWith(
+      expect.objectContaining({ custom_rate: null })
+    );
+  });
+
+  it('update accepts an integer minor-unit amount', async () => {
+    const { schedulesQuery } = seedTables([existingSchedule, undefined]);
+
+    await expect(callUpdatePricingSchedule(user, ctx, 'schedule-1', { custom_rate: 5000 }))
+      .resolves.toEqual(existingSchedule);
+    expect(schedulesQuery.update).toHaveBeenCalledWith(
+      expect.objectContaining({ custom_rate: 5000 })
+    );
+  });
+});

--- a/packages/billing/src/actions/contractPricingScheduleActions.ts
+++ b/packages/billing/src/actions/contractPricingScheduleActions.ts
@@ -31,6 +31,22 @@ async function getContractAuthoringError(
   return null;
 }
 
+/**
+ * custom_rate is an integer minor-unit amount in the contract currency;
+ * null clears the rate back to the contract default.
+ */
+function getCustomRateValidationError(customRate: number | null | undefined): string | null {
+  if (customRate === undefined || customRate === null) {
+    return null;
+  }
+
+  if (typeof customRate !== 'number' || !Number.isInteger(customRate) || customRate < 0) {
+    return 'Custom rate must be a non-negative integer amount in the currency\'s minor units';
+  }
+
+  return null;
+}
+
 
 /**
  * Get all pricing schedules for a contract
@@ -141,6 +157,11 @@ export const createPricingSchedule = withAuth(async (
   if (authoringError) {
     return actionError(authoringError);
   }
+
+  const customRateError = getCustomRateValidationError(scheduleData.custom_rate);
+  if (customRateError) {
+    return actionError(customRateError);
+  }
   const db = tenantDb(knex, tenant);
 
   // Calculate end_date from duration if provided
@@ -236,6 +257,11 @@ export const updatePricingSchedule = withAuth(async (
   const authoringError = await getContractAuthoringError(knex, tenant, existingSchedule.contract_id);
   if (authoringError) {
     return actionError(authoringError);
+  }
+
+  const customRateError = getCustomRateValidationError(scheduleData.custom_rate);
+  if (customRateError) {
+    return actionError(customRateError);
   }
 
   // Calculate end_date from duration if provided

--- a/packages/billing/src/components/billing-dashboard/contracts/ContractDetail.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/ContractDetail.tsx
@@ -2595,7 +2595,11 @@ const ContractDetail: React.FC<ContractDetailProps> = ({
         </TabsContent>
 
         <TabsContent value="pricing">
-          <PricingSchedules contractId={contract.contract_id} isReadOnly={isSystemManagedDefault} />
+          <PricingSchedules
+            contractId={contract.contract_id}
+            currencyCode={currencyMeta.currencyCode}
+            isReadOnly={isSystemManagedDefault}
+          />
         </TabsContent>
 
         <TabsContent value="documents">

--- a/packages/billing/src/components/billing-dashboard/contracts/PricingScheduleDialog.contract.test.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/PricingScheduleDialog.contract.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Hoisted mocks
+// ──────────────────────────────────────────────────────────────────────────────
+const featureFlagState = vi.hoisted(() => ({
+  enabled: false,
+  loading: false,
+  error: null as Error | null,
+}));
+
+const createPricingScheduleMock = vi.hoisted(() => vi.fn());
+const updatePricingScheduleMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@alga-psa/ui/hooks', () => ({
+  useFeatureFlag: () => featureFlagState,
+}));
+
+vi.mock('@alga-psa/billing/actions/contractPricingScheduleActions', () => ({
+  createPricingSchedule: async (...args: unknown[]) => createPricingScheduleMock(...args),
+  updatePricingSchedule: async (...args: unknown[]) => updatePricingScheduleMock(...args),
+}));
+
+vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
+  useOptionalI18n: () => null,
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | ({ defaultValue?: string } & Record<string, unknown>)) => {
+      if (!fallback) return key;
+      if (typeof fallback === 'string') return fallback;
+      const base = typeof fallback.defaultValue === 'string' ? fallback.defaultValue : key;
+      return base.replace(/\{\{(\w+)\}\}/g, (_, name: string) => String(fallback[name] ?? ''));
+    },
+  }),
+  useFormatters: () => ({ locale: 'en-US' }),
+}));
+
+vi.mock('@alga-psa/ui/components/Dialog', () => ({
+  Dialog: ({ isOpen, title, children, footer }: any) =>
+    isOpen ? (
+      <div role="dialog">
+        <h2>{title}</h2>
+        {children}
+        {footer}
+      </div>
+    ) : null,
+  DialogContent: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock('@alga-psa/ui/components/DatePicker', () => ({
+  DatePicker: ({ value }: any) => (
+    <input readOnly value={value ? value.toISOString() : ''} aria-label="date-picker" />
+  ),
+}));
+
+vi.mock('@alga-psa/ui/components/CustomSelect', () => ({
+  default: ({ id, value }: any) => <input readOnly id={id} value={value} />,
+}));
+
+vi.mock('@alga-psa/ui/components/SwitchWithLabel', () => ({
+  SwitchWithLabel: ({ label, checked, onCheckedChange }: any) => (
+    <label>
+      {label}
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onCheckedChange(e.target.checked)}
+      />
+    </label>
+  ),
+}));
+
+vi.mock('@alga-psa/ui/components/Alert', () => ({
+  Alert: ({ children }: any) => <div role="alert">{children}</div>,
+  AlertDescription: ({ children }: any) => <div>{children}</div>,
+}));
+
+// The global test setup mocks useAutomationIdAndRegister with empty automation
+// props, which strips `id` from the real Input; stub it so #custom-rate resolves.
+vi.mock('@alga-psa/ui/components/Input', () => ({
+  Input: ({ id, ...props }: any) => <input id={id} {...props} />,
+}));
+
+import type { IContractPricingSchedule } from '@alga-psa/types';
+import { CurrencyFormatProvider } from '@alga-psa/ui/lib';
+import { PricingScheduleDialog } from './PricingScheduleDialog';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ──────────────────────────────────────────────────────────────────────────────
+
+function schedule(overrides: Partial<IContractPricingSchedule> = {}): IContractPricingSchedule {
+  return {
+    tenant: 'tenant-1',
+    schedule_id: 'schedule-1',
+    contract_id: 'contract-1',
+    effective_date: '2026-01-01T00:00:00.000Z',
+    custom_rate: 12345,
+    ...overrides,
+  };
+}
+
+function renderDialog(props: {
+  schedule: IContractPricingSchedule;
+  currencyCode?: string;
+  ambientCurrency?: string;
+}) {
+  const onClose = vi.fn();
+  const onSave = vi.fn();
+  const utils = render(
+    <CurrencyFormatProvider currencyCode={props.ambientCurrency ?? 'USD'}>
+      <PricingScheduleDialog
+        contractId="contract-1"
+        schedule={props.schedule}
+        currencyCode={props.currencyCode}
+        onClose={onClose}
+        onSave={onSave}
+      />
+    </CurrencyFormatProvider>
+  );
+  return { ...utils, onClose, onSave };
+}
+
+function rateInput(): HTMLInputElement {
+  return document.getElementById('custom-rate') as HTMLInputElement;
+}
+
+function submitForm() {
+  fireEvent.submit(document.getElementById('pricing-schedule-form') as HTMLFormElement);
+}
+
+describe('PricingScheduleDialog contract-currency custom rate (release-v1.5-feature)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    featureFlagState.enabled = false;
+    featureFlagState.loading = false;
+    featureFlagState.error = null;
+    createPricingScheduleMock.mockResolvedValue(schedule());
+    updatePricingScheduleMock.mockResolvedValue(schedule());
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('flag on: renders and submits a two-decimal non-default currency (EUR) in contract minor units', async () => {
+    featureFlagState.enabled = true;
+    const { onSave } = renderDialog({
+      schedule: schedule({ custom_rate: 12345 }),
+      currencyCode: 'EUR',
+    });
+
+    const input = rateInput();
+    expect(input.value).toBe('123.45');
+    expect(input).toHaveAttribute('step', '0.01');
+    expect(screen.getByText('€')).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: '150.5' } });
+    submitForm();
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(updatePricingScheduleMock).toHaveBeenCalledWith(
+      'schedule-1',
+      expect.objectContaining({ custom_rate: 15050 })
+    );
+  });
+
+  it('flag on: round-trips a zero-decimal currency (JPY) without a x100 conversion', async () => {
+    featureFlagState.enabled = true;
+    const { onSave } = renderDialog({
+      schedule: schedule({ custom_rate: 5000 }),
+      currencyCode: 'JPY',
+    });
+
+    const input = rateInput();
+    expect(input.value).toBe('5000');
+    expect(input).toHaveAttribute('step', '1');
+    expect(input).toHaveAttribute('placeholder', '0');
+    expect(screen.getByText('¥')).toBeInTheDocument();
+
+    // Save without touching the rate: stored minor units must survive unchanged.
+    submitForm();
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(updatePricingScheduleMock).toHaveBeenCalledWith(
+      'schedule-1',
+      expect.objectContaining({ custom_rate: 5000 })
+    );
+  });
+
+  it('flag off: preserves the legacy ambient-currency two-decimal rendering and submission', async () => {
+    featureFlagState.enabled = false;
+    const { onSave } = renderDialog({
+      schedule: schedule({ custom_rate: 5000 }),
+      // Contract currency is supplied but must be ignored while the flag is off.
+      currencyCode: 'JPY',
+    });
+
+    const input = rateInput();
+    expect(input.value).toBe('50.00');
+    expect(input).toHaveAttribute('step', '0.01');
+    expect(input).toHaveAttribute('placeholder', '0.00');
+    expect(screen.getByText('$')).toBeInTheDocument();
+    expect(screen.queryByText('¥')).not.toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: '51' } });
+    submitForm();
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(updatePricingScheduleMock).toHaveBeenCalledWith(
+      'schedule-1',
+      expect.objectContaining({ custom_rate: 5100 })
+    );
+  });
+});

--- a/packages/billing/src/components/billing-dashboard/contracts/PricingScheduleDialog.contract.test.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/PricingScheduleDialog.contract.test.tsx
@@ -86,6 +86,10 @@ vi.mock('@alga-psa/ui/components/Input', () => ({
   Input: ({ id, ...props }: any) => <input id={id} {...props} />,
 }));
 
+vi.mock('@alga-psa/ui/components/Skeleton', () => ({
+  Skeleton: () => <div data-testid="rate-symbol-skeleton" />,
+}));
+
 import type { IContractPricingSchedule } from '@alga-psa/types';
 import { CurrencyFormatProvider } from '@alga-psa/ui/lib';
 import { PricingScheduleDialog } from './PricingScheduleDialog';
@@ -255,6 +259,59 @@ describe('PricingScheduleDialog contract-currency custom rate (release-v1.5-feat
 
     await waitFor(() => expect(onSave).toHaveBeenCalled());
     expect(updatePricingScheduleMock.mock.calls[0][1].custom_rate).toBeNull();
+  });
+
+  it('flag loading: disables the rate input with no legacy semantics and blocks submission', async () => {
+    featureFlagState.loading = true;
+    featureFlagState.enabled = false;
+    const { onSave } = renderDialog({
+      schedule: schedule({ custom_rate: 5000 }),
+      currencyCode: 'JPY',
+    });
+
+    const input = rateInput();
+    // Non-editable while the currency interpretation is unknown.
+    expect(input).toBeDisabled();
+    // No legacy symbol/step/placeholder semantics may be shown.
+    expect(screen.queryByText('$')).not.toBeInTheDocument();
+    expect(screen.queryByText('¥')).not.toBeInTheDocument();
+    expect(input).toHaveAttribute('step', 'any');
+    expect(input).toHaveAttribute('placeholder', '');
+    // The neutral symbol placeholder replaces the currency adornment.
+    expect(screen.getByTestId('rate-symbol-skeleton')).toBeInTheDocument();
+    // Stored minor units are not exposed through any conversion.
+    expect(input.value).toBe('');
+
+    submitForm();
+
+    expect(
+      await screen.findByText('Currency settings are still loading; try again in a moment')
+    ).toBeInTheDocument();
+    expect(updatePricingScheduleMock).not.toHaveBeenCalled();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('flag loading: restores editability and contract-currency semantics after resolution', async () => {
+    featureFlagState.loading = true;
+    featureFlagState.enabled = false;
+    const { rerenderDialog } = renderDialog({
+      schedule: schedule({ custom_rate: 12345 }),
+      currencyCode: 'EUR',
+    });
+
+    expect(rateInput()).toBeDisabled();
+
+    featureFlagState.loading = false;
+    featureFlagState.enabled = true;
+    rerenderDialog();
+
+    const input = rateInput();
+    await waitFor(() => expect(input).toBeEnabled());
+    expect(input.value).toBe('123.45');
+    expect(input).toHaveAttribute('step', '0.01');
+    expect(input).toHaveAttribute('placeholder', '0.00');
+    expect(screen.getByText('€')).toBeInTheDocument();
+    expect(screen.queryByTestId('rate-symbol-skeleton')).not.toBeInTheDocument();
   });
 
   it('flag loading: keeps the rate uninitialized instead of exposing legacy units, then derives with the resolved factor', async () => {

--- a/packages/billing/src/components/billing-dashboard/contracts/PricingScheduleDialog.contract.test.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/PricingScheduleDialog.contract.test.tsx
@@ -363,4 +363,71 @@ describe('PricingScheduleDialog contract-currency custom rate (release-v1.5-feat
       expect.objectContaining({ custom_rate: 600 })
     );
   });
+
+  it('flag loading: blocks the default-rate reset so the stored custom rate is not clobbered', async () => {
+    featureFlagState.loading = true;
+    featureFlagState.enabled = false;
+    const { onSave } = renderDialog({
+      schedule: schedule({ custom_rate: 5000 }),
+      currencyCode: 'JPY',
+    });
+
+    // Save is disabled while unresolved, with the loading reason surfaced.
+    const saveButton = screen.getByRole('button', { name: 'Update Schedule' });
+    expect(saveButton).toBeDisabled();
+    expect(saveButton).toHaveAttribute(
+      'title',
+      'Currency settings are still loading; try again in a moment'
+    );
+
+    // Switching to the default rate (the custom_rate: null path) and
+    // submitting must be blocked in the handler too — the Enter-key path
+    // bypasses the disabled button.
+    fireEvent.click(screen.getByLabelText('Use default rate'));
+    submitForm();
+
+    expect(
+      await screen.findByText('Currency settings are still loading; try again in a moment')
+    ).toBeInTheDocument();
+    expect(updatePricingScheduleMock).not.toHaveBeenCalled();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('flag loading: resolving to off lands in legacy two-decimal behavior with no stale gating', async () => {
+    featureFlagState.loading = true;
+    featureFlagState.enabled = false;
+    const { rerenderDialog, onSave } = renderDialog({
+      schedule: schedule({ custom_rate: 5000 }),
+      // Contract currency is supplied but must be ignored once the flag resolves off.
+      currencyCode: 'JPY',
+    });
+
+    // Unresolved: Save is disabled and no legacy units are exposed.
+    expect(screen.getByRole('button', { name: 'Update Schedule' })).toBeDisabled();
+    expect(rateInput().value).toBe('');
+
+    featureFlagState.loading = false;
+    featureFlagState.enabled = false;
+    rerenderDialog();
+
+    // Legacy ambient-currency semantics return end to end: /100 init,
+    // two-decimal step, ambient symbol, and no skeleton left behind.
+    const input = rateInput();
+    await waitFor(() => expect(input).toBeEnabled());
+    expect(input.value).toBe('50.00');
+    expect(input).toHaveAttribute('step', '0.01');
+    expect(screen.getByText('$')).toBeInTheDocument();
+    expect(screen.queryByTestId('rate-symbol-skeleton')).not.toBeInTheDocument();
+    // No stale loading gating survives the transition.
+    expect(screen.getByRole('button', { name: 'Update Schedule' })).toBeEnabled();
+
+    fireEvent.change(input, { target: { value: '51' } });
+    submitForm();
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(updatePricingScheduleMock).toHaveBeenCalledWith(
+      'schedule-1',
+      expect.objectContaining({ custom_rate: 5100 })
+    );
+  });
 });

--- a/packages/billing/src/components/billing-dashboard/contracts/PricingScheduleDialog.contract.test.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/PricingScheduleDialog.contract.test.tsx
@@ -112,7 +112,7 @@ function renderDialog(props: {
 }) {
   const onClose = vi.fn();
   const onSave = vi.fn();
-  const utils = render(
+  const tree = () => (
     <CurrencyFormatProvider currencyCode={props.ambientCurrency ?? 'USD'}>
       <PricingScheduleDialog
         contractId="contract-1"
@@ -123,7 +123,15 @@ function renderDialog(props: {
       />
     </CurrencyFormatProvider>
   );
-  return { ...utils, onClose, onSave };
+  const utils = render(tree());
+  return {
+    ...utils,
+    onClose,
+    onSave,
+    // Re-render the same tree so the component re-reads the (mutated) mocked
+    // feature-flag state — simulates a late flag resolution.
+    rerenderDialog: () => utils.rerender(tree()),
+  };
 }
 
 function rateInput(): HTMLInputElement {
@@ -215,6 +223,87 @@ describe('PricingScheduleDialog contract-currency custom rate (release-v1.5-feat
     expect(updatePricingScheduleMock).toHaveBeenCalledWith(
       'schedule-1',
       expect.objectContaining({ custom_rate: 5100 })
+    );
+  });
+
+  it('flag on: switching back to the default rate submits an explicit custom_rate null', async () => {
+    featureFlagState.enabled = true;
+    const { onSave } = renderDialog({
+      schedule: schedule({ custom_rate: 12345 }),
+      currencyCode: 'EUR',
+    });
+
+    fireEvent.click(screen.getByLabelText('Use default rate'));
+    submitForm();
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    const [scheduleId, payload] = updatePricingScheduleMock.mock.calls[0];
+    expect(scheduleId).toBe('schedule-1');
+    // null, not undefined — Knex drops undefined keys from updates, which
+    // silently kept the old rate.
+    expect(payload.custom_rate).toBeNull();
+  });
+
+  it('flag off: switching back to the default rate also submits an explicit custom_rate null', async () => {
+    featureFlagState.enabled = false;
+    const { onSave } = renderDialog({
+      schedule: schedule({ custom_rate: 5000 }),
+    });
+
+    fireEvent.click(screen.getByLabelText('Use default rate'));
+    submitForm();
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(updatePricingScheduleMock.mock.calls[0][1].custom_rate).toBeNull();
+  });
+
+  it('flag loading: keeps the rate uninitialized instead of exposing legacy units, then derives with the resolved factor', async () => {
+    featureFlagState.loading = true;
+    featureFlagState.enabled = false;
+    const { rerenderDialog } = renderDialog({
+      schedule: schedule({ custom_rate: 5000 }),
+      currencyCode: 'JPY',
+    });
+
+    // Unresolved flag: no legacy /100 rendering of the stored minor units.
+    expect(rateInput().value).toBe('');
+
+    featureFlagState.loading = false;
+    featureFlagState.enabled = true;
+    rerenderDialog();
+
+    await waitFor(() => expect(rateInput().value).toBe('5000'));
+  });
+
+  it('flag loading: refuses to submit a custom rate and never clobbers input typed before resolution', async () => {
+    featureFlagState.loading = true;
+    featureFlagState.enabled = false;
+    const { rerenderDialog, onSave } = renderDialog({
+      schedule: schedule({ custom_rate: 5000 }),
+      currencyCode: 'JPY',
+    });
+
+    fireEvent.change(rateInput(), { target: { value: '600' } });
+    submitForm();
+
+    // Unit math must not run against an unresolved flag.
+    expect(
+      await screen.findByText('Currency settings are still loading; try again in a moment')
+    ).toBeInTheDocument();
+    expect(updatePricingScheduleMock).not.toHaveBeenCalled();
+
+    featureFlagState.loading = false;
+    featureFlagState.enabled = true;
+    rerenderDialog();
+
+    // Late resolution must not overwrite what the user typed.
+    expect(rateInput().value).toBe('600');
+
+    submitForm();
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(updatePricingScheduleMock).toHaveBeenCalledWith(
+      'schedule-1',
+      expect.objectContaining({ custom_rate: 600 })
     );
   });
 });

--- a/packages/billing/src/components/billing-dashboard/contracts/PricingScheduleDialog.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/PricingScheduleDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Dialog, DialogContent } from '@alga-psa/ui/components/Dialog';
 import { Button } from '@alga-psa/ui/components/Button';
 import { Label } from '@alga-psa/ui/components/Label';
@@ -42,7 +42,7 @@ export function PricingScheduleDialog({
 }: PricingScheduleDialogProps) {
   const { t } = useTranslation('msp/contracts');
   const { symbol, fractionDigits } = useCurrencyFormat();
-  const { enabled: contractCurrencyEnabled } = useFeatureFlag('release-v1.5-feature', {
+  const { enabled: contractCurrencyEnabled, loading: flagLoading } = useFeatureFlag('release-v1.5-feature', {
     defaultValue: false,
   });
   // Flag off preserves the legacy ambient-currency behavior: two decimals, /100, ambient symbol.
@@ -62,11 +62,17 @@ export function PricingScheduleDialog({
   const [durationUnit, setDurationUnit] = useState<'days' | 'weeks' | 'months' | 'years'>(
     schedule?.duration_unit || 'months'
   );
-  const [customRate, setCustomRate] = useState<string>(
-    schedule?.custom_rate !== undefined && schedule?.custom_rate !== null
+  // The rate input only ever renders minor units converted with a *resolved*
+  // flag's factor: initialize empty while the flag is still loading and let the
+  // effect below fill it in on resolution.
+  const [customRate, setCustomRate] = useState<string>(() =>
+    !flagLoading && schedule?.custom_rate !== undefined && schedule?.custom_rate !== null
       ? (schedule.custom_rate / rateMinorUnitFactor).toFixed(rateFractionDigits)
       : ''
   );
+  // Once the user has touched the rate, no flag resolution or schedule re-sync
+  // may overwrite what they typed.
+  const userEditedRateRef = useRef(false);
   const [useDefaultRate, setUseDefaultRate] = useState(
     schedule?.custom_rate === undefined || schedule?.custom_rate === null
   );
@@ -79,17 +85,26 @@ export function PricingScheduleDialog({
       setEffectiveDate(schedule.effective_date ? new Date(schedule.effective_date) : undefined);
       setEndDate(schedule.end_date ? new Date(schedule.end_date) : undefined);
       setHasEndDate(!!schedule.end_date);
-      setCustomRate(
-        schedule.custom_rate !== undefined && schedule.custom_rate !== null
-          ? (schedule.custom_rate / rateMinorUnitFactor).toFixed(rateFractionDigits)
-          : ''
-      );
       setUseDefaultRate(schedule.custom_rate === undefined || schedule.custom_rate === null);
       setNotes(schedule.notes || '');
+      userEditedRateRef.current = false;
     }
-    // rateMinorUnitFactor/rateFractionDigits are deps so a late feature-flag
-    // resolution re-derives the input from the stored minor-unit value.
-  }, [schedule, rateMinorUnitFactor, rateFractionDigits]);
+  }, [schedule]);
+
+  // Derive the rate input from the stored minor units only once the feature
+  // flag has resolved, so the minor-unit factor is never taken from an
+  // unresolved flag; skip entirely once the user has typed, so a late
+  // resolution can't clobber their input.
+  useEffect(() => {
+    if (flagLoading || userEditedRateRef.current) {
+      return;
+    }
+    setCustomRate(
+      schedule?.custom_rate !== undefined && schedule?.custom_rate !== null
+        ? (schedule.custom_rate / rateMinorUnitFactor).toFixed(rateFractionDigits)
+        : ''
+    );
+  }, [schedule, flagLoading, rateMinorUnitFactor, rateFractionDigits]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -128,6 +143,14 @@ export function PricingScheduleDialog({
       return;
     }
 
+    // Never convert with an unresolved flag: the minor-unit factor isn't known yet.
+    if (!useDefaultRate && flagLoading) {
+      setError(t('pricingSchedules.dialog.validation.currencySettingsLoading', {
+        defaultValue: 'Currency settings are still loading; try again in a moment',
+      }));
+      return;
+    }
+
     if (!useDefaultRate && !customRate) {
       setError(t('pricingSchedules.dialog.validation.customRateRequired', {
         defaultValue: 'Custom rate is required when not using default rate',
@@ -151,7 +174,8 @@ export function PricingScheduleDialog({
         end_date: !useDuration && hasEndDate && endDate ? endDate.toISOString() : null,
         duration_value: useDuration ? parseInt(durationValue) : undefined,
         duration_unit: useDuration ? durationUnit : undefined,
-        custom_rate: useDefaultRate ? undefined : Math.round(parseFloat(customRate) * rateMinorUnitFactor),
+        // Explicit null — undefined is dropped by Knex on update, silently keeping the old rate.
+        custom_rate: useDefaultRate ? null : Math.round(parseFloat(customRate) * rateMinorUnitFactor),
         notes: notes || undefined
       };
 
@@ -328,6 +352,7 @@ export function PricingScheduleDialog({
               onCheckedChange={(checked) => {
                 setUseDefaultRate(checked);
                 if (checked) {
+                  userEditedRateRef.current = true;
                   setCustomRate('');
                 }
               }}
@@ -349,7 +374,10 @@ export function PricingScheduleDialog({
                   min="0"
                   step={contractCurrencyEnabled ? String(1 / rateMinorUnitFactor) : '0.01'}
                   value={customRate}
-                  onChange={(e) => setCustomRate(e.target.value)}
+                  onChange={(e) => {
+                    userEditedRateRef.current = true;
+                    setCustomRate(e.target.value);
+                  }}
                   className="pl-10 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                   placeholder={contractCurrencyEnabled
                     ? (0).toFixed(rateFractionDigits)

--- a/packages/billing/src/components/billing-dashboard/contracts/PricingScheduleDialog.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/PricingScheduleDialog.tsx
@@ -144,8 +144,12 @@ export function PricingScheduleDialog({
       return;
     }
 
-    // Never convert with an unresolved flag: the minor-unit factor isn't known yet.
-    if (!useDefaultRate && flagLoading) {
+    // No submission may run while the flag is unresolved: the minor-unit
+    // factor isn't known yet, and even the default-rate null path must not
+    // clobber the stored rate before the currency interpretation is settled.
+    // The Save button is disabled for the same reason; this guard also covers
+    // Enter-key and programmatic form submission.
+    if (flagLoading) {
       setError(t('pricingSchedules.dialog.validation.currencySettingsLoading', {
         defaultValue: 'Currency settings are still loading; try again in a moment',
       }));
@@ -227,7 +231,12 @@ export function PricingScheduleDialog({
             id="save-pricing-schedule-btn"
             type="button"
             onClick={() => (document.getElementById('pricing-schedule-form') as HTMLFormElement | null)?.requestSubmit()}
-            disabled={isSaving}
+            disabled={isSaving || flagLoading}
+            title={flagLoading
+              ? t('pricingSchedules.dialog.validation.currencySettingsLoading', {
+                defaultValue: 'Currency settings are still loading; try again in a moment',
+              })
+              : undefined}
           >
             {isSaving
               ? t('pricingSchedules.dialog.actions.saving', { defaultValue: 'Saving...' })

--- a/packages/billing/src/components/billing-dashboard/contracts/PricingScheduleDialog.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/PricingScheduleDialog.tsx
@@ -17,6 +17,7 @@ import { SwitchWithLabel } from '@alga-psa/ui/components/SwitchWithLabel';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { useCurrencyFormat } from '@alga-psa/ui/lib';
+import { useFeatureFlag } from '@alga-psa/ui/hooks';
 import {
   getErrorMessage,
   isActionMessageError,
@@ -26,6 +27,8 @@ import {
 interface PricingScheduleDialogProps {
   contractId: string;
   schedule?: IContractPricingSchedule | null;
+  /** Currency the owning contract is denominated in; custom_rate is stored in its minor units. */
+  currencyCode?: string;
   onClose: () => void;
   onSave: () => void;
 }
@@ -33,11 +36,18 @@ interface PricingScheduleDialogProps {
 export function PricingScheduleDialog({
   contractId,
   schedule,
+  currencyCode,
   onClose,
   onSave
 }: PricingScheduleDialogProps) {
   const { t } = useTranslation('msp/contracts');
-  const { symbol } = useCurrencyFormat();
+  const { symbol, fractionDigits } = useCurrencyFormat();
+  const { enabled: contractCurrencyEnabled } = useFeatureFlag('release-v1.5-feature', {
+    defaultValue: false,
+  });
+  // Flag off preserves the legacy ambient-currency behavior: two decimals, /100, ambient symbol.
+  const rateFractionDigits = contractCurrencyEnabled ? fractionDigits(currencyCode) : 2;
+  const rateMinorUnitFactor = 10 ** rateFractionDigits;
   const [effectiveDate, setEffectiveDate] = useState<Date | undefined>(
     schedule?.effective_date ? new Date(schedule.effective_date) : undefined
   );
@@ -54,7 +64,7 @@ export function PricingScheduleDialog({
   );
   const [customRate, setCustomRate] = useState<string>(
     schedule?.custom_rate !== undefined && schedule?.custom_rate !== null
-      ? (schedule.custom_rate / 100).toFixed(2)
+      ? (schedule.custom_rate / rateMinorUnitFactor).toFixed(rateFractionDigits)
       : ''
   );
   const [useDefaultRate, setUseDefaultRate] = useState(
@@ -71,13 +81,15 @@ export function PricingScheduleDialog({
       setHasEndDate(!!schedule.end_date);
       setCustomRate(
         schedule.custom_rate !== undefined && schedule.custom_rate !== null
-          ? (schedule.custom_rate / 100).toFixed(2)
+          ? (schedule.custom_rate / rateMinorUnitFactor).toFixed(rateFractionDigits)
           : ''
       );
       setUseDefaultRate(schedule.custom_rate === undefined || schedule.custom_rate === null);
       setNotes(schedule.notes || '');
     }
-  }, [schedule]);
+    // rateMinorUnitFactor/rateFractionDigits are deps so a late feature-flag
+    // resolution re-derives the input from the stored minor-unit value.
+  }, [schedule, rateMinorUnitFactor, rateFractionDigits]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -139,7 +151,7 @@ export function PricingScheduleDialog({
         end_date: !useDuration && hasEndDate && endDate ? endDate.toISOString() : null,
         duration_value: useDuration ? parseInt(durationValue) : undefined,
         duration_unit: useDuration ? durationUnit : undefined,
-        custom_rate: useDefaultRate ? undefined : Math.round(parseFloat(customRate) * 100),
+        custom_rate: useDefaultRate ? undefined : Math.round(parseFloat(customRate) * rateMinorUnitFactor),
         notes: notes || undefined
       };
 
@@ -328,16 +340,20 @@ export function PricingScheduleDialog({
                 {t('pricingSchedules.dialog.fields.customRate', { defaultValue: 'Custom Rate' })} *
               </Label>
               <div className="relative">
-                <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground">{symbol()}</span>
+                <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground">
+                  {contractCurrencyEnabled ? symbol(currencyCode) : symbol()}
+                </span>
                 <Input
                   id="custom-rate"
                   type="number"
                   min="0"
-                  step="0.01"
+                  step={contractCurrencyEnabled ? String(1 / rateMinorUnitFactor) : '0.01'}
                   value={customRate}
                   onChange={(e) => setCustomRate(e.target.value)}
                   className="pl-10 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-                  placeholder={t('pricingSchedules.dialog.fields.customRatePlaceholder', { defaultValue: '0.00' })}
+                  placeholder={contractCurrencyEnabled
+                    ? (0).toFixed(rateFractionDigits)
+                    : t('pricingSchedules.dialog.fields.customRatePlaceholder', { defaultValue: '0.00' })}
                 />
               </div>
             </div>

--- a/packages/billing/src/components/billing-dashboard/contracts/PricingScheduleDialog.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/PricingScheduleDialog.tsx
@@ -8,6 +8,7 @@ import { Input } from '@alga-psa/ui/components/Input';
 import { TextArea } from '@alga-psa/ui/components/TextArea';
 import { DatePicker } from '@alga-psa/ui/components/DatePicker';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
+import { Skeleton } from '@alga-psa/ui/components/Skeleton';
 import { IContractPricingSchedule } from '@alga-psa/types';
 import {
   createPricingSchedule,
@@ -365,23 +366,30 @@ export function PricingScheduleDialog({
                 {t('pricingSchedules.dialog.fields.customRate', { defaultValue: 'Custom Rate' })} *
               </Label>
               <div className="relative">
+                {/* While the flag is unresolved no currency semantics may be
+                    shown — not even the legacy ambient ones. */}
                 <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground">
-                  {contractCurrencyEnabled ? symbol(currencyCode) : symbol()}
+                  {flagLoading
+                    ? <Skeleton className="h-4 w-4" />
+                    : contractCurrencyEnabled ? symbol(currencyCode) : symbol()}
                 </span>
                 <Input
                   id="custom-rate"
                   type="number"
                   min="0"
-                  step={contractCurrencyEnabled ? String(1 / rateMinorUnitFactor) : '0.01'}
+                  step={flagLoading ? 'any' : contractCurrencyEnabled ? String(1 / rateMinorUnitFactor) : '0.01'}
                   value={customRate}
+                  disabled={flagLoading}
                   onChange={(e) => {
                     userEditedRateRef.current = true;
                     setCustomRate(e.target.value);
                   }}
                   className="pl-10 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-                  placeholder={contractCurrencyEnabled
-                    ? (0).toFixed(rateFractionDigits)
-                    : t('pricingSchedules.dialog.fields.customRatePlaceholder', { defaultValue: '0.00' })}
+                  placeholder={flagLoading
+                    ? ''
+                    : contractCurrencyEnabled
+                      ? (0).toFixed(rateFractionDigits)
+                      : t('pricingSchedules.dialog.fields.customRatePlaceholder', { defaultValue: '0.00' })}
                 />
               </div>
             </div>

--- a/packages/billing/src/components/billing-dashboard/contracts/PricingSchedules.contract.test.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/PricingSchedules.contract.test.tsx
@@ -69,6 +69,10 @@ vi.mock('@alga-psa/ui/components/DropdownMenu', () => ({
   DropdownMenuItem: ({ children }: any) => <div>{children}</div>,
 }));
 
+vi.mock('@alga-psa/ui/components/Skeleton', () => ({
+  Skeleton: () => <div data-testid="custom-rate-skeleton" />,
+}));
+
 import type { IContractPricingSchedule } from '@alga-psa/types';
 import { CurrencyFormatProvider } from '@alga-psa/ui/lib';
 import PricingSchedules from './PricingSchedules';
@@ -89,11 +93,18 @@ function schedule(overrides: Partial<IContractPricingSchedule> = {}): IContractP
 }
 
 function renderList(props: { currencyCode?: string } = {}) {
-  return render(
+  const tree = () => (
     <CurrencyFormatProvider currencyCode="USD">
       <PricingSchedules contractId="contract-1" currencyCode={props.currencyCode} />
     </CurrencyFormatProvider>
   );
+  const utils = render(tree());
+  return {
+    ...utils,
+    // Re-render the same tree so the component re-reads the (mutated) mocked
+    // feature-flag state — simulates a late flag resolution.
+    rerenderList: () => utils.rerender(tree()),
+  };
 }
 
 describe('PricingSchedules contract-currency custom rate (release-v1.5-feature)', () => {
@@ -137,5 +148,45 @@ describe('PricingSchedules contract-currency custom rate (release-v1.5-feature)'
 
     expect((await screen.findAllByText('$50.00')).length).toBeGreaterThanOrEqual(1);
     expect(screen.queryByText('¥5,000')).not.toBeInTheDocument();
+  });
+
+  it('flag loading: shows the neutral placeholder instead of any formatted value, then resolves flag-on', async () => {
+    featureFlagState.loading = true;
+    featureFlagState.enabled = false;
+    getPricingSchedulesByContractMock.mockResolvedValue([schedule({ custom_rate: 5000 })]);
+
+    const { rerenderList } = renderList({ currencyCode: 'JPY' });
+
+    // Once the rows arrive, both the timeline and the table cell render the
+    // neutral skeleton for the custom rate.
+    expect((await screen.findAllByTestId('custom-rate-skeleton')).length).toBe(2);
+    // While the flag is unresolved the stored minor units must not be rendered
+    // through the ambient-USD /100 formatting (nor the contract currency).
+    expect(screen.queryByText('$50.00')).not.toBeInTheDocument();
+    expect(screen.queryByText('¥5,000')).not.toBeInTheDocument();
+
+    featureFlagState.loading = false;
+    featureFlagState.enabled = true;
+    rerenderList();
+
+    expect((await screen.findAllByText('¥5,000')).length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByTestId('custom-rate-skeleton')).not.toBeInTheDocument();
+  });
+
+  it('flag loading: keeps the custom rate neutral until the flag resolves to the flag-off legacy rendering', async () => {
+    featureFlagState.loading = true;
+    featureFlagState.enabled = false;
+    getPricingSchedulesByContractMock.mockResolvedValue([schedule({ custom_rate: 5000 })]);
+
+    const { rerenderList } = renderList({ currencyCode: 'JPY' });
+
+    expect((await screen.findAllByTestId('custom-rate-skeleton')).length).toBe(2);
+    expect(screen.queryByText('$50.00')).not.toBeInTheDocument();
+
+    featureFlagState.loading = false;
+    rerenderList();
+
+    expect((await screen.findAllByText('$50.00')).length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByTestId('custom-rate-skeleton')).not.toBeInTheDocument();
   });
 });

--- a/packages/billing/src/components/billing-dashboard/contracts/PricingSchedules.contract.test.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/PricingSchedules.contract.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Hoisted mocks
+// ──────────────────────────────────────────────────────────────────────────────
+const featureFlagState = vi.hoisted(() => ({
+  enabled: false,
+  loading: false,
+  error: null as Error | null,
+}));
+
+const getPricingSchedulesByContractMock = vi.hoisted(() => vi.fn());
+const deletePricingScheduleMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@alga-psa/ui/hooks', () => ({
+  useFeatureFlag: () => featureFlagState,
+}));
+
+vi.mock('@alga-psa/billing/actions/contractPricingScheduleActions', () => ({
+  getPricingSchedulesByContract: async (...args: unknown[]) => getPricingSchedulesByContractMock(...args),
+  deletePricingSchedule: async (...args: unknown[]) => deletePricingScheduleMock(...args),
+}));
+
+vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
+  useOptionalI18n: () => null,
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | ({ defaultValue?: string } & Record<string, unknown>)) => {
+      if (!fallback) return key;
+      if (typeof fallback === 'string') return fallback;
+      const base = typeof fallback.defaultValue === 'string' ? fallback.defaultValue : key;
+      return base.replace(/\{\{(\w+)\}\}/g, (_, name: string) => String(fallback[name] ?? ''));
+    },
+  }),
+  useFormatters: () => ({ locale: 'en-US' }),
+}));
+
+vi.mock('./PricingScheduleDialog', () => ({
+  PricingScheduleDialog: () => null,
+}));
+
+vi.mock('@alga-psa/ui/components/DataTable', () => ({
+  DataTable: ({ data, columns }: any) => (
+    <table>
+      <tbody>
+        {data.map((row: any, rowIndex: number) => (
+          <tr key={rowIndex}>
+            {columns.map((column: any, columnIndex: number) => (
+              <td key={columnIndex}>
+                {column.render ? column.render(row[column.dataIndex], row) : row[column.dataIndex]}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  ),
+}));
+
+vi.mock('@alga-psa/ui/components/DropdownMenu', () => ({
+  DropdownMenu: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuItem: ({ children }: any) => <div>{children}</div>,
+}));
+
+import type { IContractPricingSchedule } from '@alga-psa/types';
+import { CurrencyFormatProvider } from '@alga-psa/ui/lib';
+import PricingSchedules from './PricingSchedules';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ──────────────────────────────────────────────────────────────────────────────
+
+function schedule(overrides: Partial<IContractPricingSchedule> = {}): IContractPricingSchedule {
+  return {
+    tenant: 'tenant-1',
+    schedule_id: 'schedule-1',
+    contract_id: 'contract-1',
+    effective_date: '2026-01-01T00:00:00.000Z',
+    custom_rate: 12345,
+    ...overrides,
+  };
+}
+
+function renderList(props: { currencyCode?: string } = {}) {
+  return render(
+    <CurrencyFormatProvider currencyCode="USD">
+      <PricingSchedules contractId="contract-1" currencyCode={props.currencyCode} />
+    </CurrencyFormatProvider>
+  );
+}
+
+describe('PricingSchedules contract-currency custom rate (release-v1.5-feature)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    featureFlagState.enabled = false;
+    featureFlagState.loading = false;
+    featureFlagState.error = null;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('flag on: renders the custom rate in a two-decimal non-default contract currency (EUR)', async () => {
+    featureFlagState.enabled = true;
+    getPricingSchedulesByContractMock.mockResolvedValue([schedule({ custom_rate: 12345 })]);
+
+    renderList({ currencyCode: 'EUR' });
+
+    // Rate appears in both the timeline and the table.
+    expect((await screen.findAllByText('€123.45')).length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText('$123.45')).not.toBeInTheDocument();
+  });
+
+  it('flag on: renders a zero-decimal currency (JPY) from minor units without dividing by 100', async () => {
+    featureFlagState.enabled = true;
+    getPricingSchedulesByContractMock.mockResolvedValue([schedule({ custom_rate: 5000 })]);
+
+    renderList({ currencyCode: 'JPY' });
+
+    expect((await screen.findAllByText('¥5,000')).length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText('¥50')).not.toBeInTheDocument();
+  });
+
+  it('flag off: preserves the legacy ambient two-decimal rendering even when a contract currency is supplied', async () => {
+    featureFlagState.enabled = false;
+    getPricingSchedulesByContractMock.mockResolvedValue([schedule({ custom_rate: 5000 })]);
+
+    renderList({ currencyCode: 'JPY' });
+
+    expect((await screen.findAllByText('$50.00')).length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText('¥5,000')).not.toBeInTheDocument();
+  });
+});

--- a/packages/billing/src/components/billing-dashboard/contracts/PricingSchedules.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/PricingSchedules.tsx
@@ -23,6 +23,7 @@ import { PricingScheduleDialog } from './PricingScheduleDialog';
 import { formatCurrency } from '@alga-psa/core';
 import { toPlainDate } from '@alga-psa/core';
 import LoadingIndicator from '@alga-psa/ui/components/LoadingIndicator';
+import { Skeleton } from '@alga-psa/ui/components/Skeleton';
 import { useTranslation, useFormatters } from '@alga-psa/ui/lib/i18n/client';
 import { useCurrencyFormat } from '@alga-psa/ui/lib';
 import { useFeatureFlag } from '@alga-psa/ui/hooks';
@@ -43,12 +44,17 @@ const PricingSchedules: React.FC<PricingSchedulesProps> = ({ contractId, currenc
   const { t } = useTranslation('msp/contracts');
   const { locale } = useFormatters();
   const { money } = useCurrencyFormat();
-  const { enabled: contractCurrencyEnabled } = useFeatureFlag('release-v1.5-feature', {
+  const { enabled: contractCurrencyEnabled, loading: flagLoading } = useFeatureFlag('release-v1.5-feature', {
     defaultValue: false,
   });
   // Flag off preserves the legacy ambient-currency two-decimal rendering.
   const formatCustomRate = (minorUnits: number): string =>
     contractCurrencyEnabled ? money(minorUnits, currencyCode) : formatCurrency(minorUnits / 100);
+  // While the flag is unresolved the minor-unit interpretation is unknown, so
+  // the stored rate must never be formatted through any currency assumption
+  // (the legacy /100 ambient-USD rendering included) — show a neutral skeleton.
+  const renderCustomRateValue = (customRate: number): React.ReactNode =>
+    flagLoading ? <Skeleton className="inline-block h-4 w-16" /> : formatCustomRate(customRate);
   const [schedules, setSchedules] = useState<IContractPricingSchedule[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -151,7 +157,7 @@ const PricingSchedules: React.FC<PricingSchedulesProps> = ({ contractId, currenc
       title: t('pricingSchedules.list.columns.customRate', { defaultValue: 'Custom Rate' }),
       dataIndex: 'custom_rate',
       render: (value) => value !== undefined && value !== null
-        ? formatCustomRate(value as number)
+        ? renderCustomRateValue(value as number)
         : (
           <span className="text-muted-foreground">
             {t('pricingSchedules.list.values.useDefaultRate', { defaultValue: 'Use default rate' })}
@@ -292,7 +298,7 @@ const PricingSchedules: React.FC<PricingSchedulesProps> = ({ contractId, currenc
                                   <div className="text-sm text-muted-foreground mt-1 flex items-center">
                                     <Coins className="h-3 w-3 mr-1" />
                                     {schedule.custom_rate !== undefined && schedule.custom_rate !== null
-                                      ? formatCustomRate(schedule.custom_rate)
+                                      ? renderCustomRateValue(schedule.custom_rate)
                                       : t('pricingSchedules.list.values.defaultRate', { defaultValue: 'Default rate' })}
                                   </div>
                                 </div>

--- a/packages/billing/src/components/billing-dashboard/contracts/PricingSchedules.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/PricingSchedules.tsx
@@ -24,6 +24,8 @@ import { formatCurrency } from '@alga-psa/core';
 import { toPlainDate } from '@alga-psa/core';
 import LoadingIndicator from '@alga-psa/ui/components/LoadingIndicator';
 import { useTranslation, useFormatters } from '@alga-psa/ui/lib/i18n/client';
+import { useCurrencyFormat } from '@alga-psa/ui/lib';
+import { useFeatureFlag } from '@alga-psa/ui/hooks';
 import {
   getErrorMessage,
   isActionMessageError,
@@ -32,12 +34,21 @@ import {
 
 interface PricingSchedulesProps {
   contractId: string;
+  /** Currency the owning contract is denominated in; custom_rate is stored in its minor units. */
+  currencyCode?: string;
   isReadOnly?: boolean;
 }
 
-const PricingSchedules: React.FC<PricingSchedulesProps> = ({ contractId, isReadOnly = false }) => {
+const PricingSchedules: React.FC<PricingSchedulesProps> = ({ contractId, currencyCode, isReadOnly = false }) => {
   const { t } = useTranslation('msp/contracts');
   const { locale } = useFormatters();
+  const { money } = useCurrencyFormat();
+  const { enabled: contractCurrencyEnabled } = useFeatureFlag('release-v1.5-feature', {
+    defaultValue: false,
+  });
+  // Flag off preserves the legacy ambient-currency two-decimal rendering.
+  const formatCustomRate = (minorUnits: number): string =>
+    contractCurrencyEnabled ? money(minorUnits, currencyCode) : formatCurrency(minorUnits / 100);
   const [schedules, setSchedules] = useState<IContractPricingSchedule[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -140,7 +151,7 @@ const PricingSchedules: React.FC<PricingSchedulesProps> = ({ contractId, isReadO
       title: t('pricingSchedules.list.columns.customRate', { defaultValue: 'Custom Rate' }),
       dataIndex: 'custom_rate',
       render: (value) => value !== undefined && value !== null
-        ? formatCurrency(value / 100)
+        ? formatCustomRate(value as number)
         : (
           <span className="text-muted-foreground">
             {t('pricingSchedules.list.values.useDefaultRate', { defaultValue: 'Use default rate' })}
@@ -281,7 +292,7 @@ const PricingSchedules: React.FC<PricingSchedulesProps> = ({ contractId, isReadO
                                   <div className="text-sm text-muted-foreground mt-1 flex items-center">
                                     <Coins className="h-3 w-3 mr-1" />
                                     {schedule.custom_rate !== undefined && schedule.custom_rate !== null
-                                      ? formatCurrency(schedule.custom_rate / 100)
+                                      ? formatCustomRate(schedule.custom_rate)
                                       : t('pricingSchedules.list.values.defaultRate', { defaultValue: 'Default rate' })}
                                   </div>
                                 </div>
@@ -315,9 +326,10 @@ const PricingSchedules: React.FC<PricingSchedulesProps> = ({ contractId, isReadO
       </Card>
 
       {showDialog && !isReadOnly && (
-          <PricingScheduleDialog 
+          <PricingScheduleDialog
             contractId={contractId}
             schedule={editingSchedule}
+            currencyCode={currencyCode}
             onClose={handleDialogClose}
             onSave={handleSaveSuccess}
           />

--- a/packages/types/src/interfaces/contract.interfaces.ts
+++ b/packages/types/src/interfaces/contract.interfaces.ts
@@ -167,7 +167,8 @@ export interface IContractPricingSchedule extends TenantEntity {
   end_date?: ISO8601String | null;
   duration_value?: number;
   duration_unit?: 'days' | 'weeks' | 'months' | 'years';
-  custom_rate?: number;
+  /** Integer minor-unit amount; explicit null clears the rate back to the contract default. */
+  custom_rate?: number | null;
   notes?: string;
   created_at?: ISO8601String;
   updated_at?: ISO8601String;

--- a/server/public/locales/de/msp/contracts.json
+++ b/server/public/locales/de/msp/contracts.json
@@ -826,6 +826,7 @@
         "editPricingSchedule": "Preisplan bearbeiten"
       },
       "validation": {
+        "currencySettingsLoading": "Währungseinstellungen werden noch geladen; bitte versuchen Sie es gleich erneut",
         "customRatePositive": "Benutzerdefinierter Tarif muss eine positive Zahl sein",
         "customRateRequired": "Benutzerdefinierter Tarif ist erforderlich, wenn der Standardtarif nicht verwendet wird",
         "durationPositive": "Dauer muss eine positive Zahl sein",

--- a/server/public/locales/en/msp/contracts.json
+++ b/server/public/locales/en/msp/contracts.json
@@ -826,6 +826,7 @@
         "editPricingSchedule": "Edit Pricing Schedule"
       },
       "validation": {
+        "currencySettingsLoading": "Currency settings are still loading; try again in a moment",
         "customRatePositive": "Custom rate must be a positive number",
         "customRateRequired": "Custom rate is required when not using default rate",
         "durationPositive": "Duration must be a positive number",

--- a/server/public/locales/es/msp/contracts.json
+++ b/server/public/locales/es/msp/contracts.json
@@ -826,6 +826,7 @@
         "editPricingSchedule": "Editar programa de precios"
       },
       "validation": {
+        "currencySettingsLoading": "La configuración de moneda aún se está cargando; inténtelo de nuevo en un momento",
         "customRatePositive": "La tarifa personalizada debe ser un número positivo",
         "customRateRequired": "La tarifa personalizada es obligatoria cuando no se usa la tarifa predeterminada",
         "durationPositive": "La duración debe ser un número positivo",

--- a/server/public/locales/fr/msp/contracts.json
+++ b/server/public/locales/fr/msp/contracts.json
@@ -826,6 +826,7 @@
         "editPricingSchedule": "Modifier le barème de prix"
       },
       "validation": {
+        "currencySettingsLoading": "Les paramètres de devise sont encore en cours de chargement ; réessayez dans un instant",
         "customRatePositive": "Le tarif personnalisé doit être un nombre positif",
         "customRateRequired": "Le tarif personnalisé est requis lorsque le tarif par défaut n'est pas utilisé",
         "durationPositive": "La durée doit être un nombre positif",

--- a/server/public/locales/it/msp/contracts.json
+++ b/server/public/locales/it/msp/contracts.json
@@ -826,6 +826,7 @@
         "editPricingSchedule": "Modifica pianificazione dei prezzi"
       },
       "validation": {
+        "currencySettingsLoading": "Le impostazioni della valuta sono ancora in caricamento; riprova tra un momento",
         "customRatePositive": "La tariffa personalizzata deve essere un numero positivo",
         "customRateRequired": "La tariffa personalizzata è obbligatoria quando non si utilizza la tariffa predefinita",
         "durationPositive": "La durata deve essere un numero positivo",

--- a/server/public/locales/nl/msp/contracts.json
+++ b/server/public/locales/nl/msp/contracts.json
@@ -826,6 +826,7 @@
         "editPricingSchedule": "Prijsschema bewerken"
       },
       "validation": {
+        "currencySettingsLoading": "Valuta-instellingen worden nog geladen; probeer het zo opnieuw",
         "customRatePositive": "Aangepast tarief moet een positief getal zijn",
         "customRateRequired": "Aangepast tarief is vereist wanneer het standaardtarief niet wordt gebruikt",
         "durationPositive": "Duur moet een positief getal zijn",

--- a/server/public/locales/pl/msp/contracts.json
+++ b/server/public/locales/pl/msp/contracts.json
@@ -826,6 +826,7 @@
         "editPricingSchedule": "Edytuj harmonogram cenowy"
       },
       "validation": {
+        "currencySettingsLoading": "Ustawienia waluty wciąż się ładują; spróbuj ponownie za chwilę",
         "customRatePositive": "Stawka niestandardowa musi być liczbą dodatnią",
         "customRateRequired": "Stawka niestandardowa jest wymagana, gdy nie używana jest stawka domyślna",
         "durationPositive": "Czas trwania musi być liczbą dodatnią",

--- a/server/public/locales/pt/msp/contracts.json
+++ b/server/public/locales/pt/msp/contracts.json
@@ -826,6 +826,7 @@
         "editPricingSchedule": "Editar tabela de preços"
       },
       "validation": {
+        "currencySettingsLoading": "As configurações de moeda ainda estão a carregar; tente novamente num instante",
         "customRatePositive": "A taxa personalizada precisa ser um número positivo",
         "customRateRequired": "A taxa personalizada é obrigatória quando não se usa a taxa padrão",
         "durationPositive": "A duração precisa ser um número positivo",

--- a/server/public/locales/xx/msp/contracts.json
+++ b/server/public/locales/xx/msp/contracts.json
@@ -826,6 +826,7 @@
         "editPricingSchedule": "11111"
       },
       "validation": {
+        "currencySettingsLoading": "11111",
         "customRatePositive": "11111",
         "customRateRequired": "11111",
         "durationPositive": "11111",

--- a/server/public/locales/yy/msp/contracts.json
+++ b/server/public/locales/yy/msp/contracts.json
@@ -826,6 +826,7 @@
         "editPricingSchedule": "55555"
       },
       "validation": {
+        "currencySettingsLoading": "55555",
         "customRatePositive": "55555",
         "customRateRequired": "55555",
         "durationPositive": "55555",


### PR DESCRIPTION
## 29.8.42 — "Custom Rate" in Pricing Schedule for Contracts needs to be multi-currency

Makes contract pricing-schedule custom rates currency-correct instead of always interpreting them through the legacy ambient-currency, two-decimal path. `custom_rate` remains an integer minor-unit amount inherited from the owning contract currency; this does not add a per-schedule currency or conversion layer. All changed user-visible behavior is gated by `release-v1.5-feature`, and the flag-off path preserves the existing UI and submission behavior.

### What changed

- Threads the owning contract's `currencyMeta.currencyCode` from `ContractDetail` through `PricingSchedules` into `PricingScheduleDialog`.
- With the flag on, renders stored minor units using `useCurrencyFormat().money(...)`, and derives the editor symbol, decimal precision, step, and minor-unit factor from the contract currency.
- With the flag off, preserves the legacy ambient-currency rendering and two-decimal `/100` submission semantics.
- Keeps the rate display and input currency-neutral while the feature flag is unresolved. Both Save-button and direct form/Enter submission paths are blocked until it resolves, and late resolution cannot overwrite user input.
- Sends `custom_rate: null` explicitly when resetting to the contract default, because Knex drops `undefined` updates.
- Validates create/update payloads so `custom_rate` is null or a non-negative integer minor-unit amount.
- Widens the shared contract pricing-schedule type to represent the explicit-null reset.
- Adds the loading-validation translation to all locale packs.

### Automated coverage

- Action tests cover rejected fractional/negative values, accepted integer minor units, and explicit-null persistence.
- Dialog component tests cover EUR two-decimal and JPY zero-decimal round trips, explicit-null reset, flag-off legacy behavior, and all unresolved-flag submission/race guards.
- Pricing-schedule component tests cover flag-on EUR/JPY rendering, flag-off legacy rendering, and neutral unresolved-flag rendering.

### Smoke test — PASS on current HEAD `172cbb6c11`

Evidence: `/tmp/alga-smoke-evidence/task-29-8-42-custom-rate-multi-currency-20260815-103404`

- **Flag on, EUR:** `€98.76` rendered with two decimals; the editor used `€` and step `0.01`. Edited to `€101.23` and verified PostgreSQL stored `10123`.
- **Flag on, JPY:** `¥12,345` rendered with zero decimals; the editor used `¥` and step `1`. Edited to `¥23,456` and verified PostgreSQL stored `23456`.
- **Default-rate reset:** reset the EUR custom rate, verified the UI showed *Default rate*, and verified PostgreSQL stored `NULL`.
- **Flag-off regression:** JPY preserved the legacy ambient-USD/two-decimal behavior. `$234.56` was edited to `$345.67`, and PostgreSQL stored `34567`.
- Restored fixtures to EUR `9876` and JPY `12345`. The worktree is clean, compose dependencies are running, and the original flag-on production bundle is answering on port `3018` under the durable dev-server service.

### Fidelity notes

The card browser pane was hidden/zero-height, so trusted typing used alga-dev while row/save interactions required its documented mounted-React fallback. Screenshots were captured afterward with a separate real headless Chrome session. Flag-off required an isolated exact-source production build with the flag forced false because the normal bundle forces it true. No simulator or mock was used.

The brief unresolved-feature-flag loading state was not live-induced because compile-time forced flags resolve immediately in these production bundles. The handler-level loading guard remains covered by the component tests, but this race was not directly exercised in the live smoke test.

Observed noise was limited to Hocuspocus/polling connection errors caused by the remote browser route and deliberate runtime swaps. No pricing mutation failed, and persistence was independently verified in PostgreSQL.
