### PR TITLE
Auto-pause inbound email providers on repeated auth failures

### DIFF
--- a/docs/plans/2026-08-15-auto-pause-inbound-auth-failures-plan.md
+++ b/docs/plans/2026-08-15-auto-pause-inbound-auth-failures-plan.md
@@ -1,0 +1,149 @@
+# Auto-pause inbound email providers on repeated auth failures
+
+## Goal
+
+Stop retrying credentials that cannot recover by themselves, without turning a noisy mailbox into a silently dead mailbox. After a small number of consecutive, explicitly classified auth failures, pause inbound ingestion through the existing lifecycle service, notify active tenant admins, show a persistent reconnect banner, and make a successful reconnect resume ingestion only with a reconciliation of the paused interval.
+
+## Grounded constraints
+
+- `shared/services/email/EmailProviderLifecycleService.ts` already owns the authoritative pause transition, tears down Graph/Gmail notification sources, and exposes resume behavior. Extend it instead of adding another pause gate.
+- `shared/services/email/unifiedInboundEmailQueueJobProcessor.ts` is the common point where Microsoft, Google, and IMAP source access either succeeds or throws. Count/reset auth outcomes here; downstream ticket-processing errors are not credential failures.
+- The queue processor and maintenance queries already honor `email_providers.inbound_paused_at`. A retry after the pause transition will therefore become `provider_paused` instead of another DLQ attempt.
+- Adapter errors retain structured metadata (`status`, `code`, `responseBody`, IMAP auth flags). Classification must use those fields and a narrow allowlist, not a broad message substring such as `401` or `auth`.
+- `packages/integrations/src/components/email/EmailProviderCard.tsx` already renders paused state and exposes pause/resume actions. The automatic case needs stronger copy and a reconnect action, not another settings surface.
+- `EmailWebhookMaintenanceService.reconcileMissedMessages` already supplies the Microsoft missed-message algorithm and durable dedupe behavior, but it is private and renewal-oriented. Extract a callable resume reconciliation entry point rather than duplicating it.
+- `package-lock.json` is already modified by Wire Up. Do not include it in any implementation or plan commit.
+
+## Design decisions
+
+### 1. One strict classifier and one provider-level counter
+
+Add a provider-neutral auth policy module under `shared/services/email/`, for example `InboundEmailAuthFailurePolicy.ts`.
+
+It should return either `unrecoverable_auth` with a safe reason code or `not_unrecoverable` from the provider type plus the structured error:
+
+- Microsoft: token-refresh context with OAuth `invalid_client`, or `invalid_grant` including the known revoked/expired grant cases such as `AADSTS50173`.
+- Google: OAuth `invalid_grant`; preserve `error_subtype` such as `invalid_rapt` as a safe reason code.
+- IMAP password/OAuth: `authenticationFailed`, `AUTHENTICATIONFAILED`, or the existing explicit invalid-credentials response; OAuth token endpoint `invalid_client`/`invalid_grant` is also unrecoverable.
+- Never classify 429, 5xx, timeouts, DNS/socket failures, webhook validation failures, Graph 403/404, or downstream ticket-processing exceptions as unrecoverable auth.
+
+Use a fixed threshold of three consecutive unrecoverable source-access failures. Keep the threshold exported and testable; do not make it an environment variable in this first version.
+
+Add nullable/defaulted columns to `email_providers` in a new `server/migrations/*.cjs` migration:
+
+- `inbound_auth_failure_count integer not null default 0`
+- `inbound_auth_failure_last_at timestamptz null`
+- `inbound_auth_failure_code text null`
+
+This is an additive alter on a tenant-distributed table, with no uniqueness or constraint build. It must remain valid on plain Postgres and Citus; no Citus-only call or parent-heap cleanup is needed.
+
+### 2. Make the pause transition atomic and idempotent
+
+Extend `EmailProviderLifecycleService` with two outcome methods:
+
+- `recordSourceAccessSuccess(providerId, tenant)` resets the three auth-failure fields, even when the fetched pointer contains no new messages.
+- `recordUnrecoverableAuthFailure(providerId, tenant, safeCode)` locks the provider row in a tenant-scoped transaction, increments the counter, and on the threshold atomically sets `inbound_paused_at`, `inbound_pause_reason = 'auth_failure'`, status/error metadata, and returns a one-time `autoPaused` result.
+
+Only the transaction that changes an unpaused row to paused may run subscription teardown and send notifications. Concurrent failing jobs must observe the already-paused row and must not tear down twice or notify twice. Keep manual `pauseProvider` behavior unchanged.
+
+Widen `InboundPauseReason` and every public/interface copy from `'manual' | 'tenant_cancelled'` to include `'auth_failure'` in:
+
+- `shared/services/email/EmailProviderLifecycleService.ts`
+- `shared/interfaces/inbound-email.interfaces.ts`
+- `server/src/interfaces/email.interfaces.ts`
+- `packages/types/src/interfaces/email.interfaces.ts`
+- `packages/integrations/src/components/email/types.ts`
+- any mapped service/interface duplicate found by TypeScript.
+
+### 3. Record outcomes only around source access
+
+In `processUnifiedInboundEmailQueueJob`:
+
+1. Keep the existing paused/inactive gate first.
+2. Wrap `fetchEmailPayloadsForJob(job)` with the classifier.
+3. On classified unrecoverable auth, record the failure and rethrow the original error. The current queue retry policy remains authoritative; if the threshold was crossed, the next attempt is stopped by the pause gate.
+4. On every successful return from `fetchEmailPayloadsForJob`—including an empty result—reset the consecutive counter before downstream ticket processing.
+5. Do not change the counter for source-message-not-found, transient provider errors, parsing errors, or application/ticket failures.
+
+Also route Microsoft polling/renewal auth failures in `EmailWebhookMaintenanceService` through the same classifier/outcome service. Successful token health checks reset the counter. This covers providers whose subscription has gone quiet and therefore no longer receives pointer jobs.
+
+### 4. Persist one admin notification per automatic pause
+
+Add a small notification helper in the email integration/service layer. Reuse the established pattern from `packages/billing/src/services/accountingSync/syncNotificationService.ts`:
+
+- enumerate active internal users whose role name is `admin` (and `owner` if that role is present in the tenant model);
+- create one `system-announcement` internal notification per recipient with `createNotificationFromTemplateInternal`;
+- include the mailbox/provider name, a safe auth reason, the instruction that reconnection is required, and link to `/msp/settings?tab=email`;
+- never include tokens, client secrets, raw OAuth responses, or tenant/provider credentials in notification data.
+
+Notification delivery happens only after the atomic pause commit. Treat per-recipient delivery failure as observable/best-effort and log tenant/provider/user identifiers plus the safe code; never roll back the pause or expose secrets. The persistent settings banner is the durable fallback.
+
+### 5. Make the automatic-pause banner actionable
+
+Update `EmailProviderCard` and its English locale strings:
+
+- Manual/tenant-cancelled pauses keep the current neutral help text and Resume menu action.
+- `auth_failure` renders a destructive, persistent alert that says inbound mail is paused, names the mailbox, explains that credentials no longer work, and tells the user mail remains in the source mailbox.
+- Put a visible `Reconnect` button inside the alert. Dispatch to the existing provider-specific reconnect/edit flow: Microsoft/Google setup flow, IMAP OAuth reconnect when applicable, otherwise edit credentials.
+- Do not offer a bare Resume action for `auth_failure`; resuming dead credentials would recreate the alert loop.
+- Preserve stable element ids for behavioral UI tests and accessibility.
+
+Thread the reconnect callback through `EmailProviderList` / `EmailProviderConfiguration` rather than placing provider-specific OAuth logic in the card.
+
+### 6. Reconnect, then resume, then reconcile
+
+Refactor resume into an explicit recovery path for `auth_failure` while keeping manual resume compatible:
+
+1. Preserve the original `inbound_paused_at` and old vendor cursor before any subscription/watch registration overwrites it.
+2. Validate the new credentials while the ingestion pause is still active.
+3. Re-establish the provider notification source.
+4. Reconcile from the saved pause boundary with the existing durable dedupe path.
+5. Only report success after the reconciliation handoff is durable; then clear the pause and auth-failure fields. If credential validation or reconciliation setup fails, leave/reinstate the pause and return a reconnect-required error.
+
+Provider-specific reuse:
+
+- Microsoft: expose a public, bounded `reconcileProviderMessages` wrapper around the existing `EmailWebhookMaintenanceService` algorithm, accepting an explicit `since` boundary. Preserve its safety margin, cursor lock, overflow handling, and durable ingress behavior.
+- Google: retain the pre-watch `history_id`, list changes from that cursor before replacing it with the new watch cursor, and enqueue the resulting message ids through the unified durable path. If Gmail rejects the old cursor, fall back to a mailbox query bounded by `inbound_paused_at` rather than silently accepting a gap.
+- IMAP: reuse the existing resync contract by clearing UID/folder cursors only after credentials validate, so the poller scans the mailbox again and normal dedupe suppresses already-processed mail.
+
+Update every successful reconnect path (Microsoft/Google setup automation, IMAP OAuth/credential update, and successful connection test) to invoke this recovery path when `inbound_pause_reason === 'auth_failure'`. Do not double-register a webhook by running both ordinary setup automation and resume registration.
+
+The return value should distinguish `resumed`, `webhookRegistered`, and `reconciliationStarted`/`reconciliationCompleted` so the settings UI cannot toast success when the mailbox is still paused.
+
+## Implementation sequence
+
+1. Add the additive migration and widen pause-reason types.
+2. Implement and unit-test strict error classification.
+3. Add transactional counter/reset/auto-pause methods to `EmailProviderLifecycleService`, including one-shot teardown and admin notification.
+4. Integrate the source-fetch and Microsoft-maintenance outcome hooks.
+5. Extract provider-specific resume reconciliation and wire successful reconnect paths to it.
+6. Add the automatic-pause banner/reconnect behavior and locale copy.
+7. Run focused tests, typecheck/build, then perform the local behavioral smoke.
+
+## Behavioral tests
+
+- Classifier table tests cover each allowed terminal auth shape and prove that 429, 5xx, timeout, Graph permission/not-found, webhook validation, parsing, and downstream processing errors do not count.
+- Lifecycle integration test: two classified failures keep the provider active; the third atomically pauses it, stores `auth_failure`, tears down once, and creates exactly one notification per active admin even with concurrent failures.
+- Processor integration test: a successful source fetch resets a prior count even when it returns no messages; a later downstream ticket failure does not increment the auth counter.
+- Maintenance test: repeated Microsoft token-health `invalid_client` failures use the same counter; a successful token-health check resets it.
+- Resume tests for Microsoft, Google, and IMAP prove the pause remains on failed credential validation, the saved pause cursor is used, successful reconciliation clears the pause, and repeated reconciliation is deduped.
+- UI tests render an `auth_failure` provider, assert the destructive reconnect banner and provider-specific callback, and assert that a bare Resume action is unavailable. Manual pause behavior remains unchanged.
+- Migration coverage should apply the migration to a test database and inspect runtime column/default behavior. Do not add source-string/import-presence tests.
+
+## Smoke test
+
+In the running worktree stack, use a disposable provider and tenant admin:
+
+1. Make the provider return a known terminal auth failure and enqueue distinct inbound pointers until the threshold is crossed.
+2. Verify `inbound_paused_at`, reason, count/code, subscription/watch teardown, queue-gate skip, one notification, and the reconnect banner.
+3. Confirm a simulated 429/timeout never increments or pauses.
+4. Repair credentials and reconnect through the settings UI.
+5. Deliver mail during the paused interval, then verify resume clears the banner, recreates delivery, and the reconciliation sweep imports that mail exactly once.
+6. Repeat for one OAuth provider and IMAP; record screenshots and database/queue evidence without secrets.
+
+## Non-goals
+
+- Manually pausing the production EQUIT provider.
+- Draining the existing DLQ backlog.
+- Changing Grafana alert labels or alert routing.
+- Building a second ingestion gate or a new notification framework.

--- a/docs/plans/auth-pause-review-guide.md
+++ b/docs/plans/auth-pause-review-guide.md
@@ -1,0 +1,129 @@
+# Auth-Pause Draft-Review Guide (bounded verification)
+
+This guide bounds a draft-review pass to **exactly three defect claims and six
+regression tests** — the concurrency fixes in commit `2e861ac53b` ("fix(email):
+close three concurrency defects in auth-failure auto-pause"). Verification is
+**limited to the claims and tests named below. Repository-wide searching,
+re-deriving the feature, auditing unrelated diffs, and running broader suites
+are out of scope** for this pass.
+
+Companion plan: `docs/plans/2026-08-15-auto-pause-inbound-auth-failures-plan.md`.
+
+## 1. Orient (run these, and only these)
+
+```bash
+git status                                  # expect: clean working tree
+git log --oneline main..HEAD               # confirm HEAD is 2e861ac53b or a descendant
+git diff main...HEAD --stat -- . ':(exclude)package-lock.json'
+```
+
+The branch is 6 commits ahead of `main` (`8f0a09cc5d` plan → `ef7bda6be7` feature
+→ three hardening fixes → `2e861ac53b`). `package-lock.json` churn is excluded
+from review scope by policy; nothing else is excluded. Do not expand the diff
+scope beyond these commands.
+
+## 2. The three claims, with their implementing code
+
+Every path below is verified against this tree. Read these functions; do not
+grep beyond them.
+
+### Claim 1 — Capped-sweep starvation + pause-snapshot race
+
+The capped sweep excludes paused providers **before** applying the LIMIT
+(paused rows can never occupy cap slots), and a failure racing a pause **parks**
+the ingress row non-terminal (`retryable_failed`, attempt budget reset to 0,
+~30 s backoff) instead of terminalizing it. Parked rows are re-driven by the
+first post-resume sweep because they stay due (`next_attempt_at` in the past).
+
+| What | Where |
+| --- | --- |
+| `sweepTenantDurableWork` — snapshots paused providers, passes them into the due scan, and consumes the guarded dead-letter outcome (`'parked_while_paused'` at line ~96) | `shared/services/email/inboundEmailRecovery.ts:56` (`excludeProviderIds` at :83, over-cap path at :94–95) |
+| `findDueIngress` — the exclusion is part of the row-selection predicate (`whereNotIn('provider_id', …)`), applied **before** `.limit()`, so paused rows cannot starve the cap | `shared/services/email/inboundEmailDurableStore.ts:1715` (predicate at :1722–1723) |
+| `deadletterIngress` — the over-cap terminal UPDATE is guarded by a NOT EXISTS over the provider's live pause state; when the guard blocks, the row is PARKED (`retryable_failed`, `attempt_count = 0`, `next_attempt_at = now()+30 s`) | `shared/services/email/inboundEmailDurableStore.ts:349` (`PAUSED_DEADLETTER_PARK_BACKOFF_MS = 30_000` at :333, park write at :378–390) |
+| `claimIngress` — keeps its early pause read and consumes the guarded outcome | `shared/services/email/inboundEmailDurableStore.ts:162` |
+| `parkIngressWhilePaused` — the staging-worker park (same non-terminal semantics) | `shared/services/email/inboundEmailDurableStore.ts:236` |
+| Staging worker park path — auth failure against a paused provider parks pre-claim | `shared/services/email/inboundEmailIngressStagingWorker.ts:213` (`PAUSED_INGRESS_PARK_BACKOFF_MS = 30_000` at :53) |
+
+### Claim 2 — Google `history_id` atomicity + monotonicity
+
+`google_email_provider_config.history_id` advances are single-statement
+compare-and-set UPDATEs — `(history_id IS NULL OR (history_id ~ <digits> AND
+history_id::bigint < candidate::bigint))` — so the comparison happens at the
+**persisted** value, not a snapshot read, and a slower stale worker can never
+regress the cursor. Both paths:
+
+| Path | Where |
+| --- | --- |
+| V2 staging worker cursor advance (CAS write) | `shared/services/email/inboundEmailIngressStagingWorker.ts:412` |
+| V1 `persistGoogleHistoryCursor` (CAS write, invoked from the job processor) | `shared/services/email/unifiedInboundEmailQueueJobProcessor.ts:688` (predicate at :704, call site at :1043) |
+| Fresh-watch baseline persist in `registerWebhookSubscription` — **intentionally authoritative, not monotonic** (a fresh watch's historyId is Gmail's own mailbox snapshot; the inline comment at ~line 317 explains why guarding it would strand a dead cursor) | `shared/services/email/providers/GmailAdapter.ts:207` (write at :332) |
+
+### Claim 3 — Microsoft lock mismatch returns remaining work
+
+A recovery reconcile pass that loses the Graph cursor lock reports
+`moreRemaining: true` (renewal passes keep the historical clean-skip), so the
+multi-pass auth-pause recovery loop runs another pass from the saved boundary
+instead of declaring the paused interval exhausted over messages that were
+never handed off. Coverage counts only monotonic markers: non-terminal ingress
+rows, settled legacy outcomes, and un-refuted caller-seeded `handedOffIds`.
+
+| What | Where |
+| --- | --- |
+| `reconcileProviderMessages` — public recovery entry (explicit `since` boundary + `handedOffIds`) | `shared/services/email/EmailWebhookMaintenanceService.ts:606` |
+| `reconcileMissedMessages` — the pass itself; lock-mismatch branch returns `moreRemaining: recoveryPass ? true : false` | `shared/services/email/EmailWebhookMaintenanceService.ts:679` (mismatch return at :939; coverage-marker rules documented at :713–731; `reviveTerminal: recoveryPass` at :851) |
+| `recoverAuthPausedProvider` — the multi-pass recovery loop that keeps looping while `moreRemaining` and clears the pause only after a completing pass | `shared/services/email/EmailProviderLifecycleService.ts:502` (loop check at :779) |
+| `reviveTerminal` handling — a terminally failed ingress is revived and re-handed-off rather than counted covered | `shared/services/email/inboundEmailProducer.ts:102` → `reviveTerminalIngress` at `shared/services/email/inboundEmailDurableStore.ts:276` |
+
+## 3. The six discriminating regression tests
+
+All six were verified to fail against the pre-`2e861ac53b` code (stash-proof
+run); each carries its pre-fix failure signal as an assertion in the test, so a
+reviewer can confirm the test discriminates by reading the highlighted
+"Pre-fix" comments.
+
+| # | Claim | Test (exact name) | File | Pre-fix failure signal |
+| --- | --- | --- | --- | --- |
+| 1 | Capped-sweep starvation | `sweep starvation: a paused provider's due ingress rows never consume the capped scan window of an unpaused provider` | `server/src/test/integration/inboundEmailDurableInbox.integration.test.ts:1925` | `sweep.enqueued.ingress` was **0** (paused rows filled the cap), must be **3** |
+| 2 | Pause-snapshot race | `sweep snapshot race: a provider pausing between the sweep snapshot and the over-cap dead-letter decision is parked, never terminalized` | `server/src/test/integration/inboundEmailDurableInbox.integration.test.ts:1988` | row ended **`terminal_failed`**, must stay parked (`retryable_failed`, `attempt_count` 0) |
+| 3 | Google CAS (V2 staging) | `google history cursor advance is an atomic compare-and-set: a slower stale writer cannot overwrite a newer cursor` | `server/src/test/integration/inboundEmailDurableInbox.integration.test.ts:2050` | cursor read back **'1500'** after the stale writer, must be **'9000'** |
+| 4 | MS lock mismatch (service) | `microsoft recovery reconcile: a cursor-lock mismatch mid-pass reports remaining work and hands off nothing` | `server/src/test/integration/inboundEmailDurableInbox.integration.test.ts:2128` | mismatch pass returned `moreRemaining` **false**, must be **true** |
+| 5 | MS lock mismatch (recovery lifecycle) | `auth-pause recovery survives a mid-recovery cursor-lock race: the pause clears only after a pass completes coverage` | `server/src/test/integration/inboundEmailDurableInbox.integration.test.ts:2187` | recovery "resumed" after **1** listing call, must loop to **2** |
+| 6 | Google monotonicity (V1) | `V1 google cursor persist is monotonic at write: a stale pointer job cannot regress the post-watch cursor` | `server/src/test/integration/inboundAuthPauseRecovery.integration.test.ts:549` | cursor regressed to **'1500'**, must stay **'9999'** |
+
+## 4. Running the six tests (the only test command to run)
+
+Run **from the `server/` directory** — vitest file filters are resolved against
+the server root, so passing `server/src/...` paths from the repo root yields
+"No test files found":
+
+```bash
+cd server
+NODE_OPTIONS=--max-old-space-size=8192 node_modules/.bin/vitest run \
+  --testNamePattern "sweep starvation|sweep snapshot race|google history cursor advance is an atomic|microsoft recovery reconcile: a cursor-lock mismatch|auth-pause recovery survives a mid-recovery|V1 google cursor persist is monotonic" \
+  src/test/integration/inboundEmailDurableInbox.integration.test.ts \
+  src/test/integration/inboundAuthPauseRecovery.integration.test.ts
+```
+
+Expected result: **`2 passed (2)` files, `6 passed | 64 skipped (70)` tests.**
+
+Host notes (this workstation):
+
+- Do **not** use root `npm run test:local` — its `dotenv` CLI bin is absent
+  here, so it fails before vitest starts.
+- The suites self-wire the database: they load the repo-root `.env.localtest`
+  and call `wireLocalTestDbEnv()` (`server/test-utils/dbConfig.ts`) to point at
+  the `alga-psa-local-test` Postgres exposed on `localhost:5472`.
+- The `alga-psa-local-test` compose stack must be up (Docker on this host
+  requires `sg docker -c "..."`; `docker ps | grep local-test` to confirm).
+- `NODE_OPTIONS=--max-old-space-size=8192` is required for heavier server
+  processes; the six tests themselves run comfortably (~20 s total).
+
+## 5. Verdict criteria
+
+- All six tests pass on the identified HEAD → the three defect claims hold;
+  the review verdict for this pass is **pass within scope**.
+- Any failure → report the failing test and its observed vs. expected value;
+  do not improvise fixes or widen the search in this pass.
+
+Anything not listed above — other features on the branch, UI, billing, other
+email paths, dependency hygiene — is out of scope for this review round.

--- a/ee/server/src/components/GmailProviderForm.tsx
+++ b/ee/server/src/components/GmailProviderForm.tsx
@@ -25,6 +25,10 @@ import { BasicConfigCard } from '@alga-psa/integrations/components/email/provide
 import { ProcessingSettingsCard } from '@alga-psa/integrations/components/email/providers/gmail/ProcessingSettingsCard';
 import { OAuthSection } from '@alga-psa/integrations/components/email/providers/gmail/OAuthSection';
 import { baseGmailProviderSchema } from '@alga-psa/integrations/components/email/providers/gmail/schemas';
+import {
+  getErrorMessage,
+  isActionMessageError,
+} from '@alga-psa/ui/lib/errorHandling';
 
 type EEGmailProviderFormData = import('@alga-psa/integrations/components').BaseGmailProviderFormData;
 
@@ -158,16 +162,28 @@ export function GmailProviderForm({
         ? await updateEmailProvider(provider.id, payload, false) // skipAutomation: false
         : await createEmailProvider(payload, false); // skipAutomation: false
 
-      // Check for setup errors or warnings
+      if (isActionMessageError(result)) {
+        setError(getErrorMessage(result));
+        return;
+      }
+
+      // A setup error (e.g. failed auth-pause recovery: the OAuth
+      // credentials were rejected or the Gmail watch could not be
+      // re-registered) means the reconnect did NOT succeed — the provider
+      // stays paused. Surface the error in the form and do not report
+      // success: closing the drawer would clear the paused-state banner
+      // while ingestion is still stopped.
       if (result.setupError) {
-        setError(t('gmailForm.warnings.setupIncomplete', { error: result.setupError }));
+        setError(t('forms.common.messages.setupIncomplete', {
+          defaultValue: 'Provider saved but setup incomplete: {{error}}',
+          error: result.setupError,
+        }));
+        return;
       }
       if (result.setupWarnings && result.setupWarnings.length > 0) {
         setSetupWarnings(result.setupWarnings);
       }
 
-      // Still call onSuccess so the provider appears in the list
-      // The user can see the error/warning state in the UI
       onSuccess(result.provider);
 
     } catch (err: any) {

--- a/ee/server/src/components/ImapProviderForm.tsx
+++ b/ee/server/src/components/ImapProviderForm.tsx
@@ -14,6 +14,10 @@ import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import type { EmailProvider } from '@alga-psa/integrations/components/email/types';
 import { createEmailProvider, updateEmailProvider } from '@alga-psa/integrations/actions/email-actions/emailProviderActions';
 import { getInboundTicketDefaults } from '@alga-psa/integrations/actions/email-actions/inboundTicketDefaultsActions';
+import {
+  getErrorMessage,
+  isActionMessageError,
+} from '@alga-psa/ui/lib/errorHandling';
 
 const eeImapProviderSchema = z.object({
   providerName: z.string().min(1, 'Configuration name is required'),
@@ -166,6 +170,24 @@ export function ImapProviderForm({
       const result = isEditing
         ? await updateEmailProvider(provider.id, payload, true)
         : await createEmailProvider(payload, true);
+
+      if (isActionMessageError(result)) {
+        setError(getErrorMessage(result));
+        return;
+      }
+
+      // A setup error (e.g. failed auth-pause recovery: the submitted
+      // credentials were rejected by the source) means the reconnect did NOT
+      // succeed — the provider stays paused. Surface the error in the form
+      // and do not report success: closing the drawer would clear the
+      // paused-state banner while ingestion is still stopped.
+      if (result.setupError) {
+        setError(t('forms.common.messages.setupIncomplete', {
+          defaultValue: 'Provider saved but setup incomplete: {{error}}',
+          error: result.setupError,
+        }));
+        return;
+      }
 
       onSuccess(result.provider);
     } catch (err: any) {

--- a/ee/temporal-workflows/src/worker.ts
+++ b/ee/temporal-workflows/src/worker.ts
@@ -14,6 +14,12 @@ import {
   getWorkerConfig,
   type WorkerConfig,
 } from "./workerConfig.js";
+import {
+  registerInboundAuthPauseEventPublisher,
+} from "@alga-psa/shared/services/email/inboundAuthPauseEventNotifier";
+import {
+  assertInboundAuthPauseNotifierRegistered,
+} from "@alga-psa/shared/services/email/inboundAuthPauseNotifier";
 
 // Load environment variables
 dotenv.config();
@@ -149,6 +155,14 @@ function startHealthCheck(): void {
 async function main(): Promise<void> {
   try {
     logger.info("Starting Temporal worker for non-authored/domain workflows");
+
+    // This runtime executes the Microsoft webhook-maintenance activities that
+    // can perform the atomic auth-failure auto-pause, but it cannot load the
+    // @alga-psa/notifications vertical (stubbed in this build graph): publish
+    // the pause on the event bus and let the server-side subscriber deliver
+    // the admin notifications (same hand-off as MAINTENANCE_JOB_REQUESTED).
+    registerInboundAuthPauseEventPublisher();
+    assertInboundAuthPauseNotifierRegistered("ee/temporal-workflows/worker");
 
     // Run startup validations
     try {

--- a/packages/event-schemas/src/schemas/domain/inboundEmailEventSchemas.ts
+++ b/packages/event-schemas/src/schemas/domain/inboundEmailEventSchemas.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+import { BaseDomainEventPayloadSchema } from './commonEventPayloadSchemas';
+
+// Emitted when an inbound email provider is automatically paused after repeated,
+// strictly classified unrecoverable auth failures. Worker-side runtimes (the
+// email-service container, the Temporal worker) cannot import the
+// @alga-psa/notifications vertical to deliver admin notifications in-process,
+// so the process that performed the atomic pause publishes this event and a
+// server-side subscriber creates the admin notifications where the domain
+// graph loads. Mirrors the MAINTENANCE_JOB_REQUESTED worker→server hand-off.
+export const inboundEmailProviderAutoPausedEventPayloadSchema = BaseDomainEventPayloadSchema.extend({
+  providerId: z.string().min(1).describe('Auto-paused email provider id'),
+  providerName: z.string().describe('Provider display name (safe, no credentials)'),
+  mailbox: z.string().describe('Monitored mailbox address'),
+  providerType: z.enum(['microsoft', 'google', 'imap']).describe('Provider type'),
+  authFailureCode: z.string().min(1).describe('Safe, sanitized classifier reason code'),
+  pausedAt: z.string().datetime().describe('ISO timestamp of the atomic pause transition'),
+}).describe('Payload for INBOUND_EMAIL_PROVIDER_AUTO_PAUSED');
+
+export type InboundEmailProviderAutoPausedEventPayload = z.infer<
+  typeof inboundEmailProviderAutoPausedEventPayloadSchema
+>;

--- a/packages/event-schemas/src/schemas/domain/index.ts
+++ b/packages/event-schemas/src/schemas/domain/index.ts
@@ -13,3 +13,4 @@ export * from './emailWorkflowSchemas';
 export * from './inventoryEventSchemas';
 export * from './commonEventPayloadSchemas';
 export * from './workflowEventPayloadSchemas';
+export * from './inboundEmailEventSchemas';

--- a/packages/event-schemas/src/schemas/eventBusSchema.ts
+++ b/packages/event-schemas/src/schemas/eventBusSchema.ts
@@ -140,6 +140,7 @@ import {
   mediaProcessingSucceededEventPayloadSchema,
 } from './domain/assetMediaEventSchemas';
 import { maintenanceJobRequestedEventPayloadSchema } from './domain/maintenanceEventSchemas';
+import { inboundEmailProviderAutoPausedEventPayloadSchema } from './domain/inboundEmailEventSchemas';
 import {
   ticketApprovalGrantedEventPayloadSchema,
   ticketApprovalRejectedEventPayloadSchema,
@@ -195,6 +196,9 @@ export const EVENT_TYPES = [
   'TICKET_AUTO_CLOSE_WARNING',
   // Maintenance / system (worker emits; server subscriber runs the handler)
   'MAINTENANCE_JOB_REQUESTED',
+  // Inbound email (worker emits after atomic auth-failure auto-pause; server
+  // subscriber delivers admin notifications)
+  'INBOUND_EMAIL_PROVIDER_AUTO_PAUSED',
   'TICKET_ASSIGNED',
   'TICKET_ADDITIONAL_AGENT_ASSIGNED',
   'TICKET_COMMENT_ADDED',
@@ -1152,6 +1156,7 @@ const TicketUpdatedPayloadSchema = z.union([TicketEventPayloadSchema, ticketUpda
 const TicketClosedPayloadSchema = z.union([TicketEventPayloadSchema, ticketClosedEventPayloadSchema]);
 const TicketAutoCloseWarningPayloadSchema = z.union([TicketEventPayloadSchema, ticketAutoCloseWarningEventPayloadSchema]);
 const MaintenanceJobRequestedPayloadSchema = maintenanceJobRequestedEventPayloadSchema;
+const InboundEmailProviderAutoPausedPayloadSchema = inboundEmailProviderAutoPausedEventPayloadSchema;
 const TicketAssignedPayloadSchema = z.union([TicketEventPayloadSchema, ticketAssignedEventPayloadSchema]);
 const TicketResponseStateChangedPayloadSchemaV2 = z.union([
   TicketResponseStateChangedPayloadSchema,
@@ -1181,6 +1186,7 @@ export const EventPayloadSchemas = {
   TICKET_CLOSED: TicketClosedPayloadSchema,
   TICKET_AUTO_CLOSE_WARNING: TicketAutoCloseWarningPayloadSchema,
   MAINTENANCE_JOB_REQUESTED: MaintenanceJobRequestedPayloadSchema,
+  INBOUND_EMAIL_PROVIDER_AUTO_PAUSED: InboundEmailProviderAutoPausedPayloadSchema,
   TICKET_DELETED: TicketEventPayloadSchema,
   TICKET_ASSIGNED: TicketAssignedPayloadSchema,
   TICKET_ADDITIONAL_AGENT_ASSIGNED: TicketAdditionalAgentPayloadSchema,

--- a/packages/integrations/src/actions/email-actions/configureGmailProvider.ts
+++ b/packages/integrations/src/actions/email-actions/configureGmailProvider.ts
@@ -178,7 +178,18 @@ export async function configureGmailProvider({
             hasRefreshToken: !!googleConfig.refresh_token
           });
           result.warnings.push('OAuth tokens missing - Gmail watch registration skipped');
-          result.success = result.pubsubConfigured; // Still considered success if pubsub was configured
+          // Without tokens the watch — and the auth-pause recovery behind
+          // it — cannot be re-established. For a provider auto-paused on
+          // auth failures this exit is a failed reconnect that must not
+          // masquerade as success over a still-paused mailbox; for everyone
+          // else it stays the historical warning-tolerant partial success.
+          if (pausedForAuthFailure) {
+            result.authFailureRecovery = 'failed';
+            result.success = false;
+            result.error = 'Gmail reconnection failed: OAuth authorization is required. Reconnect the mailbox and try again.';
+          } else {
+            result.success = result.pubsubConfigured; // Still considered success if pubsub was configured
+          }
           return;
         }
 
@@ -296,8 +307,19 @@ export async function configureGmailProvider({
         });
         // Record the error but don't throw - provider is saved, Pub/Sub may still work
         result.warnings.push('Gmail watch registration failed. Reconnect the mailbox or retry setup after verifying Google permissions.');
-        // If Pub/Sub was configured, we're partially successful
-        result.success = result.pubsubConfigured;
+        // For a provider auto-paused on auth failures this catch is the
+        // revoked/invalid-credential case: delivery was not re-established,
+        // recovery never ran, and the caller must not report success over a
+        // still-paused mailbox. Non-paused providers keep the historical
+        // warning-tolerant partial success.
+        if (pausedForAuthFailure) {
+          result.authFailureRecovery = 'failed';
+          result.success = false;
+          result.error = 'Gmail reconnection failed. Reconnect the mailbox and try again.';
+        } else {
+          // If Pub/Sub was configured, we're partially successful
+          result.success = result.pubsubConfigured;
+        }
       }
     });
   } catch (pubsubError) {

--- a/packages/integrations/src/actions/email-actions/configureGmailProvider.ts
+++ b/packages/integrations/src/actions/email-actions/configureGmailProvider.ts
@@ -36,6 +36,14 @@ export interface ConfigureGmailProviderResult {
   watchRegistered: boolean;
   error?: string;
   warnings: string[];
+  /**
+   * Outcome of the auth-failure recovery attempted when the provider was
+   * auto-paused: 'resumed' — pause cleared and reconciliation handed off;
+   * 'resumed_partial' — resumed but the paused interval was only partially
+   * reconciled (see warnings); 'failed' — still paused, reconnect required;
+   * undefined — no recovery was attempted (provider was not auth-paused).
+   */
+  authFailureRecovery?: 'resumed' | 'resumed_partial' | 'failed';
 }
 
 /**
@@ -255,6 +263,22 @@ export async function configureGmailProvider({
               reconciliation: recovery.reconciliation,
               error: recovery.error,
             });
+            // The recovery outcome is part of the action result: the caller
+            // must not toast success while the mailbox is still paused, and
+            // partial reconciliations must surface their warning.
+            if (!recovery.resumed) {
+              result.authFailureRecovery = 'failed';
+              result.success = false;
+              result.error = recovery.error || 'Gmail reconnection failed. Reconnect the mailbox and try again.';
+            } else if (recovery.reconciliation?.status === 'partial') {
+              result.authFailureRecovery = 'resumed_partial';
+              result.warnings.push(
+                recovery.reconciliation.warning ||
+                  'Reconnection resumed, but some paused-interval mail was not reconciled. Run a mailbox resync.'
+              );
+            } else {
+              result.authFailureRecovery = 'resumed';
+            }
           } catch (recoveryError) {
             console.warn('Gmail auth-failure recovery after reconnect failed (provider stays paused)', {
               tenant,
@@ -262,6 +286,9 @@ export async function configureGmailProvider({
               savedHistoryId,
               error: recoveryError instanceof Error ? recoveryError.message : String(recoveryError),
             });
+            result.authFailureRecovery = 'failed';
+            result.success = false;
+            result.error = 'Gmail reconnection failed. Reconnect the mailbox and try again.';
           }
         }
       } catch (watchError) {

--- a/packages/integrations/src/actions/email-actions/configureGmailProvider.ts
+++ b/packages/integrations/src/actions/email-actions/configureGmailProvider.ts
@@ -38,12 +38,11 @@ export interface ConfigureGmailProviderResult {
   warnings: string[];
   /**
    * Outcome of the auth-failure recovery attempted when the provider was
-   * auto-paused: 'resumed' — pause cleared and reconciliation handed off;
-   * 'resumed_partial' — resumed but the paused interval was only partially
-   * reconciled (see warnings); 'failed' — still paused, reconnect required;
-   * undefined — no recovery was attempted (provider was not auth-paused).
+   * auto-paused: 'resumed' — pause cleared and the paused interval fully
+   * reconciled; 'failed' — still paused, reconnect required; undefined — no
+   * recovery was attempted (provider was not auth-paused).
    */
-  authFailureRecovery?: 'resumed' | 'resumed_partial' | 'failed';
+  authFailureRecovery?: 'resumed' | 'failed';
 }
 
 /**
@@ -264,18 +263,14 @@ export async function configureGmailProvider({
               error: recovery.error,
             });
             // The recovery outcome is part of the action result: the caller
-            // must not toast success while the mailbox is still paused, and
-            // partial reconciliations must surface their warning.
+            // must not toast success while the mailbox is still paused.
+            // (There is no partial outcome: recovery either fully reconciles
+            // the paused interval before clearing the pause or fails with the
+            // provider left paused.)
             if (!recovery.resumed) {
               result.authFailureRecovery = 'failed';
               result.success = false;
               result.error = recovery.error || 'Gmail reconnection failed. Reconnect the mailbox and try again.';
-            } else if (recovery.reconciliation?.status === 'partial') {
-              result.authFailureRecovery = 'resumed_partial';
-              result.warnings.push(
-                recovery.reconciliation.warning ||
-                  'Reconnection resumed, but some paused-interval mail was not reconciled. Run a mailbox resync.'
-              );
             } else {
               result.authFailureRecovery = 'resumed';
             }

--- a/packages/integrations/src/actions/email-actions/configureGmailProvider.ts
+++ b/packages/integrations/src/actions/email-actions/configureGmailProvider.ts
@@ -65,8 +65,23 @@ export async function configureGmailProvider({
 
   try {
     await runWithTenant(tenant, async () => {
+      // Capture the pre-watch history cursor and pause state before any
+      // registration overwrites them: the auth-failure recovery path must
+      // reconcile from the cursor that was valid when the provider paused.
+      const { knex: boundaryKnex } = await createTenantKnex(tenant);
+      const boundaryDb = tenantDb(boundaryKnex, tenant);
+      const [boundaryProvider, boundaryGoogleConfig] = await Promise.all([
+        boundaryDb.table('email_providers').where({ id: providerId }).first('inbound_paused_at', 'inbound_pause_reason'),
+        boundaryDb.table('google_email_provider_config').where({ email_provider_id: providerId }).first('history_id'),
+      ]);
+      const savedHistoryId = boundaryGoogleConfig?.history_id ? String(boundaryGoogleConfig.history_id) : null;
+      const pausedForAuthFailure = Boolean(
+        boundaryProvider?.inbound_paused_at && boundaryProvider.inbound_pause_reason === 'auth_failure'
+      );
+
       // Check if Pub/Sub was already initialized recently (within 24 hours) unless force=true
-      if (!force) {
+      // or the provider is paused for auth failure (reconnect must re-establish the watch).
+      if (!force && !pausedForAuthFailure) {
         const {knex} = await createTenantKnex(tenant);
         const db = tenantDb(knex, tenant);
         const config = await db.table('google_email_provider_config')
@@ -217,6 +232,38 @@ export async function configureGmailProvider({
         console.log(`✅ Successfully registered Gmail watch subscription for provider ${providerId}`);
         result.watchRegistered = true;
         result.success = true;
+
+        // A successful reconnect for a provider auto-paused on repeated auth
+        // failures must resume ingestion only after durably reconciling the
+        // paused interval. Tokens are freshly saved and the watch above
+        // re-established delivery, so recovery only reconciles from the
+        // saved pre-watch cursor and clears the pause.
+        if (pausedForAuthFailure) {
+          try {
+            const { EmailProviderLifecycleService } = await import(
+              '@alga-psa/shared/services/email/EmailProviderLifecycleService'
+            );
+            const recovery = await new EmailProviderLifecycleService().recoverAuthPausedProvider(
+              providerId,
+              tenant,
+              { credentialsValidated: true, deliveryEstablished: true, savedHistoryId }
+            );
+            console.info('Gmail auth-failure recovery after reconnect', {
+              tenant,
+              providerId,
+              resumed: recovery.resumed,
+              reconciliation: recovery.reconciliation,
+              error: recovery.error,
+            });
+          } catch (recoveryError) {
+            console.warn('Gmail auth-failure recovery after reconnect failed (provider stays paused)', {
+              tenant,
+              providerId,
+              savedHistoryId,
+              error: recoveryError instanceof Error ? recoveryError.message : String(recoveryError),
+            });
+          }
+        }
       } catch (watchError) {
         const errorMessage = watchError instanceof Error ? watchError.message : String(watchError);
         console.error(`❌ Failed to register Gmail watch subscription for provider ${providerId}:`, {

--- a/packages/integrations/src/actions/email-actions/emailProviderActions.ts
+++ b/packages/integrations/src/actions/email-actions/emailProviderActions.ts
@@ -1127,13 +1127,18 @@ export const updateEmailProvider = withAuth(async (
       }
     }
 
-    if (!skipAutomation && data.providerType === 'microsoft') {
+    if (data.providerType === 'microsoft') {
       // An edited Microsoft configuration (e.g. a renewed client secret — the
       // EQUIT scenario) is a reconnect path for a provider auto-paused on
       // repeated auth failures. When the webhook initialization above ran, it
       // already re-established delivery; recovery then reconciles the paused
       // interval and only then clears the pause. Without this, the provider
       // stays paused while its freshly registered webhook feeds gated jobs.
+      // This runs even when skipAutomation skipped the webhook setup above:
+      // skipping transport automation must not skip lifecycle recovery, but
+      // the credentialsValidated/deliveryEstablished hints may only be
+      // claimed when that setup actually ran — otherwise recovery validates
+      // the credentials itself.
       try {
         const { knex: pausedKnex } = await createTenantKnex(tenant);
         const pausedProvider = await tenantDb(pausedKnex, tenant)
@@ -1144,7 +1149,7 @@ export const updateEmailProvider = withAuth(async (
           const { EmailProviderLifecycleService } = await import(
             '@alga-psa/shared/services/email/EmailProviderLifecycleService'
           );
-          const webhookInitSucceeded = !result.setupError;
+          const webhookInitSucceeded = !skipAutomation && !result.setupError;
           const recovery = await new EmailProviderLifecycleService().recoverAuthPausedProvider(
             provider.id,
             tenant,
@@ -1172,11 +1177,17 @@ export const updateEmailProvider = withAuth(async (
       }
     }
 
-    if (!skipAutomation && data.providerType === 'imap') {
+    if (data.providerType === 'imap') {
       // Edited IMAP credentials are the reconnect path for a provider
       // auto-paused on repeated auth failures. Recovery validates the new
       // credentials while still paused, clears UID/folder cursors so the
       // poller rescans the paused interval, and only then clears the pause.
+      // This deliberately runs regardless of skipAutomation: that flag means
+      // "don't touch transport automation (Pub/Sub/webhooks)" — IMAP has none
+      // in this action, and credential saves are the only reconnect surface an
+      // auth-paused IMAP provider has. Gating recovery on the flag left the
+      // Reconnect drawer's save (which passes skipAutomation=true) silently
+      // keeping the provider paused after a successful credential save.
       try {
         const { knex: pausedKnex } = await createTenantKnex(tenant);
         const pausedProvider = await tenantDb(pausedKnex, tenant)

--- a/packages/integrations/src/actions/email-actions/emailProviderActions.ts
+++ b/packages/integrations/src/actions/email-actions/emailProviderActions.ts
@@ -1109,6 +1109,38 @@ export const updateEmailProvider = withAuth(async (
       }
     }
 
+    if (!skipAutomation && data.providerType === 'imap') {
+      // Edited IMAP credentials are the reconnect path for a provider
+      // auto-paused on repeated auth failures. Recovery validates the new
+      // credentials while still paused, clears UID/folder cursors so the
+      // poller rescans the paused interval, and only then clears the pause.
+      try {
+        const { knex: pausedKnex } = await createTenantKnex(tenant);
+        const pausedProvider = await tenantDb(pausedKnex, tenant)
+          .table('email_providers')
+          .where({ id: provider.id })
+          .first('inbound_paused_at', 'inbound_pause_reason');
+        if (pausedProvider?.inbound_paused_at && pausedProvider.inbound_pause_reason === 'auth_failure') {
+          const { EmailProviderLifecycleService } = await import(
+            '@alga-psa/shared/services/email/EmailProviderLifecycleService'
+          );
+          const recovery = await new EmailProviderLifecycleService().recoverAuthPausedProvider(
+            provider.id,
+            tenant,
+            {}
+          );
+          if (!recovery.resumed) {
+            result.setupError = recovery.error || 'IMAP reconnection failed. Check the credentials and try again.';
+            provider.status = 'error';
+          }
+        }
+      } catch (error) {
+        console.error('IMAP auth-failure recovery after credential update failed:', error);
+        result.setupError = 'IMAP reconnection failed. Check the credentials and try again.';
+        provider.status = 'error';
+      }
+    }
+
     return result;
   } catch (error) {
     if (error instanceof ExpectedEmailProviderActionError) {
@@ -1377,6 +1409,35 @@ export const testEmailProviderConnection = withAuth(async (
         error_message: null,
         updated_at: knex.fn.now()
       });
+
+    // A successful connection test validates the current credentials: for a
+    // provider auto-paused on repeated auth failures this is a legitimate
+    // reconnect trigger. Recovery re-establishes delivery, reconciles the
+    // paused interval, and only then clears the pause.
+    if (provider.inbound_paused_at && provider.inbound_pause_reason === 'auth_failure') {
+      try {
+        const { EmailProviderLifecycleService } = await import(
+          '@alga-psa/shared/services/email/EmailProviderLifecycleService'
+        );
+        const recovery = await new EmailProviderLifecycleService().recoverAuthPausedProvider(
+          providerId,
+          tenant,
+          { credentialsValidated: true }
+        );
+        if (!recovery.resumed) {
+          return emailProviderOperationError(
+            recovery.error || 'Reconnection failed. Try the provider-specific reconnect flow.',
+            'connection_failed'
+          );
+        }
+      } catch (error) {
+        console.error('Auth-failure recovery after successful connection test failed:', error);
+        return emailProviderOperationError(
+          'Reconnection failed. Try the provider-specific reconnect flow.',
+          'connection_failed'
+        );
+      }
+    }
 
     return { success: true };
   } catch (error) {

--- a/packages/integrations/src/actions/email-actions/emailProviderActions.ts
+++ b/packages/integrations/src/actions/email-actions/emailProviderActions.ts
@@ -1160,11 +1160,6 @@ export const updateEmailProvider = withAuth(async (
               'Microsoft reconnection failed. Verify the client secret and try again.'
             );
             provider.status = 'error';
-          } else if (recovery.reconciliation?.status === 'partial') {
-            result.setupWarnings = [
-              ...(result.setupWarnings || []),
-              recovery.reconciliation.warning || 'Reconnection resumed, but some paused-interval mail was not reconciled. Run a mailbox resync.',
-            ];
           }
         }
       } catch (error) {

--- a/packages/integrations/src/actions/email-actions/emailProviderActions.ts
+++ b/packages/integrations/src/actions/email-actions/emailProviderActions.ts
@@ -1070,6 +1070,45 @@ export const updateEmailProvider = withAuth(async (
 
     result.provider = provider;
 
+    // Auth-pause recovery below mutates the provider row after `provider`
+    // above was assembled (pause cleared + counters reset, or status flipped
+    // to error with the pause left intact). The returned provider must
+    // reflect that persisted post-recovery state — returning the stale
+    // snapshot keeps the settings banner paused after a successful
+    // reconnect.
+    const refreshProviderAfterRecovery = async (): Promise<void> => {
+      try {
+        const { knex: refreshKnex } = await createTenantKnex(tenant);
+        const [freshRow] = await tenantDb(refreshKnex, tenant)
+          .table('email_providers')
+          .where({ id: provider.id })
+          .select([
+            ...PROVIDER_COLUMNS,
+            'inbound_auth_failure_count as inboundAuthFailureCount',
+            'inbound_auth_failure_last_at as inboundAuthFailureLastAt',
+            'inbound_auth_failure_code as inboundAuthFailureCode',
+          ]) as unknown as ProviderRow[];
+        if (freshRow) {
+          // Transport setup above may stamp lastSyncAt in memory without
+          // persisting it (initializeProviderWebhook does not write
+          // last_sync_at); keep whichever timestamp is fresher.
+          if (
+            provider.lastSyncAt &&
+            (!freshRow.lastSyncAt || new Date(provider.lastSyncAt) > new Date(freshRow.lastSyncAt))
+          ) {
+            freshRow.lastSyncAt = provider.lastSyncAt;
+          }
+          result.provider = { ...provider, ...freshRow };
+        }
+      } catch (error) {
+        // The save/recovery outcome stands; the caller just gets the
+        // pre-re-read snapshot, as before this refresh existed.
+        console.error('Failed to re-read provider after auth-failure recovery:', error);
+      }
+    };
+
+    let googleRecoveryAttempted = false;
+
     if (!skipAutomation && data.providerType === 'google' && provider.googleConfig) {
       const secretProvider = await getSecretProviderInstance();
       const effectiveProjectId =
@@ -1102,11 +1141,21 @@ export const updateEmailProvider = withAuth(async (
           }
         }
 
+        // The recovery (resumed or failed) rewrote the provider row; the
+        // returned provider must not carry the pre-recovery pause state.
+        if (gmailResult.authFailureRecovery !== undefined) {
+          googleRecoveryAttempted = true;
+        }
+
         // Add any warnings
         if (gmailResult.warnings && gmailResult.warnings.length > 0) {
           result.setupWarnings = [...(result.setupWarnings || []), ...gmailResult.warnings];
         }
       }
+    }
+
+    if (googleRecoveryAttempted) {
+      await refreshProviderAfterRecovery();
     }
 
     if (!skipAutomation && data.providerType === 'microsoft' && provider.microsoftConfig) {
@@ -1166,6 +1215,10 @@ export const updateEmailProvider = withAuth(async (
             );
             provider.status = 'error';
           }
+          // Recovery rewrote the provider row (pause cleared on success;
+          // status/error_message flipped on failure) — re-read it so the
+          // returned provider reflects the persisted post-recovery state.
+          await refreshProviderAfterRecovery();
         }
       } catch (error) {
         console.error('Microsoft auth-failure recovery after credential update failed:', error);
@@ -1207,6 +1260,10 @@ export const updateEmailProvider = withAuth(async (
             result.setupError = recovery.error || 'IMAP reconnection failed. Check the credentials and try again.';
             provider.status = 'error';
           }
+          // Recovery rewrote the provider row (pause cleared on success;
+          // status/error_message flipped on failure) — re-read it so the
+          // returned provider reflects the persisted post-recovery state.
+          await refreshProviderAfterRecovery();
         }
       } catch (error) {
         console.error('IMAP auth-failure recovery after credential update failed:', error);

--- a/packages/integrations/src/actions/email-actions/emailProviderActions.ts
+++ b/packages/integrations/src/actions/email-actions/emailProviderActions.ts
@@ -1108,6 +1108,7 @@ export const updateEmailProvider = withAuth(async (
     };
 
     let googleRecoveryAttempted = false;
+    let googleAutomationRan = false;
 
     if (!skipAutomation && data.providerType === 'google' && provider.googleConfig) {
       const secretProvider = await getSecretProviderInstance();
@@ -1116,6 +1117,7 @@ export const updateEmailProvider = withAuth(async (
         data.googleConfig?.project_id;
 
       if (effectiveProjectId) {
+        googleAutomationRan = true;
         const gmailResult = await configureGmailProvider({
           tenant,
           providerId: provider.id,
@@ -1156,6 +1158,45 @@ export const updateEmailProvider = withAuth(async (
 
     if (googleRecoveryAttempted) {
       await refreshProviderAfterRecovery();
+    }
+
+    if (data.providerType === 'google' && !googleAutomationRan) {
+      // A save of an auth_failure-paused Google provider that did not run
+      // the transport+recovery path above (skipAutomation=true, no Google
+      // config in the payload, or no resolvable project id) must never
+      // return success while the pause persists. Mirrors the IMAP and
+      // Microsoft branches: skipAutomation skips transport automation only
+      // and must not gate auth-pause recovery — recovery validates the
+      // credentials and re-establishes delivery itself.
+      try {
+        const { knex: pausedKnex } = await createTenantKnex(tenant);
+        const pausedProvider = await tenantDb(pausedKnex, tenant)
+          .table('email_providers')
+          .where({ id: provider.id })
+          .first('inbound_paused_at', 'inbound_pause_reason');
+        if (pausedProvider?.inbound_paused_at && pausedProvider.inbound_pause_reason === 'auth_failure') {
+          const { EmailProviderLifecycleService } = await import(
+            '@alga-psa/shared/services/email/EmailProviderLifecycleService'
+          );
+          const recovery = await new EmailProviderLifecycleService().recoverAuthPausedProvider(
+            provider.id,
+            tenant,
+            {}
+          );
+          if (!recovery.resumed) {
+            result.setupError = recovery.error || 'Gmail reconnection failed. Reconnect the mailbox and try again.';
+            provider.status = 'error';
+          }
+          // Recovery rewrote the provider row (pause cleared on success;
+          // status/error_message flipped on failure) — re-read it so the
+          // returned provider reflects the persisted post-recovery state.
+          await refreshProviderAfterRecovery();
+        }
+      } catch (error) {
+        console.error('Google auth-failure recovery after credential update failed:', error);
+        result.setupError = 'Gmail reconnection failed. Reconnect the mailbox and try again.';
+        provider.status = 'error';
+      }
     }
 
     if (!skipAutomation && data.providerType === 'microsoft' && provider.microsoftConfig) {

--- a/packages/integrations/src/actions/email-actions/emailProviderActions.ts
+++ b/packages/integrations/src/actions/email-actions/emailProviderActions.ts
@@ -937,6 +937,15 @@ export const upsertEmailProvider = withAuth(async (
           provider.status = 'error';
         }
 
+        // A failed auth-failure recovery leaves the mailbox ingestion-paused
+        // even when the rest of the setup succeeded; never report connected.
+        if (gmailResult.authFailureRecovery === 'failed') {
+          provider.status = 'error';
+          if (!result.setupError) {
+            result.setupError = gmailResult.error || 'Gmail reconnection failed. Reconnect the mailbox and try again.';
+          }
+        }
+
         // Add any warnings
         if (gmailResult.warnings && gmailResult.warnings.length > 0) {
           result.setupWarnings = [...(result.setupWarnings || []), ...gmailResult.warnings];
@@ -1084,6 +1093,15 @@ export const updateEmailProvider = withAuth(async (
           provider.status = 'error';
         }
 
+        // A failed auth-failure recovery leaves the mailbox ingestion-paused
+        // even when the rest of the setup succeeded; never report connected.
+        if (gmailResult.authFailureRecovery === 'failed') {
+          provider.status = 'error';
+          if (!result.setupError) {
+            result.setupError = gmailResult.error || 'Gmail reconnection failed. Reconnect the mailbox and try again.';
+          }
+        }
+
         // Add any warnings
         if (gmailResult.warnings && gmailResult.warnings.length > 0) {
           result.setupWarnings = [...(result.setupWarnings || []), ...gmailResult.warnings];
@@ -1104,6 +1122,56 @@ export const updateEmailProvider = withAuth(async (
         result.setupError = microsoft365ActionErrorMessage(
           error,
           'Failed to initialize Microsoft webhook. Check Microsoft 365 settings and try again.'
+        );
+        provider.status = 'error';
+      }
+    }
+
+    if (!skipAutomation && data.providerType === 'microsoft') {
+      // An edited Microsoft configuration (e.g. a renewed client secret — the
+      // EQUIT scenario) is a reconnect path for a provider auto-paused on
+      // repeated auth failures. When the webhook initialization above ran, it
+      // already re-established delivery; recovery then reconciles the paused
+      // interval and only then clears the pause. Without this, the provider
+      // stays paused while its freshly registered webhook feeds gated jobs.
+      try {
+        const { knex: pausedKnex } = await createTenantKnex(tenant);
+        const pausedProvider = await tenantDb(pausedKnex, tenant)
+          .table('email_providers')
+          .where({ id: provider.id })
+          .first('inbound_paused_at', 'inbound_pause_reason');
+        if (pausedProvider?.inbound_paused_at && pausedProvider.inbound_pause_reason === 'auth_failure') {
+          const { EmailProviderLifecycleService } = await import(
+            '@alga-psa/shared/services/email/EmailProviderLifecycleService'
+          );
+          const webhookInitSucceeded = !result.setupError;
+          const recovery = await new EmailProviderLifecycleService().recoverAuthPausedProvider(
+            provider.id,
+            tenant,
+            // When the webhook initialization above succeeded, the freshly
+            // saved credentials are proven and delivery is re-established;
+            // otherwise recovery re-validates the credentials itself and
+            // refuses to clear the pause if they still fail.
+            { credentialsValidated: webhookInitSucceeded, deliveryEstablished: webhookInitSucceeded }
+          );
+          if (!recovery.resumed) {
+            result.setupError = microsoft365ActionErrorMessage(
+              recovery.error,
+              'Microsoft reconnection failed. Verify the client secret and try again.'
+            );
+            provider.status = 'error';
+          } else if (recovery.reconciliation?.status === 'partial') {
+            result.setupWarnings = [
+              ...(result.setupWarnings || []),
+              recovery.reconciliation.warning || 'Reconnection resumed, but some paused-interval mail was not reconciled. Run a mailbox resync.',
+            ];
+          }
+        }
+      } catch (error) {
+        console.error('Microsoft auth-failure recovery after credential update failed:', error);
+        result.setupError = microsoft365ActionErrorMessage(
+          error,
+          'Microsoft reconnection failed. Verify the client secret and try again.'
         );
         provider.status = 'error';
       }

--- a/packages/integrations/src/components/email/EmailProviderCard.authFailure.test.tsx
+++ b/packages/integrations/src/components/email/EmailProviderCard.authFailure.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import type { EmailProvider } from './types';
+import { EmailProviderCard } from './EmailProviderCard';
+
+function buildProvider(overrides: Partial<EmailProvider> = {}): EmailProvider {
+  return {
+    id: 'provider-1',
+    tenant: 'tenant-1',
+    providerType: 'microsoft',
+    providerName: 'Support Mailbox',
+    mailbox: 'support@contoso.example',
+    isActive: true,
+    inboundPausedAt: new Date('2026-08-15T10:00:00Z').toISOString(),
+    inboundPauseReason: 'auth_failure',
+    status: 'error',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-08-15T10:00:00Z',
+    ...overrides,
+  };
+}
+
+function renderCard(provider: EmailProvider, onReconnect = vi.fn()) {
+  const handlers = {
+    onEdit: vi.fn(),
+    onDelete: vi.fn(),
+    onTestConnection: vi.fn(),
+    onRefreshWatchSubscription: vi.fn(),
+    onRetryRenewal: vi.fn(),
+    onRunDiagnostics: vi.fn(),
+    onChangeDefaults: vi.fn(),
+    onTogglePause: vi.fn(),
+    onReconnect,
+  };
+  render(
+    <EmailProviderCard
+      provider={provider}
+      defaultsOptions={[]}
+      updatingProviderId={null}
+      {...handlers}
+    />
+  );
+  return handlers;
+}
+
+function byId(id: string): HTMLElement | null {
+  return document.getElementById(id);
+}
+
+function menuTrigger(): HTMLElement {
+  const trigger = screen.getAllByRole('button').find((button) =>
+    button.getAttribute('aria-haspopup') === 'menu'
+  );
+  expect(trigger).toBeDefined();
+  return trigger!;
+}
+
+async function openMenu() {
+  const trigger = menuTrigger();
+  trigger.focus();
+  fireEvent.keyDown(trigger, { key: 'Enter', code: 'Enter' });
+  await waitFor(() => {
+    expect(screen.getByRole('menuitem', { name: /Edit Configuration/i })).toBeInTheDocument();
+  });
+  return screen.getByRole('menu');
+}
+
+describe('EmailProviderCard auth_failure pause (UI)', () => {
+  beforeAll(() => {
+    // Radix dropdown interaction helpers missing in jsdom.
+    HTMLElement.prototype.hasPointerCapture = vi.fn(() => false) as any;
+    HTMLElement.prototype.releasePointerCapture = vi.fn() as any;
+    HTMLElement.prototype.scrollIntoView = vi.fn() as any;
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('renders the destructive reconnect banner for auth_failure pauses', () => {
+    renderCard(buildProvider());
+
+    const banner = byId('provider-auth-failure-banner-provider-1');
+    expect(banner).not.toBeNull();
+    expect(banner!.getAttribute('class')).toMatch(/destructive/i);
+
+    // The banner names the mailbox and explains the failure; the neutral
+    // paused help is reserved for manual pauses.
+    expect(banner!.textContent).toContain('support@contoso.example');
+    expect(banner!.textContent).toMatch(/credentials no longer work/i);
+    expect(banner!.textContent).toMatch(/remain in the source mailbox/i);
+    expect(byId('provider-paused-help-provider-1')).toBeNull();
+
+    expect(byId('provider-paused-badge-provider-1')).not.toBeNull();
+    expect(byId('provider-auth-failure-title-provider-1')).not.toBeNull();
+  });
+
+  it('dispatches the threaded reconnect callback from the banner button', () => {
+    const onReconnect = vi.fn();
+    const handlers = renderCard(buildProvider(), onReconnect);
+
+    const button = within(byId('provider-auth-failure-banner-provider-1')!).getByRole('button');
+    fireEvent.click(button);
+
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+    expect(onReconnect).toHaveBeenCalledWith(expect.objectContaining({ id: 'provider-1' }));
+    // The reconnect action never doubles as a bare resume.
+    expect(handlers.onTogglePause).not.toHaveBeenCalled();
+  });
+
+  it('does not offer a bare Resume action for auth_failure pauses', async () => {
+    renderCard(buildProvider());
+
+    const menu = await openMenu();
+
+    const menuItems = within(menu).getAllByRole('menuitem');
+    const itemTexts = menuItems.map((item) => item.textContent || '');
+    expect(itemTexts.some((text) => text.includes('providerCard.actions.resume'))).toBe(false);
+    expect(itemTexts.some((text) => text.includes('providerCard.actions.pause'))).toBe(false);
+  });
+
+  it('keeps the neutral paused help and Resume action for manual pauses', async () => {
+    renderCard(buildProvider({ inboundPauseReason: 'manual', status: 'connected' }));
+
+    expect(byId('provider-auth-failure-banner-provider-1')).toBeNull();
+    expect(byId('provider-paused-help-provider-1')).not.toBeNull();
+
+    const menu = await openMenu();
+    const menuItems = within(menu).getAllByRole('menuitem');
+    const itemTexts = menuItems.map((item) => item.textContent || '');
+    expect(itemTexts.some((text) => text.includes('providerCard.actions.resume'))).toBe(true);
+  });
+});

--- a/packages/integrations/src/components/email/EmailProviderCard.authFailure.test.tsx
+++ b/packages/integrations/src/components/email/EmailProviderCard.authFailure.test.tsx
@@ -98,6 +98,10 @@ describe('EmailProviderCard auth_failure pause (UI)', () => {
 
     expect(byId('provider-paused-badge-provider-1')).not.toBeNull();
     expect(byId('provider-auth-failure-title-provider-1')).not.toBeNull();
+
+    // The generic status-error alert is suppressed under the auth banner —
+    // one authoritative destructive alert, not two stacked red boxes.
+    expect(screen.queryByText(/^Error:/)).toBeNull();
   });
 
   it('dispatches the threaded reconnect callback from the banner button', () => {

--- a/packages/integrations/src/components/email/EmailProviderCard.tsx
+++ b/packages/integrations/src/components/email/EmailProviderCard.tsx
@@ -348,7 +348,10 @@ export function EmailProviderCard({
           )}
         </div>
 
-        {provider.status === 'error' && provider.errorMessage && (
+        {/* The auth-failure banner already carries the actionable error
+            context; stacking the generic status-error alert on top of it is
+            redundant noise. */}
+        {provider.status === 'error' && provider.errorMessage && !authFailurePaused && (
           <Alert variant="destructive" className="mt-3">
             <AlertDescription>
               <strong>{t('providerCard.fields.error', { defaultValue: 'Error:' })}</strong> {provider.errorMessage}

--- a/packages/integrations/src/components/email/EmailProviderCard.tsx
+++ b/packages/integrations/src/components/email/EmailProviderCard.tsx
@@ -48,6 +48,12 @@ interface EmailProviderCardProps {
   onRunDiagnostics: (provider: EmailProvider) => void;
   onChangeDefaults: (provider: EmailProvider, defaultsId?: string) => void | Promise<void>;
   onTogglePause: (provider: EmailProvider) => void | Promise<void>;
+  /**
+   * Provider-specific reconnect dispatch for providers auto-paused on
+   * repeated auth failures. Threaded from EmailProviderConfiguration so the
+   * card never owns OAuth logic.
+   */
+  onReconnect: (provider: EmailProvider) => void;
 }
 
 const getProviderIcon = (providerType: string) => {
@@ -80,8 +86,10 @@ export function EmailProviderCard({
   onRunDiagnostics,
   onChangeDefaults,
   onTogglePause,
+  onReconnect,
 }: EmailProviderCardProps) {
   const { t } = useTranslation('msp/email-providers');
+  const authFailurePaused = Boolean(provider.inboundPausedAt) && provider.inboundPauseReason === 'auth_failure';
 
   const getExpirationStatus = (activeProvider: EmailProvider) => {
     if (activeProvider.providerType !== 'microsoft' || !activeProvider.microsoftConfig?.webhook_expires_at) {
@@ -249,18 +257,23 @@ export function EmailProviderCard({
                       : t('providerCard.actions.resyncMailbox', { defaultValue: 'Resync Mailbox' })}
                   </DropdownMenuItem>
                 )}
-                <DropdownMenuItem
-                  id={`${provider.inboundPausedAt ? 'resume' : 'pause'}-provider-${provider.id}`}
-                  onClick={() => onTogglePause(provider)}
-                  disabled={interactionBusy}
-                >
-                  {provider.inboundPausedAt
-                    ? <PlayCircle className="h-4 w-4 mr-2" />
-                    : <PauseCircle className="h-4 w-4 mr-2" />}
-                  {provider.inboundPausedAt
-                    ? t('providerCard.actions.resume')
-                    : t('providerCard.actions.pause')}
-                </DropdownMenuItem>
+                {/* A bare Resume must not be offered for an auth_failure
+                    pause: resuming dead credentials would recreate the
+                    alert loop. Reconnect is the only path back. */}
+                {!authFailurePaused && (
+                  <DropdownMenuItem
+                    id={`${provider.inboundPausedAt ? 'resume' : 'pause'}-provider-${provider.id}`}
+                    onClick={() => onTogglePause(provider)}
+                    disabled={interactionBusy}
+                  >
+                    {provider.inboundPausedAt
+                      ? <PlayCircle className="h-4 w-4 mr-2" />
+                      : <PauseCircle className="h-4 w-4 mr-2" />}
+                    {provider.inboundPausedAt
+                      ? t('providerCard.actions.resume')
+                      : t('providerCard.actions.pause')}
+                  </DropdownMenuItem>
+                )}
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
                   onClick={() => onDelete(provider.id)}
@@ -343,7 +356,41 @@ export function EmailProviderCard({
           </Alert>
         )}
 
-        {provider.inboundPausedAt && (
+        {authFailurePaused ? (
+          <Alert
+            id={`provider-auth-failure-banner-${provider.id}`}
+            variant="destructive"
+            className="mt-3"
+            role="alert"
+          >
+            <AlertDescription>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <strong id={`provider-auth-failure-title-${provider.id}`}>
+                    {t('providerCard.authFailure.title')}
+                  </strong>
+                  <p className="mt-1">
+                    {t('providerCard.authFailure.description', {
+                      defaultValue: 'Inbound email for {{mailbox}} is paused because its credentials no longer work. Messages are not lost — they remain in the source mailbox.',
+                      mailbox: provider.mailbox,
+                    })}
+                  </p>
+                </div>
+                <Button
+                  id={`reconnect-provider-${provider.id}`}
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => onReconnect(provider)}
+                  disabled={interactionBusy}
+                  className="shrink-0"
+                >
+                  <RefreshCw className="h-4 w-4 mr-2" />
+                  {t('providerCard.authFailure.action')}
+                </Button>
+              </div>
+            </AlertDescription>
+          </Alert>
+        ) : provider.inboundPausedAt && (
           <Alert id={`provider-paused-help-${provider.id}`} className="mt-3">
             <AlertDescription>{t('providerCard.pausedHelp')}</AlertDescription>
           </Alert>

--- a/packages/integrations/src/components/email/EmailProviderConfiguration.resync.test.tsx
+++ b/packages/integrations/src/components/email/EmailProviderConfiguration.resync.test.tsx
@@ -298,6 +298,7 @@ describe('IMAP resync status recovery', () => {
         onRetryRenewal={vi.fn()}
         onResyncProvider={vi.fn()}
         onRunDiagnostics={vi.fn()}
+        onReconnect={vi.fn()}
         onChangeDefaults={vi.fn()}
         onTogglePause={vi.fn()}
       />

--- a/packages/integrations/src/components/email/EmailProviderConfiguration.tsx
+++ b/packages/integrations/src/components/email/EmailProviderConfiguration.tsx
@@ -415,6 +415,19 @@ function EmailProviderConfigurationContent({
     setDiagnosticsOpen(true);
   };
 
+  // Provider-specific reconnect dispatch for auth_failure auto-pauses. The
+  // card's Reconnect button threads through here so no OAuth logic lives in
+  // the card: Microsoft/Google open their setup flow in the edit drawer,
+  // IMAP OAuth mailboxes start the popup reconnect flow, and password IMAP
+  // mailboxes open credential editing.
+  const handleReconnect = (provider: EmailProvider) => {
+    if (provider.providerType === 'imap' && provider.imapConfig?.auth_type === 'oauth2') {
+      handleReconnectOAuth(provider);
+      return;
+    }
+    openEditDrawer(provider);
+  };
+
   // Inline add/setup flow removed in favor of wizard
 
   const handleEditCancel = () => {
@@ -539,6 +552,7 @@ function EmailProviderConfigurationContent({
           onReconnectOAuth={handleReconnectOAuth}
           onResyncProvider={handleResyncProvider}
           onRunDiagnostics={handleRunDiagnostics}
+          onReconnect={handleReconnect}
           onAddClick={() => setWizardOpen(true)}
         />
 

--- a/packages/integrations/src/components/email/EmailProviderList.tsx
+++ b/packages/integrations/src/components/email/EmailProviderList.tsx
@@ -38,6 +38,8 @@ interface EmailProviderListProps {
   onResyncProvider?: (provider: EmailProvider) => Promise<void>;
   onRunDiagnostics: (provider: EmailProvider) => void;
   onAddClick?: () => void;
+  /** Provider-specific reconnect dispatch for auth_failure auto-pauses. */
+  onReconnect: (provider: EmailProvider) => void;
 }
 
 export function EmailProviderList({
@@ -52,7 +54,8 @@ export function EmailProviderList({
   onReconnectOAuth,
   onResyncProvider,
   onRunDiagnostics,
-  onAddClick
+  onAddClick,
+  onReconnect
 }: EmailProviderListProps) {
   const { t } = useTranslation('msp/email-providers');
   const [defaultsOptions, setDefaultsOptions] = React.useState<{ value: string; label: string }[]>([]);
@@ -223,6 +226,7 @@ export function EmailProviderList({
             onRunDiagnostics={onRunDiagnostics}
             onChangeDefaults={handleChangeDefaults}
             onTogglePause={handleTogglePause}
+            onReconnect={onReconnect}
           />
         ))}
       </div>

--- a/packages/integrations/src/components/email/GmailProviderForm.tsx
+++ b/packages/integrations/src/components/email/GmailProviderForm.tsx
@@ -180,19 +180,23 @@ export function GmailProviderForm({
         return;
       }
 
-      // Check for setup errors or warnings
+      // A setup error (e.g. failed auth-pause recovery: the OAuth
+      // credentials were rejected or the Gmail watch could not be
+      // re-registered) means the reconnect did NOT succeed — the provider
+      // stays paused. Surface the error in the form and do not report
+      // success: closing the drawer would clear the paused-state banner
+      // while ingestion is still stopped.
       if (result.setupError) {
-        setError(t('forms.gmail.messages.setupIncomplete', {
+        setError(t('forms.common.messages.setupIncomplete', {
           defaultValue: 'Provider saved but setup incomplete: {{error}}',
           error: result.setupError,
         }));
+        return;
       }
       if (result.setupWarnings && result.setupWarnings.length > 0) {
         setSetupWarnings(result.setupWarnings);
       }
 
-      // Still call onSuccess so the provider appears in the list
-      // The user can see the error/warning state in the UI
       onSuccess(result.provider);
 
     } catch (err) {

--- a/packages/integrations/src/components/email/ImapProviderForm.tsx
+++ b/packages/integrations/src/components/email/ImapProviderForm.tsx
@@ -207,6 +207,19 @@ export function ImapProviderForm({
         return;
       }
 
+      // A setup error (e.g. failed auth-pause recovery: the submitted
+      // credentials were rejected by the source) means the reconnect did NOT
+      // succeed — the provider stays paused. Surface the error in the form
+      // and do not report success: closing the drawer would clear the
+      // paused-state banner while ingestion is still stopped.
+      if (result.setupError) {
+        setError(t('forms.common.messages.setupIncomplete', {
+          defaultValue: 'Provider saved but setup incomplete: {{error}}',
+          error: result.setupError,
+        }));
+        return;
+      }
+
       onSuccess(result.provider);
     } catch (err: any) {
       setError(getErrorMessage(err));

--- a/packages/integrations/src/components/email/MicrosoftProviderForm.tsx
+++ b/packages/integrations/src/components/email/MicrosoftProviderForm.tsx
@@ -281,6 +281,19 @@ export function MicrosoftProviderForm({
         return;
       }
 
+      // A setup error (e.g. failed auth-pause recovery: the revalidated
+      // credentials were rejected) means the reconnect did NOT succeed —
+      // the provider stays paused. Surface the error in the form and do not
+      // report success: closing the drawer would clear the paused-state
+      // banner while ingestion is still stopped.
+      if (result.setupError) {
+        setError(t('forms.common.messages.setupIncomplete', {
+          defaultValue: 'Provider saved but setup incomplete: {{error}}',
+          error: result.setupError,
+        }));
+        return;
+      }
+
       onSuccess(result.provider);
 
     } catch (err: any) {

--- a/packages/integrations/src/components/email/types.ts
+++ b/packages/integrations/src/components/email/types.ts
@@ -13,6 +13,9 @@ export interface EmailProvider {
   isActive: boolean;
   inboundPausedAt?: string | null;
   inboundPauseReason?: 'manual' | 'tenant_cancelled' | 'auth_failure' | null;
+  inboundAuthFailureCount?: number;
+  inboundAuthFailureLastAt?: string | null;
+  inboundAuthFailureCode?: string | null;
   status: 'connected' | 'disconnected' | 'error' | 'configuring';
   lastSyncAt?: string;
   errorMessage?: string;

--- a/packages/integrations/src/components/email/types.ts
+++ b/packages/integrations/src/components/email/types.ts
@@ -12,7 +12,7 @@ export interface EmailProvider {
   mailbox: string;
   isActive: boolean;
   inboundPausedAt?: string | null;
-  inboundPauseReason?: 'manual' | 'tenant_cancelled' | null;
+  inboundPauseReason?: 'manual' | 'tenant_cancelled' | 'auth_failure' | null;
   status: 'connected' | 'disconnected' | 'error' | 'configuring';
   lastSyncAt?: string;
   errorMessage?: string;

--- a/packages/types/src/interfaces/email.interfaces.ts
+++ b/packages/types/src/interfaces/email.interfaces.ts
@@ -9,7 +9,7 @@ export interface EmailProviderConfig {
   folder_to_monitor: string; // Defaults to 'Inbox'
   active: boolean;
   inboundPausedAt?: string | null;
-  inboundPauseReason?: 'manual' | 'tenant_cancelled' | null;
+  inboundPauseReason?: 'manual' | 'tenant_cancelled' | 'auth_failure' | null;
   // Common webhook fields as real columns
   webhook_notification_url: string;
   webhook_subscription_id?: string;

--- a/server/migrations/20260815120000_add_inbound_auth_failure_tracking_to_email_providers.cjs
+++ b/server/migrations/20260815120000_add_inbound_auth_failure_tracking_to_email_providers.cjs
@@ -1,0 +1,90 @@
+/**
+ * Additive auth-failure tracking columns for the inbound auto-pause feature.
+ *
+ * Tracks consecutive, strictly classified unrecoverable auth failures at the
+ * provider source-fetch boundary. Plain additive ALTERs on an already
+ * tenant-distributed table: no uniqueness, no constraint builds, valid on both
+ * plain Postgres and Citus.
+ */
+
+const COLUMNS = [
+  { name: 'inbound_auth_failure_count', kind: 'integer' },
+  { name: 'inbound_auth_failure_last_at', kind: 'timestamptz' },
+  { name: 'inbound_auth_failure_code', kind: 'text' },
+];
+
+exports.up = async function up(knex) {
+  const existing = await knex('information_schema.columns')
+    .where('table_name', 'email_providers')
+    .pluck('column_name');
+  const present = new Set(existing);
+
+  await knex.schema.alterTable('email_providers', (table) => {
+    for (const column of COLUMNS) {
+      if (present.has(column.name)) continue;
+      if (column.kind === 'integer') {
+        table.integer(column.name).notNullable().defaultTo(0);
+      } else if (column.kind === 'timestamptz') {
+        table.timestamp(column.name, { useTz: true }).nullable();
+      } else {
+        table.text(column.name).nullable();
+      }
+    }
+  });
+
+  // Widen the pause-reason allowlist to include the automatic auth-failure
+  // pause. Dropping/re-adding a CHECK constraint is metadata-only on plain
+  // Postgres and valid on Citus distributed tables (no rewrite, no locks
+  // beyond a brief ACCESS EXCLUSIVE that ADD CONSTRAINT CHECK requires).
+  await knex.raw(`
+    ALTER TABLE email_providers
+    DROP CONSTRAINT IF EXISTS email_providers_inbound_pause_reason_check
+  `);
+  await knex.raw(`
+    ALTER TABLE email_providers
+    ADD CONSTRAINT email_providers_inbound_pause_reason_check
+    CHECK (
+      (inbound_paused_at IS NULL AND inbound_pause_reason IS NULL)
+      OR
+      (inbound_paused_at IS NOT NULL AND inbound_pause_reason IN ('manual', 'tenant_cancelled', 'auth_failure'))
+    )
+  `);
+};
+
+exports.down = async function down(knex) {
+  // Restore the pre-auth-failure world: clear any automatic auth-failure
+  // pauses so the narrowed constraint can be re-added. Single-table update
+  // on the distribution column's table — valid on plain Postgres and Citus.
+  await knex.raw(`
+    UPDATE email_providers
+    SET inbound_paused_at = NULL, inbound_pause_reason = NULL
+    WHERE inbound_pause_reason = 'auth_failure'
+  `);
+
+  await knex.raw(`
+    ALTER TABLE email_providers
+    DROP CONSTRAINT IF EXISTS email_providers_inbound_pause_reason_check
+  `);
+  await knex.raw(`
+    ALTER TABLE email_providers
+    ADD CONSTRAINT email_providers_inbound_pause_reason_check
+    CHECK (
+      (inbound_paused_at IS NULL AND inbound_pause_reason IS NULL)
+      OR
+      (inbound_paused_at IS NOT NULL AND inbound_pause_reason IN ('manual', 'tenant_cancelled'))
+    )
+  `);
+
+  const existing = await knex('information_schema.columns')
+    .where('table_name', 'email_providers')
+    .pluck('column_name');
+  const present = new Set(existing);
+
+  await knex.schema.alterTable('email_providers', (table) => {
+    for (const column of COLUMNS) {
+      if (present.has(column.name)) {
+        table.dropColumn(column.name);
+      }
+    }
+  });
+};

--- a/server/public/locales/de/msp/email-providers.json
+++ b/server/public/locales/de/msp/email-providers.json
@@ -167,6 +167,11 @@
       "pauseError": "Der Pausenstatus für eingehende E-Mails konnte nicht geändert werden."
     },
     "pausedHelp": "Nachrichten, die eingehen, während dieses Postfach pausiert ist, werden nicht nachträglich importiert.",
+    "authFailure": {
+      "title": "Eingehende E-Mails pausiert — erneute Verbindung erforderlich",
+      "description": "Eingehende E-Mails für {{mailbox}} sind pausiert, da die Anmeldedaten nicht mehr funktionieren. Nachrichten gehen nicht verloren — sie verbleiben im Quellpostfach und werden nach dem erneuten Verbinden importiert.",
+      "action": "Erneut verbinden"
+    },
     "fields": {
       "status": "Status",
       "lastSync": "Letzte Synchronisierung",

--- a/server/public/locales/de/msp/email-providers.json
+++ b/server/public/locales/de/msp/email-providers.json
@@ -242,6 +242,9 @@
         "authorizing": "Wird autorisiert...",
         "authorized": "Autorisiert",
         "authorizeAccess": "Zugriff autorisieren"
+      },
+      "messages": {
+        "setupIncomplete": "Anbieter gespeichert, aber Einrichtung unvollständig: {{error}}"
       }
     },
     "microsoft": {

--- a/server/public/locales/en/msp/email-providers.json
+++ b/server/public/locales/en/msp/email-providers.json
@@ -242,6 +242,9 @@
         "authorizing": "Authorizing...",
         "authorized": "Authorized",
         "authorizeAccess": "Authorize Access"
+      },
+      "messages": {
+        "setupIncomplete": "Provider saved but setup incomplete: {{error}}"
       }
     },
     "microsoft": {

--- a/server/public/locales/en/msp/email-providers.json
+++ b/server/public/locales/en/msp/email-providers.json
@@ -167,6 +167,11 @@
       "pauseError": "Failed to change inbound email pause state."
     },
     "pausedHelp": "Messages received while this inbox is paused are not imported retroactively.",
+    "authFailure": {
+      "title": "Inbound email paused — reconnection required",
+      "description": "Inbound email for {{mailbox}} is paused because its credentials no longer work. Messages are not lost — they remain in the source mailbox and will be imported after you reconnect.",
+      "action": "Reconnect"
+    },
     "fields": {
       "status": "Status",
       "lastSync": "Last Sync",

--- a/server/public/locales/es/msp/email-providers.json
+++ b/server/public/locales/es/msp/email-providers.json
@@ -167,6 +167,11 @@
       "pauseError": "No se pudo cambiar el estado de pausa del correo entrante."
     },
     "pausedHelp": "Los mensajes recibidos mientras esta bandeja está en pausa no se importan retroactivamente.",
+    "authFailure": {
+      "title": "Correo entrante en pausa — se requiere reconexión",
+      "description": "El correo entrante de {{mailbox}} está en pausa porque sus credenciales ya no funcionan. Los mensajes no se pierden: permanecen en el buzón de origen y se importarán después de que vuelva a conectar.",
+      "action": "Reconectar"
+    },
     "fields": {
       "status": "Estado",
       "lastSync": "Última sincronización",

--- a/server/public/locales/es/msp/email-providers.json
+++ b/server/public/locales/es/msp/email-providers.json
@@ -242,6 +242,9 @@
         "authorizing": "Autorizando...",
         "authorized": "Autorizado",
         "authorizeAccess": "Autorizar acceso"
+      },
+      "messages": {
+        "setupIncomplete": "Proveedor guardado pero configuración incompleta: {{error}}"
       }
     },
     "microsoft": {

--- a/server/public/locales/fr/msp/email-providers.json
+++ b/server/public/locales/fr/msp/email-providers.json
@@ -167,6 +167,11 @@
       "pauseError": "Impossible de modifier l'état de pause des e-mails entrants."
     },
     "pausedHelp": "Les messages reçus pendant que cette boîte est en pause ne sont pas importés rétroactivement.",
+    "authFailure": {
+      "title": "E-mails entrants en pause — reconnexion requise",
+      "description": "Les e-mails entrants de {{mailbox}} sont en pause car ses identifiants ne fonctionnent plus. Aucun message n'est perdu — ils restent dans la boîte source et seront importés après votre reconnexion.",
+      "action": "Reconnecter"
+    },
     "fields": {
       "status": "Statut",
       "lastSync": "Dernière synchronisation",

--- a/server/public/locales/fr/msp/email-providers.json
+++ b/server/public/locales/fr/msp/email-providers.json
@@ -242,6 +242,9 @@
         "authorizing": "Autoriser...",
         "authorized": "Autorisé",
         "authorizeAccess": "Autoriser l'accès"
+      },
+      "messages": {
+        "setupIncomplete": "Fournisseur enregistré mais configuration incomplète : {{error}}"
       }
     },
     "microsoft": {

--- a/server/public/locales/it/msp/email-providers.json
+++ b/server/public/locales/it/msp/email-providers.json
@@ -242,6 +242,9 @@
         "authorizing": "Autorizzazione in corso...",
         "authorized": "Autorizzato",
         "authorizeAccess": "Autorizza l'accesso"
+      },
+      "messages": {
+        "setupIncomplete": "Fornitore salvato ma configurazione incompleta: {{error}}"
       }
     },
     "microsoft": {

--- a/server/public/locales/it/msp/email-providers.json
+++ b/server/public/locales/it/msp/email-providers.json
@@ -167,6 +167,11 @@
       "pauseError": "Impossibile modificare lo stato di pausa delle email in arrivo."
     },
     "pausedHelp": "I messaggi ricevuti mentre questa casella è in pausa non vengono importati retroattivamente.",
+    "authFailure": {
+      "title": "Email in entrata in pausa — riconnessione necessaria",
+      "description": "Le email in entrata per {{mailbox}} sono in pausa perché le credenziali non funzionano più. I messaggi non vanno persi: restano nella casella di origine e verranno importati dopo la riconnessione.",
+      "action": "Riconnetti"
+    },
     "fields": {
       "status": "Stato",
       "lastSync": "Ultima sincronizzazione",

--- a/server/public/locales/nl/msp/email-providers.json
+++ b/server/public/locales/nl/msp/email-providers.json
@@ -167,6 +167,11 @@
       "pauseError": "Kan de pauzestatus van inkomende e-mail niet wijzigen."
     },
     "pausedHelp": "Berichten die binnenkomen terwijl deze mailbox is gepauzeerd, worden niet met terugwerkende kracht geïmporteerd.",
+    "authFailure": {
+      "title": "Inkomende e-mail gepauzeerd — opnieuw verbinden vereist",
+      "description": "Inkomende e-mail voor {{mailbox}} is gepauzeerd omdat de inloggegevens niet meer werken. Berichten gaan niet verloren — ze blijven in de bronpostvak staan en worden geïmporteerd nadat u opnieuw verbinding hebt gemaakt.",
+      "action": "Opnieuw verbinden"
+    },
     "fields": {
       "status": "Status",
       "lastSync": "Laatste synchronisatie",

--- a/server/public/locales/nl/msp/email-providers.json
+++ b/server/public/locales/nl/msp/email-providers.json
@@ -242,6 +242,9 @@
         "authorizing": "Autoriseren...",
         "authorized": "Geautoriseerd",
         "authorizeAccess": "Toegang autoriseren"
+      },
+      "messages": {
+        "setupIncomplete": "Provider opgeslagen maar installatie onvolledig: {{error}}"
       }
     },
     "microsoft": {

--- a/server/public/locales/pl/msp/email-providers.json
+++ b/server/public/locales/pl/msp/email-providers.json
@@ -242,6 +242,9 @@
         "authorizing": "Autoryzuję...",
         "authorized": "Upoważniony",
         "authorizeAccess": "Autoryzuj dostęp"
+      },
+      "messages": {
+        "setupIncomplete": "Dostawca zapisany, ale konfiguracja niekompletna: {{error}}"
       }
     },
     "microsoft": {

--- a/server/public/locales/pl/msp/email-providers.json
+++ b/server/public/locales/pl/msp/email-providers.json
@@ -167,6 +167,11 @@
       "pauseError": "Nie udało się zmienić stanu wstrzymania poczty przychodzącej."
     },
     "pausedHelp": "Wiadomości odebrane w czasie, gdy ta skrzynka jest wstrzymana, nie są importowane wstecznie.",
+    "authFailure": {
+      "title": "E-mail przychodzący wstrzymany — wymagane ponowne połączenie",
+      "description": "E-mail przychodzący dla {{mailbox}} został wstrzymany, ponieważ jego dane logowania przestały działać. Wiadomości nie znikną — pozostają w skrzynce źródłowej i zostaną zaimportowane po ponownym połączeniu.",
+      "action": "Połącz ponownie"
+    },
     "fields": {
       "status": "Status",
       "lastSync": "Ostatnia synchronizacja",

--- a/server/public/locales/pt/msp/email-providers.json
+++ b/server/public/locales/pt/msp/email-providers.json
@@ -242,6 +242,9 @@
         "authorizing": "Autorizando...",
         "authorized": "Autorizado",
         "authorizeAccess": "Autorizar acesso"
+      },
+      "messages": {
+        "setupIncomplete": "Provedor salvo, mas configuração incompleta: {{error}}"
       }
     },
     "microsoft": {

--- a/server/public/locales/pt/msp/email-providers.json
+++ b/server/public/locales/pt/msp/email-providers.json
@@ -167,6 +167,11 @@
       "pauseError": "Não foi possível alterar o estado de pausa dos e-mails recebidos."
     },
     "pausedHelp": "As mensagens recebidas enquanto esta caixa está pausada não são importadas retroativamente.",
+    "authFailure": {
+      "title": "E-mail de entrada pausado — reconexão necessária",
+      "description": "O e-mail de entrada de {{mailbox}} está pausado porque suas credenciais não funcionam mais. As mensagens não são perdidas — permanecem na caixa de correio de origem e serão importadas depois de você reconectar.",
+      "action": "Reconectar"
+    },
     "fields": {
       "status": "Status",
       "lastSync": "Última sincronização",

--- a/server/public/locales/xx/msp/email-providers.json
+++ b/server/public/locales/xx/msp/email-providers.json
@@ -167,6 +167,11 @@
       "pauseError": "11111"
     },
     "pausedHelp": "11111",
+    "authFailure": {
+      "title": "11111",
+      "description": "11111 {{mailbox}} 11111",
+      "action": "11111"
+    },
     "fields": {
       "status": "11111",
       "lastSync": "11111",

--- a/server/public/locales/xx/msp/email-providers.json
+++ b/server/public/locales/xx/msp/email-providers.json
@@ -242,6 +242,9 @@
         "authorizing": "11111",
         "authorized": "11111",
         "authorizeAccess": "11111"
+      },
+      "messages": {
+        "setupIncomplete": "11111 {{error}} 11111"
       }
     },
     "microsoft": {

--- a/server/public/locales/yy/msp/email-providers.json
+++ b/server/public/locales/yy/msp/email-providers.json
@@ -242,6 +242,9 @@
         "authorizing": "55555",
         "authorized": "55555",
         "authorizeAccess": "55555"
+      },
+      "messages": {
+        "setupIncomplete": "55555 {{error}} 55555"
       }
     },
     "microsoft": {

--- a/server/public/locales/yy/msp/email-providers.json
+++ b/server/public/locales/yy/msp/email-providers.json
@@ -167,6 +167,11 @@
       "pauseError": "55555"
     },
     "pausedHelp": "55555",
+    "authFailure": {
+      "title": "55555",
+      "description": "55555 {{mailbox}} 55555",
+      "action": "55555"
+    },
     "fields": {
       "status": "55555",
       "lastSync": "55555",

--- a/server/src/app/api/auth/google/callback/route.ts
+++ b/server/src/app/api/auth/google/callback/route.ts
@@ -259,12 +259,18 @@ export async function GET(request: NextRequest) {
 
             if (googleConfig?.project_id) {
               console.log(`🔁 Finalizing Gmail provider after OAuth for provider ${stateData.providerId}`);
-              await configureGmailProvider({
+              const gmailResult = await configureGmailProvider({
                 tenant: stateData.tenant,
                 providerId: stateData.providerId,
                 projectId: googleConfig.project_id,
                 force: true
               });
+              if (gmailResult.authFailureRecovery === 'failed') {
+                // The OAuth exchange succeeded but the auth-failure recovery
+                // could not reconcile/clear the pause; the durable settings
+                // banner keeps prompting until a retry completes recovery.
+                console.warn('⚠️ Gmail auth-failure recovery after OAuth reconnect failed (provider stays paused)');
+              }
             } else {
               console.warn('⚠️ Skipping Gmail finalize: project_id missing');
             }

--- a/server/src/app/api/auth/microsoft/callback/route.ts
+++ b/server/src/app/api/auth/microsoft/callback/route.ts
@@ -731,6 +731,40 @@ export async function GET(request: NextRequest) {
               },
             });
           });
+
+          // A successful reconnect for a provider auto-paused on repeated
+          // auth failures must resume ingestion only after durably
+          // reconciling the paused interval. Credentials are freshly
+          // exchanged and the setup hook above established delivery, so this
+          // only reconciles and clears the pause.
+          try {
+            const { knex: recoveryKnex } = await createTenantKnex(stateContext.tenant!);
+            const pausedProvider = await tenantDb(recoveryKnex, stateContext.tenant!)
+              .table('email_providers')
+              .where({ id: stateContext.providerId })
+              .first('inbound_paused_at', 'inbound_pause_reason');
+            if (pausedProvider?.inbound_paused_at && pausedProvider.inbound_pause_reason === 'auth_failure') {
+              const { EmailProviderLifecycleService } = await import(
+                '@alga-psa/shared/services/email/EmailProviderLifecycleService'
+              );
+              const recovery = await new EmailProviderLifecycleService().recoverAuthPausedProvider(
+                stateContext.providerId!,
+                stateContext.tenant!,
+                { credentialsValidated: true, deliveryEstablished: true }
+              );
+              console.info('[MS OAuth Callback] auth-failure recovery after reconnect', {
+                tenant: stateContext.tenant,
+                providerId: stateContext.providerId,
+                resumed: recovery.resumed,
+                reconciliation: recovery.reconciliation,
+                error: recovery.error,
+              });
+            }
+          } catch (recoveryError: any) {
+            // The reconnect itself succeeded; the durable settings banner
+            // keeps prompting until a retry completes the recovery.
+            console.warn('⚠️ Microsoft auth-failure recovery after reconnect failed (provider stays paused):', recoveryError?.message || recoveryError);
+          }
         } catch (persistErr: any) {
           // `persistMicrosoftEmailOAuthResult` already compensated the Graph
           // side and restored the provider to its prior connected/polling

--- a/server/src/app/api/email/oauth/imap/callback/route.ts
+++ b/server/src/app/api/email/oauth/imap/callback/route.ts
@@ -114,6 +114,37 @@ export async function GET(request: NextRequest) {
         updated_at: knex.fn.now(),
       });
 
+    // A successful reconnect for a provider auto-paused on repeated auth
+    // failures must resume ingestion only after reconciling the paused
+    // interval: recovery clears UID/folder cursors (bounded rescan with
+    // dedupe) and only then clears the pause. The token exchange above
+    // validated the new credentials.
+    if (provider.inbound_paused_at && provider.inbound_pause_reason === 'auth_failure') {
+      try {
+        const { EmailProviderLifecycleService } = await import(
+          '@alga-psa/shared/services/email/EmailProviderLifecycleService'
+        );
+        const recovery = await new EmailProviderLifecycleService().recoverAuthPausedProvider(
+          state.providerId,
+          tenant,
+          { credentialsValidated: true }
+        );
+        console.info('IMAP auth-failure recovery after reconnect', {
+          tenant,
+          providerId: state.providerId,
+          resumed: recovery.resumed,
+          reconciliation: recovery.reconciliation,
+          error: recovery.error,
+        });
+      } catch (recoveryError) {
+        console.warn('IMAP auth-failure recovery after reconnect failed (provider stays paused)', {
+          tenant,
+          providerId: state.providerId,
+          error: recoveryError instanceof Error ? recoveryError.message : String(recoveryError),
+        });
+      }
+    }
+
     const rawSuccessRedirect = state.redirectUri || url.origin;
     let successRedirect = rawSuccessRedirect;
 

--- a/server/src/bin/unifiedInboundEmailQueueConsumer.ts
+++ b/server/src/bin/unifiedInboundEmailQueueConsumer.ts
@@ -5,9 +5,16 @@ import {
   renewPostgresLeaseForV2Job,
 } from '@alga-psa/shared/services/email/unifiedInboundEmailQueueJobProcessorV2';
 import { getInboundDurableMode } from '@alga-psa/shared/services/email/inboundEmailDurableStore';
+import { assertInboundAuthPauseNotifierRegistered } from '@alga-psa/shared/services/email/inboundAuthPauseNotifier';
 import { processUnifiedInboundEmailQueueJob } from '../services/email/unifiedInboundEmailQueueJobProcessor';
+import { registerInboundAuthPauseNotifications } from '../services/email/inboundAuthPauseNotificationService';
 
 async function main(): Promise<void> {
+  // This process can perform the atomic auth-failure auto-pause; without a
+  // registered notifier those pauses would be silent to tenant admins.
+  registerInboundAuthPauseNotifications();
+  assertInboundAuthPauseNotifierRegistered('server/bin/unifiedInboundEmailQueueConsumer');
+
   const consumer = new UnifiedInboundEmailQueueConsumer({
     pollDelayMs: 250,
     handleJob: async (job) => {

--- a/server/src/interfaces/email.interfaces.ts
+++ b/server/src/interfaces/email.interfaces.ts
@@ -9,7 +9,7 @@ export interface EmailProviderConfig {
   folder_to_monitor: string; // Defaults to 'Inbox'
   active: boolean;
   inboundPausedAt?: string | null;
-  inboundPauseReason?: 'manual' | 'tenant_cancelled' | null;
+  inboundPauseReason?: 'manual' | 'tenant_cancelled' | 'auth_failure' | null;
   // Common webhook fields as real columns
   webhook_notification_url: string;
   webhook_subscription_id?: string;

--- a/server/src/lib/eventBus/subscribers/inboundAuthPauseNotificationSubscriber.ts
+++ b/server/src/lib/eventBus/subscribers/inboundAuthPauseNotificationSubscriber.ts
@@ -1,0 +1,72 @@
+/**
+ * Inbound Auth-Pause Notification Subscriber
+ *
+ * Handles INBOUND_EMAIL_PROVIDER_AUTO_PAUSED events published by worker-side
+ * runtimes (the email-service container, the Temporal worker) after they
+ * performed the atomic auth-failure auto-pause. Those runtimes cannot import
+ * the @alga-psa/notifications vertical to deliver admin notifications
+ * in-process, so the notification creation happens here on the server, where
+ * the domain graph loads — the same worker→server hand-off as
+ * MAINTENANCE_JOB_REQUESTED.
+ */
+
+import logger from '@alga-psa/core/logger';
+import { getEventBus } from '../index';
+import { EventSchemas } from '@alga-psa/event-schemas';
+import { notifyInboundAuthPauseAdmins } from '../../../services/email/inboundAuthPauseNotificationService';
+
+let isRegistered = false;
+
+export async function registerInboundAuthPauseNotificationSubscriber(): Promise<void> {
+  if (isRegistered) {
+    return;
+  }
+
+  await getEventBus().subscribe('INBOUND_EMAIL_PROVIDER_AUTO_PAUSED', handleInboundEmailProviderAutoPaused);
+
+  isRegistered = true;
+  logger.info('[InboundAuthPauseNotificationSubscriber] Registered');
+}
+
+export async function unregisterInboundAuthPauseNotificationSubscriber(): Promise<void> {
+  if (!isRegistered) {
+    return;
+  }
+
+  await getEventBus().unsubscribe('INBOUND_EMAIL_PROVIDER_AUTO_PAUSED', handleInboundEmailProviderAutoPaused);
+
+  isRegistered = false;
+  logger.info('[InboundAuthPauseNotificationSubscriber] Unregistered');
+}
+
+async function handleInboundEmailProviderAutoPaused(event: unknown): Promise<void> {
+  const validated = EventSchemas.INBOUND_EMAIL_PROVIDER_AUTO_PAUSED.parse(event);
+  const { tenantId, providerId, providerName, mailbox, providerType, authFailureCode, pausedAt } = validated.payload;
+
+  // Best-effort by contract: delivery failures are logged and never rethrown —
+  // the persistent settings banner is the durable fallback, and a retry storm
+  // around a dead-credential provider must not wedge the consumer group.
+  try {
+    await notifyInboundAuthPauseAdmins({
+      tenant: tenantId,
+      providerId,
+      providerName,
+      mailbox,
+      providerType,
+      authFailureCode,
+      pausedAt,
+    });
+    logger.info('[InboundAuthPauseNotificationSubscriber] Admin notifications delivered', {
+      tenantId,
+      providerId,
+      authFailureCode,
+    });
+  } catch (error) {
+    logger.error('[InboundAuthPauseNotificationSubscriber] Failed to deliver admin notifications', {
+      tenantId,
+      providerId,
+      authFailureCode,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/server/src/lib/eventBus/subscribers/index.ts
+++ b/server/src/lib/eventBus/subscribers/index.ts
@@ -15,6 +15,10 @@ import { registerRmmAlertTicketClosedSubscriber, unregisterRmmAlertTicketClosedS
 import { registerRmmAlertNotificationSubscriber, unregisterRmmAlertNotificationSubscriber } from './rmmAlertNotificationSubscriber';
 import { registerMaintenanceJobSubscriber, unregisterMaintenanceJobSubscriber } from './maintenanceJobSubscriber';
 import {
+  registerInboundAuthPauseNotificationSubscriber,
+  unregisterInboundAuthPauseNotificationSubscriber,
+} from './inboundAuthPauseNotificationSubscriber';
+import {
   registerProjectBillingPaymentStatusSubscriber,
   unregisterProjectBillingPaymentStatusSubscriber,
 } from './projectBillingPaymentStatusSubscriber';
@@ -41,6 +45,7 @@ const REGISTRATIONS: SubscriberRegistration[] = [
   { name: 'rmmAlertTicketClosed', register: registerRmmAlertTicketClosedSubscriber },
   { name: 'rmmAlertNotification', register: registerRmmAlertNotificationSubscriber },
   { name: 'maintenanceJob', register: registerMaintenanceJobSubscriber },
+  { name: 'inboundAuthPauseNotification', register: registerInboundAuthPauseNotificationSubscriber },
   { name: 'projectBillingPaymentStatus', register: registerProjectBillingPaymentStatusSubscriber },
 ];
 
@@ -55,6 +60,7 @@ const UNREGISTRATIONS: SubscriberRegistration[] = [
   { name: 'creditExpiring', register: unregisterCreditExpiringSubscriber },
   { name: 'ticketAutoCloseWarning', register: unregisterTicketAutoCloseWarningSubscriber },
   { name: 'maintenanceJob', register: unregisterMaintenanceJobSubscriber },
+  { name: 'inboundAuthPauseNotification', register: unregisterInboundAuthPauseNotificationSubscriber },
   { name: 'webhook', register: unregisterWebhookSubscriber },
   { name: 'searchIndex', register: unregisterSearchIndexSubscriber },
   { name: 'inventoryNotification', register: unregisterInventoryNotificationSubscriber },

--- a/server/src/lib/initializeApp.ts
+++ b/server/src/lib/initializeApp.ts
@@ -62,6 +62,19 @@ export async function initializeApp() {
     await bootstrapInboundWebhookActions();
     logger.info('Inbound webhook actions bootstrapped');
 
+    // Register the admin-notification implementation for the inbound
+    // auth-failure auto-pause (the shared lifecycle service owns the pause
+    // transition but cannot depend on @alga-psa/notifications).
+    try {
+      const { registerInboundAuthPauseNotifications } = await import(
+        '../services/email/inboundAuthPauseNotificationService'
+      );
+      registerInboundAuthPauseNotifications();
+      logger.info('Inbound auth-pause notifications registered');
+    } catch (error) {
+      logger.error('Failed to register inbound auth-pause notifications:', error);
+    }
+
     // Validate secret uniqueness first (must succeed)
     try {
       await validateSecretUniqueness();

--- a/server/src/lib/initializeApp.ts
+++ b/server/src/lib/initializeApp.ts
@@ -70,10 +70,15 @@ export async function initializeApp() {
         '../services/email/inboundAuthPauseNotificationService'
       );
       registerInboundAuthPauseNotifications();
+      const { assertInboundAuthPauseNotifierRegistered } = await import(
+        '@alga-psa/shared/services/email/inboundAuthPauseNotifier'
+      );
+      assertInboundAuthPauseNotifierRegistered('server/initializeApp');
       logger.info('Inbound auth-pause notifications registered');
     } catch (error) {
       logger.error('Failed to register inbound auth-pause notifications:', error);
     }
+
 
     // Validate secret uniqueness first (must succeed)
     try {

--- a/server/src/services/email/inboundAuthPauseNotificationService.ts
+++ b/server/src/services/email/inboundAuthPauseNotificationService.ts
@@ -1,0 +1,105 @@
+/**
+ * Admin notifications for the inbound auth-failure auto-pause.
+ *
+ * Mirrors the established accounting-sync notification pattern
+ * (packages/billing syncNotificationService): enumerate active internal users
+ * whose role is admin (or owner, when the tenant model has that role) and
+ * create one `system-announcement` internal notification per recipient.
+ *
+ * Delivery is strictly best-effort: per-recipient failures are logged with
+ * tenant/provider/user identifiers plus the safe reason code and never roll
+ * back the pause. The persistent settings banner is the durable fallback.
+ *
+ * Registered into the shared lifecycle service's notifier hook at app startup
+ * because `shared/` cannot depend on `@alga-psa/notifications` (package cycle).
+ */
+
+import type { Knex } from 'knex';
+import { tenantDb } from '@alga-psa/db';
+import { createNotificationFromTemplateInternal } from '@alga-psa/notifications/actions/internal-notification-actions/internalNotificationActions';
+import {
+  registerInboundAuthPauseNotifier,
+  type InboundAuthPauseNotificationParams,
+} from '@alga-psa/shared/services/email/inboundAuthPauseNotifier';
+import { getAdminConnection } from '@alga-psa/db/admin';
+
+function describeAuthFailureReason(params: InboundAuthPauseNotificationParams): string {
+  switch (params.providerType) {
+    case 'microsoft':
+      return 'Microsoft rejected the saved sign-in for this mailbox';
+    case 'google':
+      return 'Google rejected the saved sign-in for this mailbox';
+    default:
+      return 'The mail server rejected the saved sign-in for this mailbox';
+  }
+}
+
+async function findAdminUserIds(knex: Knex, tenantId: string): Promise<string[]> {
+  const db = tenantDb(knex, tenantId);
+  const query = db.table('users')
+    .where('users.user_type', 'internal')
+    .whereRaw('LOWER(roles.role_name) IN (?, ?)', ['admin', 'owner'])
+    .whereNot('users.is_inactive', true)
+    .distinct('users.user_id');
+  db.tenantJoin(query, 'user_roles', 'user_roles.user_id', 'users.user_id');
+  db.tenantJoin(query, 'roles', 'roles.role_id', 'user_roles.role_id');
+  const rows = (await query) as unknown as Array<{ user_id: string }>;
+  return rows.map((row) => row.user_id);
+}
+
+export async function notifyInboundAuthPauseAdmins(
+  params: InboundAuthPauseNotificationParams
+): Promise<void> {
+  const knex = await getAdminConnection();
+  const adminUserIds = await findAdminUserIds(knex, params.tenant);
+  if (adminUserIds.length === 0) {
+    console.warn('[InboundAuthPauseNotifications] no active admin recipients found', {
+      tenant: params.tenant,
+      providerId: params.providerId,
+      authFailureCode: params.authFailureCode,
+    });
+    return;
+  }
+
+  const mailboxLabel = params.providerName || params.mailbox;
+  const announcementTitle =
+    `Inbound email paused for ${mailboxLabel} (${params.mailbox}) — reconnection required. ` +
+    `${describeAuthFailureReason(params)} repeatedly, so ingestion was paused to stop the failure loop. ` +
+    `Messages are not lost; they remain in the source mailbox. Reconnect the mailbox in Email Provider Settings to resume.`;
+
+  let delivered = 0;
+  for (const userId of adminUserIds) {
+    try {
+      await knex.transaction(async (trx) => {
+        await createNotificationFromTemplateInternal(trx, {
+          tenant: params.tenant,
+          user_id: userId,
+          template_name: 'system-announcement',
+          data: { announcementTitle },
+          link: '/msp/settings?tab=email',
+        } as any);
+      });
+      delivered += 1;
+    } catch (error) {
+      console.warn('[InboundAuthPauseNotifications] per-recipient delivery failed', {
+        tenant: params.tenant,
+        providerId: params.providerId,
+        userId,
+        authFailureCode: params.authFailureCode,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  console.info('[InboundAuthPauseNotifications] delivered auth-pause notifications', {
+    tenant: params.tenant,
+    providerId: params.providerId,
+    authFailureCode: params.authFailureCode,
+    recipients: adminUserIds.length,
+    delivered,
+  });
+}
+
+export function registerInboundAuthPauseNotifications(): void {
+  registerInboundAuthPauseNotifier(notifyInboundAuthPauseAdmins);
+}

--- a/server/src/services/email/providers/GmailAdapter.ts
+++ b/server/src/services/email/providers/GmailAdapter.ts
@@ -302,7 +302,14 @@ This indicates a problem with the OAuth token saving process.`;
       
       this.config.provider_config.watch_expiration = expirationISO || undefined;
 
-      // Save updated history_id and watch_expiration to database
+      // Save updated history_id and watch_expiration to database.
+      // INTENTIONALLY AUTHORITATIVE (not monotonic): a freshly registered
+      // watch's historyId is Gmail's own authoritative snapshot of the current
+      // mailbox state at watch creation — the baseline every subsequent
+      // notification advances from — so it must replace any prior cursor,
+      // including the older one a watch re-establishment after historyId
+      // invalidation is recovering from. Guarding this write with a monotonic
+      // predicate would strand that dead cursor forever.
       try {
         const knex = await getAdminConnection();
         await tenantDb(knex, this.config.tenant).table('google_email_provider_config')

--- a/server/src/test/integration/emailWebhookMaintenanceAuthFailure.integration.test.ts
+++ b/server/src/test/integration/emailWebhookMaintenanceAuthFailure.integration.test.ts
@@ -181,6 +181,53 @@ describeDb('Microsoft maintenance token-health auth outcomes (DB-backed)', () =>
     expect(row.inbound_paused_at).toBeNull();
   });
 
+  it('flags reconciliation as truncated when the requested boundary predates the 7-day window cap', async () => {
+    const providerId = await seedPollingProvider();
+    tokenHealthMock.ensureTokenHealthy.mockResolvedValue(undefined);
+    tokenHealthMock.listMessagesReceivedSince.mockResolvedValue([]);
+
+    // The module-level vi.mock only stubs the adapter; the service class
+    // (and therefore the real reconciliation algorithm) runs against the DB.
+    const result = await new EmailWebhookMaintenanceService().reconcileProviderMessages({
+      providerId,
+      tenant: testTenant,
+      since: new Date(Date.now() - 9 * 24 * 60 * 60 * 1000),
+    });
+
+    expect(result.truncated).toBe(true);
+
+    // Within the cap: no truncation flag.
+    const withinCap = await new EmailWebhookMaintenanceService().reconcileProviderMessages({
+      providerId,
+      tenant: testTenant,
+      since: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000),
+    });
+    expect(withinCap.truncated).toBeFalsy();
+  });
+
+  it('keeps the curated auto-pause error message when the token-health catch path runs after the pause', async () => {
+    const providerId = await seedPollingProvider();
+    // First two calls pause the provider; the third verifies the catch path.
+    tokenHealthMock.ensureTokenHealthy.mockRejectedValue(sanitizedInvalidClientError());
+    tokenHealthMock.listMessagesReceivedSince.mockResolvedValue([]);
+
+    const service = new EmailWebhookMaintenanceService();
+    await service.reconcilePollingProviders({ tenantId: testTenant, providerId });
+    await service.reconcilePollingProviders({ tenantId: testTenant, providerId });
+    await service.reconcilePollingProviders({ tenantId: testTenant, providerId });
+
+    const row = await tenantTable('email_providers')
+      .where({ id: providerId })
+      .first('inbound_paused_at', 'inbound_pause_reason', 'status', 'error_message');
+    expect(row.inbound_pause_reason).toBe('auth_failure');
+    expect(row.status).toBe('error');
+    // The catch block's raw refresh-error text must NOT replace the curated
+    // reconnect-required instruction written by the auto-pause transaction.
+    expect(row.error_message).toBe(
+      'Sign-in was rejected by the email provider. Reconnect the mailbox to resume inbound email.'
+    );
+  });
+
   it('does not count transient token-health failures', async () => {
     const providerId = await seedPollingProvider();
     const transient: any = new Error('timeout of 30000ms exceeded');

--- a/server/src/test/integration/emailWebhookMaintenanceAuthFailure.integration.test.ts
+++ b/server/src/test/integration/emailWebhookMaintenanceAuthFailure.integration.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Behavioral integration tests for Microsoft token-health auth outcomes in
+ * EmailWebhookMaintenanceService (covers providers whose subscription has
+ * gone quiet and therefore no longer receive pointer jobs):
+ *
+ * - repeated terminal `invalid_client` token-health failures advance the same
+ *   provider counter used by the queue processor (and pause at the threshold);
+ * - a successful token-health check resets the counter.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { Knex } from 'knex';
+import { v4 as uuidv4 } from 'uuid';
+import { tenantDb } from '@alga-psa/db';
+import { createTestDbConnection, wireLocalTestDbEnv } from '../../../test-utils/dbConfig';
+import { describeWithDb } from '../../../test-utils/requireDb';
+import { EmailWebhookMaintenanceService } from '@alga-psa/shared/services/email/EmailWebhookMaintenanceService';
+
+const describeDb = await describeWithDb();
+
+let testDb: Knex;
+let testTenant: string;
+
+const tokenHealthMock = vi.hoisted(() => ({
+  ensureTokenHealthy: vi.fn(),
+  listMessagesReceivedSince: vi.fn(),
+}));
+
+vi.mock('redis', () => ({
+  createClient: () => {
+    throw new Error('redis unavailable in maintenance auth-failure tests');
+  },
+}));
+
+vi.mock('@alga-psa/db/admin', () => ({
+  getAdminConnection: async () => testDb,
+}));
+
+vi.mock('@alga-psa/shared/services/email/microsoftEmailProviderConfig', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@alga-psa/shared/services/email/microsoftEmailProviderConfig')>();
+  return {
+    ...actual,
+    buildMicrosoftEmailProviderConfig: async (config: any) => config,
+  };
+});
+
+vi.mock('@alga-psa/shared/services/email/providers/MicrosoftGraphAdapter', () => ({
+  MicrosoftGraphError: class MicrosoftGraphError extends Error {},
+  MicrosoftGraphAdapter: class MicrosoftGraphAdapter {
+    constructor(public config: any) {}
+    async ensureTokenHealthy() {
+      return tokenHealthMock.ensureTokenHealthy();
+    }
+    async listMessagesReceivedSince() {
+      return tokenHealthMock.listMessagesReceivedSince();
+    }
+  },
+}));
+
+function tenantTable<Row = Record<string, unknown>>(table: string) {
+  return tenantDb(testDb, testTenant).table<Row>(table);
+}
+
+function tenantFixtureTable() {
+  return tenantDb(testDb, testTenant).unscoped(
+    'tenants',
+    'maintenance auth-failure test fixture creates and removes tenant rows'
+  );
+}
+
+async function seedPollingProvider(): Promise<string> {
+  const providerId = uuidv4();
+  const now = new Date();
+  await tenantTable('email_providers').insert({
+    id: providerId,
+    tenant: testTenant,
+    provider_type: 'microsoft',
+    provider_name: 'Quiet Mailbox',
+    mailbox: `quiet-${providerId.slice(0, 8)}@example.com`,
+    is_active: true,
+    status: 'connected',
+    inbound_paused_at: null,
+    error_message: null,
+    created_at: now,
+    updated_at: now,
+  });
+  await tenantTable('microsoft_email_provider_config').insert({
+    email_provider_id: providerId,
+    tenant: testTenant,
+    client_id: 'client-id',
+    client_secret: 'client-secret',
+    tenant_id: 'directory-tenant-guid',
+    redirect_uri: 'https://psa.example.com/api/auth/microsoft/callback',
+    auto_process_emails: true,
+    max_emails_per_sync: 50,
+    folder_filters: JSON.stringify(['Inbox']),
+    access_token: 'stale',
+    refresh_token: 'revoked',
+    token_expires_at: new Date(Date.now() - 3600_000).toISOString(),
+    delivery_mode: 'polling',
+    created_at: now,
+    updated_at: now,
+  });
+  return providerId;
+}
+
+async function getCount(providerId: string): Promise<number> {
+  const row = await tenantTable('email_providers').where({ id: providerId }).first('inbound_auth_failure_count');
+  return Number(row?.inbound_auth_failure_count || 0);
+}
+
+function sanitizedInvalidClientError(): Error {
+  const failure: any = new Error('Error in refreshAccessToken: Request failed with status code 401 (code: 401)');
+  failure.status = 401;
+  failure.code = '401';
+  failure.responseBody = { error: 'invalid_client', error_description: 'AADSTS7000215' };
+  return failure;
+}
+
+describeDb('Microsoft maintenance token-health auth outcomes (DB-backed)', () => {
+  beforeAll(async () => {
+    wireLocalTestDbEnv();
+    testDb = await createTestDbConnection();
+    testTenant = uuidv4();
+    await tenantFixtureTable().insert({
+      tenant: testTenant,
+      client_name: 'Maintenance Auth Test Client',
+      email: 'maintenance-auth@client.com',
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+  }, 180_000);
+
+  afterAll(async () => {
+    if (testTenant) {
+      await tenantTable('email_provider_health').delete();
+      await tenantTable('microsoft_email_provider_config').delete();
+      await tenantTable('email_providers').delete();
+      await tenantFixtureTable().where('tenant', testTenant).delete();
+    }
+    await testDb?.destroy().catch(() => undefined);
+  }, 30_000);
+
+  it('uses the same counter for repeated token-health invalid_client failures and pauses at the threshold', async () => {
+    const providerId = await seedPollingProvider();
+    tokenHealthMock.ensureTokenHealthy.mockRejectedValue(sanitizedInvalidClientError());
+    tokenHealthMock.listMessagesReceivedSince.mockResolvedValue([]);
+
+    const service = new EmailWebhookMaintenanceService();
+
+    await service.reconcilePollingProviders({ tenantId: testTenant, providerId });
+    expect(await getCount(providerId)).toBe(1);
+
+    await service.reconcilePollingProviders({ tenantId: testTenant, providerId });
+    expect(await getCount(providerId)).toBe(2);
+
+    await service.reconcilePollingProviders({ tenantId: testTenant, providerId });
+    expect(await getCount(providerId)).toBe(3);
+
+    const row = await tenantTable('email_providers').where({ id: providerId }).first();
+    expect(row.inbound_paused_at).not.toBeNull();
+    expect(row.inbound_pause_reason).toBe('auth_failure');
+    expect(row.inbound_auth_failure_code).toBe('microsoft:invalid_client');
+  });
+
+  it('resets the counter after a successful token-health check', async () => {
+    const providerId = await seedPollingProvider();
+    tokenHealthMock.ensureTokenHealthy.mockRejectedValueOnce(sanitizedInvalidClientError());
+    tokenHealthMock.ensureTokenHealthy.mockResolvedValue(undefined);
+    tokenHealthMock.listMessagesReceivedSince.mockResolvedValue([]);
+
+    const service = new EmailWebhookMaintenanceService();
+
+    await service.reconcilePollingProviders({ tenantId: testTenant, providerId });
+    expect(await getCount(providerId)).toBe(1);
+
+    await service.reconcilePollingProviders({ tenantId: testTenant, providerId });
+    expect(await getCount(providerId)).toBe(0);
+
+    const row = await tenantTable('email_providers').where({ id: providerId }).first();
+    expect(row.inbound_paused_at).toBeNull();
+  });
+
+  it('does not count transient token-health failures', async () => {
+    const providerId = await seedPollingProvider();
+    const transient: any = new Error('timeout of 30000ms exceeded');
+    transient.code = 'ECONNABORTED';
+    tokenHealthMock.ensureTokenHealthy.mockRejectedValueOnce(transient);
+    tokenHealthMock.listMessagesReceivedSince.mockResolvedValue([]);
+
+    await new EmailWebhookMaintenanceService().reconcilePollingProviders({
+      tenantId: testTenant,
+      providerId,
+    });
+
+    expect(await getCount(providerId)).toBe(0);
+    const row = await tenantTable('email_providers').where({ id: providerId }).first();
+    expect(row.inbound_paused_at).toBeNull();
+  });
+});

--- a/server/src/test/integration/emailWebhookMaintenanceAuthFailure.integration.test.ts
+++ b/server/src/test/integration/emailWebhookMaintenanceAuthFailure.integration.test.ts
@@ -32,6 +32,11 @@ vi.mock('redis', () => ({
   },
 }));
 
+vi.mock('@alga-psa/shared/services/email/unifiedInboundEmailQueue', () => ({
+  enqueueUnifiedInboundEmailQueueJob: vi.fn(async () => ({ job: {}, queueDepth: 0 })),
+  getInboundEmailRedisClient: vi.fn(async () => ({})),
+}));
+
 vi.mock('@alga-psa/db/admin', () => ({
   getAdminConnection: async () => testDb,
 }));
@@ -51,8 +56,8 @@ vi.mock('@alga-psa/shared/services/email/providers/MicrosoftGraphAdapter', () =>
     async ensureTokenHealthy() {
       return tokenHealthMock.ensureTokenHealthy();
     }
-    async listMessagesReceivedSince() {
-      return tokenHealthMock.listMessagesReceivedSince();
+    async listMessagesReceivedSince(...args: any[]) {
+      return tokenHealthMock.listMessagesReceivedSince(...args);
     }
   },
 }));
@@ -181,28 +186,46 @@ describeDb('Microsoft maintenance token-health auth outcomes (DB-backed)', () =>
     expect(row.inbound_paused_at).toBeNull();
   });
 
-  it('flags reconciliation as truncated when the requested boundary predates the 7-day window cap', async () => {
+  it('honors an explicit recovery boundary beyond the renewal window cap and reports paging state', async () => {
     const providerId = await seedPollingProvider();
     tokenHealthMock.ensureTokenHealthy.mockResolvedValue(undefined);
+    tokenHealthMock.listMessagesReceivedSince.mockReset();
     tokenHealthMock.listMessagesReceivedSince.mockResolvedValue([]);
 
     // The module-level vi.mock only stubs the adapter; the service class
     // (and therefore the real reconciliation algorithm) runs against the DB.
+    // An explicit `since` (auth-pause recovery) must NOT be clamped by the
+    // 7-day renewal window cap: a 9-day-old pause boundary is listed from
+    // directly (minus the safety margin), so the paused interval has no gap.
+    const requestedSince = new Date(Date.now() - 9 * 24 * 60 * 60 * 1000);
     const result = await new EmailWebhookMaintenanceService().reconcileProviderMessages({
       providerId,
       tenant: testTenant,
-      since: new Date(Date.now() - 9 * 24 * 60 * 60 * 1000),
+      since: requestedSince,
     });
 
-    expect(result.truncated).toBe(true);
+    const listedSince = tokenHealthMock.listMessagesReceivedSince.mock.calls[0][0] as Date;
+    const marginMs = 15 * 60 * 1000;
+    expect(Math.abs(listedSince.getTime() - (requestedSince.getTime() - marginMs))).toBeLessThanOrEqual(2000);
+    expect(result.moreRemaining).toBe(false);
+    expect(result.enqueuedMessageIds).toEqual([]);
 
-    // Within the cap: no truncation flag.
-    const withinCap = await new EmailWebhookMaintenanceService().reconcileProviderMessages({
+    // A full batch with Graph not exhausted reports that more may remain, so
+    // the recovery loop sweeps again instead of clearing the pause.
+    tokenHealthMock.listMessagesReceivedSince.mockImplementation(
+      async (_since: Date, maxCount: number) =>
+        Array.from({ length: maxCount }, (_, index) => ({
+          id: `ms-${index}`,
+          receivedDateTime: new Date().toISOString(),
+        }))
+    );
+    const capped = await new EmailWebhookMaintenanceService().reconcileProviderMessages({
       providerId,
       tenant: testTenant,
-      since: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000),
+      since: requestedSince,
     });
-    expect(withinCap.truncated).toBeFalsy();
+    expect(capped.moreRemaining).toBe(true);
+    expect(capped.enqueuedMessageIds).toHaveLength(50);
   });
 
   it('keeps the curated auto-pause error message when the token-health catch path runs after the pause', async () => {

--- a/server/src/test/integration/inboundAuthFailureAutoPause.integration.test.ts
+++ b/server/src/test/integration/inboundAuthFailureAutoPause.integration.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Behavioral integration tests for the inbound auth-failure auto-pause:
+ *
+ * - two classified failures keep the provider active; the third atomically
+ *   pauses it with reason `auth_failure`, tears down the external
+ *   subscription exactly once, and dispatches the admin notification
+ *   exactly once — including under concurrent failing jobs;
+ * - `recordSourceAccessSuccess` resets the counter;
+ * - the server-side admin notifier creates exactly one `system-announcement`
+ *   internal notification per active admin (never for non-admins).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi, beforeEach, afterEach } from 'vitest';
+import type { Knex } from 'knex';
+import { v4 as uuidv4 } from 'uuid';
+import { tenantDb } from '@alga-psa/db';
+import { createTestDbConnection, wireLocalTestDbEnv } from '../../../test-utils/dbConfig';
+import { describeWithDb } from '../../../test-utils/requireDb';
+import { EmailProviderLifecycleService } from '@alga-psa/shared/services/email/EmailProviderLifecycleService';
+import { INBOUND_AUTH_FAILURE_PAUSE_THRESHOLD } from '@alga-psa/shared/services/email/InboundEmailAuthFailurePolicy';
+import {
+  clearInboundAuthPauseNotifier,
+  registerInboundAuthPauseNotifier,
+  type InboundAuthPauseNotificationParams,
+} from '@alga-psa/shared/services/email/inboundAuthPauseNotifier';
+
+const describeDb = await describeWithDb();
+
+let testDb: Knex;
+let testTenant: string;
+
+const stopWatchCalls: any[] = [];
+const dispatchedNotifications: InboundAuthPauseNotificationParams[] = [];
+
+vi.mock('@alga-psa/db/admin', () => ({
+  getAdminConnection: async () => testDb,
+}));
+
+vi.mock('@alga-psa/shared/services/email/providers/GmailAdapter', () => ({
+  GmailAdapter: class GmailAdapter {
+    constructor(public config: any) {}
+    async stopWatch() {
+      stopWatchCalls.push(this.config?.id);
+    }
+    async registerWebhookSubscription() {}
+    async connect() {}
+    async testConnection() {
+      return { success: true };
+    }
+    async listMessagesSince() {
+      return [];
+    }
+    async listMessageIdsSinceTime() {
+      return [];
+    }
+  },
+}));
+
+function tenantTable<Row = Record<string, unknown>>(table: string) {
+  return tenantDb(testDb, testTenant).table<Row>(table);
+}
+
+function tenantFixtureTable() {
+  return tenantDb(testDb, testTenant).unscoped(
+    'tenants',
+    'inbound auth-failure auto-pause test fixture creates and removes tenant rows'
+  );
+}
+
+async function seedGoogleProvider(): Promise<string> {
+  const providerId = uuidv4();
+  const now = new Date();
+  await tenantTable('email_providers').insert({
+    id: providerId,
+    tenant: testTenant,
+    provider_type: 'google',
+    provider_name: 'Paused Mailbox',
+    mailbox: `pause-${providerId.slice(0, 8)}@example.com`,
+    is_active: true,
+    status: 'connected',
+    inbound_paused_at: null,
+    error_message: null,
+    created_at: now,
+    updated_at: now,
+  });
+  await tenantTable('google_email_provider_config').insert({
+    email_provider_id: providerId,
+    tenant: testTenant,
+    client_id: 'client-id',
+    client_secret: 'client-secret',
+    project_id: 'project',
+    auto_process_emails: true,
+    max_emails_per_sync: 50,
+    label_filters: JSON.stringify([]),
+    access_token: 'access',
+    refresh_token: 'refresh',
+    token_expires_at: new Date(Date.now() + 3600_000).toISOString(),
+    history_id: '1000',
+    watch_expiration: new Date(Date.now() + 3600_000).toISOString(),
+    created_at: now,
+    updated_at: now,
+  });
+  return providerId;
+}
+
+async function seedUserWithRole(roleName: 'admin' | 'owner' | 'member'): Promise<string> {
+  const userId = uuidv4();
+  await tenantTable('users').insert({
+    tenant: testTenant,
+    user_id: userId,
+    username: `user-${userId.slice(0, 8)}`,
+    hashed_password: 'unused',
+    user_type: 'internal',
+    email: `user-${userId.slice(0, 8)}@test.co`,
+    created_at: new Date(),
+    updated_at: new Date(),
+  });
+  if (roleName !== 'member') {
+    const roleId = uuidv4();
+    await tenantTable('roles').insert({
+      tenant: testTenant,
+      role_id: roleId,
+      role_name: roleName,
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+    await tenantTable('user_roles').insert({
+      tenant: testTenant,
+      user_id: userId,
+      role_id: roleId,
+    });
+  }
+  return userId;
+}
+
+async function getProviderRow(providerId: string) {
+  return tenantTable('email_providers').where({ id: providerId }).first();
+}
+
+describeDb('inbound auth-failure auto-pause lifecycle (DB-backed)', () => {
+  beforeAll(async () => {
+    wireLocalTestDbEnv();
+    testDb = await createTestDbConnection();
+    testTenant = uuidv4();
+    await tenantFixtureTable().insert({
+      tenant: testTenant,
+      client_name: 'Auth Pause Test Client',
+      email: 'auth-pause@client.com',
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+  }, 180_000);
+
+  afterAll(async () => {
+    if (testTenant) {
+      await tenantTable('internal_notifications').delete();
+      await tenantTable('user_roles').delete();
+      await tenantTable('roles').delete();
+      await tenantTable('users').delete();
+      await tenantTable('google_email_provider_config').delete();
+      await tenantTable('email_providers').delete();
+      await tenantFixtureTable().where('tenant', testTenant).delete();
+    }
+    await testDb?.destroy().catch(() => undefined);
+  }, 30_000);
+
+  beforeEach(() => {
+    stopWatchCalls.length = 0;
+    dispatchedNotifications.length = 0;
+    registerInboundAuthPauseNotifier(async (params) => {
+      dispatchedNotifications.push(params);
+    });
+  });
+
+  afterEach(() => {
+    clearInboundAuthPauseNotifier();
+  });
+
+  it('exposes the fixed threshold of three', () => {
+    expect(INBOUND_AUTH_FAILURE_PAUSE_THRESHOLD).toBe(3);
+  });
+
+  it('keeps the provider active after two failures and pauses atomically on the third', async () => {
+    const providerId = await seedGoogleProvider();
+    const service = new EmailProviderLifecycleService();
+
+    const first = await service.recordUnrecoverableAuthFailure(providerId, testTenant, 'google:invalid_grant');
+    expect(first.autoPaused).toBe(false);
+    expect(first.count).toBe(1);
+
+    let row = await getProviderRow(providerId);
+    expect(row.inbound_paused_at).toBeNull();
+    expect(Number(row.inbound_auth_failure_count)).toBe(1);
+    expect(row.inbound_auth_failure_code).toBe('google:invalid_grant');
+    expect(row.status).toBe('connected');
+
+    const second = await service.recordUnrecoverableAuthFailure(providerId, testTenant, 'google:invalid_grant');
+    expect(second.autoPaused).toBe(false);
+    expect(second.count).toBe(2);
+    row = await getProviderRow(providerId);
+    expect(row.inbound_paused_at).toBeNull();
+
+    const third = await service.recordUnrecoverableAuthFailure(providerId, testTenant, 'google:invalid_grant');
+    expect(third.autoPaused).toBe(true);
+    expect(third.count).toBe(3);
+
+    row = await getProviderRow(providerId);
+    expect(row.inbound_paused_at).not.toBeNull();
+    expect(row.inbound_pause_reason).toBe('auth_failure');
+    expect(Number(row.inbound_auth_failure_count)).toBe(3);
+    expect(row.inbound_auth_failure_code).toBe('google:invalid_grant');
+    expect(row.inbound_auth_failure_last_at).not.toBeNull();
+    expect(row.status).toBe('error');
+    expect(row.error_message).not.toContain('invalid_grant');
+
+    // Exactly one teardown and one notification dispatch for the pause.
+    expect(stopWatchCalls).toEqual([providerId]);
+    expect(dispatchedNotifications).toHaveLength(1);
+    expect(dispatchedNotifications[0]).toMatchObject({
+      tenant: testTenant,
+      providerId,
+      providerName: 'Paused Mailbox',
+      authFailureCode: 'google:invalid_grant',
+    });
+  });
+
+  it('pauses exactly once under concurrent failing jobs (no double teardown or notification)', async () => {
+    const providerId = await seedGoogleProvider();
+    const service = new EmailProviderLifecycleService();
+
+    const outcomes = await Promise.all(
+      Array.from({ length: 6 }, () =>
+        service.recordUnrecoverableAuthFailure(providerId, testTenant, 'google:invalid_grant')
+      )
+    );
+
+    // Serialized by the row lock: the transaction observing the
+    // unpaused→paused transition is the only one that tears down/notifies.
+    expect(outcomes.filter((outcome) => outcome.autoPaused)).toHaveLength(1);
+
+    const row = await getProviderRow(providerId);
+    expect(row.inbound_paused_at).not.toBeNull();
+    expect(row.inbound_pause_reason).toBe('auth_failure');
+    // Once paused, later failures no-op instead of inflating the counter.
+    expect(Number(row.inbound_auth_failure_count)).toBe(3);
+
+    expect(stopWatchCalls).toEqual([providerId]);
+    expect(dispatchedNotifications).toHaveLength(1);
+  });
+
+  it('resets the counter on successful source access (including no new messages)', async () => {
+    const providerId = await seedGoogleProvider();
+    const service = new EmailProviderLifecycleService();
+
+    await service.recordUnrecoverableAuthFailure(providerId, testTenant, 'google:invalid_grant');
+    await service.recordUnrecoverableAuthFailure(providerId, testTenant, 'google:invalid_grant');
+
+    await service.recordSourceAccessSuccess(providerId, testTenant);
+
+    let row = await getProviderRow(providerId);
+    expect(row.inbound_paused_at).toBeNull();
+    expect(Number(row.inbound_auth_failure_count)).toBe(0);
+    expect(row.inbound_auth_failure_last_at).toBeNull();
+    expect(row.inbound_auth_failure_code).toBeNull();
+
+    // The next failure starts a fresh consecutive run: two more are needed.
+    const afterReset = await service.recordUnrecoverableAuthFailure(providerId, testTenant, 'google:invalid_grant');
+    expect(afterReset.autoPaused).toBe(false);
+    expect(afterReset.count).toBe(1);
+    row = await getProviderRow(providerId);
+    expect(row.inbound_paused_at).toBeNull();
+  });
+
+  it('keeps manual pause semantics: recordUnrecoverableAuthFailure no-ops on an already-paused provider', async () => {
+    const providerId = await seedGoogleProvider();
+    const service = new EmailProviderLifecycleService();
+
+    const paused = await service.pauseProvider(providerId, testTenant, 'manual');
+    expect(paused).toBe(true);
+
+    const outcome = await service.recordUnrecoverableAuthFailure(providerId, testTenant, 'google:invalid_grant');
+    expect(outcome.autoPaused).toBe(false);
+
+    const row = await getProviderRow(providerId);
+    expect(row.inbound_pause_reason).toBe('manual');
+    expect(Number(row.inbound_auth_failure_count)).toBe(0);
+    expect(stopWatchCalls).toEqual([providerId]); // manual pause tore down; the no-op added nothing
+    expect(dispatchedNotifications).toHaveLength(0);
+  });
+
+  it('creates one system-announcement notification per active admin (never for members)', async () => {
+    const { notifyInboundAuthPauseAdmins } = await import(
+      '../../services/email/inboundAuthPauseNotificationService'
+    );
+
+    await seedUserWithRole('admin');
+    await seedUserWithRole('admin');
+    await seedUserWithRole('owner');
+    await seedUserWithRole('member');
+
+    const admins = await tenantTable('user_roles')
+      .join('roles', 'roles.role_id', 'user_roles.role_id')
+      .whereRaw("LOWER(roles.role_name) IN ('admin', 'owner')")
+      .count('user_roles.user_id as count');
+    const expectedAdminCount = Number((admins[0] as any).count);
+
+    await notifyInboundAuthPauseAdmins({
+      tenant: testTenant,
+      providerId: 'provider-notif-test',
+      providerName: 'Notif Mailbox',
+      mailbox: 'notif@example.com',
+      providerType: 'microsoft',
+      authFailureCode: 'microsoft:invalid_grant',
+      pausedAt: new Date().toISOString(),
+    });
+
+    const notifications = await tenantTable('internal_notifications')
+      .where({ template_name: 'system-announcement' })
+      .select('user_id', 'link', 'title', 'message');
+
+    expect(notifications).toHaveLength(expectedAdminCount);
+    for (const notification of notifications) {
+      expect(notification.link).toBe('/msp/settings?tab=email');
+      // 'system-announcement' renders its message from {{announcementTitle}}.
+      expect(notification.message).toContain('Notif Mailbox');
+      expect(notification.message).toContain('notif@example.com');
+      // No credential material may leak into the notification payload.
+      expect(notification.message).not.toMatch(/refresh|token|secret/i);
+    }
+  });
+});

--- a/server/src/test/integration/inboundAuthFailureAutoPause.integration.test.ts
+++ b/server/src/test/integration/inboundAuthFailureAutoPause.integration.test.ts
@@ -19,6 +19,10 @@ import { describeWithDb } from '../../../test-utils/requireDb';
 import { EmailProviderLifecycleService } from '@alga-psa/shared/services/email/EmailProviderLifecycleService';
 import { INBOUND_AUTH_FAILURE_PAUSE_THRESHOLD } from '@alga-psa/shared/services/email/InboundEmailAuthFailurePolicy';
 import {
+  recordInboundSourceAccessSuccess,
+  recordInboundSourceAuthFailure,
+} from '@alga-psa/shared/services/email/inboundEmailAuthOutcomeRecorder';
+import {
   clearInboundAuthPauseNotifier,
   registerInboundAuthPauseNotifier,
   type InboundAuthPauseNotificationParams,
@@ -103,6 +107,43 @@ async function seedGoogleProvider(): Promise<string> {
   return providerId;
 }
 
+async function seedImapProvider(): Promise<string> {
+  const providerId = uuidv4();
+  const now = new Date();
+  await tenantTable('email_providers').insert({
+    id: providerId,
+    tenant: testTenant,
+    provider_type: 'imap',
+    provider_name: 'IMAP Mailbox',
+    mailbox: `imap-${providerId.slice(0, 8)}@example.com`,
+    is_active: true,
+    status: 'connected',
+    inbound_paused_at: null,
+    error_message: null,
+    created_at: now,
+    updated_at: now,
+  });
+  await tenantTable('imap_email_provider_config').insert({
+    email_provider_id: providerId,
+    tenant: testTenant,
+    host: 'imap.example.com',
+    port: 993,
+    secure: true,
+    allow_starttls: false,
+    auth_type: 'password',
+    username: `imap-${providerId.slice(0, 8)}`,
+    folder_filters: JSON.stringify(['INBOX']),
+    auto_process_emails: true,
+    max_emails_per_sync: 50,
+    uid_validity: 'abc',
+    last_uid: '410',
+    folder_state: JSON.stringify({ INBOX: { uid_validity: 'abc', last_uid: '410' } }),
+    created_at: now,
+    updated_at: now,
+  });
+  return providerId;
+}
+
 async function seedUserWithRole(roleName: 'admin' | 'owner' | 'member'): Promise<string> {
   const userId = uuidv4();
   await tenantTable('users').insert({
@@ -158,6 +199,7 @@ describeDb('inbound auth-failure auto-pause lifecycle (DB-backed)', () => {
       await tenantTable('roles').delete();
       await tenantTable('users').delete();
       await tenantTable('google_email_provider_config').delete();
+      await tenantTable('imap_email_provider_config').delete();
       await tenantTable('email_providers').delete();
       await tenantFixtureTable().where('tenant', testTenant).delete();
     }
@@ -352,5 +394,137 @@ describeDb('inbound auth-failure auto-pause lifecycle (DB-backed)', () => {
       // No credential material may leak into the notification payload.
       expect(notification.message).not.toMatch(/refresh|token|secret/i);
     }
+  });
+
+  describe('IMAP email-service source-access accounting (standalone listener path)', () => {
+    // These tests drive the exact recorder the standalone IMAP email-service
+    // listener loop calls at its connection/fetch boundary
+    // (services/email-service/src/emailService.ts): strict classification →
+    // counter, success → reset, transient → neither. The admin notification
+    // flows through the notifier registered at startup in that runtime
+    // (event-publisher hand-off; asserted by the topology contract test).
+
+    function imapAuthenticationRejection(): Error {
+      // Shape produced by ImapFlow on an AUTHENTICATE failure.
+      const failure: any = new Error('Authentication failed');
+      failure.authenticationFailed = true;
+      failure.serverResponseCode = 'AUTHENTICATIONFAILED';
+      failure.responseText = 'INVALID CREDENTIALS';
+      return failure;
+    }
+
+    it('counts classified IMAP auth failures and pauses at the threshold with a notification', async () => {
+      const providerId = await seedImapProvider();
+
+      const first = await recordInboundSourceAuthFailure({
+        tenant: testTenant,
+        providerId,
+        providerType: 'imap',
+        error: imapAuthenticationRejection(),
+        source: 'imap-email-service',
+      });
+      expect(first).toEqual({ unrecoverable: true, autoPaused: false });
+
+      await recordInboundSourceAuthFailure({
+        tenant: testTenant,
+        providerId,
+        providerType: 'imap',
+        error: imapAuthenticationRejection(),
+        source: 'imap-email-service',
+      });
+
+      let row = await getProviderRow(providerId);
+      expect(row.inbound_paused_at).toBeNull();
+      expect(Number(row.inbound_auth_failure_count)).toBe(2);
+      expect(row.inbound_auth_failure_code).toBe('imap:authentication_failed');
+
+      const third = await recordInboundSourceAuthFailure({
+        tenant: testTenant,
+        providerId,
+        providerType: 'imap',
+        error: imapAuthenticationRejection(),
+        source: 'imap-email-service',
+      });
+      expect(third.autoPaused).toBe(true);
+
+      row = await getProviderRow(providerId);
+      expect(row.inbound_paused_at).not.toBeNull();
+      expect(row.inbound_pause_reason).toBe('auth_failure');
+      expect(Number(row.inbound_auth_failure_count)).toBe(3);
+
+      // The notification reaches admins from the email-service runtime via the
+      // registered notifier (event-publisher → server subscriber in prod).
+      expect(dispatchedNotifications).toHaveLength(1);
+      expect(dispatchedNotifications[0]).toMatchObject({
+        tenant: testTenant,
+        providerId,
+        providerType: 'imap',
+        authFailureCode: 'imap:authentication_failed',
+      });
+    });
+
+    it('counts IMAP OAuth token-endpoint terminal failures', async () => {
+      const providerId = await seedImapProvider();
+      // Shape produced by the email-service refreshAccessToken rethrow: the
+      // raw axios error carries the OAuth error body on response.data.
+      const oauthFailure: any = new Error('Request failed with status code 400');
+      oauthFailure.response = { data: { error: 'invalid_grant' } };
+
+      const outcome = await recordInboundSourceAuthFailure({
+        tenant: testTenant,
+        providerId,
+        providerType: 'imap',
+        error: oauthFailure,
+        source: 'imap-email-service',
+      });
+      expect(outcome).toEqual({ unrecoverable: true, autoPaused: false });
+
+      const row = await getProviderRow(providerId);
+      expect(Number(row.inbound_auth_failure_count)).toBe(1);
+      expect(row.inbound_auth_failure_code).toBe('imap:invalid_grant');
+    });
+
+    it('never counts transient connection errors and resets on successful access', async () => {
+      const providerId = await seedImapProvider();
+
+      const transientOutcome = await recordInboundSourceAuthFailure({
+        tenant: testTenant,
+        providerId,
+        providerType: 'imap',
+        error: new Error('connect ETIMEDOUT 10.0.0.5:993'),
+        source: 'imap-email-service',
+      });
+      expect(transientOutcome).toEqual({ unrecoverable: false, autoPaused: false });
+      expect(Number((await getProviderRow(providerId)).inbound_auth_failure_count)).toBe(0);
+
+      // Arm the counter with two classified failures, then a successful
+      // mailbox access (the listener's connect-success path) resets it.
+      await recordInboundSourceAuthFailure({
+        tenant: testTenant,
+        providerId,
+        providerType: 'imap',
+        error: imapAuthenticationRejection(),
+        source: 'imap-email-service',
+      });
+      await recordInboundSourceAuthFailure({
+        tenant: testTenant,
+        providerId,
+        providerType: 'imap',
+        error: imapAuthenticationRejection(),
+        source: 'imap-email-service',
+      });
+      expect(Number((await getProviderRow(providerId)).inbound_auth_failure_count)).toBe(2);
+
+      await recordInboundSourceAccessSuccess({
+        tenant: testTenant,
+        providerId,
+        source: 'imap-email-service',
+      });
+
+      const row = await getProviderRow(providerId);
+      expect(Number(row.inbound_auth_failure_count)).toBe(0);
+      expect(row.inbound_auth_failure_last_at).toBeNull();
+      expect(row.inbound_paused_at).toBeNull();
+    });
   });
 });

--- a/server/src/test/integration/inboundAuthFailureAutoPause.integration.test.ts
+++ b/server/src/test/integration/inboundAuthFailureAutoPause.integration.test.ts
@@ -271,6 +271,31 @@ describeDb('inbound auth-failure auto-pause lifecycle (DB-backed)', () => {
     expect(row.inbound_paused_at).toBeNull();
   });
 
+  it('resets stale auth-failure counters on manual resume so one later failure does not auto-pause', async () => {
+    const providerId = await seedGoogleProvider();
+    const service = new EmailProviderLifecycleService();
+
+    // Arm the counter to 2, then pause/resume manually (e.g. an operator
+    // pause during maintenance).
+    await service.recordUnrecoverableAuthFailure(providerId, testTenant, 'google:invalid_grant');
+    await service.recordUnrecoverableAuthFailure(providerId, testTenant, 'google:invalid_grant');
+    expect(await service.pauseProvider(providerId, testTenant, 'manual')).toBe(true);
+
+    const resumed = await service.resumeProvider(providerId, testTenant);
+    expect(resumed.resumed).toBe(true);
+
+    let row = await getProviderRow(providerId);
+    expect(Number(row.inbound_auth_failure_count)).toBe(0);
+    expect(row.inbound_auth_failure_last_at).toBeNull();
+    expect(row.inbound_auth_failure_code).toBeNull();
+
+    // A single later classified failure must NOT auto-pause anymore.
+    const outcome = await service.recordUnrecoverableAuthFailure(providerId, testTenant, 'google:invalid_grant');
+    expect(outcome.autoPaused).toBe(false);
+    row = await getProviderRow(providerId);
+    expect(row.inbound_paused_at).toBeNull();
+  });
+
   it('keeps manual pause semantics: recordUnrecoverableAuthFailure no-ops on an already-paused provider', async () => {
     const providerId = await seedGoogleProvider();
     const service = new EmailProviderLifecycleService();

--- a/server/src/test/integration/inboundAuthFailureMigration.integration.test.ts
+++ b/server/src/test/integration/inboundAuthFailureMigration.integration.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Migration coverage for the inbound auth-failure tracking columns:
+ * applies the migration to the test database (up is idempotent) and inspects
+ * runtime column/default behavior, including the widened pause-reason CHECK
+ * constraint that admits 'auth_failure'.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Knex } from 'knex';
+import { v4 as uuidv4 } from 'uuid';
+import { createRequire } from 'node:module';
+import { tenantDb } from '@alga-psa/db';
+import { createTestDbConnection, wireLocalTestDbEnv } from '../../../test-utils/dbConfig';
+import { describeWithDb } from '../../../test-utils/requireDb';
+
+const describeDb = await describeWithDb();
+
+const require = createRequire(import.meta.url);
+const migration = require('../../../migrations/20260815120000_add_inbound_auth_failure_tracking_to_email_providers.cjs');
+
+let testDb: Knex;
+let testTenant: string;
+
+function tenantTable<Row = Record<string, unknown>>(table: string) {
+  return tenantDb(testDb, testTenant).table<Row>(table);
+}
+
+function tenantFixtureTable() {
+  return tenantDb(testDb, testTenant).unscoped(
+    'tenants',
+    'auth-failure migration test fixture creates and removes tenant rows'
+  );
+}
+
+async function columnNames(): Promise<Set<string>> {
+  const rows = await testDb('information_schema.columns').where('table_name', 'email_providers').pluck('column_name');
+  return new Set(rows);
+}
+
+describeDb('inbound auth-failure tracking migration (DB-backed)', () => {
+  beforeAll(async () => {
+    wireLocalTestDbEnv();
+    testDb = await createTestDbConnection();
+    testTenant = uuidv4();
+    await tenantFixtureTable().insert({
+      tenant: testTenant,
+      client_name: 'Migration Test Client',
+      email: 'migration@client.com',
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+  }, 180_000);
+
+  afterAll(async () => {
+    if (testTenant) {
+      await tenantTable('email_providers').delete();
+      await tenantFixtureTable().where('tenant', testTenant).delete();
+    }
+    await testDb?.destroy().catch(() => undefined);
+  }, 30_000);
+
+  it('is already applied by the test-database bootstrap and is idempotent', async () => {
+    const before = await columnNames();
+    expect(before).toContain('inbound_auth_failure_count');
+    expect(before).toContain('inbound_auth_failure_last_at');
+    expect(before).toContain('inbound_auth_failure_code');
+
+    // Re-running up must be a no-op (hasColumn-guarded alters).
+    await migration.up(testDb);
+    const after = await columnNames();
+    expect(after).toEqual(before);
+  });
+
+  it('defaults inbound_auth_failure_count to 0 for new rows without an explicit value', async () => {
+    const providerId = uuidv4();
+    const now = new Date();
+    await tenantTable('email_providers').insert({
+      id: providerId,
+      tenant: testTenant,
+      provider_type: 'imap',
+      provider_name: 'Migration Provider',
+      mailbox: `migration-${providerId.slice(0, 8)}@example.com`,
+      is_active: true,
+      status: 'connected',
+      created_at: now,
+      updated_at: now,
+    });
+
+    const row = await tenantTable('email_providers').where({ id: providerId }).first(
+      'inbound_auth_failure_count',
+      'inbound_auth_failure_last_at',
+      'inbound_auth_failure_code'
+    );
+    expect(Number(row.inbound_auth_failure_count)).toBe(0);
+    expect(row.inbound_auth_failure_last_at).toBeNull();
+    expect(row.inbound_auth_failure_code).toBeNull();
+  });
+
+  it("admits 'auth_failure' through the widened pause-reason CHECK constraint", async () => {
+    const providerId = uuidv4();
+    const now = new Date();
+    await tenantTable('email_providers').insert({
+      id: providerId,
+      tenant: testTenant,
+      provider_type: 'imap',
+      provider_name: 'Constraint Provider',
+      mailbox: `constraint-${providerId.slice(0, 8)}@example.com`,
+      is_active: true,
+      status: 'error',
+      inbound_paused_at: now,
+      inbound_pause_reason: 'auth_failure',
+      created_at: now,
+      updated_at: now,
+    });
+
+    const row = await tenantTable('email_providers').where({ id: providerId }).first('inbound_pause_reason');
+    expect(row.inbound_pause_reason).toBe('auth_failure');
+
+    // Manual reasons remain valid after the constraint swap.
+    await tenantTable('email_providers').where({ id: providerId }).update({
+      inbound_pause_reason: 'manual',
+    });
+    const manualRow = await tenantTable('email_providers').where({ id: providerId }).first('inbound_pause_reason');
+    expect(manualRow.inbound_pause_reason).toBe('manual');
+  });
+
+  it('down restores the pre-feature columns and narrowed constraint, then up re-adds them', async () => {
+    await migration.down(testDb);
+
+    const narrowed = await columnNames();
+    expect(narrowed).not.toContain('inbound_auth_failure_count');
+    expect(narrowed).not.toContain('inbound_auth_failure_last_at');
+    expect(narrowed).not.toContain('inbound_auth_failure_code');
+
+    // The narrowed constraint rejects auth_failure again.
+    const providerId = uuidv4();
+    const now = new Date();
+    await expect(
+      tenantTable('email_providers').insert({
+        id: providerId,
+        tenant: testTenant,
+        provider_type: 'imap',
+        provider_name: 'Down Provider',
+        mailbox: `down-${providerId.slice(0, 8)}@example.com`,
+        is_active: true,
+        status: 'error',
+        inbound_paused_at: now,
+        inbound_pause_reason: 'auth_failure',
+        created_at: now,
+        updated_at: now,
+      })
+    ).rejects.toThrow(/email_providers_inbound_pause_reason_check/);
+
+    await migration.up(testDb);
+
+    const restored = await columnNames();
+    expect(restored).toContain('inbound_auth_failure_count');
+    expect(restored).toContain('inbound_auth_failure_last_at');
+    expect(restored).toContain('inbound_auth_failure_code');
+
+    // And auth_failure rows are writable again.
+    await tenantTable('email_providers').insert({
+      id: providerId,
+      tenant: testTenant,
+      provider_type: 'imap',
+      provider_name: 'Up Again Provider',
+      mailbox: `up-${providerId.slice(0, 8)}@example.com`,
+      is_active: true,
+      status: 'error',
+      inbound_paused_at: now,
+      inbound_pause_reason: 'auth_failure',
+      created_at: now,
+      updated_at: now,
+    });
+  });
+});

--- a/server/src/test/integration/inboundAuthPauseReconnectSave.integration.test.ts
+++ b/server/src/test/integration/inboundAuthPauseReconnectSave.integration.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Behavioral integration tests for the auth-pause RECONNECT SAVE path — the
+ * exact `updateEmailProvider(providerId, payload, skipAutomation)` call the
+ * provider forms' Reconnect drawer makes (ImapProviderForm passes
+ * skipAutomation=true). A credential-bearing save for a provider auto-paused
+ * on repeated auth failures must route through the lifecycle recovery:
+ * validate the submitted credentials against the source, atomically clear the
+ * pause + auth-failure counters + stale IMAP cursors (the pause-window
+ * backfill arming), and only then report success. Recovery must NOT fire for
+ * unrelated saves on healthy or manually-paused providers, and invalid
+ * credentials must leave the pause intact and surface an error.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from 'vitest';
+import type { Knex } from 'knex';
+import { v4 as uuidv4 } from 'uuid';
+import { tenantDb } from '@alga-psa/db';
+import { createTestDbConnection, wireLocalTestDbEnv } from '../../../test-utils/dbConfig';
+import { describeWithDb } from '../../../test-utils/requireDb';
+import { updateEmailProvider } from '@alga-psa/integrations/actions/email-actions/emailProviderActions';
+
+const describeDb = await describeWithDb();
+
+let testDb: Knex;
+let testTenant: string;
+
+const imapFlowMock = vi.hoisted(() => ({
+  instances: [] as any[],
+  connectShouldFail: false,
+}));
+const secretsMock = vi.hoisted(() => ({
+  store: new Map<string, string>(),
+}));
+
+vi.mock('redis', () => ({
+  createClient: () => {
+    throw new Error('redis unavailable in auth-pause reconnect save tests');
+  },
+}));
+
+// Route the action's tenant resolution (global withAuth mock) at our test
+// tenant, same harness as emailProviderCreation.test.ts.
+vi.mock('../../lib/db', () => ({
+  getCurrentTenantId: () => testTenant,
+  createTenantKnex: vi.fn().mockImplementation(async () => ({
+    knex: testDb,
+    tenant: testTenant
+  }))
+}));
+
+vi.mock('@alga-psa/db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@alga-psa/db')>();
+  return {
+    ...actual,
+    createTenantKnex: vi.fn(async () => ({ knex: testDb, tenant: testTenant })),
+  };
+});
+
+// The lifecycle recovery service resolves its own admin connection.
+vi.mock('@alga-psa/db/admin', () => ({
+  getAdminConnection: async () => testDb,
+}));
+
+// In-memory tenant secrets: persistImapConfig writes the submitted password,
+// credential validation reads it back — proving validation runs against the
+// credentials that were just saved.
+vi.mock('@alga-psa/core/secrets', () => ({
+  getSecretProviderInstance: async () => ({
+    getTenantSecret: async (tenant: string, key: string) =>
+      secretsMock.store.get(`${tenant}:${key}`) ?? null,
+    setTenantSecret: async (tenant: string, key: string, value: string) => {
+      secretsMock.store.set(`${tenant}:${key}`, value);
+    },
+    getAppSecret: async () => undefined,
+  }),
+}));
+
+vi.mock('imapflow', () => ({
+  ImapFlow: class ImapFlow {
+    constructor(public options: any) {
+      imapFlowMock.instances.push(this);
+    }
+    async connect() {
+      if (imapFlowMock.connectShouldFail) {
+        const failure: any = new Error('Authentication failed');
+        failure.authenticationFailed = true;
+        throw failure;
+      }
+    }
+    async logout() {}
+    close() {}
+  },
+}));
+
+function tenantTable<Row = Record<string, unknown>>(table: string) {
+  return tenantDb(testDb, testTenant).table<Row>(table);
+}
+
+function tenantFixtureTable() {
+  return tenantDb(testDb, testTenant).unscoped(
+    'tenants',
+    'auth-pause reconnect save test fixture creates and removes tenant rows'
+  );
+}
+
+type PauseState = 'auth_failure' | 'manual' | null;
+
+async function seedImapProvider(pause: PauseState): Promise<string> {
+  const providerId = uuidv4();
+  const pausedAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
+  const now = new Date();
+  await tenantTable('email_providers').insert({
+    id: providerId,
+    tenant: testTenant,
+    provider_type: 'imap',
+    provider_name: 'Support IMAP (paused)',
+    mailbox: `reconnect-${providerId.slice(0, 8)}@example.com`,
+    is_active: true,
+    status: pause ? 'error' : 'connected',
+    error_message: pause
+      ? 'Sign-in was rejected by the email provider. Reconnect the mailbox to resume inbound email.'
+      : null,
+    inbound_paused_at: pause ? pausedAt : null,
+    inbound_pause_reason: pause,
+    inbound_auth_failure_count: pause === 'auth_failure' ? 3 : 0,
+    inbound_auth_failure_last_at: pause === 'auth_failure' ? pausedAt : null,
+    inbound_auth_failure_code: pause === 'auth_failure' ? 'imap:AUTHENTICATIONFAILED' : null,
+    created_at: now,
+    updated_at: now,
+  });
+  await tenantTable('imap_email_provider_config').insert({
+    email_provider_id: providerId,
+    tenant: testTenant,
+    host: 'imap.example.com',
+    port: 993,
+    secure: true,
+    allow_starttls: false,
+    auth_type: 'password',
+    username: `reconnect-${providerId.slice(0, 8)}`,
+    folder_filters: JSON.stringify(['INBOX']),
+    auto_process_emails: true,
+    max_emails_per_sync: 50,
+    uid_validity: 'abc',
+    last_uid: '400',
+    folder_state: JSON.stringify({ INBOX: { uid_validity: 'abc', last_uid: '400' } }),
+    last_error: pause ? 'AUTHENTICATIONFAILED (paused-interval state)' : null,
+    created_at: now,
+    updated_at: now,
+  });
+  // The stored credential the pause was earned with (dead), so a recovery
+  // that ignores the submitted password is distinguishable from one that
+  // validates the just-saved credential.
+  secretsMock.store.set(`${testTenant}:imap_password_${providerId}`, 'old-dead-password');
+  return providerId;
+}
+
+// Mirrors ImapProviderForm's onSubmit payload (packages/integrations and the
+// EE copies), including the skipAutomation=true third argument used at the
+// call site — that exact combination is the Reconnect drawer's save.
+function formImapPayload(providerId: string) {
+  return {
+    tenant: testTenant,
+    providerType: 'imap',
+    providerName: 'Support IMAP (reconnected)',
+    senderDisplayName: null as const,
+    mailbox: `reconnect-${providerId.slice(0, 8)}@example.com`,
+    isActive: true,
+    imapConfig: {
+      host: 'imap.example.com',
+      port: 993,
+      secure: true,
+      allow_starttls: false,
+      auth_type: 'password',
+      username: `reconnect-${providerId.slice(0, 8)}`,
+      password: 'new-valid-password',
+      auto_process_emails: true,
+      folder_filters: ['INBOX'],
+      max_emails_per_sync: 5,
+      connection_timeout_ms: 10_000,
+      socket_keepalive: true,
+    },
+  };
+}
+
+async function getProviderRow(providerId: string) {
+  return tenantTable('email_providers').where({ id: providerId }).first();
+}
+
+async function getImapConfigRow(providerId: string) {
+  return tenantTable('imap_email_provider_config')
+    .where({ email_provider_id: providerId })
+    .first('uid_validity', 'last_uid', 'folder_state', 'last_error');
+}
+
+describeDb('auth-pause reconnect save path (updateEmailProvider, DB-backed)', () => {
+  beforeAll(async () => {
+    wireLocalTestDbEnv();
+    testDb = await createTestDbConnection();
+    testTenant = uuidv4();
+    await tenantFixtureTable().insert({
+      tenant: testTenant,
+      client_name: 'Reconnect Save Test Client',
+      email: 'reconnect-save@client.com',
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+  }, 180_000);
+
+  afterAll(async () => {
+    if (testTenant) {
+      await tenantTable('email_providers').delete();
+      await tenantTable('imap_email_provider_config').delete();
+      await tenantFixtureTable().where({ tenant: testTenant }).delete();
+    }
+    await testDb?.destroy().catch(() => undefined);
+  }, 30_000);
+
+  beforeEach(() => {
+    imapFlowMock.instances.length = 0;
+    imapFlowMock.connectShouldFail = false;
+    secretsMock.store.clear();
+  });
+
+  it('the Reconnect drawer save (skipAutomation=true) recovers an auth-paused IMAP provider end-to-end', async () => {
+    const providerId = await seedImapProvider('auth_failure');
+
+    // Pre-fix failure signal: with the recovery branch gated on
+    // !skipAutomation, this save reported success while every pause column,
+    // the auth-failure counter, and the stale IMAP cursors survived — the
+    // provider stayed dead after a "successful" reconnect.
+    const result = await updateEmailProvider(providerId, formImapPayload(providerId), true);
+
+    expect((result as any).actionError).toBeUndefined();
+    expect((result as any).setupError).toBeUndefined();
+    expect(result.provider).toBeDefined();
+
+    // Credential validation ran against the SOURCE with the just-saved
+    // password (not the stored dead one), exactly once.
+    expect(imapFlowMock.instances).toHaveLength(1);
+    expect(imapFlowMock.instances[0].options.auth.pass).toBe('new-valid-password');
+
+    // Pause cleared and counters reset: ingestion (discovery/poller gating)
+    // resumes.
+    const row = await getProviderRow(providerId);
+    expect(row.inbound_paused_at).toBeNull();
+    expect(row.inbound_pause_reason).toBeNull();
+    expect(Number(row.inbound_auth_failure_count)).toBe(0);
+    expect(row.inbound_auth_failure_last_at).toBeNull();
+    expect(row.inbound_auth_failure_code).toBeNull();
+    expect(row.status).toBe('connected');
+    expect(row.error_message).toBeNull();
+
+    // Pause-window backfill armed: UID/folder cursors reset so the poller
+    // rescans the paused interval (last_uid '0' = scan from UID 1).
+    const config = await getImapConfigRow(providerId);
+    expect(config.uid_validity).toBeNull();
+    expect(config.last_uid).toBe('0');
+    expect(config.folder_state).toEqual({});
+    expect(config.last_error).toBeNull();
+  });
+
+  it('invalid credentials: the same save leaves the pause, counter, and cursors intact and surfaces the error', async () => {
+    const providerId = await seedImapProvider('auth_failure');
+    imapFlowMock.connectShouldFail = true;
+
+    // Pre-fix failure signal: no recovery ran at all, so the save reported
+    // success with no error while the provider stayed paused. Post-fix the
+    // failed source validation must refuse the recovery.
+    const result = await updateEmailProvider(providerId, formImapPayload(providerId), true);
+
+    expect((result as any).actionError).toBeUndefined();
+    expect((result as any).setupError).toBeTruthy();
+    expect((result as any).provider.status).toBe('error');
+
+    expect(imapFlowMock.instances).toHaveLength(1);
+
+    const row = await getProviderRow(providerId);
+    expect(row.inbound_paused_at).not.toBeNull();
+    expect(row.inbound_pause_reason).toBe('auth_failure');
+    expect(Number(row.inbound_auth_failure_count)).toBe(3);
+    expect(row.inbound_auth_failure_code).toBe('imap:AUTHENTICATIONFAILED');
+
+    // Cursors survive: they are only cleared AFTER validation succeeds.
+    const config = await getImapConfigRow(providerId);
+    expect(config.uid_validity).toBe('abc');
+    expect(config.last_uid).toBe('400');
+  });
+
+  it('unrelated edit on a healthy provider: no recovery, no credential validation, cursors preserved', async () => {
+    const providerId = await seedImapProvider(null);
+
+    const result = await updateEmailProvider(providerId, formImapPayload(providerId), true);
+
+    expect((result as any).actionError).toBeUndefined();
+    expect((result as any).setupError).toBeUndefined();
+
+    // No ImapFlow instance: the recovery's validate-against-source never ran.
+    expect(imapFlowMock.instances).toHaveLength(0);
+
+    const row = await getProviderRow(providerId);
+    expect(row.inbound_paused_at).toBeNull();
+    expect(row.inbound_pause_reason).toBeNull();
+
+    const config = await getImapConfigRow(providerId);
+    expect(config.uid_validity).toBe('abc');
+    expect(config.last_uid).toBe('400');
+  });
+
+  it('unrelated edit on a manually-paused provider: the manual pause is not lifted', async () => {
+    const providerId = await seedImapProvider('manual');
+
+    const result = await updateEmailProvider(providerId, formImapPayload(providerId), true);
+
+    expect((result as any).actionError).toBeUndefined();
+    expect((result as any).setupError).toBeUndefined();
+    expect(imapFlowMock.instances).toHaveLength(0);
+
+    const row = await getProviderRow(providerId);
+    expect(row.inbound_paused_at).not.toBeNull();
+    expect(row.inbound_pause_reason).toBe('manual');
+
+    const config = await getImapConfigRow(providerId);
+    expect(config.last_uid).toBe('400');
+  });
+});

--- a/server/src/test/integration/inboundAuthPauseReconnectSave.integration.test.ts
+++ b/server/src/test/integration/inboundAuthPauseReconnectSave.integration.test.ts
@@ -9,6 +9,12 @@
  * backfill arming), and only then report success. Recovery must NOT fire for
  * unrelated saves on healthy or manually-paused providers, and invalid
  * credentials must leave the pause intact and surface an error.
+ *
+ * The Google siblings cover the OAuth reconnect path: a paused provider's
+ * save must surface recovery failure (watch registration failure, missing
+ * OAuth tokens, or automation-skipped saves) and never report success while
+ * the pause persists, while a genuine watch re-registration resumes the
+ * provider end-to-end.
  */
 
 import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from 'vitest';
@@ -30,6 +36,18 @@ const imapFlowMock = vi.hoisted(() => ({
 }));
 const secretsMock = vi.hoisted(() => ({
   store: new Map<string, string>(),
+}));
+const pubsubMock = vi.hoisted(() => ({
+  calls: [] as any[],
+}));
+const gmailWatchMock = vi.hoisted(() => ({
+  instances: [] as any[],
+  registerShouldFail: false,
+}));
+const gmailAdapterMock = vi.hoisted(() => ({
+  instances: [] as any[],
+  testConnectionShouldFail: false,
+  listMessagesSinceCalls: [] as any[],
 }));
 
 vi.mock('redis', () => ({
@@ -89,6 +107,53 @@ vi.mock('imapflow', () => ({
     }
     async logout() {}
     close() {}
+  },
+}));
+
+// Google transport surface of configureGmailProvider: Pub/Sub provisioning
+// and the Gmail watch registration are stubbed so the REAL orchestrator
+// (and its DB pause-state decisions) runs against the test database.
+vi.mock('@alga-psa/integrations/actions/email-actions/setupPubSub', () => ({
+  setupPubSub: async (params: any) => {
+    pubsubMock.calls.push(params);
+  },
+}));
+
+vi.mock('@alga-psa/integrations/services/email/GmailWebhookService', () => ({
+  GmailWebhookService: class GmailWebhookService {
+    constructor() {
+      gmailWatchMock.instances.push(this);
+    }
+    async registerWatch() {
+      if (gmailWatchMock.registerShouldFail) {
+        throw new Error('Watch registration failed: invalid grant');
+      }
+    }
+  },
+}));
+
+// GmailAdapter backs the lifecycle recovery's credential validation, watch
+// re-establishment, and paused-interval reconciliation.
+vi.mock('@alga-psa/shared/services/email/providers/GmailAdapter', () => ({
+  GmailAdapter: class GmailAdapter {
+    constructor(public config: any) {
+      gmailAdapterMock.instances.push(this);
+    }
+    async testConnection() {
+      return gmailAdapterMock.testConnectionShouldFail
+        ? { success: false, error: 'Invalid Credentials' }
+        : { success: true };
+    }
+    async registerWebhookSubscription() {
+      return { success: true };
+    }
+    async listMessagesSince(historyId: any) {
+      gmailAdapterMock.listMessagesSinceCalls.push(historyId);
+      return [];
+    }
+    async listMessageIdsSinceTime() {
+      return [];
+    }
   },
 }));
 
@@ -192,10 +257,97 @@ async function getImapConfigRow(providerId: string) {
     .first('uid_validity', 'last_uid', 'folder_state', 'last_error');
 }
 
+async function seedGoogleProvider(pause: PauseState, options?: { tokens?: boolean }): Promise<string> {
+  const providerId = uuidv4();
+  const pausedAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
+  const now = new Date();
+  const withTokens = options?.tokens !== false;
+  await tenantTable('email_providers').insert({
+    id: providerId,
+    tenant: testTenant,
+    provider_type: 'google',
+    provider_name: 'Support Gmail (paused)',
+    mailbox: `gmail-${providerId.slice(0, 8)}@example.com`,
+    is_active: true,
+    status: pause ? 'error' : 'connected',
+    error_message: pause
+      ? 'Sign-in was rejected by the email provider. Reconnect the mailbox to resume inbound email.'
+      : null,
+    inbound_paused_at: pause ? pausedAt : null,
+    inbound_pause_reason: pause,
+    inbound_auth_failure_count: pause === 'auth_failure' ? 3 : 0,
+    inbound_auth_failure_last_at: pause === 'auth_failure' ? pausedAt : null,
+    inbound_auth_failure_code: pause === 'auth_failure' ? 'google:INVALID_CREDENTIALS' : null,
+    created_at: now,
+    updated_at: now,
+  });
+  await tenantTable('google_email_provider_config').insert({
+    email_provider_id: providerId,
+    tenant: testTenant,
+    client_id: null,
+    client_secret: null,
+    project_id: 'test-project',
+    redirect_uri: 'http://localhost:3000/api/auth/google/callback',
+    pubsub_topic_name: `gmail-notifications-${testTenant}`,
+    pubsub_subscription_name: `gmail-webhook-${testTenant}`,
+    auto_process_emails: true,
+    max_emails_per_sync: 50,
+    label_filters: JSON.stringify(['INBOX']),
+    // Tokens are only stale placeholders — every Google transport call is
+    // mocked — but their presence/absence steers configureGmailProvider's
+    // watch-registration guard, which is under test.
+    access_token: withTokens ? 'stale-access-token' : null,
+    refresh_token: withTokens ? 'stale-refresh-token' : null,
+    history_id: '5000',
+    created_at: now,
+    updated_at: now,
+  });
+  // Tenant-level Google OAuth settings persistGoogleConfig requires (the
+  // forms send client_id/client_secret: null and rely on these secrets).
+  secretsMock.store.set(`${testTenant}:google_client_id`, 'test-client-id');
+  secretsMock.store.set(`${testTenant}:google_client_secret`, 'test-client-secret');
+  secretsMock.store.set(`${testTenant}:google_project_id`, 'test-project');
+  return providerId;
+}
+
+// Mirrors GmailProviderForm's onSubmit payload (packages/integrations and
+// the EE copy), including the skipAutomation argument used at the call
+// site. Without `withFreshTokens` the payload carries no OAuth tokens —
+// the "user saved without re-authorizing" shape.
+function formGooglePayload(providerId: string, withFreshTokens = true) {
+  return {
+    tenant: testTenant,
+    providerType: 'google',
+    providerName: 'Support Gmail (reconnected)',
+    senderDisplayName: null as const,
+    mailbox: `gmail-${providerId.slice(0, 8)}@example.com`,
+    isActive: true,
+    googleConfig: {
+      client_id: null,
+      client_secret: null,
+      auto_process_emails: true,
+      label_filters: ['INBOX'],
+      max_emails_per_sync: 50,
+      ...(withFreshTokens && {
+        access_token: 'fresh-access-token',
+        refresh_token: 'fresh-refresh-token',
+      }),
+    },
+  };
+}
+
 describeDb('auth-pause reconnect save path (updateEmailProvider, DB-backed)', () => {
   beforeAll(async () => {
     wireLocalTestDbEnv();
-    testDb = await createTestDbConnection();
+    // Scratch database instead of the shared test_database: every
+    // DB-backed suite bootstrap DROPs its database, and parallel worktree
+    // agents sharing the local test Postgres repeatedly dropped
+    // test_database mid-suite here, killing this run's migrations. All
+    // app-layer DB access in this suite is mocked to the returned handle,
+    // so a private name isolates the bootstrap without changing behavior.
+    testDb = await createTestDbConnection({
+      databaseName: 'test_database_auth_pause_reconnect',
+    });
     testTenant = uuidv4();
     await tenantFixtureTable().insert({
       tenant: testTenant,
@@ -210,6 +362,7 @@ describeDb('auth-pause reconnect save path (updateEmailProvider, DB-backed)', ()
     if (testTenant) {
       await tenantTable('email_providers').delete();
       await tenantTable('imap_email_provider_config').delete();
+      await tenantTable('google_email_provider_config').delete();
       await tenantFixtureTable().where({ tenant: testTenant }).delete();
     }
     await testDb?.destroy().catch(() => undefined);
@@ -219,6 +372,12 @@ describeDb('auth-pause reconnect save path (updateEmailProvider, DB-backed)', ()
     imapFlowMock.instances.length = 0;
     imapFlowMock.connectShouldFail = false;
     secretsMock.store.clear();
+    pubsubMock.calls.length = 0;
+    gmailWatchMock.instances.length = 0;
+    gmailWatchMock.registerShouldFail = false;
+    gmailAdapterMock.instances.length = 0;
+    gmailAdapterMock.testConnectionShouldFail = false;
+    gmailAdapterMock.listMessagesSinceCalls.length = 0;
   });
 
   it('the Reconnect drawer save (skipAutomation=true) recovers an auth-paused IMAP provider end-to-end', async () => {
@@ -339,5 +498,121 @@ describeDb('auth-pause reconnect save path (updateEmailProvider, DB-backed)', ()
 
     const config = await getImapConfigRow(providerId);
     expect(config.last_uid).toBe('400');
+  });
+
+  it('Google: a watch registration failure (revoked credentials) on an auth-paused provider is a recovery failure, not success', async () => {
+    const providerId = await seedGoogleProvider('auth_failure');
+    gmailWatchMock.registerShouldFail = true;
+
+    // Pre-fix failure signal: the watch-throw catch converted the failure
+    // into `success = pubsubConfigured` with no authFailureRecovery, so the
+    // save returned a clean success — provider "connected", no setupError —
+    // while every pause column survived. The mailbox stayed dark with the
+    // UI reporting everything fine.
+    const result = await updateEmailProvider(providerId, formGooglePayload(providerId), false);
+
+    expect((result as any).actionError).toBeUndefined();
+    expect((result as any).setupError).toBeTruthy();
+    expect(result.provider.status).toBe('error');
+    // The returned provider shows the still-paused state (post-recovery
+    // re-read), so the banner persists alongside the form error.
+    expect(result.provider.inboundPausedAt).not.toBeNull();
+    expect(result.provider.inboundPauseReason).toBe('auth_failure');
+
+    expect(gmailWatchMock.instances).toHaveLength(1);
+
+    const row = await getProviderRow(providerId);
+    expect(row.status).not.toBe('connected');
+    expect(row.inbound_paused_at).not.toBeNull();
+    expect(row.inbound_pause_reason).toBe('auth_failure');
+    expect(Number(row.inbound_auth_failure_count)).toBe(3);
+    expect(row.inbound_auth_failure_code).toBe('google:INVALID_CREDENTIALS');
+  });
+
+  it('Google: missing OAuth tokens on an auth-paused provider fail the reconnect instead of warning-tolerated success', async () => {
+    // Stored tokens were cleared (revoked) and the save carries no fresh
+    // OAuth tokens — the reconnect cannot re-establish the watch at all.
+    const providerId = await seedGoogleProvider('auth_failure', { tokens: false });
+
+    // Pre-fix failure signal: the missing-tokens early return reported
+    // `success = pubsubConfigured` (true) with authFailureRecovery unset —
+    // another clean success over a still-paused mailbox.
+    const result = await updateEmailProvider(providerId, formGooglePayload(providerId, false), false);
+
+    expect((result as any).actionError).toBeUndefined();
+    expect((result as any).setupError).toBeTruthy();
+    expect(result.provider.status).toBe('error');
+    expect(result.provider.inboundPausedAt).not.toBeNull();
+    expect(result.provider.inboundPauseReason).toBe('auth_failure');
+
+    // The watch guard fired before any registration attempt.
+    expect(gmailWatchMock.instances).toHaveLength(0);
+
+    const row = await getProviderRow(providerId);
+    expect(row.status).not.toBe('connected');
+    expect(row.inbound_paused_at).not.toBeNull();
+    expect(row.inbound_pause_reason).toBe('auth_failure');
+    expect(Number(row.inbound_auth_failure_count)).toBe(3);
+  });
+
+  it('Google: a skipAutomation save of an auth-paused provider never returns silent success', async () => {
+    const providerId = await seedGoogleProvider('auth_failure');
+    // Recovery must validate the stored credentials itself (no transport
+    // ran to prove them); the source rejects them.
+    gmailAdapterMock.testConnectionShouldFail = true;
+
+    // Pre-fix failure signal: the Google branch was gated on
+    // !skipAutomation, so no recovery was attempted and the save returned
+    // a clean success while the provider stayed paused.
+    const result = await updateEmailProvider(providerId, formGooglePayload(providerId), true);
+
+    expect((result as any).actionError).toBeUndefined();
+    expect((result as any).setupError).toBeTruthy();
+    expect(result.provider.status).toBe('error');
+    expect(result.provider.inboundPausedAt).not.toBeNull();
+    expect(result.provider.inboundPauseReason).toBe('auth_failure');
+
+    // skipAutomation still means no transport automation: Pub/Sub setup and
+    // watch registration never ran; only lifecycle recovery (credential
+    // validation) did.
+    expect(pubsubMock.calls).toHaveLength(0);
+    expect(gmailWatchMock.instances).toHaveLength(0);
+    expect(gmailAdapterMock.instances).toHaveLength(1);
+
+    const row = await getProviderRow(providerId);
+    expect(row.status).not.toBe('connected');
+    expect(row.inbound_paused_at).not.toBeNull();
+    expect(row.inbound_pause_reason).toBe('auth_failure');
+    expect(Number(row.inbound_auth_failure_count)).toBe(3);
+  });
+
+  it('Google: a successful reconnect (watch re-registered) resumes the paused provider end-to-end', async () => {
+    const providerId = await seedGoogleProvider('auth_failure');
+
+    const result = await updateEmailProvider(providerId, formGooglePayload(providerId), false);
+
+    expect((result as any).actionError).toBeUndefined();
+    expect((result as any).setupError).toBeUndefined();
+
+    // The watch was re-registered (fresh OAuth tokens saved), and the
+    // paused interval was reconciled from the pre-watch history cursor.
+    expect(gmailWatchMock.instances).toHaveLength(1);
+    expect(gmailAdapterMock.listMessagesSinceCalls).toEqual(['5000']);
+
+    const row = await getProviderRow(providerId);
+    expect(row.inbound_paused_at).toBeNull();
+    expect(row.inbound_pause_reason).toBeNull();
+    expect(Number(row.inbound_auth_failure_count)).toBe(0);
+    expect(row.inbound_auth_failure_last_at).toBeNull();
+    expect(row.inbound_auth_failure_code).toBeNull();
+    expect(row.status).toBe('connected');
+    expect(row.error_message).toBeNull();
+
+    // The returned provider mirrors the post-recovery row, not the
+    // pre-recovery snapshot (the settings banner renders from it).
+    expect(result.provider.inboundPausedAt).toBeNull();
+    expect(result.provider.inboundPauseReason).toBeNull();
+    expect(Number(result.provider.inboundAuthFailureCount)).toBe(0);
+    expect(result.provider.status).toBe('connected');
   });
 });

--- a/server/src/test/integration/inboundAuthPauseReconnectSave.integration.test.ts
+++ b/server/src/test/integration/inboundAuthPauseReconnectSave.integration.test.ts
@@ -250,6 +250,19 @@ describeDb('auth-pause reconnect save path (updateEmailProvider, DB-backed)', ()
     expect(row.status).toBe('connected');
     expect(row.error_message).toBeNull();
 
+    // The RETURNED provider must mirror that post-recovery row, not the
+    // pre-recovery snapshot assembled before recovery ran: the settings
+    // banner renders from this object, so a stale pause/status here keeps
+    // the "reconnect required" banner on screen after a successful
+    // reconnect until a manual refresh.
+    expect(result.provider.inboundPausedAt).toBeNull();
+    expect(result.provider.inboundPauseReason).toBeNull();
+    expect(Number(result.provider.inboundAuthFailureCount)).toBe(0);
+    expect(result.provider.inboundAuthFailureLastAt).toBeNull();
+    expect(result.provider.inboundAuthFailureCode).toBeNull();
+    expect(result.provider.status).toBe('connected');
+    expect(result.provider.errorMessage).toBeNull();
+
     // Pause-window backfill armed: UID/folder cursors reset so the poller
     // rescans the paused interval (last_uid '0' = scan from UID 1).
     const config = await getImapConfigRow(providerId);
@@ -271,6 +284,11 @@ describeDb('auth-pause reconnect save path (updateEmailProvider, DB-backed)', ()
     expect((result as any).actionError).toBeUndefined();
     expect((result as any).setupError).toBeTruthy();
     expect((result as any).provider.status).toBe('error');
+
+    // The returned provider must show the still-paused state (post-recovery
+    // re-read), so the settings banner persists alongside the form error.
+    expect(result.provider.inboundPausedAt).not.toBeNull();
+    expect(result.provider.inboundPauseReason).toBe('auth_failure');
 
     expect(imapFlowMock.instances).toHaveLength(1);
 

--- a/server/src/test/integration/inboundAuthPauseRecovery.integration.test.ts
+++ b/server/src/test/integration/inboundAuthPauseRecovery.integration.test.ts
@@ -546,6 +546,87 @@ describeDb('auth-failure recovery path (DB-backed)', () => {
       expect(row.inbound_pause_reason).toBe('auth_failure');
     });
 
+    it('V1 google cursor persist is monotonic at write: a stale pointer job cannot regress the post-watch cursor', async () => {
+      const { providerId } = await seedPausedProvider('google');
+
+      // Recovery re-registers the watch (the mocked adapter persists the
+      // fresh watch cursor 9999, faithful to the real adapter's authoritative
+      // baseline write) and clears the pause so V1 jobs process.
+      const recovered = await new EmailProviderLifecycleService().recoverAuthPausedProvider(providerId, testTenant);
+      expect(recovered.resumed).toBe(true);
+      const readCursor = async (): Promise<string> =>
+        String(
+          (await tenantTable('google_email_provider_config')
+            .where({ email_provider_id: providerId })
+            .first('history_id')).history_id
+        );
+      expect(await readCursor()).toBe('9999');
+
+      const { processUnifiedInboundEmailQueueJob } = await import(
+        '@alga-psa/shared/services/email/unifiedInboundEmailQueueJobProcessor'
+      );
+      const processInboundEmailInAppModule = await vi.importActual<
+        typeof import('@alga-psa/shared/services/email/processInboundEmailInApp')
+      >('@alga-psa/shared/services/email/processInboundEmailInApp');
+      const spy = vi
+        .spyOn(processInboundEmailInAppModule, 'processInboundEmailInApp')
+        .mockResolvedValue({
+          outcome: 'created',
+          ticketId: '00000000-0000-4000-8000-0000000000cc',
+          diagnostics: {},
+        } as any);
+
+      try {
+        // A replayed/stale pointer job (historyId 1500, older than the fresh
+        // watch cursor 9999) completes AFTER the watch persist. Its cursor
+        // write must lose at the database predicate itself — pre-fix the
+        // unconditional UPDATE regressed the cursor to 1500 and the next sync
+        // re-scanned the whole interval.
+        gmailAdapterMock.getMessageDetails.mockResolvedValueOnce({
+          id: 'g-stale-cursor',
+          provider: 'google',
+          providerId,
+          tenant: testTenant,
+          receivedAt: new Date().toISOString(),
+          from: { email: 'sender@example.com' },
+          to: [{ email: 'support@example.com' }],
+          subject: 'Stale cursor',
+          body: { text: 'hello' },
+          attachments: [],
+        });
+        const staleJob = {
+          ...googleJob(providerId),
+          pointer: { historyId: '1500', emailAddress: 'recovery@example.com', discoveredMessageIds: ['g-stale-cursor'] },
+        };
+        const stale = await processUnifiedInboundEmailQueueJob(staleJob);
+        expect(stale.outcome).toBe('processed');
+        expect(await readCursor()).toBe('9999');
+
+        // A pointer newer than the current cursor still advances it.
+        gmailAdapterMock.getMessageDetails.mockResolvedValueOnce({
+          id: 'g-fresh-cursor',
+          provider: 'google',
+          providerId,
+          tenant: testTenant,
+          receivedAt: new Date().toISOString(),
+          from: { email: 'sender@example.com' },
+          to: [{ email: 'support@example.com' }],
+          subject: 'Fresh cursor',
+          body: { text: 'hello' },
+          attachments: [],
+        });
+        const freshJob = {
+          ...googleJob(providerId),
+          pointer: { historyId: '10500', emailAddress: 'recovery@example.com', discoveredMessageIds: ['g-fresh-cursor'] },
+        };
+        const fresh = await processUnifiedInboundEmailQueueJob(freshJob);
+        expect(fresh.outcome).toBe('processed');
+        expect(await readCursor()).toBe('10500');
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
     it('reconciled messages are deduped on repeated processing', async () => {
       const { providerId } = await seedPausedProvider('google');
 

--- a/server/src/test/integration/inboundAuthPauseRecovery.integration.test.ts
+++ b/server/src/test/integration/inboundAuthPauseRecovery.integration.test.ts
@@ -271,11 +271,12 @@ describeDb('auth-failure recovery path (DB-backed)', () => {
   afterAll(async () => {
     if (testTenant) {
       await tenantTable('email_processed_messages').delete();
+      await tenantTable('inbound_email_ingress').delete();
       await tenantTable('microsoft_email_provider_config').delete();
       await tenantTable('google_email_provider_config').delete();
       await tenantTable('imap_email_provider_config').delete();
       await tenantTable('email_providers').delete();
-      await tenantFixtureTable().where('tenant', testTenant).delete();
+      await tenantFixtureTable().where({ tenant: testTenant }).delete();
     }
     await testDb?.destroy().catch(() => undefined);
   }, 30_000);
@@ -403,6 +404,51 @@ describeDb('auth-failure recovery path (DB-backed)', () => {
       const row = await getProviderRow(providerId);
       expect(row.inbound_paused_at).toBeNull();
       expect(Number(row.inbound_auth_failure_count)).toBe(0);
+    });
+
+    it('enforce mode: durable pointers carry the post-watch cursor, mailbox identity, and discovered ids (one ingress per message)', async () => {
+      const { providerId } = await seedPausedProvider('google');
+      const providerRow = await getProviderRow(providerId);
+
+      const prevMode = process.env.UNIFIED_INBOUND_EMAIL_DURABLE_MODE;
+      process.env.UNIFIED_INBOUND_EMAIL_DURABLE_MODE = 'enforce';
+      try {
+        const result = await new EmailProviderLifecycleService().recoverAuthPausedProvider(providerId, testTenant);
+        expect(result.resumed).toBe(true);
+
+        // No legacy V1 handoff in enforce mode — the durable ingress rows are
+        // the hand-off.
+        expect(enqueueMock.enqueueUnifiedInboundEmailQueueJob).not.toHaveBeenCalled();
+
+        const rows = await tenantTable('inbound_email_ingress')
+          .where({ tenant: testTenant, provider_id: providerId });
+        // One ingress row per reconciled message id. Pre-fix every message
+        // shared the single deterministic key `history:<pre-watch-cursor>`,
+        // collapsing the whole interval into one row.
+        expect(rows.length).toBe(2);
+        expect(new Set(rows.map((row: any) => row.ingress_key)).size).toBe(2);
+
+        for (const row of rows) {
+          const pointer = row.provider_pointer;
+          // Post-watch cursor (9999), never the pre-watch one (1500): the
+          // staging worker persists pointer.historyId back to
+          // google_email_provider_config, and the pre-watch value would
+          // regress it below the fresh watch.
+          expect(String(pointer.historyId)).toBe('9999');
+          // Mailbox identity parity with the direct-enqueue branch.
+          expect(pointer.mailbox).toBe(providerRow.mailbox);
+          expect(pointer.emailAddress).toBe(providerRow.mailbox);
+          // The staging worker only downloads explicitly discovered ids;
+          // without them it re-lists from the post-watch cursor and finds
+          // nothing from the paused interval.
+          expect(Array.isArray(pointer.discoveredMessageIds)).toBe(true);
+          expect(pointer.discoveredMessageIds).toHaveLength(1);
+          expect(['g-1', 'g-2']).toContain(pointer.discoveredMessageIds[0]);
+        }
+      } finally {
+        process.env.UNIFIED_INBOUND_EMAIL_DURABLE_MODE = prevMode;
+        await tenantTable('inbound_email_ingress').where({ tenant: testTenant, provider_id: providerId }).delete();
+      }
     });
 
     it('falls back to a pause-bounded mailbox query when the saved cursor is rejected', async () => {

--- a/server/src/test/integration/inboundAuthPauseRecovery.integration.test.ts
+++ b/server/src/test/integration/inboundAuthPauseRecovery.integration.test.ts
@@ -1,0 +1,509 @@
+/**
+ * Behavioral integration tests for the auth-failure recovery path
+ * (reconnect → validate → re-establish → reconcile → clear) per provider:
+ *
+ * - the pause remains when credential validation fails;
+ * - the saved pause boundary/cursor is used for reconciliation;
+ * - a successful reconciliation clears the pause and counters;
+ * - repeated ingestion of the same reconciled message is deduped.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from 'vitest';
+import type { Knex } from 'knex';
+import { v4 as uuidv4 } from 'uuid';
+import { tenantDb } from '@alga-psa/db';
+import { createTestDbConnection, wireLocalTestDbEnv } from '../../../test-utils/dbConfig';
+import { describeWithDb } from '../../../test-utils/requireDb';
+import { EmailProviderLifecycleService } from '@alga-psa/shared/services/email/EmailProviderLifecycleService';
+import type { UnifiedInboundEmailQueueJob } from '@alga-psa/shared/interfaces/inbound-email.interfaces';
+
+const describeDb = await describeWithDb();
+
+let testDb: Knex;
+let testTenant: string;
+
+const reconcileMock = vi.hoisted(() => ({ reconcileProviderMessages: vi.fn() }));
+const graphAdapterMock = vi.hoisted(() => ({ testConnection: vi.fn() }));
+const gmailAdapterMock = vi.hoisted(() => ({
+  testConnection: vi.fn(),
+  registerWebhookSubscription: vi.fn(),
+  listMessagesSince: vi.fn(),
+  listMessageIdsSinceTime: vi.fn(),
+  getMessageDetails: vi.fn(),
+}));
+const imapFlowMock = vi.hoisted(() => ({
+  instances: [] as any[],
+  connectShouldFail: false,
+}));
+const enqueueMock = vi.hoisted(() => ({ enqueueUnifiedInboundEmailQueueJob: vi.fn() }));
+
+vi.mock('redis', () => ({
+  createClient: () => {
+    throw new Error('redis unavailable in auth-failure recovery tests');
+  },
+}));
+
+vi.mock('@alga-psa/db/admin', () => ({
+  getAdminConnection: async () => testDb,
+}));
+
+vi.mock('@alga-psa/core/secrets', () => ({
+  getSecretProviderInstance: async () => ({
+    getTenantSecret: async () => 'unit-test-password',
+    setTenantSecret: async () => undefined,
+    getAppSecret: async () => undefined,
+  }),
+}));
+
+vi.mock('@alga-psa/shared/services/email/microsoftEmailProviderConfig', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@alga-psa/shared/services/email/microsoftEmailProviderConfig')>();
+  return {
+    ...actual,
+    buildMicrosoftEmailProviderConfig: async (config: any) => config,
+  };
+});
+
+vi.mock('@alga-psa/shared/services/email/providers/MicrosoftGraphAdapter', () => ({
+  MicrosoftGraphError: class MicrosoftGraphError extends Error {},
+  MicrosoftGraphAdapter: class MicrosoftGraphAdapter {
+    constructor(public config: any) {}
+    async testConnection() {
+      return graphAdapterMock.testConnection();
+    }
+    async initializeWebhook() {
+      return { success: true, subscriptionId: 'sub-new' };
+    }
+  },
+}));
+
+vi.mock('@alga-psa/shared/services/email/providers/GmailAdapter', () => ({
+  GmailAdapter: class GmailAdapter {
+    constructor(public config: any) {}
+    async connect() {}
+    async testConnection() {
+      return gmailAdapterMock.testConnection();
+    }
+    async registerWebhookSubscription() {
+      return gmailAdapterMock.registerWebhookSubscription();
+    }
+    async listMessagesSince(startHistoryId: string) {
+      return gmailAdapterMock.listMessagesSince(startHistoryId);
+    }
+    async listMessageIdsSinceTime(since: Date, maxResults?: number) {
+      return gmailAdapterMock.listMessageIdsSinceTime(since, maxResults);
+    }
+    async getMessageDetails(messageId: string) {
+      return gmailAdapterMock.getMessageDetails(messageId);
+    }
+  },
+}));
+
+vi.mock('@alga-psa/shared/services/email/EmailWebhookMaintenanceService', () => ({
+  EmailWebhookMaintenanceService: class EmailWebhookMaintenanceService {
+    async reconcileProviderMessages(params: any) {
+      return reconcileMock.reconcileProviderMessages(params);
+    }
+  },
+}));
+
+vi.mock('@alga-psa/shared/services/email/unifiedInboundEmailQueue', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@alga-psa/shared/services/email/unifiedInboundEmailQueue')>();
+  return {
+    ...actual,
+    enqueueUnifiedInboundEmailQueueJob: enqueueMock.enqueueUnifiedInboundEmailQueueJob,
+  };
+});
+
+vi.mock('imapflow', () => ({
+  ImapFlow: class ImapFlow {
+    constructor(public options: any) {
+      imapFlowMock.instances.push(this);
+    }
+    async connect() {
+      if (imapFlowMock.connectShouldFail) {
+        const failure: any = new Error('Authentication failed');
+        failure.authenticationFailed = true;
+        throw failure;
+      }
+    }
+    async logout() {}
+    close() {}
+  },
+}));
+
+function tenantTable<Row = Record<string, unknown>>(table: string) {
+  return tenantDb(testDb, testTenant).table<Row>(table);
+}
+
+function tenantFixtureTable() {
+  return tenantDb(testDb, testTenant).unscoped(
+    'tenants',
+    'auth-failure recovery test fixture creates and removes tenant rows'
+  );
+}
+
+async function seedPausedProvider(providerType: 'microsoft' | 'google' | 'imap'): Promise<{
+  providerId: string;
+  pausedAt: Date;
+}> {
+  const providerId = uuidv4();
+  const pausedAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
+  const now = new Date();
+  await tenantTable('email_providers').insert({
+    id: providerId,
+    tenant: testTenant,
+    provider_type: providerType,
+    provider_name: `Recovery ${providerType}`,
+    mailbox: `recovery-${providerId.slice(0, 8)}@example.com`,
+    is_active: true,
+    status: 'error',
+    error_message: 'Sign-in was rejected by the email provider. Reconnect the mailbox to resume inbound email.',
+    inbound_paused_at: pausedAt,
+    inbound_pause_reason: 'auth_failure',
+    inbound_auth_failure_count: 3,
+    inbound_auth_failure_last_at: pausedAt,
+    inbound_auth_failure_code: `${providerType}:invalid_grant`,
+    created_at: now,
+    updated_at: now,
+  });
+
+  if (providerType === 'microsoft') {
+    await tenantTable('microsoft_email_provider_config').insert({
+      email_provider_id: providerId,
+      tenant: testTenant,
+      client_id: 'client-id',
+      client_secret: 'client-secret',
+      tenant_id: 'directory-tenant-guid',
+      redirect_uri: 'https://psa.example.com/api/auth/microsoft/callback',
+      auto_process_emails: true,
+      max_emails_per_sync: 50,
+      folder_filters: JSON.stringify(['Inbox']),
+      access_token: 'new-access',
+      refresh_token: 'new-refresh',
+      token_expires_at: new Date(Date.now() + 3600_000).toISOString(),
+      delivery_mode: 'polling',
+      created_at: now,
+      updated_at: now,
+    });
+  } else if (providerType === 'google') {
+    await tenantTable('google_email_provider_config').insert({
+      email_provider_id: providerId,
+      tenant: testTenant,
+      client_id: 'client-id',
+      client_secret: 'client-secret',
+      project_id: 'project',
+      auto_process_emails: true,
+      max_emails_per_sync: 50,
+      label_filters: JSON.stringify([]),
+      access_token: 'new-access',
+      refresh_token: 'new-refresh',
+      token_expires_at: new Date(Date.now() + 3600_000).toISOString(),
+      history_id: '1500',
+      created_at: now,
+      updated_at: now,
+    });
+  } else {
+    await tenantTable('imap_email_provider_config').insert({
+      email_provider_id: providerId,
+      tenant: testTenant,
+      host: 'imap.example.com',
+      port: 993,
+      secure: true,
+      allow_starttls: false,
+      auth_type: 'password',
+      username: `recovery-${providerId.slice(0, 8)}`,
+      folder_filters: JSON.stringify(['INBOX']),
+      auto_process_emails: true,
+      max_emails_per_sync: 50,
+      uid_validity: 'abc',
+      last_uid: '400',
+      folder_state: JSON.stringify({ INBOX: { uid_validity: 'abc', last_uid: '400' } }),
+      created_at: now,
+      updated_at: now,
+    });
+  }
+  return { providerId, pausedAt };
+}
+
+async function getProviderRow(providerId: string) {
+  return tenantTable('email_providers').where({ id: providerId }).first();
+}
+
+function googleJob(providerId: string): UnifiedInboundEmailQueueJob {
+  return {
+    jobId: `job-${uuidv4()}`,
+    schemaVersion: 1,
+    tenantId: testTenant,
+    providerId,
+    provider: 'google',
+    enqueuedAt: new Date().toISOString(),
+    attempt: 1,
+    maxAttempts: 5,
+    pointer: { historyId: '1500', emailAddress: 'recovery@example.com', discoveredMessageIds: ['g-1'] },
+  };
+}
+
+describeDb('auth-failure recovery path (DB-backed)', () => {
+  beforeAll(async () => {
+    wireLocalTestDbEnv();
+    testDb = await createTestDbConnection();
+    testTenant = uuidv4();
+    await tenantFixtureTable().insert({
+      tenant: testTenant,
+      client_name: 'Recovery Test Client',
+      email: 'recovery@client.com',
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+  }, 180_000);
+
+  afterAll(async () => {
+    if (testTenant) {
+      await tenantTable('email_processed_messages').delete();
+      await tenantTable('microsoft_email_provider_config').delete();
+      await tenantTable('google_email_provider_config').delete();
+      await tenantTable('imap_email_provider_config').delete();
+      await tenantTable('email_providers').delete();
+      await tenantFixtureTable().where('tenant', testTenant).delete();
+    }
+    await testDb?.destroy().catch(() => undefined);
+  }, 30_000);
+
+  beforeEach(() => {
+    reconcileMock.reconcileProviderMessages.mockReset().mockResolvedValue({ queuedMessages: 4 });
+    graphAdapterMock.testConnection.mockReset().mockResolvedValue({ success: true });
+    gmailAdapterMock.testConnection.mockReset().mockResolvedValue({ success: true });
+    gmailAdapterMock.registerWebhookSubscription.mockReset().mockResolvedValue(undefined);
+    gmailAdapterMock.listMessagesSince.mockReset().mockResolvedValue(['g-1', 'g-2']);
+    gmailAdapterMock.listMessageIdsSinceTime.mockReset().mockResolvedValue(['g-fb-1']);
+    gmailAdapterMock.getMessageDetails.mockReset().mockResolvedValue({
+      id: 'g-1',
+      provider: 'google',
+      providerId: 'x',
+      tenant: testTenant,
+      receivedAt: new Date().toISOString(),
+      from: { email: 'sender@example.com' },
+      to: [{ email: 'support@example.com' }],
+      subject: 'Paused-interval mail',
+      body: { text: 'hello' },
+      attachments: [],
+    });
+    enqueueMock.enqueueUnifiedInboundEmailQueueJob.mockReset().mockResolvedValue({ job: {}, queueDepth: 1 });
+    imapFlowMock.instances.length = 0;
+    imapFlowMock.connectShouldFail = false;
+  });
+
+  describe('Microsoft', () => {
+    it('keeps the pause when credential validation fails', async () => {
+      const { providerId } = await seedPausedProvider('microsoft');
+      graphAdapterMock.testConnection.mockResolvedValue({
+        success: false,
+        error: 'Error in refreshAccessToken: Request failed with status code 400 (code: 400)',
+      });
+
+      const result = await new EmailProviderLifecycleService().recoverAuthPausedProvider(providerId, testTenant);
+
+      expect(result.resumed).toBe(false);
+      expect(result.reconnectRequired).toBe(true);
+      expect(reconcileMock.reconcileProviderMessages).not.toHaveBeenCalled();
+
+      const row = await getProviderRow(providerId);
+      expect(row.inbound_paused_at).not.toBeNull();
+      expect(row.inbound_pause_reason).toBe('auth_failure');
+    });
+
+    it('reconciles from the saved pause boundary and clears the pause on success', async () => {
+      const { providerId, pausedAt } = await seedPausedProvider('microsoft');
+
+      const result = await new EmailProviderLifecycleService().recoverAuthPausedProvider(
+        providerId,
+        testTenant,
+        { credentialsValidated: true, deliveryEstablished: true }
+      );
+
+      expect(result.resumed).toBe(true);
+      expect(result.reconciliation).toEqual({ status: 'completed', queuedMessages: 4 });
+      expect(reconcileMock.reconcileProviderMessages).toHaveBeenCalledTimes(1);
+      const call = reconcileMock.reconcileProviderMessages.mock.calls[0][0];
+      expect(call.providerId).toBe(providerId);
+      expect(call.tenant).toBe(testTenant);
+      expect(new Date(call.since).getTime()).toBe(pausedAt.getTime());
+
+      const row = await getProviderRow(providerId);
+      expect(row.inbound_paused_at).toBeNull();
+      expect(row.inbound_pause_reason).toBeNull();
+      expect(Number(row.inbound_auth_failure_count)).toBe(0);
+      expect(row.inbound_auth_failure_code).toBeNull();
+      expect(row.status).toBe('connected');
+    });
+
+    it('routes resumeProvider through the recovery path for auth_failure pauses', async () => {
+      const { providerId } = await seedPausedProvider('microsoft');
+      graphAdapterMock.testConnection.mockResolvedValue({
+        success: false,
+        error: 'credentials still rejected',
+      });
+
+      const result = await new EmailProviderLifecycleService().resumeProvider(providerId, testTenant);
+
+      // No bare resume: dead credentials cannot clear the pause.
+      expect(result.resumed).toBe(false);
+      expect(result.reconnectRequired).toBe(true);
+      const row = await getProviderRow(providerId);
+      expect(row.inbound_paused_at).not.toBeNull();
+    });
+  });
+
+  describe('Google', () => {
+    it('uses the saved pre-watch history cursor, re-registers the watch, and clears the pause', async () => {
+      const { providerId } = await seedPausedProvider('google');
+
+      const result = await new EmailProviderLifecycleService().recoverAuthPausedProvider(providerId, testTenant);
+
+      expect(result.resumed).toBe(true);
+      expect(result.webhookRegistered).toBe(true);
+
+      // The pre-watch cursor is the seeded history_id.
+      expect(gmailAdapterMock.listMessagesSince).toHaveBeenCalledWith('1500');
+      expect(gmailAdapterMock.registerWebhookSubscription).toHaveBeenCalledTimes(1);
+
+      // One durable enqueue per reconciled message id.
+      expect(enqueueMock.enqueueUnifiedInboundEmailQueueJob).toHaveBeenCalledTimes(2);
+      const firstEnqueue = enqueueMock.enqueueUnifiedInboundEmailQueueJob.mock.calls[0][0];
+      expect(firstEnqueue).toMatchObject({
+        tenantId: testTenant,
+        providerId,
+        provider: 'google',
+      });
+      expect(firstEnqueue.pointer.discoveredMessageIds).toEqual(['g-1']);
+
+      const row = await getProviderRow(providerId);
+      expect(row.inbound_paused_at).toBeNull();
+      expect(Number(row.inbound_auth_failure_count)).toBe(0);
+    });
+
+    it('falls back to a pause-bounded mailbox query when the saved cursor is rejected', async () => {
+      const { providerId, pausedAt } = await seedPausedProvider('google');
+      const rejected: any = new Error('Gmail history_id is no longer valid.');
+      rejected.code = 'gmail.historyIdNotFound';
+      rejected.status = 404;
+      gmailAdapterMock.listMessagesSince.mockRejectedValue(rejected);
+
+      const result = await new EmailProviderLifecycleService().recoverAuthPausedProvider(providerId, testTenant);
+
+      expect(result.resumed).toBe(true);
+      expect(gmailAdapterMock.listMessageIdsSinceTime).toHaveBeenCalledTimes(1);
+      const [sinceDate] = gmailAdapterMock.listMessageIdsSinceTime.mock.calls[0];
+      expect(new Date(sinceDate).getTime()).toBe(pausedAt.getTime());
+      expect(enqueueMock.enqueueUnifiedInboundEmailQueueJob).toHaveBeenCalledTimes(1);
+      expect(
+        enqueueMock.enqueueUnifiedInboundEmailQueueJob.mock.calls[0][0].pointer.discoveredMessageIds
+      ).toEqual(['g-fb-1']);
+
+      const row = await getProviderRow(providerId);
+      expect(row.inbound_paused_at).toBeNull();
+    });
+
+    it('reconciled messages are deduped on repeated processing', async () => {
+      const { providerId } = await seedPausedProvider('google');
+
+      const { processUnifiedInboundEmailQueueJob } = await import(
+        '@alga-psa/shared/services/email/unifiedInboundEmailQueueJobProcessor'
+      );
+      const processInboundEmailInAppModule = await vi.importActual<
+        typeof import('@alga-psa/shared/services/email/processInboundEmailInApp')
+      >('@alga-psa/shared/services/email/processInboundEmailInApp');
+      const spy = vi
+        .spyOn(processInboundEmailInAppModule, 'processInboundEmailInApp')
+        .mockResolvedValue({
+          outcome: 'created',
+          ticketId: '00000000-0000-4000-8000-0000000000bb',
+          diagnostics: {},
+        } as any);
+
+      try {
+        const uniqueMessageId = `g-dedupe-${uuidv4()}`;
+        gmailAdapterMock.getMessageDetails.mockResolvedValue({
+          id: uniqueMessageId,
+          provider: 'google',
+          providerId: 'x',
+          tenant: testTenant,
+          receivedAt: new Date().toISOString(),
+          from: { email: 'sender@example.com' },
+          to: [{ email: 'support@example.com' }],
+          subject: 'Paused-interval mail',
+          body: { text: 'hello' },
+          attachments: [],
+        });
+
+        // Lift the pause first (the queue gate skips paused providers).
+        const recovered = await new EmailProviderLifecycleService().recoverAuthPausedProvider(
+          providerId,
+          testTenant,
+          { credentialsValidated: true, deliveryEstablished: true }
+        );
+        expect(recovered.resumed).toBe(true);
+
+        const job = {
+          ...googleJob(providerId),
+          pointer: { historyId: '1500', emailAddress: 'recovery@example.com', discoveredMessageIds: [uniqueMessageId] },
+        };
+
+        const first = await processUnifiedInboundEmailQueueJob(job);
+        expect(first.outcome).toBe('processed');
+
+        const second = await processUnifiedInboundEmailQueueJob(job);
+        expect(second.outcome).toBe('skipped');
+        expect(second.dedupedCount).toBe(1);
+        expect(spy).toHaveBeenCalledTimes(1);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  });
+
+  describe('IMAP', () => {
+    it('keeps the pause when stored credentials cannot connect', async () => {
+      const { providerId } = await seedPausedProvider('imap');
+      imapFlowMock.connectShouldFail = true;
+
+      const result = await new EmailProviderLifecycleService().recoverAuthPausedProvider(providerId, testTenant);
+
+      expect(result.resumed).toBe(false);
+      expect(result.reconnectRequired).toBe(true);
+
+      const config = await tenantTable('imap_email_provider_config')
+        .where({ email_provider_id: providerId })
+        .first('uid_validity', 'last_uid');
+      // Cursors must survive: they are only cleared AFTER validation.
+      expect(config.uid_validity).toBe('abc');
+      expect(config.last_uid).toBe('400');
+
+      const row = await getProviderRow(providerId);
+      expect(row.inbound_paused_at).not.toBeNull();
+    });
+
+    it('clears UID/folder cursors and the pause after credentials validate', async () => {
+      const { providerId } = await seedPausedProvider('imap');
+
+      const result = await new EmailProviderLifecycleService().recoverAuthPausedProvider(providerId, testTenant, {
+        credentialsValidated: true,
+      });
+
+      expect(result.resumed).toBe(true);
+      expect(result.reconciliation).toEqual({ status: 'started', queuedMessages: 0 });
+
+      const config = await tenantTable('imap_email_provider_config')
+        .where({ email_provider_id: providerId })
+        .first('uid_validity', 'last_uid', 'folder_state');
+      expect(config.uid_validity).toBeNull();
+      expect(config.last_uid).toBeNull();
+      expect(config.folder_state).toEqual({});
+
+      const row = await getProviderRow(providerId);
+      expect(row.inbound_paused_at).toBeNull();
+      expect(row.inbound_pause_reason).toBeNull();
+      expect(Number(row.inbound_auth_failure_count)).toBe(0);
+    });
+  });
+});

--- a/server/src/test/integration/inboundAuthPauseRecovery.integration.test.ts
+++ b/server/src/test/integration/inboundAuthPauseRecovery.integration.test.ts
@@ -84,7 +84,15 @@ vi.mock('@alga-psa/shared/services/email/providers/GmailAdapter', () => ({
       return gmailAdapterMock.testConnection();
     }
     async registerWebhookSubscription() {
-      return gmailAdapterMock.registerWebhookSubscription();
+      await gmailAdapterMock.registerWebhookSubscription();
+      // Faithful to the real adapter: a new watch persists its own (newer)
+      // history cursor, overwriting the pre-watch one.
+      const { getAdminConnection } = await import('@alga-psa/db/admin');
+      const { tenantDb } = await import('@alga-psa/db');
+      const knex = await getAdminConnection();
+      await tenantDb(knex, this.config.tenant).table('google_email_provider_config')
+        .where({ email_provider_id: this.config.id })
+        .update({ history_id: '9999' });
     }
     async listMessagesSince(startHistoryId: string) {
       return gmailAdapterMock.listMessagesSince(startHistoryId);
@@ -142,12 +150,15 @@ function tenantFixtureTable() {
   );
 }
 
-async function seedPausedProvider(providerType: 'microsoft' | 'google' | 'imap'): Promise<{
+async function seedPausedProvider(
+  providerType: 'microsoft' | 'google' | 'imap',
+  options: { pausedDaysAgo?: number } = {}
+): Promise<{
   providerId: string;
   pausedAt: Date;
 }> {
   const providerId = uuidv4();
-  const pausedAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
+  const pausedAt = new Date(Date.now() - (options.pausedDaysAgo ?? 0) * 24 * 60 * 60 * 1000 - 2 * 60 * 60 * 1000);
   const now = new Date();
   await tenantTable('email_providers').insert({
     id: providerId,
@@ -358,14 +369,23 @@ describeDb('auth-failure recovery path (DB-backed)', () => {
     it('uses the saved pre-watch history cursor, re-registers the watch, and clears the pause', async () => {
       const { providerId } = await seedPausedProvider('google');
 
+      // No options.savedHistoryId: recovery must snapshot the pre-watch
+      // cursor itself, BEFORE registerWebhookSubscription overwrites it with
+      // the new watch cursor (regression: this path used to reconcile from
+      // the post-watch cursor and silently drop the paused interval).
       const result = await new EmailProviderLifecycleService().recoverAuthPausedProvider(providerId, testTenant);
 
       expect(result.resumed).toBe(true);
       expect(result.webhookRegistered).toBe(true);
 
-      // The pre-watch cursor is the seeded history_id.
+      // The reconciliation read the PRE-watch cursor, not the new one.
       expect(gmailAdapterMock.listMessagesSince).toHaveBeenCalledWith('1500');
+      expect(gmailAdapterMock.listMessagesSince).not.toHaveBeenCalledWith('9999');
       expect(gmailAdapterMock.registerWebhookSubscription).toHaveBeenCalledTimes(1);
+      const cursorRow = await tenantTable('google_email_provider_config')
+        .where({ email_provider_id: providerId })
+        .first('history_id');
+      expect(cursorRow.history_id).toBe('9999');
 
       // One durable enqueue per reconciled message id.
       expect(enqueueMock.enqueueUnifiedInboundEmailQueueJob).toHaveBeenCalledTimes(2);
@@ -376,6 +396,9 @@ describeDb('auth-failure recovery path (DB-backed)', () => {
         provider: 'google',
       });
       expect(firstEnqueue.pointer.discoveredMessageIds).toEqual(['g-1']);
+      // The enqueued pointer carries the post-watch cursor so processing does
+      // not regress google_email_provider_config.history_id below the new watch.
+      expect(firstEnqueue.pointer.historyId).toBe('9999');
 
       const row = await getProviderRow(providerId);
       expect(row.inbound_paused_at).toBeNull();
@@ -399,6 +422,41 @@ describeDb('auth-failure recovery path (DB-backed)', () => {
       expect(
         enqueueMock.enqueueUnifiedInboundEmailQueueJob.mock.calls[0][0].pointer.discoveredMessageIds
       ).toEqual(['g-fb-1']);
+
+      const row = await getProviderRow(providerId);
+      expect(row.inbound_paused_at).toBeNull();
+    });
+
+    it('reports a partial reconciliation when the paused interval exceeds the batch cap', async () => {
+      const { providerId } = await seedPausedProvider('google');
+      // More message ids than the 200-message recovery cap.
+      gmailAdapterMock.listMessagesSince.mockResolvedValue(
+        Array.from({ length: 203 }, (_, index) => `g-overflow-${index}`)
+      );
+
+      const result = await new EmailProviderLifecycleService().recoverAuthPausedProvider(providerId, testTenant);
+
+      expect(result.resumed).toBe(true);
+      expect(result.reconciliation?.status).toBe('partial');
+      expect(result.reconciliation?.queuedMessages).toBe(200);
+      expect(result.reconciliation?.warning).toMatch(/more than 200 messages.*3 were not queued/i);
+      // The cap-bounded batch was still enqueued.
+      expect(enqueueMock.enqueueUnifiedInboundEmailQueueJob).toHaveBeenCalledTimes(200);
+    });
+
+    it('reports a partial reconciliation when the Microsoft window clamp truncates the pause interval', async () => {
+      const { providerId } = await seedPausedProvider('microsoft', { pausedDaysAgo: 9 });
+      reconcileMock.reconcileProviderMessages.mockResolvedValue({ queuedMessages: 5, truncated: true });
+
+      const result = await new EmailProviderLifecycleService().recoverAuthPausedProvider(
+        providerId,
+        testTenant,
+        { credentialsValidated: true, deliveryEstablished: true }
+      );
+
+      expect(result.resumed).toBe(true);
+      expect(result.reconciliation?.status).toBe('partial');
+      expect(result.reconciliation?.warning).toMatch(/most recent 7 days.*resync/i);
 
       const row = await getProviderRow(providerId);
       expect(row.inbound_paused_at).toBeNull();

--- a/server/src/test/integration/inboundAuthPauseRecovery.integration.test.ts
+++ b/server/src/test/integration/inboundAuthPauseRecovery.integration.test.ts
@@ -427,9 +427,11 @@ describeDb('auth-failure recovery path (DB-backed)', () => {
       expect(row.inbound_paused_at).toBeNull();
     });
 
-    it('reports a partial reconciliation when the paused interval exceeds the batch cap', async () => {
+    it('queues the entire paused interval when it exceeds a single batch (no dropped mail)', async () => {
       const { providerId } = await seedPausedProvider('google');
-      // More message ids than the 200-message recovery cap.
+      // More message ids than the previous 200-message recovery cap: every
+      // message must now be handed off — the pause may not clear over a
+      // known gap, so the cap is gone.
       gmailAdapterMock.listMessagesSince.mockResolvedValue(
         Array.from({ length: 203 }, (_, index) => `g-overflow-${index}`)
       );
@@ -437,16 +439,17 @@ describeDb('auth-failure recovery path (DB-backed)', () => {
       const result = await new EmailProviderLifecycleService().recoverAuthPausedProvider(providerId, testTenant);
 
       expect(result.resumed).toBe(true);
-      expect(result.reconciliation?.status).toBe('partial');
-      expect(result.reconciliation?.queuedMessages).toBe(200);
-      expect(result.reconciliation?.warning).toMatch(/more than 200 messages.*3 were not queued/i);
-      // The cap-bounded batch was still enqueued.
-      expect(enqueueMock.enqueueUnifiedInboundEmailQueueJob).toHaveBeenCalledTimes(200);
+      expect(result.reconciliation?.status).toBe('completed');
+      expect(result.reconciliation?.queuedMessages).toBe(203);
+      expect(enqueueMock.enqueueUnifiedInboundEmailQueueJob).toHaveBeenCalledTimes(203);
     });
 
-    it('reports a partial reconciliation when the Microsoft window clamp truncates the pause interval', async () => {
-      const { providerId } = await seedPausedProvider('microsoft', { pausedDaysAgo: 9 });
-      reconcileMock.reconcileProviderMessages.mockResolvedValue({ queuedMessages: 5, truncated: true });
+    it('loops Microsoft reconciliation passes until the paused interval is exhausted', async () => {
+      const { providerId, pausedAt } = await seedPausedProvider('microsoft');
+      reconcileMock.reconcileProviderMessages
+        .mockResolvedValueOnce({ queuedMessages: 50, moreRemaining: true, enqueuedMessageIds: Array.from({ length: 50 }, (_, i) => `ms-a-${i}`) })
+        .mockResolvedValueOnce({ queuedMessages: 30, moreRemaining: true, enqueuedMessageIds: Array.from({ length: 30 }, (_, i) => `ms-b-${i}`) })
+        .mockResolvedValueOnce({ queuedMessages: 2, moreRemaining: false, enqueuedMessageIds: ['ms-c-0', 'ms-c-1'] });
 
       const result = await new EmailProviderLifecycleService().recoverAuthPausedProvider(
         providerId,
@@ -455,11 +458,46 @@ describeDb('auth-failure recovery path (DB-backed)', () => {
       );
 
       expect(result.resumed).toBe(true);
-      expect(result.reconciliation?.status).toBe('partial');
-      expect(result.reconciliation?.warning).toMatch(/most recent 7 days.*resync/i);
+      expect(result.reconciliation).toEqual({ status: 'completed', queuedMessages: 82 });
+      expect(reconcileMock.reconcileProviderMessages).toHaveBeenCalledTimes(3);
+
+      // Every pass sweeps from the pause boundary; ids handed off by earlier
+      // passes are seeded so later passes recognize them as covered.
+      for (const call of reconcileMock.reconcileProviderMessages.mock.calls) {
+        expect(call[0].providerId).toBe(providerId);
+        expect(new Date(call[0].since).getTime()).toBe(pausedAt.getTime());
+      }
+      expect(reconcileMock.reconcileProviderMessages.mock.calls[1][0].handedOffIds.has('ms-a-0')).toBe(true);
+      expect(reconcileMock.reconcileProviderMessages.mock.calls[2][0].handedOffIds.has('ms-b-29')).toBe(true);
 
       const row = await getProviderRow(providerId);
       expect(row.inbound_paused_at).toBeNull();
+    });
+
+    it('keeps the pause when Microsoft reconciliation never exhausts the interval', async () => {
+      const { providerId } = await seedPausedProvider('microsoft');
+      // A pathological provider that always reports more remaining: recovery
+      // must fail (bounded passes) and the provider must stay paused — never
+      // "resumed with a known gap".
+      reconcileMock.reconcileProviderMessages.mockResolvedValue({
+        queuedMessages: 50,
+        moreRemaining: true,
+        enqueuedMessageIds: Array.from({ length: 50 }, (_, i) => `ms-x-${i}`),
+      });
+
+      const result = await new EmailProviderLifecycleService().recoverAuthPausedProvider(
+        providerId,
+        testTenant,
+        { credentialsValidated: true, deliveryEstablished: true }
+      );
+
+      expect(result.resumed).toBe(false);
+      expect(result.reconnectRequired).toBe(true);
+      expect(result.error).toMatch(/unexhausted/i);
+
+      const row = await getProviderRow(providerId);
+      expect(row.inbound_paused_at).not.toBeNull();
+      expect(row.inbound_pause_reason).toBe('auth_failure');
     });
 
     it('reconciled messages are deduped on repeated processing', async () => {
@@ -541,7 +579,7 @@ describeDb('auth-failure recovery path (DB-backed)', () => {
       expect(row.inbound_paused_at).not.toBeNull();
     });
 
-    it('clears UID/folder cursors and the pause after credentials validate', async () => {
+    it('arms the covering resync cursor and clears the pause after credentials validate', async () => {
       const { providerId } = await seedPausedProvider('imap');
 
       const result = await new EmailProviderLifecycleService().recoverAuthPausedProvider(providerId, testTenant, {
@@ -555,7 +593,10 @@ describeDb('auth-failure recovery path (DB-backed)', () => {
         .where({ email_provider_id: providerId })
         .first('uid_validity', 'last_uid', 'folder_state');
       expect(config.uid_validity).toBeNull();
-      expect(config.last_uid).toBeNull();
+      // '0' is the explicit scan-from-UID-1 marker: a NULL cursor would make
+      // the email-service listener resume from the most recent window and
+      // silently skip paused-interval mail older than that window.
+      expect(config.last_uid).toBe('0');
       expect(config.folder_state).toEqual({});
 
       const row = await getProviderRow(providerId);

--- a/server/src/test/integration/inboundEmailDurableInbox.integration.test.ts
+++ b/server/src/test/integration/inboundEmailDurableInbox.integration.test.ts
@@ -369,6 +369,11 @@ describeDb('Inbound email durable inbox (integration)', () => {
 
   beforeAll(async () => {
     process.env.UNIFIED_INBOUND_EMAIL_DURABLE_MODE = 'enforce';
+    // Same local-env wiring as the sibling integration suites: .env.localtest
+    // can carry stale DB_PASSWORD_* values, while the repo secrets dir is
+    // authoritative for the local test Postgres.
+    const { wireLocalTestDbEnv } = await import('../../../test-utils/dbConfig');
+    wireLocalTestDbEnv();
     db = await createTestDbConnection();
 
     const tenant = await tenantDb(db, SEEDED_TENANT_DISCOVERY_REASON)
@@ -1447,6 +1452,115 @@ describeDb('Inbound email durable inbox (integration)', () => {
     const failedIngress = await tenantTable('inbound_email_ingress').where({ ingress_id: failed.ingressId }).first();
     expect(failedIngress.status).toBe('retryable_failed');
     expect(failedIngress.last_error).toContain('provider_unavailable_temporarily');
+  });
+
+  it('stage_ingress counts classified source auth failures, ignores transient ones, and resets on success', async () => {
+    const { providerId } = await setupProvider({ mailbox: 'v2-auth-count@example.com', providerType: 'microsoft' });
+    const { persistIngressPointer } = await import('@alga-psa/shared/services/email/inboundEmailProducer');
+    const { processIngressStageJob } = await import('@alga-psa/shared/services/email/inboundEmailIngressStagingWorker');
+
+    const authCount = async (): Promise<number> => {
+      const row = await tenantTable('email_providers').where({ id: providerId }).first('inbound_auth_failure_count');
+      return Number(row?.inbound_auth_failure_count || 0);
+    };
+
+    const produced = await persistIngressPointer({
+      tenant: tenantId,
+      providerId,
+      providerType: 'microsoft',
+      pointer: { providerType: 'microsoft', providerMessageId: `v2-auth-${randomUUID()}` },
+    });
+    expect(produced.ingressId).toBeTruthy();
+
+    const job: any = {
+      schemaVersion: 2,
+      workType: 'stage_ingress',
+      tenantId,
+      recordId: produced.ingressId,
+      jobId: `stage-${randomUUID()}`,
+      enqueuedAt: new Date().toISOString(),
+      attempt: 0,
+      maxAttempts: 5,
+    };
+    const ctx = { signal: new AbortController().signal, renew: async () => true, registerPostgresLease: () => undefined };
+    const makeDue = async () => {
+      await tenantTable('inbound_email_ingress')
+        .where({ ingress_id: produced.ingressId })
+        .update({ next_attempt_at: db.raw("now() - interval '1 minute'") });
+    };
+
+    // A terminal OAuth rejection from the Microsoft source fetch advances the
+    // provider's consecutive auth-failure counter (same counter as V1).
+    const invalidGrant: any = new Error('Error in refreshAccessToken: Request failed with status code 400 (code: 400)');
+    invalidGrant.status = 400;
+    invalidGrant.responseBody = { error: 'invalid_grant' };
+    microsoftFetchMock.mockRejectedValueOnce(invalidGrant);
+    const failed = await processIngressStageJob(job, ctx);
+    expect(failed.disposition).toBe('retry');
+    expect(await authCount()).toBe(1);
+
+    // A transient fetch error does not count (queue retry stays authoritative).
+    await makeDue();
+    microsoftFetchMock.mockRejectedValueOnce(new Error('provider_unavailable_temporarily'));
+    await processIngressStageJob(job, ctx);
+    expect(await authCount()).toBe(1);
+
+    // A successful stage is a successful source access: the counter resets
+    // even though this fetch returns a single ordinary message.
+    await makeDue();
+    microsoftFetchMock.mockResolvedValueOnce({
+      id: 'ms-auth-ok',
+      rawMime: 'From: Sender <sender@example.com>\r\nTo: Support <v2-auth-count@example.com>\r\nSubject: OK\r\nMessage-ID: <ms-auth-ok@example.com>\r\n\r\nbody\r\n',
+    });
+    const ok = await processIngressStageJob(job, ctx);
+    expect(ok.disposition).toBe('ack');
+    expect(await authCount()).toBe(0);
+
+    const row = await tenantTable('email_providers').where({ id: providerId }).first('inbound_paused_at', 'inbound_pause_reason');
+    expect(row.inbound_paused_at).toBeNull();
+  });
+
+  it('stage_ingress auth failures pause the provider at the threshold and stop being retried through the source gate', async () => {
+    const { providerId } = await setupProvider({ mailbox: 'v2-auth-pause@example.com', providerType: 'microsoft' });
+    const { persistIngressPointer } = await import('@alga-psa/shared/services/email/inboundEmailProducer');
+    const { processIngressStageJob } = await import('@alga-psa/shared/services/email/inboundEmailIngressStagingWorker');
+
+    const ctx = { signal: new AbortController().signal, renew: async () => true, registerPostgresLease: () => undefined };
+    const invalidClient: any = new Error('Error in refreshAccessToken: Request failed with status code 401 (code: 401)');
+    invalidClient.status = 401;
+    invalidClient.responseBody = { error: 'invalid_client' };
+    microsoftFetchMock.mockRejectedValue(invalidClient);
+
+    // Three distinct ingress rows, each failing its staged source fetch with
+    // a terminal credential error: the third trips the automatic pause.
+    for (let i = 0; i < 3; i += 1) {
+      const produced = await persistIngressPointer({
+        tenant: tenantId,
+        providerId,
+        providerType: 'microsoft',
+        pointer: { providerType: 'microsoft', providerMessageId: `v2-pause-${i}-${randomUUID()}` },
+      });
+      const job: any = {
+        schemaVersion: 2,
+        workType: 'stage_ingress',
+        tenantId,
+        recordId: produced.ingressId,
+        jobId: `stage-${randomUUID()}`,
+        enqueuedAt: new Date().toISOString(),
+        attempt: 0,
+        maxAttempts: 5,
+      };
+      const result = await processIngressStageJob(job, ctx);
+      expect(result.disposition).toBe('retry');
+    }
+
+    const row = await tenantTable('email_providers')
+      .where({ id: providerId })
+      .first('inbound_paused_at', 'inbound_pause_reason', 'inbound_auth_failure_count', 'inbound_auth_failure_code');
+    expect(row.inbound_paused_at).not.toBeNull();
+    expect(row.inbound_pause_reason).toBe('auth_failure');
+    expect(Number(row.inbound_auth_failure_count)).toBe(3);
+    expect(row.inbound_auth_failure_code).toBe('microsoft:invalid_client');
   });
 
   it('core processing succeeds from the staged source when the provider message is gone', async () => {
@@ -2980,10 +3094,14 @@ describeDb('Inbound email durable inbox (integration)', () => {
     const failedIngress = await tenantTable('inbound_email_ingress').where({ ingress_id: ingresses[0].ingress_id }).first();
     expect(failedIngress.status).toBe('retryable_failed');
 
-    // Re-run reconcile: the failed message is re-listed (its source is not
-    // staged) and re-ingressed idempotently; the cursor still does not advance.
+    // Re-run reconcile: both messages already have ingress rows, so they are
+    // handed off — the durable pipeline (retry backoff + recovery sweep) owns
+    // their fate and reconcile must not re-enqueue them. The cursor still
+    // does not advance past the unstaged message.
+    v2EnqueueMock.mockClear();
     const rerun = await service.reconcileMissedMessages(adapter, config, false);
-    expect(rerun.queuedMessages).toBeGreaterThanOrEqual(1);
+    expect(rerun.queuedMessages).toBe(0);
+    expect(v2EnqueueMock).not.toHaveBeenCalled();
     cursor = await tenantTable('microsoft_email_provider_config').where({ email_provider_id: providerId }).first();
     expect(new Date(cursor.last_reconciliation_at).getTime()).toBe(new Date(oldCursor).getTime());
 

--- a/server/src/test/integration/inboundEmailDurableInbox.integration.test.ts
+++ b/server/src/test/integration/inboundEmailDurableInbox.integration.test.ts
@@ -1532,7 +1532,12 @@ describeDb('Inbound email durable inbox (integration)', () => {
     microsoftFetchMock.mockRejectedValue(invalidClient);
 
     // Three distinct ingress rows, each failing its staged source fetch with
-    // a terminal credential error: the third trips the automatic pause.
+    // a terminal credential error: the third trips the automatic pause. The
+    // first two stay retryable ('retry'); the third fails while the provider
+    // is now paused, so it PARKS non-terminal with a voided attempt budget
+    // ('ack' + paused) instead of burning its retry budget against the dead
+    // credential — the message must survive until the pause is recovered.
+    const producedIds: string[] = [];
     for (let i = 0; i < 3; i += 1) {
       const produced = await persistIngressPointer({
         tenant: tenantId,
@@ -1540,6 +1545,7 @@ describeDb('Inbound email durable inbox (integration)', () => {
         providerType: 'microsoft',
         pointer: { providerType: 'microsoft', providerMessageId: `v2-pause-${i}-${randomUUID()}` },
       });
+      producedIds.push(produced.ingressId!);
       const job: any = {
         schemaVersion: 2,
         workType: 'stage_ingress',
@@ -1551,8 +1557,20 @@ describeDb('Inbound email durable inbox (integration)', () => {
         maxAttempts: 5,
       };
       const result = await processIngressStageJob(job, ctx);
-      expect(result.disposition).toBe('retry');
+      if (i < 2) {
+        expect(result.disposition).toBe('retry');
+      } else {
+        expect(result.disposition).toBe('ack');
+        expect(result.outcome).toBe('paused');
+      }
     }
+    // The pause-raced row is parked non-terminal (never dead-lettered), with
+    // its attempt budget voided for the post-recovery retry.
+    const parkedRow = await tenantTable('inbound_email_ingress')
+      .where({ ingress_id: producedIds[2] })
+      .first('status', 'attempt_count');
+    expect(parkedRow.status).toBe('retryable_failed');
+    expect(Number(parkedRow.attempt_count)).toBe(0);
 
     const row = await tenantTable('email_providers')
       .where({ id: providerId })
@@ -1561,6 +1579,342 @@ describeDb('Inbound email durable inbox (integration)', () => {
     expect(row.inbound_pause_reason).toBe('auth_failure');
     expect(Number(row.inbound_auth_failure_count)).toBe(3);
     expect(row.inbound_auth_failure_code).toBe('microsoft:invalid_client');
+  });
+
+  it('auth-paused provider ingress rows are gated pre-claim, survive the pause non-terminally, and are re-driven after resume', async () => {
+    const { providerId } = await setupProvider({ mailbox: 'pause-survive@example.com', providerType: 'microsoft' });
+    const { persistIngressPointer } = await import('@alga-psa/shared/services/email/inboundEmailProducer');
+    const { processIngressStageJob } = await import('@alga-psa/shared/services/email/inboundEmailIngressStagingWorker');
+    const ctx = { signal: new AbortController().signal, renew: async () => true, registerPostgresLease: () => undefined };
+
+    const produced = await persistIngressPointer({
+      tenant: tenantId,
+      providerId,
+      providerType: 'microsoft',
+      pointer: {
+        providerType: 'microsoft',
+        providerMessageId: 'ms-pause-survive-1',
+        extra: {
+          resource: 'maintenance-reconcile',
+          reconcileReceivedAt: new Date(Date.now() - 30 * 60_000).toISOString(),
+        },
+      },
+    });
+    expect(produced.ingressId).toBeTruthy();
+    const job: any = {
+      schemaVersion: 2,
+      workType: 'stage_ingress',
+      tenantId,
+      recordId: produced.ingressId,
+      jobId: `stage-${randomUUID()}`,
+      enqueuedAt: new Date().toISOString(),
+      attempt: 0,
+      maxAttempts: 5,
+    };
+
+    // Pause the provider (auth-failure shape, as the auto-pause would).
+    await tenantTable('email_providers').where({ id: providerId }).update({
+      inbound_paused_at: db.fn.now(),
+      inbound_pause_reason: 'auth_failure',
+    });
+
+    // Pre-claim gate: the wake-up acks without claiming (no attempt burned,
+    // no provider access) — pre-fix the claim+fetch ran and the pause gate
+    // inside fetchMicrosoftProviderConfig ('microsoft_provider_not_found')
+    // terminalized the row.
+    microsoftFetchMock.mockClear();
+    const gated = await processIngressStageJob(job, ctx);
+    expect(gated.disposition).toBe('ack');
+    expect(gated.outcome).toBe('paused');
+    expect(microsoftFetchMock).not.toHaveBeenCalled();
+    let row = await tenantTable('inbound_email_ingress').where({ ingress_id: produced.ingressId }).first();
+    expect(row.status).toBe('received');
+    expect(Number(row.attempt_count)).toBe(0);
+
+    // The sweep must not wake or dead-letter a paused provider's ingress row,
+    // even when it is due and over-cap (attempts accrued while the credential
+    // was dead must not terminalize a paused-interval message).
+    await tenantTable('inbound_email_ingress').where({ ingress_id: produced.ingressId })
+      .update({ status: 'retryable_failed', attempt_count: 9, next_attempt_at: db.raw("now() - interval '1 minute'") });
+    const { claimIngress } = await import('@alga-psa/shared/services/email/inboundEmailDurableStore');
+    const claim = await claimIngress(db, { tenant: tenantId, ingress_id: produced.ingressId, owner: 'paused-claim', leaseTtlMs: 30_000, allowRetryable: true });
+    expect(claim.claimed).toBe(false);
+    expect(claim.reason).toBe('not_due');
+    const { sweepTenantDurableWork } = await import('@alga-psa/shared/services/email/inboundEmailRecovery');
+    v2EnqueueMock.mockClear();
+    await sweepTenantDurableWork(tenantId, 10);
+    expect(v2EnqueueMock).not.toHaveBeenCalledWith(expect.objectContaining({ workType: 'stage_ingress', recordId: produced.ingressId }));
+    row = await tenantTable('inbound_email_ingress').where({ ingress_id: produced.ingressId }).first();
+    expect(row.status).toBe('retryable_failed');
+
+    // Resume: the very next sweep re-drives the parked row and it stages. The
+    // attempt budget is voided exactly as the park flow does (the 9 forced
+    // above existed only to prove the paused-state over-cap guard).
+    await tenantTable('email_providers').where({ id: providerId }).update({
+      inbound_paused_at: null,
+      inbound_pause_reason: null,
+    });
+    await tenantTable('inbound_email_ingress').where({ ingress_id: produced.ingressId })
+      .update({ attempt_count: 0 });
+    v2EnqueueMock.mockClear();
+    const sweep = await sweepTenantDurableWork(tenantId, 10);
+    expect(sweep.enqueued.ingress).toBeGreaterThanOrEqual(1);
+    expect(v2EnqueueMock).toHaveBeenCalledWith(expect.objectContaining({ workType: 'stage_ingress', tenantId, recordId: produced.ingressId }));
+    microsoftFetchMock.mockResolvedValueOnce({
+      id: 'ms-pause-survive-1',
+      rawMime: 'From: Sender <s@example.com>\r\nTo: Support <pause-survive@example.com>\r\nSubject: Survive\r\nMessage-ID: <ms-pause-survive-1@example.com>\r\n\r\nbody\r\n',
+    });
+    const staged = await processIngressStageJob(job, ctx);
+    expect(staged.disposition).toBe('ack');
+    row = await tenantTable('inbound_email_ingress').where({ ingress_id: produced.ingressId }).first();
+    expect(row.status).toBe('staged');
+  });
+
+  it('V2 staging resets the auth-failure counter immediately after a successful source fetch, even when staging then fails', async () => {
+    const { providerId } = await setupProvider({ mailbox: 'v2-reset@example.com', providerType: 'microsoft' });
+    await tenantTable('email_providers').where({ id: providerId }).update({
+      inbound_auth_failure_count: 2,
+      inbound_auth_failure_last_at: new Date().toISOString(),
+      inbound_auth_failure_code: 'microsoft:invalid_grant',
+    });
+    const { persistIngressPointer } = await import('@alga-psa/shared/services/email/inboundEmailProducer');
+    const { processIngressStageJob } = await import('@alga-psa/shared/services/email/inboundEmailIngressStagingWorker');
+    const produced = await persistIngressPointer({
+      tenant: tenantId,
+      providerId,
+      providerType: 'microsoft',
+      pointer: { providerType: 'microsoft', providerMessageId: 'ms-reset-1' },
+    });
+    const job: any = {
+      schemaVersion: 2,
+      workType: 'stage_ingress',
+      tenantId,
+      recordId: produced.ingressId,
+      jobId: `stage-${randomUUID()}`,
+      enqueuedAt: new Date().toISOString(),
+      attempt: 0,
+      maxAttempts: 5,
+    };
+    const ctx = { signal: new AbortController().signal, renew: async () => true, registerPostgresLease: () => undefined };
+
+    // The provider fetch SUCCEEDS (credentials are healthy), but the
+    // downstream object upload fails. The reset must already have fired at
+    // the fetch boundary — pre-fix it only ran after all staging work, so a
+    // healthy-credential provider kept a stale counter and a later blip plus
+    // one real auth error could mis-trip the pause.
+    microsoftFetchMock.mockResolvedValueOnce({
+      id: 'ms-reset-1',
+      rawMime: 'From: Sender <s@example.com>\r\nTo: Support <v2-reset@example.com>\r\nSubject: Reset\r\nMessage-ID: <ms-reset-1@example.com>\r\n\r\nbody\r\n',
+    });
+    storageProviderMock.upload.mockRejectedValueOnce(new Error('object store unavailable'));
+    const result = await processIngressStageJob(job, ctx);
+    expect(result.disposition).toBe('retry');
+
+    const providerRow = await tenantTable('email_providers').where({ id: providerId }).first('inbound_auth_failure_count', 'inbound_auth_failure_last_at');
+    expect(Number(providerRow.inbound_auth_failure_count)).toBe(0);
+    expect(providerRow.inbound_auth_failure_last_at).toBeNull();
+    const ingressRow = await tenantTable('inbound_email_ingress').where({ ingress_id: produced.ingressId }).first('status');
+    expect(ingressRow.status).toBe('retryable_failed');
+  });
+
+  it('V2 google staging resets the auth-failure counter at the first successful download, before staging work', async () => {
+    const { providerId } = await setupProvider({ mailbox: 'v2-reset-g@example.com', providerType: 'google' });
+    await tenantTable('email_providers').where({ id: providerId }).update({
+      inbound_auth_failure_count: 2,
+      inbound_auth_failure_last_at: new Date().toISOString(),
+      inbound_auth_failure_code: 'google:invalid_grant',
+    });
+    const { upsertIngress } = await import('@alga-psa/shared/services/email/inboundEmailDurableStore');
+    const { processIngressStageJob } = await import('@alga-psa/shared/services/email/inboundEmailIngressStagingWorker');
+
+    // Pointer with explicitly discovered ids: no listing runs, so the first
+    // successful download is the source-access proof.
+    const ingress = await upsertIngress(db, {
+      tenant: tenantId,
+      provider_id: providerId,
+      provider_type: 'google',
+      ingress_key: 'history:90:auth-pause-reconcile:g-reset-1',
+      provider_pointer: { historyId: '90', discoveredMessageIds: ['g-reset-1'] },
+    });
+    const job: any = {
+      schemaVersion: 2,
+      workType: 'stage_ingress',
+      tenantId,
+      recordId: ingress.ingress_id,
+      jobId: `stage-${randomUUID()}`,
+      enqueuedAt: new Date().toISOString(),
+      attempt: 0,
+      maxAttempts: 5,
+    };
+    const ctx = { signal: new AbortController().signal, renew: async () => true, registerPostgresLease: () => undefined };
+
+    gmailAdapterMock.downloadMessageSource.mockImplementationOnce(async () =>
+      buildMime({ from: 'a@b.c', to: 'v2-reset-g@example.com', subject: 'Reset', messageId: `g-reset-${randomUUID()}@example.com`, text: 'x' })
+    );
+    storageProviderMock.upload.mockRejectedValueOnce(new Error('object store unavailable'));
+    const result = await processIngressStageJob(job, ctx);
+    expect(result.disposition).toBe('retry');
+
+    const providerRow = await tenantTable('email_providers').where({ id: providerId }).first('inbound_auth_failure_count');
+    expect(Number(providerRow.inbound_auth_failure_count)).toBe(0);
+  });
+
+  it('google staging never regresses the history cursor below the current watch cursor', async () => {
+    const { providerId } = await setupProvider({ mailbox: 'gmail-monotonic@example.com', providerType: 'google' });
+    const { upsertIngress } = await import('@alga-psa/shared/services/email/inboundEmailDurableStore');
+    const { processIngressStageJob } = await import('@alga-psa/shared/services/email/inboundEmailIngressStagingWorker');
+    const ctx = { signal: new AbortController().signal, renew: async () => true, registerPostgresLease: () => undefined };
+
+    // The staging worker's view of the current cursor is the fresh watch
+    // cursor (9999); the pointer carries an older stale cursor (1500) — the
+    // exact shape the pre-fix enforce-mode Google recovery produced. One mock
+    // per staging run so the override cannot leak into other tests.
+    googleProviderConfigMock.fetchGoogleProviderConfig
+      .mockResolvedValueOnce({
+        provider: { id: providerId, tenant: tenantId },
+        googleConfig: { history_id: '9999' },
+        config: {},
+      })
+      .mockResolvedValueOnce({
+        provider: { id: providerId, tenant: tenantId },
+        googleConfig: { history_id: '9999' },
+        config: {},
+      });
+    gmailAdapterMock.downloadMessageSource
+      .mockImplementationOnce(async () =>
+        buildMime({ from: 'a@b.c', to: 'gmail-monotonic@example.com', subject: 'Stale', messageId: `gm-stale-${randomUUID()}@example.com`, text: 'x' })
+      )
+      .mockImplementationOnce(async () =>
+        buildMime({ from: 'a@b.c', to: 'gmail-monotonic@example.com', subject: 'Fresh', messageId: `gm-fresh-${randomUUID()}@example.com`, text: 'x' })
+      );
+
+    const stale = await upsertIngress(db, {
+      tenant: tenantId,
+      provider_id: providerId,
+      provider_type: 'google',
+      ingress_key: 'history:1500:auth-pause-reconcile:g-stale-1',
+      provider_pointer: { historyId: '1500', discoveredMessageIds: ['g-stale-1'] },
+    });
+    const staleJob: any = {
+      schemaVersion: 2, workType: 'stage_ingress', tenantId,
+      recordId: stale.ingress_id, jobId: `stage-${randomUUID()}`,
+      enqueuedAt: new Date().toISOString(), attempt: 0, maxAttempts: 5,
+    };
+    const staleResult = await processIngressStageJob(staleJob, ctx);
+    expect(staleResult.disposition).toBe('ack');
+    let configRow = await tenantTable('google_email_provider_config').where({ email_provider_id: providerId }).first('history_id');
+    // Pre-fix: pointer processing wrote the stale '1500' back. Post-fix: a
+    // stale cursor writes nothing (the seeded value stays).
+    expect(String(configRow.history_id)).toBe('1');
+
+    // A pointer newer than the current cursor still advances it.
+    const fresh = await upsertIngress(db, {
+      tenant: tenantId,
+      provider_id: providerId,
+      provider_type: 'google',
+      ingress_key: 'history:15000:auth-pause-reconcile:g-fresh-1',
+      provider_pointer: { historyId: '15000', discoveredMessageIds: ['g-fresh-1'] },
+    });
+    const freshJob: any = {
+      schemaVersion: 2, workType: 'stage_ingress', tenantId,
+      recordId: fresh.ingress_id, jobId: `stage-${randomUUID()}`,
+      enqueuedAt: new Date().toISOString(), attempt: 0, maxAttempts: 5,
+    };
+    const freshResult = await processIngressStageJob(freshJob, ctx);
+    expect(freshResult.disposition).toBe('ack');
+    configRow = await tenantTable('google_email_provider_config').where({ email_provider_id: providerId }).first('history_id');
+    expect(String(configRow.history_id)).toBe('15000');
+  });
+
+  it('microsoft recovery reconcile: a terminally failed ingress is not covered — it is revived and re-handed-off between passes', async () => {
+    const { providerId } = await setupProvider({ mailbox: 'ms-revive@example.com', providerType: 'microsoft' });
+    const { EmailWebhookMaintenanceService } = await import('@alga-psa/shared/services/email/EmailWebhookMaintenanceService');
+
+    const since = new Date(Date.now() - 3 * 60 * 60_000);
+    const T1 = new Date(Date.now() - 2 * 60 * 60_000).toISOString();
+    const T2 = new Date(Date.now() - 90 * 60_000).toISOString();
+    const T3 = new Date(Date.now() - 60 * 60_000).toISOString();
+    microsoftGraphAdapterMock.listMessagesReceivedSince.mockResolvedValue([
+      { id: 'ms-revive-1', receivedDateTime: T1 },
+      { id: 'ms-revive-2', receivedDateTime: T2 },
+    ]);
+
+    const service: any = new EmailWebhookMaintenanceService();
+    const config: any = {
+      id: providerId,
+      tenant: tenantId,
+      provider_type: 'microsoft',
+      mailbox: 'ms-revive@example.com',
+      delivery_mode: 'polling',
+      webhook_subscription_id: null,
+      webhook_notification_url: 'https://example.com/api/email/webhooks/microsoft',
+      provider_config: { max_emails_per_sync: 50 },
+    };
+    const adapter = new (await import('@alga-psa/shared/services/email/providers/MicrosoftGraphAdapter')).MicrosoftGraphAdapter(config);
+
+    // Recovery pass 1 (explicit since boundary): both messages are handed off.
+    const pass1 = await service.reconcileMissedMessages(adapter, config, false, since, new Set<string>());
+    expect(pass1.queuedMessages).toBe(2);
+
+    // Deterministic interleave: between passes, a concurrent worker
+    // terminalizes the first message's ingress (the pause-window
+    // terminalization shape — e.g. attempts burned against the dead
+    // credential).
+    await tenantTable('inbound_email_ingress')
+      .where({ tenant: tenantId, ingress_key: 'message:ms-revive-1' })
+      .update({
+        status: 'terminal_failed',
+        completed_at: db.fn.now(),
+        lease_owner: null,
+        lease_token: null,
+        lease_expires_at: null,
+        next_attempt_at: null,
+      });
+
+    // Recovery pass 2 with the loop-seeded handedOffIds: a terminal row is NOT
+    // a durable hand-off. Pre-fix ("any ingress row counts as handed off")
+    // this pass reported queuedMessages 0 and the interval was declared
+    // exhausted with a message never durably handed off.
+    const pass2 = await service.reconcileMissedMessages(adapter, config, false, since, new Set(['ms-revive-1', 'ms-revive-2']));
+    expect(pass2.queuedMessages).toBe(1);
+    expect(pass2.moreRemaining).toBe(false);
+
+    const revived = await tenantTable('inbound_email_ingress')
+      .where({ tenant: tenantId, ingress_key: 'message:ms-revive-1' })
+      .first('status', 'attempt_count', 'completed_at');
+    expect(revived.status).toBe('received');
+    expect(Number(revived.attempt_count)).toBe(0);
+    expect(revived.completed_at).toBeNull();
+
+    // The non-terminal row stays covered — no duplicate hand-off.
+    const untouched = await tenantTable('inbound_email_ingress')
+      .where({ tenant: tenantId, provider_id: providerId, ingress_key: 'message:ms-revive-2' })
+      .first('status', 'attempt_count');
+    expect(untouched.status).toBe('received');
+    expect(Number(untouched.attempt_count)).toBe(0);
+
+    // A legacy audit row only counts as covered when SETTLED: a 'failed'
+    // legacy outcome never durably imported the message, so a recovery pass
+    // must hand it off again.
+    await tenantTable('email_processed_messages').insert({
+      message_id: 'ms-revive-3',
+      provider_id: providerId,
+      tenant: tenantId,
+      processed_at: db.fn.now(),
+      processing_status: 'failed',
+      error_message: 'legacy pipeline died',
+    });
+    microsoftGraphAdapterMock.listMessagesReceivedSince.mockResolvedValue([
+      { id: 'ms-revive-1', receivedDateTime: T1 },
+      { id: 'ms-revive-2', receivedDateTime: T2 },
+      { id: 'ms-revive-3', receivedDateTime: T3 },
+    ]);
+    const pass3 = await service.reconcileMissedMessages(adapter, config, false, since, new Set(['ms-revive-1', 'ms-revive-2']));
+    expect(pass3.queuedMessages).toBe(1);
+    const revived3 = await tenantTable('inbound_email_ingress')
+      .where({ tenant: tenantId, ingress_key: 'message:ms-revive-3' })
+      .first('status');
+    expect(revived3.status).toBe('received');
   });
 
   it('core processing succeeds from the staged source when the provider message is gone', async () => {

--- a/server/src/test/integration/inboundEmailDurableInbox.integration.test.ts
+++ b/server/src/test/integration/inboundEmailDurableInbox.integration.test.ts
@@ -1765,10 +1765,15 @@ describeDb('Inbound email durable inbox (integration)', () => {
     const { processIngressStageJob } = await import('@alga-psa/shared/services/email/inboundEmailIngressStagingWorker');
     const ctx = { signal: new AbortController().signal, renew: async () => true, registerPostgresLease: () => undefined };
 
-    // The staging worker's view of the current cursor is the fresh watch
-    // cursor (9999); the pointer carries an older stale cursor (1500) — the
-    // exact shape the pre-fix enforce-mode Google recovery produced. One mock
-    // per staging run so the override cannot leak into other tests.
+    // Persist the fresh watch cursor (9999) in the database first, exactly as
+    // a real registerWebhookSubscription persist would: the monotonic guard
+    // compares against the PERSISTED cursor at write time, not the worker's
+    // in-memory view. The pointer then carries an older stale cursor (1500) —
+    // the exact shape the pre-fix enforce-mode Google recovery produced. One
+    // mock per staging run so the override cannot leak into other tests.
+    await tenantTable('google_email_provider_config')
+      .where({ email_provider_id: providerId })
+      .update({ history_id: '9999' });
     googleProviderConfigMock.fetchGoogleProviderConfig
       .mockResolvedValueOnce({
         provider: { id: providerId, tenant: tenantId },
@@ -1804,8 +1809,8 @@ describeDb('Inbound email durable inbox (integration)', () => {
     expect(staleResult.disposition).toBe('ack');
     let configRow = await tenantTable('google_email_provider_config').where({ email_provider_id: providerId }).first('history_id');
     // Pre-fix: pointer processing wrote the stale '1500' back. Post-fix: a
-    // stale cursor writes nothing (the seeded value stays).
-    expect(String(configRow.history_id)).toBe('1');
+    // stale cursor writes nothing (the persisted watch cursor stays).
+    expect(String(configRow.history_id)).toBe('9999');
 
     // A pointer newer than the current cursor still advances it.
     const fresh = await upsertIngress(db, {
@@ -1915,6 +1920,314 @@ describeDb('Inbound email durable inbox (integration)', () => {
       .where({ tenant: tenantId, ingress_key: 'message:ms-revive-3' })
       .first('status');
     expect(revived3.status).toBe('received');
+  });
+
+  it('sweep starvation: a paused provider\'s due ingress rows never consume the capped scan window of an unpaused provider', async () => {
+    const paused = await setupProvider({ mailbox: 'starve-paused@example.com', providerType: 'google' });
+    const active = await setupProvider({ mailbox: 'starve-active@example.com', providerType: 'google' });
+    const { upsertIngress } = await import('@alga-psa/shared/services/email/inboundEmailDurableStore');
+    const { sweepTenantDurableWork } = await import('@alga-psa/shared/services/email/inboundEmailRecovery');
+
+    // The paused provider holds the OLDEST due rows: a capped scan that
+    // includes them fills its window before ever reaching the active
+    // provider's work — the exact starvation shape the exclusion must
+    // prevent at the row-selection predicate, not after the cap.
+    const pausedIds: string[] = [];
+    for (let i = 0; i < 4; i += 1) {
+      const row = await upsertIngress(db, {
+        tenant: tenantId,
+        provider_id: paused.providerId,
+        provider_type: 'google',
+        ingress_key: `starve:paused:${i}`,
+        provider_pointer: { messageId: `starve-p-${i}` },
+      });
+      pausedIds.push(row.ingress_id);
+    }
+    const activeIds: string[] = [];
+    for (let i = 0; i < 3; i += 1) {
+      const row = await upsertIngress(db, {
+        tenant: tenantId,
+        provider_id: active.providerId,
+        provider_type: 'google',
+        ingress_key: `starve:active:${i}`,
+        provider_pointer: { messageId: `starve-a-${i}` },
+      });
+      activeIds.push(row.ingress_id);
+    }
+    for (const [index, id] of pausedIds.entries()) {
+      await tenantTable('inbound_email_ingress')
+        .where({ ingress_id: id })
+        .update({ received_at: db.raw(`now() - interval '${10 - index} minutes'`) });
+    }
+    await tenantTable('email_providers').where({ id: paused.providerId }).update({
+      inbound_paused_at: db.fn.now(),
+      inbound_pause_reason: 'auth_failure',
+    });
+
+    v2EnqueueMock.mockClear();
+    // limit=3: every cap slot must belong to the active provider's due work.
+    // Pre-fix, the paused provider's three oldest rows filled the window and
+    // the sweep enqueued zero ingress work.
+    const sweep = await sweepTenantDurableWork(tenantId, 3);
+    expect(sweep.enqueued.ingress).toBe(3);
+    const enqueuedIngressIds = v2EnqueueMock.mock.calls
+      .map((call: any) => call[0])
+      .filter((job: any) => job.workType === 'stage_ingress')
+      .map((job: any) => job.recordId)
+      .sort();
+    expect(enqueuedIngressIds).toEqual([...activeIds].sort());
+
+    // The paused provider's rows were not even selected: untouched, non-terminal.
+    for (const id of pausedIds) {
+      const row = await tenantTable('inbound_email_ingress').where({ ingress_id: id }).first('status', 'attempt_count');
+      expect(row.status).toBe('received');
+      expect(Number(row.attempt_count)).toBe(0);
+    }
+  });
+
+  it('sweep snapshot race: a provider pausing between the sweep snapshot and the over-cap dead-letter decision is parked, never terminalized', async () => {
+    const { providerId } = await setupProvider({ mailbox: 'race-pause@example.com', providerType: 'google' });
+    const { upsertIngress } = await import('@alga-psa/shared/services/email/inboundEmailDurableStore');
+    const { sweepTenantDurableWork } = await import('@alga-psa/shared/services/email/inboundEmailRecovery');
+
+    const first = await upsertIngress(db, {
+      tenant: tenantId,
+      provider_id: providerId,
+      provider_type: 'google',
+      ingress_key: 'race:1',
+      provider_pointer: { messageId: 'race-1' },
+    });
+    const overCap = await upsertIngress(db, {
+      tenant: tenantId,
+      provider_id: providerId,
+      provider_type: 'google',
+      ingress_key: 'race:2',
+      provider_pointer: { messageId: 'race-2' },
+    });
+    // `first` sorts before `overCap` so the sweep reaches it first.
+    await tenantTable('inbound_email_ingress')
+      .where({ ingress_id: first.ingress_id })
+      .update({ received_at: db.raw("now() - interval '2 minutes'") });
+    // An over-cap due retryable row: the dead-letter candidate.
+    await tenantTable('inbound_email_ingress')
+      .where({ ingress_id: overCap.ingress_id })
+      .update({
+        status: 'retryable_failed',
+        attempt_count: 9,
+        next_attempt_at: db.raw("now() - interval '1 minute'"),
+        last_error: 'provider_unavailable_temporarily',
+      });
+
+    // Deterministic interleave: the sweep's snapshot of paused providers and
+    // its capped selection both happen BEFORE the enqueue of the first row;
+    // pausing the provider inside that enqueue lands strictly between the
+    // selection and the over-cap dead-letter decision for the second row.
+    v2EnqueueMock.mockImplementationOnce(async (input: any) => {
+      await tenantTable('email_providers').where({ id: providerId }).update({
+        inbound_paused_at: db.fn.now(),
+        inbound_pause_reason: 'auth_failure',
+      });
+      return {
+        job: { ...input, jobId: `v2-${randomUUID()}`, schemaVersion: 2, enqueuedAt: new Date().toISOString(), attempt: 0, maxAttempts: 5 },
+        queueDepth: 1,
+      };
+    });
+
+    await sweepTenantDurableWork(tenantId, 10);
+
+    // The pause raced the snapshot, so the row must be PARKED with the
+    // park-while-paused semantics — never terminalized.
+    const row = await tenantTable('inbound_email_ingress').where({ ingress_id: overCap.ingress_id }).first();
+    expect(row.status).toBe('retryable_failed');
+    expect(Number(row.attempt_count)).toBe(0);
+    expect(row.completed_at).toBeNull();
+    expect(row.next_attempt_at).not.toBeNull();
+    expect(new Date(row.next_attempt_at as string).getTime()).toBeGreaterThan(Date.now() - 1000);
+    expect((row.error_details as Record<string, unknown>)?.parkedWhilePaused).toBe(true);
+    expect(row.last_error).toBe('provider_unavailable_temporarily');
+  });
+
+  it('google history cursor advance is an atomic compare-and-set: a slower stale writer cannot overwrite a newer cursor', async () => {
+    const { providerId } = await setupProvider({ mailbox: 'gmail-cas@example.com', providerType: 'google' });
+    const { upsertIngress } = await import('@alga-psa/shared/services/email/inboundEmailDurableStore');
+    const { processIngressStageJob } = await import('@alga-psa/shared/services/email/inboundEmailIngressStagingWorker');
+    const ctx = { signal: new AbortController().signal, renew: async () => true, registerPostgresLease: () => undefined };
+
+    const readCursor = async (): Promise<string> => {
+      const row = await tenantTable('google_email_provider_config')
+        .where({ email_provider_id: providerId })
+        .first('history_id');
+      return String(row.history_id);
+    };
+
+    // The interleaving control: BOTH workers' config reads return the same
+    // pre-race snapshot ('1000') — one mock per staging run so nothing leaks.
+    // The fresh worker (pointer 9000) completes and persists first; the stale
+    // worker (pointer 1500, holding the pre-race read) completes AFTER it.
+    // This is the classic read-compare-write race the verifier found: the
+    // comparison must happen at the database write itself, not against the
+    // snapshot read at staging start.
+    googleProviderConfigMock.fetchGoogleProviderConfig
+      .mockResolvedValueOnce({
+        provider: { id: providerId, tenant: tenantId },
+        googleConfig: { history_id: '1000' },
+        config: {},
+      })
+      .mockResolvedValueOnce({
+        provider: { id: providerId, tenant: tenantId },
+        googleConfig: { history_id: '1000' },
+        config: {},
+      });
+    gmailAdapterMock.downloadMessageSource
+      .mockImplementationOnce(async () =>
+        buildMime({ from: 'a@b.c', to: 'gmail-cas@example.com', subject: 'Fresh', messageId: `cas-fresh-${randomUUID()}@example.com`, text: 'x' })
+      )
+      .mockImplementationOnce(async () =>
+        buildMime({ from: 'a@b.c', to: 'gmail-cas@example.com', subject: 'Stale', messageId: `cas-stale-${randomUUID()}@example.com`, text: 'x' })
+      );
+
+    const fresh = await upsertIngress(db, {
+      tenant: tenantId,
+      provider_id: providerId,
+      provider_type: 'google',
+      ingress_key: 'history:9000:cas:fresh-1',
+      provider_pointer: { historyId: '9000', discoveredMessageIds: ['cas-fresh-1'] },
+    });
+    const stale = await upsertIngress(db, {
+      tenant: tenantId,
+      provider_id: providerId,
+      provider_type: 'google',
+      ingress_key: 'history:1500:cas:stale-1',
+      provider_pointer: { historyId: '1500', discoveredMessageIds: ['cas-stale-1'] },
+    });
+
+    // Newer-cursor writer completes first and advances 1000 -> 9000.
+    const freshJob: any = {
+      schemaVersion: 2, workType: 'stage_ingress', tenantId,
+      recordId: fresh.ingress_id, jobId: `stage-${randomUUID()}`,
+      enqueuedAt: new Date().toISOString(), attempt: 0, maxAttempts: 5,
+    };
+    const freshResult = await processIngressStageJob(freshJob, ctx);
+    expect(freshResult.disposition).toBe('ack');
+    expect(await readCursor()).toBe('9000');
+
+    // Older-cursor writer completes afterwards holding the stale pre-race
+    // read (1000): its comparison says "advance", but the write itself must
+    // lose to the newer persisted cursor. Pre-fix, the unconditional UPDATE
+    // regressed the cursor to '1500'.
+    const staleJob: any = {
+      schemaVersion: 2, workType: 'stage_ingress', tenantId,
+      recordId: stale.ingress_id, jobId: `stage-${randomUUID()}`,
+      enqueuedAt: new Date().toISOString(), attempt: 0, maxAttempts: 5,
+    };
+    const staleResult = await processIngressStageJob(staleJob, ctx);
+    expect(staleResult.disposition).toBe('ack');
+    expect(await readCursor()).toBe('9000');
+  });
+
+  it('microsoft recovery reconcile: a cursor-lock mismatch mid-pass reports remaining work and hands off nothing', async () => {
+    const { providerId } = await setupProvider({ mailbox: 'ms-lock-race@example.com', providerType: 'microsoft' });
+    const { EmailWebhookMaintenanceService } = await import('@alga-psa/shared/services/email/EmailWebhookMaintenanceService');
+
+    const since = new Date(Date.now() - 3 * 60 * 60_000);
+    const T1 = new Date(Date.now() - 2 * 60 * 60_000).toISOString();
+
+    // Deterministic interleave: the concurrent actor moves the Graph
+    // reconciliation cursor WHILE this pass is listing (strictly between the
+    // pass's initial cursor read and its locked transactional decision), so
+    // the lock re-read observes a different cursor than the pass started
+    // with — the cursor-lock mismatch.
+    let listingCalls = 0;
+    microsoftGraphAdapterMock.listMessagesReceivedSince.mockImplementation(async () => {
+      listingCalls += 1;
+      if (listingCalls === 1) {
+        await tenantTable('microsoft_email_provider_config')
+          .where({ email_provider_id: providerId })
+          .update({ last_reconciliation_at: new Date(Date.now() - 90 * 60_000).toISOString() });
+      }
+      return [{ id: 'ms-lock-race-1', receivedDateTime: T1 }];
+    });
+
+    // Recovery pass (explicit since boundary): the mismatched pass handed
+    // off nothing and proved nothing about window coverage, so it must
+    // report remaining work instead of clean completion. Pre-fix this
+    // returned moreRemaining: false and the multi-pass recovery caller
+    // declared the paused interval exhausted.
+    const service = new EmailWebhookMaintenanceService();
+    const mismatchPass = await service.reconcileProviderMessages({
+      providerId,
+      tenant: tenantId,
+      since,
+      handedOffIds: new Set<string>(),
+    });
+    expect(mismatchPass.queuedMessages).toBe(0);
+    expect(mismatchPass.moreRemaining).toBe(true);
+    expect(mismatchPass.enqueuedMessageIds).toEqual([]);
+    const noHandoff = await tenantTable('inbound_email_ingress')
+      .where({ tenant: tenantId, provider_id: providerId })
+      .first('ingress_id');
+    expect(noHandoff).toBeFalsy();
+
+    // The next pass re-reads the saved boundary and completes the hand-off.
+    const cleanPass = await service.reconcileProviderMessages({
+      providerId,
+      tenant: tenantId,
+      since,
+      handedOffIds: new Set<string>(),
+    });
+    expect(cleanPass.queuedMessages).toBe(1);
+    expect(cleanPass.moreRemaining).toBe(false);
+    expect(cleanPass.enqueuedMessageIds).toEqual(['ms-lock-race-1']);
+    const handedOff = await tenantTable('inbound_email_ingress')
+      .where({ tenant: tenantId, ingress_key: 'message:ms-lock-race-1' })
+      .first('status');
+    expect(handedOff?.status).toBe('received');
+  });
+
+  it('auth-pause recovery survives a mid-recovery cursor-lock race: the pause clears only after a pass completes coverage', async () => {
+    const { providerId } = await setupProvider({ mailbox: 'ms-recover-race@example.com', providerType: 'microsoft' });
+    await tenantTable('email_providers').where({ id: providerId }).update({
+      inbound_paused_at: new Date(Date.now() - 2 * 60 * 60_000).toISOString(),
+      inbound_pause_reason: 'auth_failure',
+      inbound_auth_failure_count: 3,
+    });
+
+    const T1 = new Date(Date.now() - 60 * 60_000).toISOString();
+    // First listing during recovery moves the cursor mid-pass (the lock
+    // race); the second listing is clean.
+    let listingCalls = 0;
+    microsoftGraphAdapterMock.listMessagesReceivedSince.mockImplementation(async () => {
+      listingCalls += 1;
+      if (listingCalls === 1) {
+        await tenantTable('microsoft_email_provider_config')
+          .where({ email_provider_id: providerId })
+          .update({ last_reconciliation_at: new Date(Date.now() - 30 * 60_000).toISOString() });
+      }
+      return [{ id: 'ms-recover-race-1', receivedDateTime: T1 }];
+    });
+
+    const { EmailProviderLifecycleService } = await import('@alga-psa/shared/services/email/EmailProviderLifecycleService');
+    const result = await new EmailProviderLifecycleService().recoverAuthPausedProvider(providerId, tenantId, {
+      credentialsValidated: true,
+      deliveryEstablished: true,
+    });
+
+    // The mismatched pass must NOT be treated as exhaustion: recovery loops
+    // to a second pass that completes the hand-off. Pre-fix, the mismatch
+    // pass reported clean completion, recovery "resumed" after ONE pass, the
+    // pause was cleared, and the paused-interval message was stranded.
+    expect(result.resumed).toBe(true);
+    expect(listingCalls).toBe(2);
+    expect(result.reconciliation).toEqual({ status: 'completed', queuedMessages: 1 });
+
+    const providerRow = await tenantTable('email_providers').where({ id: providerId }).first('inbound_paused_at');
+    expect(providerRow.inbound_paused_at).toBeNull();
+
+    // The pause cleared only once the message was durably handed off.
+    const handedOff = await tenantTable('inbound_email_ingress')
+      .where({ tenant: tenantId, ingress_key: 'message:ms-recover-race-1' })
+      .first('status');
+    expect(handedOff?.status).toBe('received');
   });
 
   it('core processing succeeds from the staged source when the provider message is gone', async () => {

--- a/server/src/test/integration/unifiedInboundEmailQueueProcessor.authFailure.integration.test.ts
+++ b/server/src/test/integration/unifiedInboundEmailQueueProcessor.authFailure.integration.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Behavioral integration tests for auth-failure outcome recording at the
+ * source-fetch boundary of the unified inbound email queue processor:
+ *
+ * - a classified terminal auth failure increments the provider counter and
+ *   rethrows the original error (queue retry policy stays authoritative);
+ * - a transient 429/timeout never increments;
+ * - a successful source fetch — including one that returns no messages —
+ *   resets a prior count before downstream processing;
+ * - a downstream ticket-processing failure after a successful fetch does
+ *   NOT increment the auth counter.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { Knex } from 'knex';
+import { v4 as uuidv4 } from 'uuid';
+import { tenantDb } from '@alga-psa/db';
+import { createTestDbConnection, wireLocalTestDbEnv } from '../../../test-utils/dbConfig';
+import { describeWithDb } from '../../../test-utils/requireDb';
+import { processUnifiedInboundEmailQueueJob } from '@alga-psa/shared/services/email/unifiedInboundEmailQueueJobProcessor';
+import type { UnifiedInboundEmailQueueJob } from '@alga-psa/shared/interfaces/inbound-email.interfaces';
+
+const describeDb = await describeWithDb();
+
+let testDb: Knex;
+let testTenant: string;
+
+const microsoftAdapterMock = vi.hoisted(() => ({
+  downloadMessageSource: vi.fn(),
+}));
+
+vi.mock('redis', () => ({
+  createClient: () => {
+    throw new Error('redis unavailable in inbound auth-failure processor tests');
+  },
+}));
+
+vi.mock('@alga-psa/db/admin', () => ({
+  getAdminConnection: async () => testDb,
+}));
+
+vi.mock('@alga-psa/shared/services/email/microsoftEmailProviderConfig', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@alga-psa/shared/services/email/microsoftEmailProviderConfig')>();
+  return {
+    ...actual,
+    buildMicrosoftEmailProviderConfig: async (config: any) => config,
+  };
+});
+
+vi.mock('@alga-psa/shared/services/email/providers/MicrosoftGraphAdapter', () => ({
+  MicrosoftGraphAdapter: class MicrosoftGraphAdapter {
+    constructor(public config: any) {}
+    async connect() {
+      // connect() rethrows sanitized token-refresh failures with structured
+      // metadata; the classifier reads error.responseBody.
+      const failure: any = new Error('Error in connect: Request failed with status code 400 (code: 400)');
+      failure.status = 400;
+      failure.code = '400';
+      failure.responseBody = {
+        error: 'invalid_grant',
+        error_description: 'AADSTS50173: The provided grant has expired or was revoked.',
+      };
+      throw failure;
+    }
+    async downloadMessageSource() {
+      return microsoftAdapterMock.downloadMessageSource();
+    }
+  },
+}));
+
+vi.mock('@alga-psa/shared/services/email/providers/GmailAdapter', () => ({
+  GmailAdapter: class GmailAdapter {
+    constructor(public config: any) {}
+    async connect() {}
+    async listMessagesSince() {
+      return [];
+    }
+    async getMessageDetails() {
+      throw new Error('not expected in these tests');
+    }
+  },
+}));
+
+function tenantTable<Row = Record<string, unknown>>(table: string) {
+  return tenantDb(testDb, testTenant).table<Row>(table);
+}
+
+function tenantFixtureTable() {
+  return tenantDb(testDb, testTenant).unscoped(
+    'tenants',
+    'inbound auth-failure processor test fixture creates and removes tenant rows'
+  );
+}
+
+async function seedMicrosoftProvider(withCount = 0): Promise<string> {
+  const providerId = uuidv4();
+  const now = new Date();
+  await tenantTable('email_providers').insert({
+    id: providerId,
+    tenant: testTenant,
+    provider_type: 'microsoft',
+    provider_name: 'Processor Mailbox',
+    mailbox: `processor-${providerId.slice(0, 8)}@example.com`,
+    is_active: true,
+    status: 'connected',
+    inbound_paused_at: null,
+    error_message: null,
+    inbound_auth_failure_count: withCount,
+    created_at: now,
+    updated_at: now,
+  });
+  await tenantTable('microsoft_email_provider_config').insert({
+    email_provider_id: providerId,
+    tenant: testTenant,
+    client_id: 'client-id',
+    client_secret: 'client-secret',
+    tenant_id: 'directory-tenant-guid',
+    redirect_uri: 'https://psa.example.com/api/auth/microsoft/callback',
+    auto_process_emails: true,
+    max_emails_per_sync: 50,
+    folder_filters: JSON.stringify(['Inbox']),
+    access_token: 'stale-access',
+    refresh_token: 'revoked-refresh',
+    token_expires_at: new Date(Date.now() - 3600_000).toISOString(),
+    delivery_mode: 'polling',
+    created_at: now,
+    updated_at: now,
+  });
+  return providerId;
+}
+
+async function seedGoogleProvider(): Promise<string> {
+  const providerId = uuidv4();
+  const now = new Date();
+  await tenantTable('email_providers').insert({
+    id: providerId,
+    tenant: testTenant,
+    provider_type: 'google',
+    provider_name: 'Google Processor Mailbox',
+    mailbox: `gprocessor-${providerId.slice(0, 8)}@example.com`,
+    is_active: true,
+    status: 'connected',
+    inbound_paused_at: null,
+    error_message: null,
+    inbound_auth_failure_count: 2,
+    created_at: now,
+    updated_at: now,
+  });
+  await tenantTable('google_email_provider_config').insert({
+    email_provider_id: providerId,
+    tenant: testTenant,
+    client_id: 'client-id',
+    client_secret: 'client-secret',
+    project_id: 'project',
+    auto_process_emails: true,
+    max_emails_per_sync: 50,
+    label_filters: JSON.stringify([]),
+    access_token: 'access',
+    refresh_token: 'refresh',
+    token_expires_at: new Date(Date.now() + 3600_000).toISOString(),
+    history_id: '2000',
+    created_at: now,
+    updated_at: now,
+  });
+  return providerId;
+}
+
+function microsoftJob(providerId: string): UnifiedInboundEmailQueueJob {
+  return {
+    jobId: `job-${uuidv4()}`,
+    schemaVersion: 1,
+    tenantId: testTenant,
+    providerId,
+    provider: 'microsoft',
+    enqueuedAt: new Date().toISOString(),
+    attempt: 1,
+    maxAttempts: 5,
+    pointer: { subscriptionId: 'sub', messageId: 'msg-1' },
+  };
+}
+
+function googleJob(providerId: string): UnifiedInboundEmailQueueJob {
+  return {
+    jobId: `job-${uuidv4()}`,
+    schemaVersion: 1,
+    tenantId: testTenant,
+    providerId,
+    provider: 'google',
+    enqueuedAt: new Date().toISOString(),
+    attempt: 1,
+    maxAttempts: 5,
+    pointer: { historyId: '2000', emailAddress: 'mailbox@example.com' },
+  };
+}
+
+async function getCount(providerId: string): Promise<number> {
+  const row = await tenantTable('email_providers').where({ id: providerId }).first('inbound_auth_failure_count');
+  return Number(row?.inbound_auth_failure_count || 0);
+}
+
+describeDb('unified inbound queue processor auth-failure outcomes (DB-backed)', () => {
+  beforeAll(async () => {
+    wireLocalTestDbEnv();
+    testDb = await createTestDbConnection();
+    testTenant = uuidv4();
+    await tenantFixtureTable().insert({
+      tenant: testTenant,
+      client_name: 'Auth Pause Processor Test Client',
+      email: 'auth-pause-processor@client.com',
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+  }, 180_000);
+
+  afterAll(async () => {
+    if (testTenant) {
+      await tenantTable('email_processed_messages').delete();
+      await tenantTable('microsoft_email_provider_config').delete();
+      await tenantTable('google_email_provider_config').delete();
+      await tenantTable('email_providers').delete();
+      await tenantFixtureTable().where('tenant', testTenant).delete();
+    }
+    await testDb?.destroy().catch(() => undefined);
+  }, 30_000);
+
+  it('records a classified terminal auth failure and rethrows the original error', async () => {
+    const providerId = await seedMicrosoftProvider(0);
+
+    await expect(processUnifiedInboundEmailQueueJob(microsoftJob(providerId))).rejects.toThrow(
+      /AADSTS50173|invalid_grant|status code 400/i
+    );
+
+    expect(await getCount(providerId)).toBe(1);
+    const row = await tenantTable('email_providers').where({ id: providerId }).first();
+    expect(row.inbound_paused_at).toBeNull();
+    expect(row.inbound_auth_failure_code).toBe('microsoft:invalid_grant');
+  });
+
+  it('does not increment for a transient throttling error', async () => {
+    const providerId = await seedMicrosoftProvider(1);
+
+    // Override connect to throw a 429 with a Graph-shaped body.
+    const { MicrosoftGraphAdapter } = await import(
+      '@alga-psa/shared/services/email/providers/MicrosoftGraphAdapter'
+    );
+    const originalConnect = MicrosoftGraphAdapter.prototype.connect;
+    (MicrosoftGraphAdapter.prototype as any).connect = async function () {
+      const failure: any = new Error('Error in connect: Too many requests (code: 429)');
+      failure.status = 429;
+      failure.code = '429';
+      failure.responseBody = { error: { code: '429', message: 'Too many requests' } };
+      throw failure;
+    };
+    try {
+      await expect(processUnifiedInboundEmailQueueJob(microsoftJob(providerId))).rejects.toThrow(/429|Too many/i);
+    } finally {
+      (MicrosoftGraphAdapter.prototype as any).connect = originalConnect;
+    }
+
+    expect(await getCount(providerId)).toBe(1);
+    const row = await tenantTable('email_providers').where({ id: providerId }).first();
+    expect(row.inbound_paused_at).toBeNull();
+  });
+
+  it('resets a prior count when the source fetch succeeds with no messages', async () => {
+    const providerId = await seedGoogleProvider();
+    expect(await getCount(providerId)).toBe(2);
+
+    const result = await processUnifiedInboundEmailQueueJob(googleJob(providerId));
+
+    // GmailAdapter mock lists zero message ids since the pause boundary.
+    expect(result.outcome).toBe('skipped');
+    expect(result.reason).toBe('no_messages_from_pointer');
+    expect(await getCount(providerId)).toBe(0);
+  });
+
+  it('does not increment the auth counter when downstream ticket processing fails after a successful fetch', async () => {
+    const processInboundEmailInAppModule = await vi.importActual<
+      typeof import('@alga-psa/shared/services/email/processInboundEmailInApp')
+    >('@alga-psa/shared/services/email/processInboundEmailInApp');
+    const spy = vi
+      .spyOn(processInboundEmailInAppModule, 'processInboundEmailInApp')
+      .mockRejectedValueOnce(new Error('ticket processing exploded'));
+
+    try {
+      const { GmailAdapter } = await import('@alga-psa/shared/services/email/providers/GmailAdapter');
+      (GmailAdapter.prototype as any).listMessagesSince = async () => ['gmail-msg-1'];
+      (GmailAdapter.prototype as any).getMessageDetails = async () => ({
+        id: 'gmail-msg-1',
+        provider: 'google',
+        providerId: 'x',
+        tenant: testTenant,
+        receivedAt: new Date().toISOString(),
+        from: { email: 'sender@example.com' },
+        to: [{ email: 'support@example.com' }],
+        subject: 'Hello',
+        body: { text: 'body' },
+        attachments: [],
+      });
+
+      const providerId = await seedGoogleProvider();
+      expect(await getCount(providerId)).toBe(2);
+
+      await expect(processUnifiedInboundEmailQueueJob(googleJob(providerId))).rejects.toThrow(
+        /ticket processing exploded/
+      );
+
+      // The successful source fetch already reset the counter; the downstream
+      // application failure must not re-inflate it.
+      expect(await getCount(providerId)).toBe(0);
+      const row = await tenantTable('email_providers').where({ id: providerId }).first();
+      expect(row.inbound_paused_at).toBeNull();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/server/src/test/integration/unifiedInboundEmailQueueProcessor.authFailure.integration.test.ts
+++ b/server/src/test/integration/unifiedInboundEmailQueueProcessor.authFailure.integration.test.ts
@@ -282,8 +282,12 @@ describeDb('unified inbound queue processor auth-failure outcomes (DB-backed)', 
       .spyOn(processInboundEmailInAppModule, 'processInboundEmailInApp')
       .mockRejectedValueOnce(new Error('ticket processing exploded'));
 
+    // Restore the prototype patches in a finally: sequence.shuffle can run
+    // this before the empty-fetch test, and a leaked patch flips its outcome.
+    const { GmailAdapter } = await import('@alga-psa/shared/services/email/providers/GmailAdapter');
+    const originalList = (GmailAdapter.prototype as any).listMessagesSince;
+    const originalDetails = (GmailAdapter.prototype as any).getMessageDetails;
     try {
-      const { GmailAdapter } = await import('@alga-psa/shared/services/email/providers/GmailAdapter');
       (GmailAdapter.prototype as any).listMessagesSince = async () => ['gmail-msg-1'];
       (GmailAdapter.prototype as any).getMessageDetails = async () => ({
         id: 'gmail-msg-1',
@@ -311,6 +315,8 @@ describeDb('unified inbound queue processor auth-failure outcomes (DB-backed)', 
       const row = await tenantTable('email_providers').where({ id: providerId }).first();
       expect(row.inbound_paused_at).toBeNull();
     } finally {
+      (GmailAdapter.prototype as any).listMessagesSince = originalList;
+      (GmailAdapter.prototype as any).getMessageDetails = originalDetails;
       spy.mockRestore();
     }
   });

--- a/server/src/test/unit/components/GmailProviderForm.test.tsx
+++ b/server/src/test/unit/components/GmailProviderForm.test.tsx
@@ -146,4 +146,43 @@ describe('GmailProviderForm', () => {
 
     expect(mockOnCancel).toHaveBeenCalledTimes(1);
   });
+
+  it('surfaces setupError in the form and does not report success when reconnect recovery fails', async () => {
+    // The reconnect save on an auth-paused Gmail provider: OAuth recovery
+    // failed (revoked credentials / watch registration failure), so the
+    // action returns setupError AND the still-paused provider. The form
+    // must keep the drawer open with the error shown and never call
+    // onSuccess — EmailProviderConfiguration wires onSuccess to
+    // closeDrawer, which would destroy the error message and the
+    // paused-state context while ingestion is still stopped.
+    const pausedGmailProvider = {
+      id: 'paused-gmail-1',
+      tenant: defaultProps.tenant,
+      providerType: 'google',
+      providerName: 'Support Gmail (paused)',
+      mailbox: 'support@gmail.com',
+      isActive: true,
+      status: 'error',
+      googleConfig: {},
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    vi.mocked(emailProviderActions.updateEmailProvider).mockResolvedValueOnce({
+      provider: { ...pausedGmailProvider },
+      setupError: 'Gmail reconnection failed. Reconnect the mailbox and try again.',
+    } as any);
+
+    const user = userEvent.setup();
+    renderWithProviders(<GmailProviderForm {...defaultProps} provider={pausedGmailProvider as any} />);
+
+    await user.click(screen.getByRole('button', { name: /update provider/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Provider saved but setup incomplete: Gmail reconnection failed/)
+      ).toBeInTheDocument();
+    });
+
+    expect(mockOnSuccess).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/test/unit/components/GmailProviderFormEE.test.tsx
+++ b/server/src/test/unit/components/GmailProviderFormEE.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { screen, waitFor, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import '@testing-library/jest-dom';
+import { GmailProviderForm } from '@ee/components/GmailProviderForm';
+import { renderWithProviders } from '../../utils/testWrapper';
+
+// The EE copy (ee/server/src/components/GmailProviderForm.tsx) imports its
+// server actions via the deep module paths rather than the actions barrel
+// the CE test mocks, so each deep module is mocked directly here.
+vi.mock('@alga-psa/integrations/actions/email-actions/emailProviderActions', () => ({
+  createEmailProvider: vi.fn(),
+  updateEmailProvider: vi.fn(),
+  upsertEmailProvider: vi.fn(),
+}));
+vi.mock('@alga-psa/integrations/actions/email-actions/inboundTicketDefaultsActions', () => ({
+  getInboundTicketDefaults: vi.fn().mockResolvedValue({ defaults: [] }),
+}));
+vi.mock('@alga-psa/integrations/actions/email-actions/oauthActions', () => ({
+  initiateEmailOAuth: vi.fn().mockResolvedValue({ success: false, error: 'not used in unit tests' }),
+}));
+vi.mock('@alga-psa/integrations/actions/integrations/googleActions', () => ({
+  getGoogleIntegrationStatus: vi.fn().mockResolvedValue({
+    success: true,
+    config: {
+      gmailClientId: 'client-id',
+      gmailClientSecretMasked: '****',
+      projectId: 'test-project',
+      hasServiceAccountKey: true,
+    },
+  }),
+}));
+
+import * as emailProviderActions from '@alga-psa/integrations/actions/email-actions/emailProviderActions';
+
+describe('GmailProviderForm (EE copy, ee/server)', () => {
+  const mockOnSuccess = vi.fn();
+  const mockOnCancel = vi.fn();
+
+  const defaultProps = {
+    tenant: 'test-tenant-123',
+    onSuccess: mockOnSuccess,
+    onCancel: mockOnCancel,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        origin: 'http://localhost:3000',
+        href: 'http://localhost:3000',
+      },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('surfaces setupError in the form and does not report success when reconnect recovery fails', async () => {
+    // The reconnect save on an auth-paused Gmail provider: OAuth recovery
+    // failed (revoked credentials / watch registration failure), so the
+    // action returns setupError AND the still-paused provider. The EE form
+    // must keep the drawer open with the error shown and never call
+    // onSuccess — EmailProviderConfiguration wires onSuccess to
+    // closeDrawer, which would destroy the error message and the
+    // paused-state context while ingestion is still stopped.
+    const pausedGmailProvider = {
+      id: 'paused-gmail-1-ee',
+      tenant: defaultProps.tenant,
+      providerType: 'google',
+      providerName: 'Support Gmail (paused)',
+      mailbox: 'support@gmail.com',
+      isActive: true,
+      status: 'error',
+      // googleConfig must be present for the form to seed defaultValues
+      // from the provider (otherwise zod validation rejects the submit).
+      googleConfig: {
+        auto_process_emails: true,
+        label_filters: ['INBOX'],
+        max_emails_per_sync: 50,
+      },
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    vi.mocked(emailProviderActions.updateEmailProvider).mockResolvedValueOnce({
+      provider: { ...pausedGmailProvider },
+      setupError: 'Gmail reconnection failed. Reconnect the mailbox and try again.',
+    } as any);
+
+    const user = userEvent.setup();
+    renderWithProviders(<GmailProviderForm {...defaultProps} provider={pausedGmailProvider as any} />);
+
+    // The EE button label has no defaultValue, so without an i18n provider
+    // the key itself renders as the accessible name.
+    await user.click(screen.getByRole('button', { name: 'gmailForm.buttons.updateProvider' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Provider saved but setup incomplete: Gmail reconnection failed/)
+      ).toBeInTheDocument();
+    });
+
+    expect(mockOnSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/test/unit/components/ImapProviderForm.test.tsx
+++ b/server/src/test/unit/components/ImapProviderForm.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { screen, waitFor, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import '@testing-library/jest-dom';
+import { ImapProviderForm } from '@alga-psa/integrations/components';
+import { renderWithProviders } from '../../utils/testWrapper';
+
+// Mock server actions (single factory: repeated vi.mock calls for the same
+// module override each other, so all exports must live in one mock).
+vi.mock('@alga-psa/integrations/actions', () => ({
+  createEmailProvider: vi.fn(),
+  updateEmailProvider: vi.fn(),
+  upsertEmailProvider: vi.fn(),
+  getInboundTicketDefaults: vi.fn().mockResolvedValue({ defaults: [] }),
+  initiateEmailOAuth: vi.fn().mockResolvedValue({ success: false, error: 'not used in unit tests' }),
+}));
+
+import * as emailProviderActions from '@alga-psa/integrations/actions';
+
+const pausedImapProvider = {
+  id: 'paused-imap-1',
+  tenant: 'test-tenant-123',
+  providerType: 'imap' as const,
+  providerName: 'Paused IMAP',
+  mailbox: 'paused@example.com',
+  isActive: true,
+  status: 'error' as const,
+  inboundPausedAt: '2026-08-16T00:00:00.000Z',
+  inboundPauseReason: 'auth_failure' as const,
+  imapConfig: {
+    email_provider_id: 'paused-imap-1',
+    tenant: 'test-tenant-123',
+    host: 'imap.example.com',
+    port: 993,
+    secure: true,
+    allow_starttls: false,
+    auth_type: 'password' as const,
+    username: 'paused',
+    folder_filters: ['INBOX'],
+    auto_process_emails: true,
+    max_emails_per_sync: 5,
+    created_at: '2026-08-15T00:00:00.000Z',
+    updated_at: '2026-08-15T00:00:00.000Z',
+  },
+  createdAt: '2026-08-15T00:00:00.000Z',
+  updatedAt: '2026-08-15T00:00:00.000Z',
+};
+
+describe('ImapProviderForm', () => {
+  const mockOnSuccess = vi.fn();
+  const mockOnCancel = vi.fn();
+
+  const defaultProps = {
+    tenant: 'test-tenant-123',
+    onSuccess: mockOnSuccess,
+    onCancel: mockOnCancel,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Mock window.location
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        origin: 'http://localhost:3000',
+        href: 'http://localhost:3000',
+      },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('should render form fields in edit mode', () => {
+    renderWithProviders(<ImapProviderForm {...defaultProps} provider={pausedImapProvider as any} />);
+
+    expect(screen.getByDisplayValue('Paused IMAP')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('paused@example.com')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('imap.example.com')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /update provider/i })).toBeInTheDocument();
+  });
+
+  it('should pass the fresh provider through on a successful reconnect save', async () => {
+    vi.mocked(emailProviderActions.updateEmailProvider).mockResolvedValueOnce({
+      provider: {
+        ...pausedImapProvider,
+        status: 'connected',
+        inboundPausedAt: null,
+        inboundPauseReason: null,
+      },
+    } as any);
+
+    const user = userEvent.setup();
+    renderWithProviders(<ImapProviderForm {...defaultProps} provider={pausedImapProvider as any} />);
+
+    await user.click(screen.getByRole('button', { name: /update provider/i }));
+
+    await waitFor(() => {
+      expect(emailProviderActions.updateEmailProvider).toHaveBeenCalledTimes(1);
+    });
+    expect(mockOnSuccess).toHaveBeenCalledTimes(1);
+    expect(mockOnSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'paused-imap-1', inboundPausedAt: null })
+    );
+  });
+
+  it('surfaces setupError in the form and does not report success when reconnect recovery fails', async () => {
+    // The Reconnect drawer's save (skipAutomation=true) on an auth-paused
+    // provider: the credentials were persisted but recovery refused them, so
+    // the action returns setupError AND the still-paused provider. The form
+    // must keep the drawer open with the error shown and never call
+    // onSuccess — the parent only re-renders the pause banner from the
+    // provider delivered on success.
+    vi.mocked(emailProviderActions.updateEmailProvider).mockResolvedValueOnce({
+      provider: { ...pausedImapProvider },
+      setupError: 'Authentication failed',
+    } as any);
+
+    const user = userEvent.setup();
+    renderWithProviders(<ImapProviderForm {...defaultProps} provider={pausedImapProvider as any} />);
+
+    await user.click(screen.getByRole('button', { name: /update provider/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Provider saved but setup incomplete: Authentication failed/)
+      ).toBeInTheDocument();
+    });
+
+    expect(mockOnSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/test/unit/components/MicrosoftProviderForm.test.tsx
+++ b/server/src/test/unit/components/MicrosoftProviderForm.test.tsx
@@ -236,6 +236,67 @@ describe('MicrosoftProviderForm', () => {
     });
   });
 
+  it('surfaces setupError in the form and does not report success when reconnect recovery fails', async () => {
+    // The reconnect save on an auth-paused provider: the action persisted the
+    // credentials but recovery was refused (bad client secret), so it returns
+    // setupError AND the still-paused provider. The form must keep the
+    // drawer open with the error shown and never call onSuccess — the parent
+    // renders the cleared/kept pause banner from the provider it gets on
+    // success only.
+    vi.mocked(emailProviderActions.updateEmailProvider).mockResolvedValueOnce({
+      provider: {
+        id: 'paused-1',
+        tenant: 'test-tenant-123',
+        providerType: 'microsoft',
+        providerName: 'Paused Mailbox',
+        mailbox: 'paused@client.com',
+        isActive: true,
+        status: 'error',
+        inboundPausedAt: '2026-08-16T00:00:00.000Z',
+        inboundPauseReason: 'auth_failure',
+        createdAt: '2026-08-15T00:00:00.000Z',
+        updatedAt: '2026-08-15T00:00:00.000Z',
+      },
+      setupError: 'Microsoft reconnection failed. Verify the client secret and try again.',
+    } as any);
+
+    const user = userEvent.setup();
+    renderWithProviders(
+      <MicrosoftProviderForm
+        {...defaultProps}
+        provider={{
+          id: 'paused-1',
+          tenant: 'test-tenant-123',
+          providerType: 'microsoft' as const,
+          providerName: 'Paused Mailbox',
+          mailbox: 'paused@client.com',
+          isActive: true,
+          status: 'error' as const,
+          inboundPausedAt: '2026-08-16T00:00:00.000Z',
+          inboundPauseReason: 'auth_failure' as const,
+          microsoftConfig: {
+            redirect_uri: 'http://localhost:3000/api/auth/microsoft/callback',
+            folder_filters: ['Inbox'],
+            auto_process_emails: true,
+            max_emails_per_sync: 50,
+          },
+          createdAt: '2026-08-15T00:00:00.000Z',
+          updatedAt: '2026-08-15T00:00:00.000Z',
+        } as any}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /update provider/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Provider saved but setup incomplete: Microsoft reconnection failed/)
+      ).toBeInTheDocument();
+    });
+
+    expect(mockOnSuccess).not.toHaveBeenCalled();
+  });
+
   it('enables Microsoft sign-in once an app is selected, without a setup banner', async () => {
     renderWithProviders(<MicrosoftProviderForm {...defaultProps} />);
 

--- a/server/src/test/unit/email/inboundAuthPauseNotificationSubscriber.test.ts
+++ b/server/src/test/unit/email/inboundAuthPauseNotificationSubscriber.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+
+const subscribeMock = vi.hoisted(() => vi.fn());
+const unsubscribeMock = vi.hoisted(() => vi.fn());
+const notifyMock = vi.hoisted(() => vi.fn());
+const eventBusFactory = vi.hoisted(() => () => ({
+  default: {
+    getEventBus: () => ({
+      subscribe: subscribeMock,
+      unsubscribe: unsubscribeMock,
+    }),
+  },
+  getEventBus: () => ({
+    subscribe: subscribeMock,
+    unsubscribe: unsubscribeMock,
+  }),
+}));
+
+// The subscriber imports getEventBus via '../index'; mock every specifier
+// shape that resolves to the same module so the mock always applies.
+vi.mock('@/lib/eventBus', eventBusFactory);
+vi.mock('../../../lib/eventBus/index', eventBusFactory);
+vi.mock('../../../lib/eventBus', eventBusFactory);
+
+vi.mock('@/services/email/inboundAuthPauseNotificationService', () => ({
+  notifyInboundAuthPauseAdmins: (...args: unknown[]) => notifyMock(...args),
+}));
+
+import {
+  registerInboundAuthPauseNotificationSubscriber,
+  unregisterInboundAuthPauseNotificationSubscriber,
+} from '@/lib/eventBus/subscribers/inboundAuthPauseNotificationSubscriber';
+
+function autoPausedEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    id: '33333333-3333-4333-8333-333333333333',
+    timestamp: new Date().toISOString(),
+    eventType: 'INBOUND_EMAIL_PROVIDER_AUTO_PAUSED',
+    payload: {
+      tenantId: '11111111-1111-4111-8111-111111111111',
+      occurredAt: new Date().toISOString(),
+      actorType: 'SYSTEM',
+      providerId: '22222222-2222-4222-8222-222222222222',
+      providerName: 'Worker Mailbox',
+      mailbox: 'worker@example.com',
+      providerType: 'google',
+      authFailureCode: 'google:invalid_grant:invalid_rapt',
+      pausedAt: new Date().toISOString(),
+      ...overrides,
+    },
+  };
+}
+
+describe('inboundAuthPauseNotificationSubscriber', () => {
+  let handler: (event: unknown) => Promise<void>;
+
+  // The module-level registration guard makes tests order-dependent under
+  // sequence.shuffle; normalize state around every test.
+  beforeAll(async () => {
+    await unregisterInboundAuthPauseNotificationSubscriber().catch(() => undefined);
+  });
+
+  afterAll(async () => {
+    await unregisterInboundAuthPauseNotificationSubscriber().catch(() => undefined);
+  });
+
+  beforeEach(async () => {
+    subscribeMock.mockReset();
+    unsubscribeMock.mockReset();
+    notifyMock.mockReset();
+    await unregisterInboundAuthPauseNotificationSubscriber().catch(() => undefined);
+    await registerInboundAuthPauseNotificationSubscriber();
+    handler = subscribeMock.mock.calls[0][1];
+  });
+
+  afterEach(async () => {
+    await unregisterInboundAuthPauseNotificationSubscriber().catch(() => undefined);
+  });
+
+  it('subscribes to INBOUND_EMAIL_PROVIDER_AUTO_PAUSED (idempotently)', async () => {
+    expect(subscribeMock).toHaveBeenCalledTimes(1);
+    expect(subscribeMock).toHaveBeenCalledWith(
+      'INBOUND_EMAIL_PROVIDER_AUTO_PAUSED',
+      expect.any(Function)
+    );
+
+    // Re-registration is a no-op (module-level guard).
+    await registerInboundAuthPauseNotificationSubscriber();
+    expect(subscribeMock).toHaveBeenCalledTimes(1);
+
+    await unregisterInboundAuthPauseNotificationSubscriber();
+    expect(unsubscribeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('delegates valid events to the admin notifier with the safe payload', async () => {
+    await handler(autoPausedEvent());
+
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+    expect(notifyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenant: '11111111-1111-4111-8111-111111111111',
+        providerId: '22222222-2222-4222-8222-222222222222',
+        providerType: 'google',
+        authFailureCode: 'google:invalid_grant:invalid_rapt',
+      })
+    );
+  });
+
+  it('contains delivery failures (never rethrows into the consumer group)', async () => {
+    notifyMock.mockRejectedValueOnce(new Error('notifications table unavailable'));
+
+    await expect(handler(autoPausedEvent())).resolves.toBeUndefined();
+  });
+
+  it('rejects malformed events instead of notifying garbage', async () => {
+    await expect(
+      handler(autoPausedEvent({ providerType: 'smtp' }))
+    ).rejects.toThrow();
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/test/unit/email/inboundAuthPauseNotifierTopology.contract.test.ts
+++ b/server/src/test/unit/email/inboundAuthPauseNotifierTopology.contract.test.ts
@@ -41,6 +41,26 @@ describe('inbound auth-pause notifier deployment topology', () => {
     expect(source).toContain("assertInboundAuthPauseNotifierRegistered('services/email-service')");
   });
 
+  it('email-service IMAP listener loop accounts auth outcomes and honours the pause', () => {
+    // The standalone IMAP listener is a real provider source-access boundary:
+    // classified auth failures must advance the counter, successful mailbox
+    // access must reset it, and the discovery/poll loop must stop connecting a
+    // paused provider (IMAP has no Graph/Gmail subscription to tear down —
+    // the poll loop itself is the noise source).
+    const source = read('services/email-service/src/emailService.ts');
+    expect(source).toContain('recordInboundSourceAuthFailure({');
+    expect(source).toContain("providerType: 'imap'");
+    expect(source).toContain('recordInboundSourceAccessSuccess({');
+    expect(source).toContain('isInboundPaused()');
+    expect(source).toContain("whereNull('ep.inbound_paused_at')");
+  });
+
+  it('durable-V2 staging worker accounts source auth outcomes at its fetch boundary', () => {
+    const source = read('shared/services/email/inboundEmailIngressStagingWorker.ts');
+    expect(source).toContain('recordInboundSourceAuthFailure({');
+    expect(source).toContain('recordInboundSourceAccessSuccess({');
+  });
+
   it('EE Temporal worker bootstrap registers the event-publisher notifier', () => {
     const source = read('ee/temporal-workflows/src/worker.ts');
     expect(source).toContain('registerInboundAuthPauseEventPublisher()');

--- a/server/src/test/unit/email/inboundAuthPauseNotifierTopology.contract.test.ts
+++ b/server/src/test/unit/email/inboundAuthPauseNotifierTopology.contract.test.ts
@@ -1,0 +1,87 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Every runtime that can perform the atomic auth-failure auto-pause must have
+ * an admin-notification notifier registered at startup — a silent pause is the
+ * exact failure this feature exists to prevent. This contract test pins the
+ * registration wiring across all four deployment topologies:
+ *
+ *   - Next server process (initializeApp — direct notifications implementation)
+ *   - server bin consumer (direct implementation)
+ *   - standalone email-service container (event-publisher notifier; the
+ *     @alga-psa/notifications vertical is not in its build graph)
+ *   - EE Temporal worker (event-publisher notifier; notifications vertical is
+ *     stubbed in that build graph)
+ *
+ * plus the server-side subscriber that turns the worker event back into admin
+ * notifications, and the event-bus schema entry that makes it publishable.
+ */
+
+const repoRoot = path.resolve(__dirname, '../../../../..');
+const read = (relativePath: string) => fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+
+describe('inbound auth-pause notifier deployment topology', () => {
+  it('Next server registers the direct notifications implementation', () => {
+    const source = read('server/src/lib/initializeApp.ts');
+    expect(source).toContain('registerInboundAuthPauseNotifications()');
+    expect(source).toContain('assertInboundAuthPauseNotifierRegistered');
+  });
+
+  it('bin consumer registers the direct notifications implementation', () => {
+    const source = read('server/src/bin/unifiedInboundEmailQueueConsumer.ts');
+    expect(source).toContain('registerInboundAuthPauseNotifications()');
+    expect(source).toContain("assertInboundAuthPauseNotifierRegistered('server/bin/unifiedInboundEmailQueueConsumer')");
+  });
+
+  it('email-service container registers the event-publisher notifier', () => {
+    const source = read('services/email-service/src/index.ts');
+    expect(source).toContain('registerInboundAuthPauseEventPublisher()');
+    expect(source).toContain("assertInboundAuthPauseNotifierRegistered('services/email-service')");
+  });
+
+  it('EE Temporal worker bootstrap registers the event-publisher notifier', () => {
+    const source = read('ee/temporal-workflows/src/worker.ts');
+    expect(source).toContain('registerInboundAuthPauseEventPublisher()');
+    expect(source).toContain("assertInboundAuthPauseNotifierRegistered(\"ee/temporal-workflows/worker\")");
+  });
+
+  it('server subscribes to the worker-published auto-pause event and is registered with the other subscribers', () => {
+    const subscriber = read('server/src/lib/eventBus/subscribers/inboundAuthPauseNotificationSubscriber.ts');
+    expect(subscriber).toContain("'INBOUND_EMAIL_PROVIDER_AUTO_PAUSED'");
+    expect(subscriber).toContain('notifyInboundAuthPauseAdmins');
+
+    const registrations = read('server/src/lib/eventBus/subscribers/index.ts');
+    expect(registrations).toContain('registerInboundAuthPauseNotificationSubscriber');
+    expect(registrations).toContain('unregisterInboundAuthPauseNotificationSubscriber');
+  });
+
+  it('event schema admits INBOUND_EMAIL_PROVIDER_AUTO_PAUSED with the safe payload shape', async () => {
+    const { EventSchemas } = await import('@alga-psa/event-schemas');
+    const schema = EventSchemas.INBOUND_EMAIL_PROVIDER_AUTO_PAUSED;
+    expect(schema).toBeTruthy();
+
+    const event = {
+      id: '33333333-3333-4333-8333-333333333333',
+      timestamp: new Date().toISOString(),
+      eventType: 'INBOUND_EMAIL_PROVIDER_AUTO_PAUSED' as const,
+      payload: {
+        tenantId: '11111111-1111-4111-8111-111111111111',
+        occurredAt: new Date().toISOString(),
+        actorType: 'SYSTEM',
+        providerId: '22222222-2222-4222-8222-222222222222',
+        providerName: 'Worker Mailbox',
+        mailbox: 'worker@example.com',
+        providerType: 'google',
+        authFailureCode: 'google:invalid_grant:invalid_rapt',
+        pausedAt: new Date().toISOString(),
+      },
+    };
+    expect(() => schema.parse(event)).not.toThrow();
+    // Unknown provider types must be rejected (no free-form reason strings).
+    expect(() =>
+      schema.parse({ ...event, payload: { ...event.payload, providerType: 'smtp' } })
+    ).toThrow();
+  });
+});

--- a/server/src/test/unit/unifiedInboundEmailQueueJobProcessor.fetch.test.ts
+++ b/server/src/test/unit/unifiedInboundEmailQueueJobProcessor.fetch.test.ts
@@ -157,6 +157,9 @@ function createDbMock(params: {
         where() {
           return builder;
         },
+        whereRaw() {
+          return builder;
+        },
         async first() {
           return params.googleConfigRow || null;
         },

--- a/services/email-service/src/emailService.ts
+++ b/services/email-service/src/emailService.ts
@@ -12,6 +12,11 @@ import type {
   EmailIngressSkipReason,
 } from '@alga-psa/shared/interfaces/inbound-email.interfaces';
 import { stageReadyInboundSource } from '@alga-psa/shared/services/email/inboundEmailProducer';
+import {
+  recordInboundSourceAccessSuccess,
+  recordInboundSourceAuthFailure,
+} from '@alga-psa/shared/services/email/inboundEmailAuthOutcomeRecorder';
+import { resolveImapSyncStartUid } from '@alga-psa/shared/services/email/imapSyncCursor';
 
 const DEFAULT_REFRESH_MS = 60_000;
 const DEFAULT_RECONNECT_BASE_MS = 2_000;
@@ -495,6 +500,25 @@ class ImapFolderListener {
     const prevError = this.provider.error_message;
     const db = await getAdminConnection();
     const scopedDb = tenantDb(db, this.provider.tenant);
+    if (status === 'error') {
+      // The failure may have just triggered the atomic auth-failure auto-pause,
+      // which wrote the curated reconnect-required message. Overwriting it with
+      // the raw connection error would bury the actionable instruction.
+      const current = await scopedDb.table('email_providers')
+        .where({ id: this.provider.id })
+        .first('inbound_paused_at', 'inbound_pause_reason') as
+        | { inbound_paused_at: string | null; inbound_pause_reason: string | null }
+        | undefined;
+      if (current?.inbound_paused_at && current.inbound_pause_reason === 'auth_failure') {
+        stateLog('provider_status_skip_auth_paused', {
+          providerId: this.provider.id,
+          tenant: this.provider.tenant,
+          folder: this.folder,
+          listenerId: this.listenerId,
+        });
+        return;
+      }
+    }
     await scopedDb.table('email_providers')
       .where({ id: this.provider.id })
       .update({
@@ -533,6 +557,24 @@ class ImapFolderListener {
         last_sync_at: db.fn.now(),
         updated_at: db.fn.now(),
       });
+  }
+
+  /**
+   * Whether the provider is currently ingestion-paused (any pause reason, any
+   * triggering runtime). The listener checks this after connection failures so
+   * it never fights the pause with its own reconnect loop; the periodic
+   * provider refresh removes the worker entirely within one cycle.
+   */
+  private async isInboundPaused(): Promise<boolean> {
+    try {
+      const db = await getAdminConnection();
+      const row = await tenantDb(db, this.provider.tenant).table('email_providers')
+        .where({ id: this.provider.id })
+        .first('inbound_paused_at') as { inbound_paused_at: string | null } | undefined;
+      return Boolean(row?.inbound_paused_at);
+    } catch {
+      return false;
+    }
   }
 
   private resolveWebhookUrl(): string {
@@ -781,12 +823,9 @@ class ImapFolderListener {
       );
 
       // When we have no cursor (initial connect or after manual resync), start from the most recent window
-      // instead of replaying the entire mailbox from UID 1.
-      const startUid = this.folderState.last_uid
-        ? Number(this.folderState.last_uid) + 1
-        : mailbox?.uidNext && Number(mailbox.uidNext) > 1
-          ? Math.max(1, Number(mailbox.uidNext) - maxEmailsPerSync)
-          : 1;
+      // instead of replaying the entire mailbox from UID 1. A '0' cursor (auth-pause recovery
+      // resync) deliberately scans from UID 1 so the whole paused interval is covered.
+      const startUid = resolveImapSyncStartUid(this.folderState.last_uid, mailbox?.uidNext, maxEmailsPerSync);
 
       const range = `${startUid}:*`;
 
@@ -1119,6 +1158,14 @@ class ImapFolderListener {
           await this.persistServerCapabilities((this.client as any).capabilities);
         }
         await this.updateProviderStatus('connected', null);
+        // A successful mailbox login is a successful provider source access:
+        // reset the consecutive auth-failure counter (same semantics as the
+        // queue processor's source-fetch boundary). Best-effort, logged.
+        await recordInboundSourceAccessSuccess({
+          tenant: this.provider.tenant,
+          providerId: this.provider.id,
+          source: 'imap-email-service',
+        });
         await this.client.mailboxOpen(this.folder, { readOnly: true });
         await this.syncNewMessages(this.client);
         await this.idleLoop(this.client);
@@ -1138,6 +1185,32 @@ class ImapFolderListener {
           ...errorDetails,
         });
         await this.updateProviderStatus('error', errorDetails.message || 'IMAP connection error');
+        // Source-access auth accounting with the same semantics as the queue
+        // processor boundary: only strictly classified terminal credential
+        // failures (IMAP protocol auth rejection or OAuth token-endpoint
+        // invalid_client/invalid_grant) advance the counter; transient
+        // connection errors never count. The raw error is classified — it
+        // carries the structured flags/body the classifier reads.
+        await recordInboundSourceAuthFailure({
+          tenant: this.provider.tenant,
+          providerId: this.provider.id,
+          providerType: 'imap',
+          error,
+          source: 'imap-email-service',
+        });
+        // Honour the pause: once the provider is paused (by this loop crossing
+        // the threshold or by any other runtime), stop reconnecting instead of
+        // fighting the pause. The periodic provider refresh removes the worker.
+        if (await this.isInboundPaused()) {
+          stateLog('listener_stop_inbound_paused', {
+            providerId: this.provider.id,
+            tenant: this.provider.tenant,
+            folder: this.folder,
+            listenerId: this.listenerId,
+          });
+          this.running = false;
+          break;
+        }
         await this.persistFolderState({ last_seen_at: new Date().toISOString() });
         await this.delayWithBackoff();
       } finally {
@@ -1350,6 +1423,14 @@ export class EmailService {
     const rows = await providerRoot
       .where('ep.provider_type', 'imap')
       .andWhere('ep.is_active', true)
+      // Ingestion-paused providers (e.g. the automatic auth-failure pause) must
+      // not be polled or connected to: IMAP has no Graph/Gmail subscription to
+      // tear down, so this discovery gate IS the pause enforcement for IMAP.
+      // Existing workers are stopped within one refresh cycle via the
+      // active-id set below, and the auth-pause recovery path re-arms the
+      // cursors before the pause clears so the fresh worker rescans the
+      // paused interval.
+      .whereNull('ep.inbound_paused_at')
       .select(
         'ep.id',
         'ep.tenant',

--- a/services/email-service/src/index.ts
+++ b/services/email-service/src/index.ts
@@ -10,8 +10,19 @@ import {
   renewPostgresLeaseForV2Job,
 } from '@alga-psa/shared/services/email/unifiedInboundEmailQueueJobProcessorV2';
 import { getInboundDurableMode } from '@alga-psa/shared/services/email/inboundEmailDurableStore';
+import {
+  assertInboundAuthPauseNotifierRegistered,
+} from '@alga-psa/shared/services/email/inboundAuthPauseNotifier';
+import { registerInboundAuthPauseEventPublisher } from '@alga-psa/shared/services/email/inboundAuthPauseEventNotifier';
 
 dotenv.config();
+
+// This process performs the atomic auth-failure auto-pause, but its build
+// graph cannot load the @alga-psa/notifications vertical: publish the pause
+// on the event bus and let the server-side subscriber deliver the admin
+// notifications (same hand-off as MAINTENANCE_JOB_REQUESTED).
+registerInboundAuthPauseEventPublisher();
+assertInboundAuthPauseNotifierRegistered('services/email-service');
 
 const service = new EmailService();
 let healthServer: http.Server | undefined;

--- a/shared/interfaces/inbound-email.interfaces.ts
+++ b/shared/interfaces/inbound-email.interfaces.ts
@@ -9,7 +9,7 @@ export interface EmailProviderConfig {
   folder_to_monitor: string; // Defaults to 'Inbox'
   active: boolean;
   inboundPausedAt?: string | null;
-  inboundPauseReason?: 'manual' | 'tenant_cancelled' | null;
+  inboundPauseReason?: 'manual' | 'tenant_cancelled' | 'auth_failure' | null;
   // Common webhook fields as real columns
   webhook_notification_url: string;
   webhook_subscription_id?: string;

--- a/shared/services/email/EmailProviderLifecycleService.ts
+++ b/shared/services/email/EmailProviderLifecycleService.ts
@@ -843,11 +843,28 @@ export class EmailProviderLifecycleService {
         tenant: params.tenant,
         providerId: params.providerId,
         providerType: 'google',
+        // The enforce-mode pointer must carry exactly what the direct-enqueue
+        // branch carries: the POST-watch cursor (the staging worker persists
+        // pointer.historyId back to google_email_provider_config after
+        // staging, and the pre-watch cursor would regress it below the fresh
+        // watch), the mailbox identity, and the discovered message id (the
+        // staging worker only downloads ids it finds in the pointer — without
+        // them it re-lists from the post-watch cursor and finds nothing from
+        // the paused interval). pubsubMessageId keeps one ingress row per
+        // reconciled message (the deterministic key is
+        // `history:<historyId>:<pubsubMessageId>`), so re-reconciles are
+        // idempotent and a terminally failed row is revived, not skipped.
+        reviveTerminal: true,
         pointer: {
           providerType: 'google',
-          providerMessageId: messageId,
-          historyId: savedHistoryId,
-          extra: { resource: 'auth-pause-reconcile' },
+          historyId: currentHistoryId || savedHistoryId,
+          pubsubMessageId: `auth-pause-reconcile:${messageId}`,
+          mailbox: loaded.provider.mailbox,
+          extra: {
+            resource: 'auth-pause-reconcile',
+            emailAddress: loaded.provider.mailbox,
+            discoveredMessageIds: [messageId],
+          },
         },
       });
       if (!(durable.mode === 'enforce' && durable.ingressId)) {

--- a/shared/services/email/EmailProviderLifecycleService.ts
+++ b/shared/services/email/EmailProviderLifecycleService.ts
@@ -6,14 +6,72 @@ import { buildMicrosoftEmailProviderConfig } from './microsoftEmailProviderConfi
 import { GmailAdapter } from './providers/GmailAdapter';
 import { MicrosoftGraphAdapter } from './providers/MicrosoftGraphAdapter';
 import { getEmailWebhookBaseUrl } from './webhookBaseUrl';
+import { INBOUND_AUTH_FAILURE_PAUSE_THRESHOLD } from './InboundEmailAuthFailurePolicy';
+import {
+  dispatchInboundAuthPauseNotification,
+} from './inboundAuthPauseNotifier';
+import { persistIngressPointer } from './inboundEmailProducer';
+import { enqueueUnifiedInboundEmailQueueJob } from './unifiedInboundEmailQueue';
+import { refreshImapAccessToken } from './imapOauthToken';
 
-export type InboundPauseReason = 'manual' | 'tenant_cancelled';
+export type InboundPauseReason = 'manual' | 'tenant_cancelled' | 'auth_failure';
 
 export interface ResumeProviderResult {
   resumed: boolean;
   webhookRegistered: boolean;
   error?: string;
+  reconciliation?: InboundAuthPauseReconciliation;
+  /** True when the provider is paused for auth_failure and credentials must be re-established before resume. */
+  reconnectRequired?: boolean;
 }
+
+export interface InboundAuthPauseReconciliation {
+  status: 'started' | 'completed';
+  queuedMessages: number;
+}
+
+export interface RecoverAuthPausedProviderOptions {
+  /**
+   * The reconnect path already proved the new credentials work (e.g. an OAuth
+   * callback that just exchanged tokens, or a successful connection test).
+   */
+  credentialsValidated?: boolean;
+  /**
+   * The reconnect path already re-established delivery (e.g. webhook/watch
+   * registration inside setup automation), so recovery must not double-register.
+   */
+  deliveryEstablished?: boolean;
+  /**
+   * Google only: the pre-watch history_id captured before the reconnect flow
+   * replaced it with a new watch cursor. When omitted, recovery captures the
+   * current cursor itself before any registration it performs.
+   */
+  savedHistoryId?: string | null;
+}
+
+export type RecoverAuthPausedProviderResult = ResumeProviderResult & {
+  reconciliation?: InboundAuthPauseReconciliation;
+};
+
+export interface RecordUnrecoverableAuthFailureResult {
+  count: number;
+  autoPaused: boolean;
+  providerType?: 'microsoft' | 'google' | 'imap';
+  providerName?: string;
+  mailbox?: string;
+  pausedAt?: string;
+}
+
+/** Safe, secret-free provider-facing error for the auth_failure pause state. */
+export const INBOUND_AUTH_FAILURE_PAUSE_ERROR_MESSAGE =
+  'Sign-in was rejected by the email provider. Reconnect the mailbox to resume inbound email.';
+
+/** Upper bound on Google recovery message ids enqueued per reconnect. */
+const GOOGLE_RECOVERY_MAX_MESSAGES = 200;
+
+/** IMAP credential validation timeouts (mirror the queue processor defaults). */
+const IMAP_VALIDATION_CONNECTION_TIMEOUT_MS = 10_000;
+const IMAP_VALIDATION_SOCKET_TIMEOUT_MS = 30_000;
 
 type ProviderRecord = {
   id: string;
@@ -25,9 +83,22 @@ type ProviderRecord = {
   status: EmailProviderConfig['connection_status'];
   inbound_paused_at?: string | Date | null;
   inbound_pause_reason?: InboundPauseReason | null;
+  inbound_auth_failure_count?: number | null;
+  inbound_auth_failure_code?: string | null;
   created_at: string;
   updated_at: string;
 };
+
+function isImapTokenExpired(tokenExpiresAt: unknown): boolean {
+  if (typeof tokenExpiresAt !== 'string' || !tokenExpiresAt.trim()) return true;
+  const expiresAtMs = new Date(tokenExpiresAt).getTime();
+  if (!Number.isFinite(expiresAtMs)) return true;
+  return expiresAtMs - Date.now() < 5 * 60 * 1000;
+}
+
+function isGmailHistoryIdRejected(error: any): boolean {
+  return error?.code === 'gmail.historyIdNotFound';
+}
 
 export class EmailProviderLifecycleService {
   private async loadProvider(providerId: string, tenant: string): Promise<{
@@ -160,9 +231,141 @@ export class EmailProviderLifecycleService {
     return true;
   }
 
+  /**
+   * Reset the consecutive auth-failure counter after any successful provider
+   * source access — including a fetch that returned no new messages.
+   */
+  async recordSourceAccessSuccess(providerId: string, tenant: string): Promise<void> {
+    const knex = await getAdminConnection();
+    const db = tenantDb(knex, tenant);
+    await db.table('email_providers')
+      .where({ id: providerId })
+      .where((builder: any) => {
+        builder
+          .where('inbound_auth_failure_count', '>', 0)
+          .orWhereNotNull('inbound_auth_failure_last_at');
+      })
+      .update({
+        inbound_auth_failure_count: 0,
+        inbound_auth_failure_last_at: null,
+        inbound_auth_failure_code: null,
+        updated_at: knex.fn.now(),
+      });
+  }
+
+  /**
+   * Record one strictly classified unrecoverable auth failure. The provider
+   * row is locked in a tenant-scoped transaction so the counter increment and
+   * the pause transition are atomic; exactly one caller observes the
+   * unpaused→paused transition and performs teardown + admin notification.
+   * Concurrent failing jobs see the already-paused row and no-op.
+   */
+  async recordUnrecoverableAuthFailure(
+    providerId: string,
+    tenant: string,
+    safeCode: string
+  ): Promise<RecordUnrecoverableAuthFailureResult> {
+    const knex = await getAdminConnection();
+    const outcome = await knex.transaction(async (trx) => {
+      const trxDb = tenantDb(trx, tenant);
+      const row = await trxDb.table('email_providers')
+        .where({ id: providerId })
+        .forUpdate()
+        .first() as ProviderRecord | undefined;
+      if (!row) {
+        throw new Error('Provider not found');
+      }
+
+      if (row.inbound_paused_at) {
+        return {
+          count: Number(row.inbound_auth_failure_count || 0),
+          autoPaused: false,
+        };
+      }
+
+      const nextCount = Number(row.inbound_auth_failure_count || 0) + 1;
+      const nowIso = new Date().toISOString();
+      const shouldPause = nextCount >= INBOUND_AUTH_FAILURE_PAUSE_THRESHOLD;
+
+      await trxDb.table('email_providers')
+        .where({ id: providerId })
+        .update({
+          inbound_auth_failure_count: nextCount,
+          inbound_auth_failure_last_at: nowIso,
+          inbound_auth_failure_code: safeCode,
+          ...(shouldPause
+            ? {
+                inbound_paused_at: nowIso,
+                inbound_pause_reason: 'auth_failure' as InboundPauseReason,
+                status: 'error',
+                error_message: INBOUND_AUTH_FAILURE_PAUSE_ERROR_MESSAGE,
+              }
+            : {}),
+          updated_at: trx.fn.now(),
+        });
+
+      return {
+        count: nextCount,
+        autoPaused: shouldPause,
+        providerType: row.provider_type,
+        providerName: row.provider_name,
+        mailbox: row.mailbox,
+        pausedAt: shouldPause ? nowIso : undefined,
+      };
+    });
+
+    // Only the transaction that flipped an unpaused row to paused may tear
+    // down subscriptions and notify admins — exactly once per pause.
+    if (outcome.autoPaused) {
+      console.info('[EmailProviderLifecycle] auto-paused provider after repeated auth failures', {
+        tenant,
+        providerId,
+        providerType: outcome.providerType,
+        authFailureCode: safeCode,
+        count: outcome.count,
+        pausedAt: outcome.pausedAt,
+      });
+      try {
+        await this.teardownProviderSubscriptions(providerId, tenant);
+      } catch (error) {
+        console.warn('[EmailProviderLifecycle] teardown after auth-failure pause failed', {
+          tenant,
+          providerId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      await dispatchInboundAuthPauseNotification({
+        tenant,
+        providerId,
+        providerName: outcome.providerName || '',
+        mailbox: outcome.mailbox || '',
+        providerType: outcome.providerType || 'microsoft',
+        authFailureCode: safeCode,
+        pausedAt: outcome.pausedAt || new Date().toISOString(),
+      });
+    }
+
+    return outcome;
+  }
+
   async resumeProvider(providerId: string, tenant: string): Promise<ResumeProviderResult> {
     const knex = await getAdminConnection();
     const db = tenantDb(knex, tenant);
+    const current = await db.table('email_providers')
+      .where({ id: providerId })
+      .first('id', 'inbound_paused_at', 'inbound_pause_reason') as
+      | { id: string; inbound_paused_at: string | null; inbound_pause_reason: InboundPauseReason | null }
+      | undefined;
+
+    if (!current) throw new Error('Provider not found');
+
+    // A provider paused because its credentials were rejected must not be
+    // resumed bare: dead credentials would immediately recreate the failure
+    // loop. Route through validate → re-establish → reconcile → clear.
+    if (current.inbound_paused_at && current.inbound_pause_reason === 'auth_failure') {
+      return await this.recoverAuthPausedProvider(providerId, tenant);
+    }
+
     const updated = await db.table('email_providers')
       .where({ id: providerId })
       .whereNotNull('inbound_paused_at')
@@ -189,48 +392,8 @@ export class EmailProviderLifecycleService {
     }
 
     try {
-      const adapterConfig = this.toAdapterConfig(provider, vendorConfig);
-      if (provider.provider_type === 'microsoft') {
-        const adapter = new MicrosoftGraphAdapter(
-          await buildMicrosoftEmailProviderConfig(adapterConfig)
-        );
-        const result = await adapter.initializeWebhook(adapterConfig.webhook_notification_url);
-        if (!result.success && result.errorKind === 'validation') {
-          // Same degradation as initializeProviderWebhook: an unreachable
-          // endpoint means polling, not a dead provider.
-          await new EmailWebhookMaintenanceService().usePollingDelivery({
-            providerId,
-            tenant,
-            reason: result.error || 'Microsoft webhook endpoint validation failed on resume',
-          });
-          await db.table('email_providers').where({ id: providerId }).update({
-            status: 'connected',
-            error_message: null,
-            updated_at: knex.fn.now(),
-          });
-          return { resumed: true, webhookRegistered: false };
-        }
-        if (!result.success) throw new Error(result.error || 'Microsoft webhook registration failed');
-        await db.table('microsoft_email_provider_config')
-          .where({ email_provider_id: providerId })
-          .update({
-            webhook_subscription_id: result.subscriptionId || null,
-            updated_at: knex.fn.now(),
-          });
-        await new EmailWebhookMaintenanceService().recordWebhookDeliveryMode({
-          providerId,
-          tenant,
-          reason: 'inbound pause resumed; webhook re-registered',
-        });
-      } else {
-        await new GmailAdapter(adapterConfig).registerWebhookSubscription();
-      }
-      await db.table('email_providers').where({ id: providerId }).update({
-        status: 'connected',
-        error_message: null,
-        updated_at: knex.fn.now(),
-      });
-      return { resumed: true, webhookRegistered: true };
+      const webhookRegistered = await this.establishProviderDelivery(providerId, tenant, provider, vendorConfig);
+      return { resumed: true, webhookRegistered };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       await db.table('email_providers').where({ id: providerId }).update({
@@ -240,6 +403,392 @@ export class EmailProviderLifecycleService {
       });
       return { resumed: true, webhookRegistered: false, error: message };
     }
+  }
+
+  /**
+   * Re-establish delivery for a provider after its pause columns were already
+   * cleared. Shared by manual resume and the auth-failure recovery path.
+   * Returns whether a webhook/watch was registered.
+   */
+  private async establishProviderDelivery(
+    providerId: string,
+    tenant: string,
+    provider: ProviderRecord,
+    vendorConfig: any
+  ): Promise<boolean> {
+    const knex = await getAdminConnection();
+    const db = tenantDb(knex, tenant);
+    const adapterConfig = this.toAdapterConfig(provider, vendorConfig);
+    if (provider.provider_type === 'microsoft') {
+      const adapter = new MicrosoftGraphAdapter(
+        await buildMicrosoftEmailProviderConfig(adapterConfig)
+      );
+      const result = await adapter.initializeWebhook(adapterConfig.webhook_notification_url);
+      if (!result.success && result.errorKind === 'validation') {
+        // Same degradation as initializeProviderWebhook: an unreachable
+        // endpoint means polling, not a dead provider.
+        await new EmailWebhookMaintenanceService().usePollingDelivery({
+          providerId,
+          tenant,
+          reason: result.error || 'Microsoft webhook endpoint validation failed on resume',
+        });
+        await db.table('email_providers').where({ id: providerId }).update({
+          status: 'connected',
+          error_message: null,
+          updated_at: knex.fn.now(),
+        });
+        return false;
+      }
+      if (!result.success) throw new Error(result.error || 'Microsoft webhook registration failed');
+      await db.table('microsoft_email_provider_config')
+        .where({ email_provider_id: providerId })
+        .update({
+          webhook_subscription_id: result.subscriptionId || null,
+          updated_at: knex.fn.now(),
+        });
+      await new EmailWebhookMaintenanceService().recordWebhookDeliveryMode({
+        providerId,
+        tenant,
+        reason: 'inbound pause resumed; webhook re-registered',
+      });
+    } else {
+      await new GmailAdapter(adapterConfig).registerWebhookSubscription();
+    }
+    await db.table('email_providers').where({ id: providerId }).update({
+      status: 'connected',
+      error_message: null,
+      updated_at: knex.fn.now(),
+    });
+    return true;
+  }
+
+  /**
+   * Recovery path for providers auto-paused for auth_failure.
+   *
+   * Order is deliberate and matches the approved plan: save the pause
+   * boundary and old vendor cursor, validate credentials while still paused,
+   * re-establish delivery, reconcile the paused interval durably, and only
+   * then clear the pause and auth-failure counters. A failure at any step
+   * leaves/reinststates the pause and returns a reconnect-required error.
+   */
+  async recoverAuthPausedProvider(
+    providerId: string,
+    tenant: string,
+    options: RecoverAuthPausedProviderOptions = {}
+  ): Promise<RecoverAuthPausedProviderResult> {
+    const knex = await getAdminConnection();
+    const db = tenantDb(knex, tenant);
+    const provider = await db.table('email_providers')
+      .where({ id: providerId })
+      .first() as ProviderRecord | undefined;
+    if (!provider) throw new Error('Provider not found');
+
+    if (!provider.inbound_paused_at || provider.inbound_pause_reason !== 'auth_failure') {
+      return { resumed: false, webhookRegistered: false };
+    }
+
+    // 1. Pause boundary snapshot — before any registration can overwrite cursors.
+    const pausedAt = new Date(provider.inbound_paused_at);
+
+    const failRecovery = async (error: unknown): Promise<RecoverAuthPausedProviderResult> => {
+      const message = error instanceof Error ? error.message : String(error);
+      await db.table('email_providers').where({ id: providerId }).update({
+        status: 'error',
+        error_message: INBOUND_AUTH_FAILURE_PAUSE_ERROR_MESSAGE,
+        updated_at: knex.fn.now(),
+      });
+      console.warn('[EmailProviderLifecycle] auth-failure recovery rejected; provider stays paused', {
+        tenant,
+        providerId,
+        error: message,
+      });
+      return {
+        resumed: false,
+        webhookRegistered: false,
+        reconnectRequired: true,
+        error: message,
+      };
+    };
+
+    // 2. Validate credentials while the ingestion pause is still active.
+    if (!options.credentialsValidated) {
+      try {
+        await this.validateProviderCredentials(provider, tenant);
+      } catch (error) {
+        return await failRecovery(error);
+      }
+    }
+
+    // 3. Re-establish the notification source (unless the reconnect path
+    //    already did it — never double-register a webhook/watch).
+    let webhookRegistered = false;
+    if (!options.deliveryEstablished) {
+      const loaded = await this.loadProvider(providerId, tenant);
+      if (!loaded) throw new Error('Provider not found');
+      const shouldRegister = loaded.provider.is_active && (
+        loaded.provider.provider_type === 'google'
+        || (loaded.provider.provider_type === 'microsoft' && loaded.vendorConfig.delivery_mode === 'webhook')
+      );
+      if (shouldRegister) {
+        try {
+          webhookRegistered = await this.establishProviderDelivery(
+            providerId,
+            tenant,
+            loaded.provider,
+            loaded.vendorConfig
+          );
+        } catch (error) {
+          return await failRecovery(error);
+        }
+      }
+    }
+
+    // 4. Reconcile from the saved pause boundary with the durable dedupe path.
+    let reconciliation: InboundAuthPauseReconciliation;
+    try {
+      if (provider.provider_type === 'microsoft') {
+        const result = await new EmailWebhookMaintenanceService().reconcileProviderMessages({
+          providerId,
+          tenant,
+          since: pausedAt,
+        });
+        reconciliation = { status: 'completed', queuedMessages: result.queuedMessages };
+      } else if (provider.provider_type === 'google') {
+        const result = await this.reconcileGooglePausedInterval({
+          providerId,
+          tenant,
+          pausedAt,
+          savedHistoryId: options.savedHistoryId,
+        });
+        reconciliation = { status: 'completed', queuedMessages: result.queuedMessages };
+      } else {
+        const result = await this.reconcileImapPausedInterval({ providerId, tenant });
+        reconciliation = { status: 'started', queuedMessages: result.queuedMessages };
+      }
+    } catch (error) {
+      return await failRecovery(error);
+    }
+
+    // 5. The reconciliation handoff is durable; clear the pause and counters.
+    await this.clearAuthPause(providerId, tenant);
+
+    console.info('[EmailProviderLifecycle] auth-failure recovery completed', {
+      tenant,
+      providerId,
+      providerType: provider.provider_type,
+      webhookRegistered,
+      reconciliation,
+    });
+
+    return { resumed: true, webhookRegistered, reconciliation };
+  }
+
+  private async clearAuthPause(providerId: string, tenant: string): Promise<void> {
+    const knex = await getAdminConnection();
+    const db = tenantDb(knex, tenant);
+    await db.table('email_providers')
+      .where({ id: providerId })
+      .update({
+        inbound_paused_at: null,
+        inbound_pause_reason: null,
+        inbound_auth_failure_count: 0,
+        inbound_auth_failure_last_at: null,
+        inbound_auth_failure_code: null,
+        status: 'connected',
+        error_message: null,
+        updated_at: knex.fn.now(),
+      });
+  }
+
+  /**
+   * Credential validation for the recovery path. Deliberately read-only: it
+   * proves the stored credentials can access the mailbox without registering
+   * anything or clearing the pause.
+   */
+  private async validateProviderCredentials(provider: ProviderRecord, tenant: string): Promise<void> {
+    const loaded = await this.loadProvider(provider.id, tenant);
+    if (!loaded) throw new Error('Provider not found');
+    const adapterConfig = this.toAdapterConfig(loaded.provider, loaded.vendorConfig);
+
+    if (loaded.provider.provider_type === 'microsoft') {
+      const adapter = new MicrosoftGraphAdapter(
+        await buildMicrosoftEmailProviderConfig(adapterConfig)
+      );
+      const test = await adapter.testConnection();
+      if (!test.success) {
+        throw new Error(test.error || 'Microsoft Graph connection test failed');
+      }
+      return;
+    }
+
+    if (loaded.provider.provider_type === 'google') {
+      const adapter = new GmailAdapter(adapterConfig);
+      const test = await adapter.testConnection();
+      if (!test.success) {
+        throw new Error(test.error || 'Gmail connection test failed');
+      }
+      return;
+    }
+
+    await this.validateImapCredentials(provider.id, tenant, loaded.vendorConfig);
+  }
+
+  private async validateImapCredentials(
+    providerId: string,
+    tenant: string,
+    imapConfig: any
+  ): Promise<void> {
+    if (!imapConfig?.host) {
+      throw new Error('IMAP provider config not found');
+    }
+
+    const knex = await getAdminConnection();
+    let accessToken = typeof imapConfig.access_token === 'string' && imapConfig.access_token.trim()
+      ? imapConfig.access_token
+      : null;
+
+    if (imapConfig.auth_type === 'oauth2' && (!accessToken || isImapTokenExpired(imapConfig.token_expires_at))) {
+      accessToken = await refreshImapAccessToken({ provider: imapConfig, db: knex });
+    }
+
+    const auth: any = { user: imapConfig.username };
+    if (imapConfig.auth_type === 'oauth2') {
+      auth.accessToken = accessToken;
+      auth.method = process.env.IMAP_OAUTH_AUTH_MECHANISM === 'OAUTHBEARER' ? 'OAUTHBEARER' : 'XOAUTH2';
+    } else {
+      const { getSecretProviderInstance } = await import('@alga-psa/core/secrets');
+      const secretProvider = await getSecretProviderInstance();
+      auth.pass = await secretProvider.getTenantSecret(tenant, `imap_password_${providerId}`);
+    }
+
+    if (!auth.pass && !auth.accessToken) {
+      throw new Error('IMAP credentials missing');
+    }
+
+    const { ImapFlow } = await import('imapflow');
+    const client = new ImapFlow({
+      host: imapConfig.host,
+      port: Number(imapConfig.port),
+      secure: Boolean(imapConfig.secure),
+      auth,
+      disableAutoIdle: true,
+      logger: false,
+      connectionTimeout: IMAP_VALIDATION_CONNECTION_TIMEOUT_MS,
+      greetingTimeout: IMAP_VALIDATION_CONNECTION_TIMEOUT_MS,
+      socketTimeout: IMAP_VALIDATION_SOCKET_TIMEOUT_MS,
+      tls: imapConfig.secure || imapConfig.allow_starttls ? { rejectUnauthorized: (process.env.IMAP_TLS_REJECT_UNAUTHORIZED || 'true') !== 'false' } : undefined,
+    });
+
+    try {
+      await client.connect();
+    } finally {
+      try {
+        await client.logout();
+      } catch {
+        try {
+          client.close();
+        } catch {
+          // best effort
+        }
+      }
+    }
+  }
+
+  /**
+   * Google reconciliation: list changes from the pre-watch history cursor and
+   * enqueue the resulting message ids through the unified durable path. If
+   * Gmail rejects the old cursor, fall back to a mailbox query bounded by the
+   * pause timestamp rather than silently accepting a gap.
+   */
+  private async reconcileGooglePausedInterval(params: {
+    providerId: string;
+    tenant: string;
+    pausedAt: Date;
+    savedHistoryId?: string | null;
+  }): Promise<{ queuedMessages: number }> {
+    const loaded = await this.loadProvider(params.providerId, params.tenant);
+    if (!loaded) throw new Error('Provider not found');
+
+    const currentHistoryId = loaded.vendorConfig?.history_id
+      ? String(loaded.vendorConfig.history_id)
+      : null;
+    const savedHistoryId = params.savedHistoryId
+      ? String(params.savedHistoryId)
+      : currentHistoryId;
+
+    const adapter = new GmailAdapter(this.toAdapterConfig(loaded.provider, loaded.vendorConfig));
+    let messageIds: string[] = [];
+    if (savedHistoryId) {
+      try {
+        messageIds = await adapter.listMessagesSince(savedHistoryId);
+      } catch (error) {
+        if (!isGmailHistoryIdRejected(error)) throw error;
+        console.info('[EmailProviderLifecycle] Gmail paused-interval cursor rejected; falling back to pause-bounded query', {
+          tenant: params.tenant,
+          providerId: params.providerId,
+          savedHistoryId,
+        });
+        messageIds = await adapter.listMessageIdsSinceTime(params.pausedAt, GOOGLE_RECOVERY_MAX_MESSAGES);
+      }
+    } else {
+      messageIds = await adapter.listMessageIdsSinceTime(params.pausedAt, GOOGLE_RECOVERY_MAX_MESSAGES);
+    }
+
+    messageIds = messageIds.slice(0, GOOGLE_RECOVERY_MAX_MESSAGES);
+
+    let queuedMessages = 0;
+    for (const messageId of messageIds) {
+      const durable = await persistIngressPointer({
+        tenant: params.tenant,
+        providerId: params.providerId,
+        providerType: 'google',
+        pointer: {
+          providerType: 'google',
+          providerMessageId: messageId,
+          historyId: savedHistoryId,
+          extra: { resource: 'auth-pause-reconcile' },
+        },
+      });
+      if (!(durable.mode === 'enforce' && durable.ingressId)) {
+        await enqueueUnifiedInboundEmailQueueJob({
+          tenantId: params.tenant,
+          providerId: params.providerId,
+          provider: 'google',
+          pointer: {
+            historyId: currentHistoryId || savedHistoryId || '',
+            emailAddress: loaded.provider.mailbox,
+            discoveredMessageIds: [messageId],
+          },
+        });
+      }
+      queuedMessages += 1;
+    }
+
+    return { queuedMessages };
+  }
+
+  /**
+   * IMAP reconciliation: clear UID/folder cursors (the existing resync
+   * contract) so the poller scans the mailbox again; normal dedupe suppresses
+   * already-processed mail. Only reachable after credentials validated.
+   */
+  private async reconcileImapPausedInterval(params: {
+    providerId: string;
+    tenant: string;
+  }): Promise<{ queuedMessages: number }> {
+    const knex = await getAdminConnection();
+    const db = tenantDb(knex, params.tenant);
+    await db.table('imap_email_provider_config')
+      .where({ email_provider_id: params.providerId })
+      .update({
+        uid_validity: null,
+        last_uid: null,
+        last_processed_message_id: null,
+        folder_state: {},
+        last_error: null,
+        updated_at: knex.fn.now(),
+      });
+    return { queuedMessages: 0 };
   }
 
   async deleteProvider(providerId: string, tenant: string): Promise<void> {

--- a/shared/services/email/EmailProviderLifecycleService.ts
+++ b/shared/services/email/EmailProviderLifecycleService.ts
@@ -26,8 +26,18 @@ export interface ResumeProviderResult {
 }
 
 export interface InboundAuthPauseReconciliation {
-  status: 'started' | 'completed';
+  /**
+   * 'completed' — the whole paused interval was handed off durably.
+   * 'partial'  — some paused-interval mail could not be reconciled (batch cap
+   *              or window clamp); the operator must resync manually.
+   * 'started'  — provider-specific asynchronous reconciliation (IMAP cursor
+   *              rescan) has been kicked off; completion is not directly
+   *              observable here.
+   */
+  status: 'started' | 'completed' | 'partial';
   queuedMessages: number;
+  /** Present only on partial reconciliations; explains what was left behind. */
+  warning?: string;
 }
 
 export interface RecoverAuthPausedProviderOptions {
@@ -68,6 +78,16 @@ export const INBOUND_AUTH_FAILURE_PAUSE_ERROR_MESSAGE =
 
 /** Upper bound on Google recovery message ids enqueued per reconnect. */
 const GOOGLE_RECOVERY_MAX_MESSAGES = 200;
+
+/** Human label of the Microsoft reconciliation window cap (mirrors the maintenance service). */
+const MICROSOFT_RECONCILE_WINDOW_LABEL = '7 days';
+
+interface GooglePausedIntervalReconciliation {
+  queuedMessages: number;
+  truncated: boolean;
+  droppedMessages: number;
+  usedFallbackQuery: boolean;
+}
 
 /** IMAP credential validation timeouts (mirror the queue processor defaults). */
 const IMAP_VALIDATION_CONNECTION_TIMEOUT_MS = 10_000;
@@ -372,6 +392,11 @@ export class EmailProviderLifecycleService {
       .update({
         inbound_paused_at: null,
         inbound_pause_reason: null,
+        // A manual resume is a fresh start: any stale auth-failure count from
+        // before the pause must not arm the next single failure to auto-pause.
+        inbound_auth_failure_count: 0,
+        inbound_auth_failure_last_at: null,
+        inbound_auth_failure_code: null,
         updated_at: knex.fn.now(),
       });
     if (Number(updated) === 0) {
@@ -487,8 +512,18 @@ export class EmailProviderLifecycleService {
       return { resumed: false, webhookRegistered: false };
     }
 
-    // 1. Pause boundary snapshot — before any registration can overwrite cursors.
+    // 1. Pause boundary snapshot — before any registration can overwrite
+    //    cursors. For Google this MUST capture the pre-watch history_id: a
+    //    new watch registration persists its own newer cursor, and listing
+    //    from that cursor would silently accept the paused interval as empty.
     const pausedAt = new Date(provider.inbound_paused_at);
+    let savedHistoryId = options.savedHistoryId !== undefined ? options.savedHistoryId : null;
+    if (provider.provider_type === 'google' && savedHistoryId === null) {
+      const googleConfig = await db.table('google_email_provider_config')
+        .where({ email_provider_id: providerId })
+        .first('history_id');
+      savedHistoryId = googleConfig?.history_id ? String(googleConfig.history_id) : null;
+    }
 
     const failRecovery = async (error: unknown): Promise<RecoverAuthPausedProviderResult> => {
       const message = error instanceof Error ? error.message : String(error);
@@ -552,15 +587,27 @@ export class EmailProviderLifecycleService {
           tenant,
           since: pausedAt,
         });
-        reconciliation = { status: 'completed', queuedMessages: result.queuedMessages };
+        reconciliation = {
+          status: result.truncated ? 'partial' : 'completed',
+          queuedMessages: result.queuedMessages,
+          warning: result.truncated
+            ? `Reconciliation covered only the most recent ${MICROSOFT_RECONCILE_WINDOW_LABEL} of the pause; older mail was not imported. Run a mailbox resync to cover the full paused interval.`
+            : undefined,
+        };
       } else if (provider.provider_type === 'google') {
         const result = await this.reconcileGooglePausedInterval({
           providerId,
           tenant,
           pausedAt,
-          savedHistoryId: options.savedHistoryId,
+          savedHistoryId,
         });
-        reconciliation = { status: 'completed', queuedMessages: result.queuedMessages };
+        reconciliation = {
+          status: result.truncated ? 'partial' : 'completed',
+          queuedMessages: result.queuedMessages,
+          warning: result.truncated
+            ? `The paused interval held more than ${GOOGLE_RECOVERY_MAX_MESSAGES} messages; ${result.droppedMessages} were not queued. Run a mailbox resync to import the remainder.`
+            : undefined,
+        };
       } else {
         const result = await this.reconcileImapPausedInterval({ providerId, tenant });
         reconciliation = { status: 'started', queuedMessages: result.queuedMessages };
@@ -699,25 +746,36 @@ export class EmailProviderLifecycleService {
    * enqueue the resulting message ids through the unified durable path. If
    * Gmail rejects the old cursor, fall back to a mailbox query bounded by the
    * pause timestamp rather than silently accepting a gap.
+   *
+   * The reconciliation batch is capped at GOOGLE_RECOVERY_MAX_MESSAGES; when
+   * the paused interval holds more mail than the cap, the overflow is dropped
+   * LOUDLY (error-level log naming the provider/tenant and dropped count) and
+   * the result reports a partial status so the UI cannot toast a clean
+   * success over an unreconciled gap.
    */
   private async reconcileGooglePausedInterval(params: {
     providerId: string;
     tenant: string;
     pausedAt: Date;
     savedHistoryId?: string | null;
-  }): Promise<{ queuedMessages: number }> {
+  }): Promise<GooglePausedIntervalReconciliation> {
     const loaded = await this.loadProvider(params.providerId, params.tenant);
     if (!loaded) throw new Error('Provider not found');
 
+    // LIST from the pre-watch cursor, but carry the CURRENT (post-watch)
+    // cursor on the enqueued pointers: the queue processor persists
+    // pointer.historyId after processing, and regressing it below the fresh
+    // watch cursor would make the next sync re-scan the whole interval.
     const currentHistoryId = loaded.vendorConfig?.history_id
       ? String(loaded.vendorConfig.history_id)
       : null;
     const savedHistoryId = params.savedHistoryId
       ? String(params.savedHistoryId)
-      : currentHistoryId;
+      : null;
 
     const adapter = new GmailAdapter(this.toAdapterConfig(loaded.provider, loaded.vendorConfig));
     let messageIds: string[] = [];
+    let usedFallbackQuery = false;
     if (savedHistoryId) {
       try {
         messageIds = await adapter.listMessagesSince(savedHistoryId);
@@ -728,13 +786,30 @@ export class EmailProviderLifecycleService {
           providerId: params.providerId,
           savedHistoryId,
         });
+        usedFallbackQuery = true;
         messageIds = await adapter.listMessageIdsSinceTime(params.pausedAt, GOOGLE_RECOVERY_MAX_MESSAGES);
       }
     } else {
+      usedFallbackQuery = true;
       messageIds = await adapter.listMessageIdsSinceTime(params.pausedAt, GOOGLE_RECOVERY_MAX_MESSAGES);
     }
 
+    const droppedMessages = Math.max(0, messageIds.length - GOOGLE_RECOVERY_MAX_MESSAGES);
     messageIds = messageIds.slice(0, GOOGLE_RECOVERY_MAX_MESSAGES);
+    if (droppedMessages > 0) {
+      // No silent gaps: the operator must learn that mail was left behind and
+      // resync manually. Logged at error level so alerting picks it up.
+      console.error('[EmailProviderLifecycle] Gmail auth-pause reconciliation hit its batch cap; overflow mail was NOT reconciled', {
+        event: 'inbound_auth_pause_reconcile_truncated',
+        tenant: params.tenant,
+        providerId: params.providerId,
+        cap: GOOGLE_RECOVERY_MAX_MESSAGES,
+        queued: messageIds.length,
+        dropped: droppedMessages,
+        pausedAt: params.pausedAt.toISOString(),
+        remediation: 'Run a mailbox resync for this provider to import the remaining paused-interval mail.',
+      });
+    }
 
     let queuedMessages = 0;
     for (const messageId of messageIds) {
@@ -764,7 +839,12 @@ export class EmailProviderLifecycleService {
       queuedMessages += 1;
     }
 
-    return { queuedMessages };
+    return {
+      queuedMessages,
+      truncated: droppedMessages > 0,
+      droppedMessages,
+      usedFallbackQuery,
+    };
   }
 
   /**

--- a/shared/services/email/EmailProviderLifecycleService.ts
+++ b/shared/services/email/EmailProviderLifecycleService.ts
@@ -28,16 +28,18 @@ export interface ResumeProviderResult {
 export interface InboundAuthPauseReconciliation {
   /**
    * 'completed' — the whole paused interval was handed off durably.
-   * 'partial'  — some paused-interval mail could not be reconciled (batch cap
-   *              or window clamp); the operator must resync manually.
    * 'started'  — provider-specific asynchronous reconciliation (IMAP cursor
-   *              rescan) has been kicked off; completion is not directly
-   *              observable here.
+   *              rescan) has been kicked off; the covering rescan is guaranteed
+   *              by the reset cursors and dedupe, not awaited here.
+   *
+   * There is deliberately no 'partial': an auth-pause recovery may never
+   * report success while paused-interval mail is knowingly unreconciled.
+   * When the interval cannot be fully swept (e.g. reconciliation keeps
+   * reporting more remaining), recovery fails and the provider stays paused
+   * with a reconnect-required error.
    */
-  status: 'started' | 'completed' | 'partial';
+  status: 'started' | 'completed';
   queuedMessages: number;
-  /** Present only on partial reconciliations; explains what was left behind. */
-  warning?: string;
 }
 
 export interface RecoverAuthPausedProviderOptions {
@@ -76,16 +78,17 @@ export interface RecordUnrecoverableAuthFailureResult {
 export const INBOUND_AUTH_FAILURE_PAUSE_ERROR_MESSAGE =
   'Sign-in was rejected by the email provider. Reconnect the mailbox to resume inbound email.';
 
-/** Upper bound on Google recovery message ids enqueued per reconnect. */
-const GOOGLE_RECOVERY_MAX_MESSAGES = 200;
-
-/** Human label of the Microsoft reconciliation window cap (mirrors the maintenance service). */
-const MICROSOFT_RECONCILE_WINDOW_LABEL = '7 days';
+/**
+ * Upper bound on Microsoft recovery reconciliation passes. Each pass enqueues
+ * at most the per-pass cap and reports whether Graph still holds more
+ * unprocessed messages in the paused interval; recovery loops until the
+ * interval is exhausted. The bound converts a pathological non-terminating
+ * sweep into a failed recovery (provider stays paused) instead of a hang.
+ */
+const MICROSOFT_RECOVERY_MAX_PASSES = 500;
 
 interface GooglePausedIntervalReconciliation {
   queuedMessages: number;
-  truncated: boolean;
-  droppedMessages: number;
   usedFallbackQuery: boolean;
 }
 
@@ -579,20 +582,19 @@ export class EmailProviderLifecycleService {
     }
 
     // 4. Reconcile from the saved pause boundary with the durable dedupe path.
+    //    The interval must be FULLY handed off before the pause clears — a
+    //    recovery may never report success over a known gap.
     let reconciliation: InboundAuthPauseReconciliation;
     try {
       if (provider.provider_type === 'microsoft') {
-        const result = await new EmailWebhookMaintenanceService().reconcileProviderMessages({
+        const result = await this.reconcileMicrosoftPausedInterval({
           providerId,
           tenant,
           since: pausedAt,
         });
         reconciliation = {
-          status: result.truncated ? 'partial' : 'completed',
+          status: 'completed',
           queuedMessages: result.queuedMessages,
-          warning: result.truncated
-            ? `Reconciliation covered only the most recent ${MICROSOFT_RECONCILE_WINDOW_LABEL} of the pause; older mail was not imported. Run a mailbox resync to cover the full paused interval.`
-            : undefined,
         };
       } else if (provider.provider_type === 'google') {
         const result = await this.reconcileGooglePausedInterval({
@@ -602,11 +604,8 @@ export class EmailProviderLifecycleService {
           savedHistoryId,
         });
         reconciliation = {
-          status: result.truncated ? 'partial' : 'completed',
+          status: 'completed',
           queuedMessages: result.queuedMessages,
-          warning: result.truncated
-            ? `The paused interval held more than ${GOOGLE_RECOVERY_MAX_MESSAGES} messages; ${result.droppedMessages} were not queued. Run a mailbox resync to import the remainder.`
-            : undefined,
         };
       } else {
         const result = await this.reconcileImapPausedInterval({ providerId, tenant });
@@ -742,16 +741,60 @@ export class EmailProviderLifecycleService {
   }
 
   /**
+   * Microsoft reconciliation: loop `reconcileProviderMessages` passes until
+   * the paused interval is exhausted. Each pass enqueues at most the per-pass
+   * cap (the maintenance algorithm's cursor lock, safety margin, and overflow
+   * handling stay authoritative) and reports whether Graph still holds more
+   * unprocessed messages; ids handed off by earlier passes are seeded into
+   * the next pass so re-listed messages are recognized as covered in every
+   * durable mode. Durable dedupe makes re-enqueueing safe.
+   *
+   * If the sweep cannot exhaust the interval within the pass bound, this
+   * throws so the caller fails the recovery and the provider stays paused —
+   * never "resumed with a known gap".
+   */
+  private async reconcileMicrosoftPausedInterval(params: {
+    providerId: string;
+    tenant: string;
+    since: Date;
+  }): Promise<{ queuedMessages: number }> {
+    const maintenance = new EmailWebhookMaintenanceService();
+    const handedOffIds = new Set<string>();
+    let queuedMessages = 0;
+    for (let pass = 1; pass <= MICROSOFT_RECOVERY_MAX_PASSES; pass += 1) {
+      const result = await maintenance.reconcileProviderMessages({
+        providerId: params.providerId,
+        tenant: params.tenant,
+        since: params.since,
+        handedOffIds,
+      });
+      queuedMessages += result.queuedMessages;
+      for (const id of result.enqueuedMessageIds || []) handedOffIds.add(id);
+      if (!result.moreRemaining) {
+        return { queuedMessages };
+      }
+      console.info('[EmailProviderLifecycle] Microsoft auth-pause reconciliation pass complete; more paused-interval mail remains', {
+        tenant: params.tenant,
+        providerId: params.providerId,
+        pass,
+        queuedSoFar: queuedMessages,
+      });
+    }
+    throw new Error(
+      `microsoft_auth_pause_reconcile_unexhausted_after_${MICROSOFT_RECOVERY_MAX_PASSES}_passes`
+    );
+  }
+
+  /**
    * Google reconciliation: list changes from the pre-watch history cursor and
    * enqueue the resulting message ids through the unified durable path. If
    * Gmail rejects the old cursor, fall back to a mailbox query bounded by the
    * pause timestamp rather than silently accepting a gap.
    *
-   * The reconciliation batch is capped at GOOGLE_RECOVERY_MAX_MESSAGES; when
-   * the paused interval holds more mail than the cap, the overflow is dropped
-   * LOUDLY (error-level log naming the provider/tenant and dropped count) and
-   * the result reports a partial status so the UI cannot toast a clean
-   * success over an unreconciled gap.
+   * Both listing paths paginate the FULL paused interval — there is no batch
+   * cap to truncate it. Every discovered id is handed off through the durable
+   * dedupe path, so a large backlog is reconciled completely and re-running
+   * the reconciliation is safe.
    */
   private async reconcileGooglePausedInterval(params: {
     providerId: string;
@@ -787,28 +830,11 @@ export class EmailProviderLifecycleService {
           savedHistoryId,
         });
         usedFallbackQuery = true;
-        messageIds = await adapter.listMessageIdsSinceTime(params.pausedAt, GOOGLE_RECOVERY_MAX_MESSAGES);
+        messageIds = await adapter.listMessageIdsSinceTime(params.pausedAt, undefined, { paginateAll: true });
       }
     } else {
       usedFallbackQuery = true;
-      messageIds = await adapter.listMessageIdsSinceTime(params.pausedAt, GOOGLE_RECOVERY_MAX_MESSAGES);
-    }
-
-    const droppedMessages = Math.max(0, messageIds.length - GOOGLE_RECOVERY_MAX_MESSAGES);
-    messageIds = messageIds.slice(0, GOOGLE_RECOVERY_MAX_MESSAGES);
-    if (droppedMessages > 0) {
-      // No silent gaps: the operator must learn that mail was left behind and
-      // resync manually. Logged at error level so alerting picks it up.
-      console.error('[EmailProviderLifecycle] Gmail auth-pause reconciliation hit its batch cap; overflow mail was NOT reconciled', {
-        event: 'inbound_auth_pause_reconcile_truncated',
-        tenant: params.tenant,
-        providerId: params.providerId,
-        cap: GOOGLE_RECOVERY_MAX_MESSAGES,
-        queued: messageIds.length,
-        dropped: droppedMessages,
-        pausedAt: params.pausedAt.toISOString(),
-        remediation: 'Run a mailbox resync for this provider to import the remaining paused-interval mail.',
-      });
+      messageIds = await adapter.listMessageIdsSinceTime(params.pausedAt, undefined, { paginateAll: true });
     }
 
     let queuedMessages = 0;
@@ -841,16 +867,24 @@ export class EmailProviderLifecycleService {
 
     return {
       queuedMessages,
-      truncated: droppedMessages > 0,
-      droppedMessages,
       usedFallbackQuery,
     };
   }
 
   /**
-   * IMAP reconciliation: clear UID/folder cursors (the existing resync
-   * contract) so the poller scans the mailbox again; normal dedupe suppresses
-   * already-processed mail. Only reachable after credentials validated.
+   * IMAP reconciliation: arm the covering resync (the existing resync
+   * contract, made gap-free) so the poller scans the mailbox from UID 1 and
+   * normal dedupe suppresses already-processed mail. Only reachable after
+   * credentials validated.
+   *
+   * Cursor semantics: `last_uid = '0'` is the explicit "scan from the
+   * beginning" marker — a NULL cursor would make the email-service listener
+   * resume from the most recent window (uidNext - max_emails_per_sync) and
+   * silently skip paused-interval mail older than that window. '0' makes the
+   * listener's start-uid resolution scan from UID 1, covering the entire
+   * paused interval; the scan then advances the cursor back to the newest
+   * UID. Because IMAP workers are gated on the pause in provider discovery,
+   * the rescan runs on the fresh listener started after the pause clears.
    */
   private async reconcileImapPausedInterval(params: {
     providerId: string;
@@ -862,7 +896,7 @@ export class EmailProviderLifecycleService {
       .where({ email_provider_id: params.providerId })
       .update({
         uid_validity: null,
-        last_uid: null,
+        last_uid: '0',
         last_processed_message_id: null,
         folder_state: {},
         last_error: null,

--- a/shared/services/email/EmailProviderLifecycleService.ts
+++ b/shared/services/email/EmailProviderLifecycleService.ts
@@ -749,6 +749,12 @@ export class EmailProviderLifecycleService {
    * the next pass so re-listed messages are recognized as covered in every
    * durable mode. Durable dedupe makes re-enqueueing safe.
    *
+   * A cursor-lock mismatch (another actor moved/held the Graph cursor during
+   * a pass) also reports `moreRemaining: true`: that pass handed off nothing,
+   * so it must never be treated as exhaustion. The loop simply re-drives the
+   * next pass from the saved boundary, and the pause is only cleared once a
+   * pass actually completes coverage.
+   *
    * If the sweep cannot exhaust the interval within the pass bound, this
    * throws so the caller fails the recovery and the provider stays paused —
    * never "resumed with a known gap".

--- a/shared/services/email/EmailWebhookMaintenanceService.ts
+++ b/shared/services/email/EmailWebhookMaintenanceService.ts
@@ -592,7 +592,11 @@ export class EmailWebhookMaintenanceService {
    * whether Graph still holds unprocessed messages in the window so recovery
    * callers can loop until the paused interval is exhausted. `handedOffIds`
    * lets such callers treat previously handed-off messages as covered (the
-   * off/shadow modes have no ingress ledger to read that from).
+   * off/shadow modes have no ingress ledger to read that from). Recovery
+   * passes (explicit `since` and/or `handedOffIds`) only count monotonic
+   * coverage markers — this recovery's own hand-offs, non-terminal ingress
+   * rows, and settled legacy outcomes — so concurrent worker transitions
+   * between passes can never make an un-handed-off message look covered.
    */
   async reconcileProviderMessages(params: {
     providerId: string;
@@ -708,6 +712,23 @@ export class EmailWebhookMaintenanceService {
     let unprocessedMessages: Array<{ id: string; receivedDateTime?: string }> = [];
     const processedMessageIds = new Set<string>(handedOffIds || []);
     const checkedMessageIds = new Set<string>();
+    // An auth-pause recovery pass (explicit `since` boundary and/or
+    // caller-seeded handed-off ids) must decide "is this message covered?"
+    // from markers that cannot regress under concurrent workers:
+    //   - ids THIS recovery durably handed off (handedOffIds) — except where
+    //     the durable ledger refutes the hand-off (the ingress row later
+    //     transitioned to `terminal_failed`: the pipeline gave up, e.g.
+    //     attempts burned against the dead credential),
+    //   - ingress rows that are still owned by the durable pipeline
+    //     (received/staging/retryable_failed/staged — never deleted, and a
+    //     sweep will process them),
+    //   - SETTLED legacy audit outcomes (success/skipped).
+    // A `terminal_failed` ingress row is NOT a hand-off, and a legacy
+    // 'processing'/'failed' row is not an import. Counting either as covered
+    // could declare the interval exhausted (`moreRemaining: false`) while a
+    // message was never durably handed off. Renewal passes keep the
+    // historical any-row semantics.
+    const recoveryPass = Boolean(sinceOverride) || Boolean(handedOffIds);
 
     // A capped oldest-first query can initially contain only messages from the
     // safety-margin overlap. Expand the read until either maxCount unprocessed
@@ -720,24 +741,28 @@ export class EmailWebhookMaintenanceService {
         .filter((messageId) => !checkedMessageIds.has(messageId));
 
       if (uncheckedMessageIds.length > 0) {
-        const processedRows = await db.table('email_processed_messages')
+        const processedQuery = db.table('email_processed_messages')
           .where({ provider_id: config.id })
-          .whereIn('message_id', uncheckedMessageIds)
-          .select('message_id');
-        // Durable mode: a message with ANY ingress row has been handed to the
-        // durable pipeline (received/staging = claimed by a worker,
-        // retryable_failed = owned by its backoff + recovery sweep,
-        // staged/terminal = settled) and must not be re-enqueued by
-        // reconciliation. Previously only `staged` counted, which made
-        // consecutive recovery passes re-see freshly enqueued rows and
-        // prevented the paused interval from being paged through in enforce
-        // mode.
-        let handedOffRows: Array<{ ingress_key: string }> = [];
+          .whereIn('message_id', uncheckedMessageIds);
+        if (recoveryPass) {
+          processedQuery.andWhere('processing_status', 'in', ['success', 'skipped']);
+        }
+        const processedRows = await processedQuery.select('message_id');
+        // Durable mode: a message with a NON-TERMINAL ingress row has been
+        // handed to the durable pipeline (received/staging = claimed by a
+        // worker, retryable_failed = owned by its backoff + recovery sweep,
+        // staged = settled) and must not be re-enqueued by reconciliation.
+        // Recovery passes additionally treat a `terminal_failed` row as NOT
+        // handed off — including revoking a seeded handedOffIds entry — and
+        // revive it on re-hand-off so the explicit hand-off results in
+        // processing.
+        let handedOffRows: Array<{ ingress_key: string; status?: string }> = [];
+        const terminalIngressIds = new Set<string>();
         try {
           handedOffRows = await db.table('inbound_email_ingress')
             .where({ tenant: config.tenant, provider_id: config.id })
             .whereIn('ingress_key', uncheckedMessageIds.map((id) => `message:${id}`))
-            .select('ingress_key');
+            .select('ingress_key', 'status');
         } catch {
           // Ledger not available yet (pre-durable deploy): legacy dedupe only.
         }
@@ -745,8 +770,18 @@ export class EmailWebhookMaintenanceService {
         for (const row of processedRows) processedMessageIds.add(String(row.message_id));
         for (const row of handedOffRows) {
           const key = String(row.ingress_key);
-          if (key.startsWith('message:')) processedMessageIds.add(key.slice('message:'.length));
+          if (!key.startsWith('message:')) continue;
+          const messageId = key.slice('message:'.length);
+          if (recoveryPass && String(row.status) === 'terminal_failed') {
+            // The durable ledger refutes the hand-off: a terminal row will
+            // never be processed, so a seeded handedOffIds entry must not
+            // count as covered either.
+            terminalIngressIds.add(messageId);
+            continue;
+          }
+          processedMessageIds.add(messageId);
         }
+        for (const messageId of terminalIngressIds) processedMessageIds.delete(messageId);
       }
 
       unprocessedMessages = messages
@@ -806,10 +841,14 @@ export class EmailWebhookMaintenanceService {
       for (const message of unprocessedMessages) {
         // Durable path: persist the ingress pointer before the Redis handoff so
         // reconciliation never advances its cursor past an unstaged message.
+        // Recovery passes revive a terminally failed row: a terminal row is
+        // not a durable hand-off, and the explicit re-hand-off must result in
+        // processing (see the recoveryPass coverage rules above).
         const durable = await persistIngressPointer({
           tenant: config.tenant,
           providerId: config.id,
           providerType: 'microsoft',
+          reviveTerminal: recoveryPass,
           pointer: {
             providerType: 'microsoft',
             providerMessageId: message.id,

--- a/shared/services/email/EmailWebhookMaintenanceService.ts
+++ b/shared/services/email/EmailWebhookMaintenanceService.ts
@@ -8,6 +8,7 @@ import { enqueueUnifiedInboundEmailQueueJob } from './unifiedInboundEmailQueue';
 import { persistIngressPointer } from './inboundEmailProducer';
 import { getInboundDurableMode } from './inboundEmailDurableStore';
 import { getEmailWebhookBaseUrl } from './webhookBaseUrl';
+import { classifyInboundAuthFailure } from './InboundEmailAuthFailurePolicy';
 
 const PROVIDER_TENANT_DISCOVERY = 'tenant-discovery';
 
@@ -29,6 +30,45 @@ interface RenewalResult {
 interface ReconciliationResult {
   queuedMessages: number;
   switchedToPolling: boolean;
+}
+
+/**
+ * Record a Microsoft token-health outcome on the provider's auth-failure
+ * counter. This covers providers whose subscription has gone quiet (polling
+ * mode / lapsed webhook) and therefore no longer receive pointer jobs: their
+ * only regular source access is the maintenance token check.
+ *
+ * Lazy-imported to avoid a static module cycle with the lifecycle service.
+ */
+async function recordTokenHealthOutcome(params: {
+  providerId: string;
+  tenant: string;
+  error?: unknown;
+}): Promise<void> {
+  try {
+    const { EmailProviderLifecycleService } = await import('./EmailProviderLifecycleService');
+    const lifecycle = new EmailProviderLifecycleService();
+    if (!params.error) {
+      await lifecycle.recordSourceAccessSuccess(params.providerId, params.tenant);
+      return;
+    }
+    const classification = classifyInboundAuthFailure({
+      providerType: 'microsoft',
+      error: params.error,
+    });
+    if (classification.kind !== 'unrecoverable_auth') return;
+    await lifecycle.recordUnrecoverableAuthFailure(
+      params.providerId,
+      params.tenant,
+      classification.code
+    );
+  } catch (error) {
+    logger.warn('Failed to record Microsoft token-health auth outcome', {
+      providerId: params.providerId,
+      tenant: params.tenant,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 }
 
 const TOKEN_REFRESH_LOOK_AHEAD_MINUTES = 30;
@@ -93,7 +133,17 @@ export class EmailWebhookMaintenanceService {
       try {
         const resolvedConfig = await buildMicrosoftEmailProviderConfig(candidate);
         const adapter = new MicrosoftGraphAdapter(resolvedConfig);
-        await adapter.ensureTokenHealthy(TOKEN_REFRESH_LOOK_AHEAD_MINUTES);
+        try {
+          await adapter.ensureTokenHealthy(TOKEN_REFRESH_LOOK_AHEAD_MINUTES);
+          await recordTokenHealthOutcome({ providerId: candidate.id, tenant: candidate.tenant });
+        } catch (error: any) {
+          await recordTokenHealthOutcome({
+            providerId: candidate.id,
+            tenant: candidate.tenant,
+            error,
+          });
+          throw error;
+        }
         await this.updateProviderConnectionStatus(candidate.id, candidate.tenant, 'connected', null);
         await this.reconcileMissedMessages(adapter, resolvedConfig, false);
         results.push({
@@ -287,8 +337,14 @@ export class EmailWebhookMaintenanceService {
 
       try {
         await adapter.ensureTokenHealthy(TOKEN_REFRESH_LOOK_AHEAD_MINUTES);
+        await recordTokenHealthOutcome({ providerId: config.id, tenant: config.tenant });
         await this.updateProviderConnectionStatus(config.id, config.tenant, 'connected', null);
       } catch (error: any) {
+        await recordTokenHealthOutcome({
+          providerId: config.id,
+          tenant: config.tenant,
+          error,
+        });
         const message = error?.message || 'Microsoft token refresh failed';
         await this.updateProviderConnectionStatus(config.id, config.tenant, 'error', message);
         await this.updateHealthStatus(config.id, config.tenant, {
@@ -514,10 +570,88 @@ export class EmailWebhookMaintenanceService {
     };
   }
 
+  /**
+   * Public, bounded reconciliation entry point for the auth-failure recovery
+   * path. Accepts an explicit `since` boundary (the provider's saved
+   * `inbound_paused_at`) and preserves the internal algorithm's safety
+   * margin, cursor lock, overflow handling, and durable ingress behavior.
+   *
+   * Unlike renewal candidates, the provider may still be ingestion-paused when
+   * this runs — the recovery flow only clears the pause after this handoff is
+   * durable — so the loader must not apply the paused gate.
+   */
+  async reconcileProviderMessages(params: {
+    providerId: string;
+    tenant: string;
+    since: string | Date;
+  }): Promise<{ queuedMessages: number }> {
+    const config = await this.loadMicrosoftProviderIgnoringPauseGate(params.providerId, params.tenant);
+    const resolvedConfig = await buildMicrosoftEmailProviderConfig(config);
+    const adapter = new MicrosoftGraphAdapter(resolvedConfig);
+    const result = await this.reconcileMissedMessages(adapter, resolvedConfig, false, new Date(params.since));
+    return { queuedMessages: result.queuedMessages };
+  }
+
+  /** Like findActiveMicrosoftProviders but tenant-scoped, exact-provider, and without the paused gate. */
+  private async loadMicrosoftProviderIgnoringPauseGate(
+    providerId: string,
+    tenant: string
+  ): Promise<EmailProviderConfig> {
+    const knex = await getAdminConnection();
+    const db = tenantDb(knex, tenant);
+    const query = db.table('email_providers as ep');
+    db.tenantJoin(
+      query,
+      'microsoft_email_provider_config as mpc',
+      'ep.id',
+      'mpc.email_provider_id',
+      { rootTenantColumn: 'ep.tenant' }
+    );
+    const row = await query
+      .where('ep.id', providerId)
+      .andWhere('ep.provider_type', 'microsoft')
+      .first(
+        'ep.id',
+        'ep.tenant',
+        'ep.provider_name',
+        'ep.provider_type',
+        'ep.mailbox',
+        'ep.is_active',
+        'ep.status',
+        'ep.last_sync_at',
+        'ep.error_message',
+        'ep.created_at',
+        'ep.updated_at',
+        'mpc.webhook_subscription_id',
+        'mpc.webhook_verification_token',
+        'mpc.webhook_expires_at',
+        'mpc.last_subscription_renewal',
+        'mpc.delivery_mode',
+        'mpc.last_webhook_delivery_at',
+        'mpc.webhook_silent_runs',
+        'mpc.next_subscription_probe_at',
+        'mpc.client_id',
+        'mpc.client_secret',
+        'mpc.tenant_id',
+        'mpc.access_token',
+        'mpc.refresh_token',
+        'mpc.token_expires_at',
+        'mpc.folder_filters',
+        'mpc.max_emails_per_sync',
+        'mpc.microsoft_profile_id',
+        'mpc.client_secret_ref'
+      );
+    if (!row) {
+      throw new Error(`Microsoft email provider ${providerId} not found for reconciliation`);
+    }
+    return this.mapRowToConfig(row);
+  }
+
   private async reconcileMissedMessages(
     adapter: MicrosoftGraphAdapter,
     config: EmailProviderConfig,
-    detectWebhookSilence: boolean
+    detectWebhookSilence: boolean,
+    sinceOverride?: Date
   ): Promise<ReconciliationResult> {
     const knex = await getAdminConnection();
     const db = tenantDb(knex, config.tenant);
@@ -531,7 +665,12 @@ export class EmailWebhookMaintenanceService {
     const lastReconciliationMs = reconciliationState?.last_reconciliation_at
       ? new Date(reconciliationState.last_reconciliation_at).getTime() - RECONCILE_SAFETY_MARGIN_MS
       : Date.now() - RECONCILE_WINDOW_CAP_MS;
-    const since = new Date(Math.max(lastReconciliationMs, Date.now() - RECONCILE_WINDOW_CAP_MS));
+    // An explicit boundary (auth-pause recovery) keeps the same safety margin
+    // and window cap as the renewal-driven path.
+    const sinceFloorMs = sinceOverride
+      ? sinceOverride.getTime() - RECONCILE_SAFETY_MARGIN_MS
+      : lastReconciliationMs;
+    const since = new Date(Math.max(sinceFloorMs, Date.now() - RECONCILE_WINDOW_CAP_MS));
     const maxCount = Math.max(
       1,
       Number(config.provider_config?.max_emails_per_sync || DEFAULT_RECONCILE_MAX_MESSAGES)

--- a/shared/services/email/EmailWebhookMaintenanceService.ts
+++ b/shared/services/email/EmailWebhookMaintenanceService.ts
@@ -30,8 +30,14 @@ interface RenewalResult {
 interface ReconciliationResult {
   queuedMessages: number;
   switchedToPolling: boolean;
-  /** True when the effective `since` was clamped by the window cap and the requested interval was not fully covered. */
-  truncated?: boolean;
+  /**
+   * True when the pass stopped at the per-pass enqueue cap while Graph still
+   * had more messages in the window — i.e. the interval is NOT yet fully
+   * handed off and another pass is required.
+   */
+  moreRemaining?: boolean;
+  /** Message ids this pass handed off (enqueued), for multi-pass callers. */
+  enqueuedMessageIds?: string[];
 }
 
 /**
@@ -581,17 +587,34 @@ export class EmailWebhookMaintenanceService {
    * Unlike renewal candidates, the provider may still be ingestion-paused when
    * this runs — the recovery flow only clears the pause after this handoff is
    * durable — so the loader must not apply the paused gate.
+   *
+   * A single pass enqueues at most the per-pass cap; `moreRemaining` reports
+   * whether Graph still holds unprocessed messages in the window so recovery
+   * callers can loop until the paused interval is exhausted. `handedOffIds`
+   * lets such callers treat previously handed-off messages as covered (the
+   * off/shadow modes have no ingress ledger to read that from).
    */
   async reconcileProviderMessages(params: {
     providerId: string;
     tenant: string;
     since: string | Date;
-  }): Promise<{ queuedMessages: number; truncated?: boolean }> {
+    handedOffIds?: Set<string>;
+  }): Promise<{ queuedMessages: number; moreRemaining: boolean; enqueuedMessageIds: string[] }> {
     const config = await this.loadMicrosoftProviderIgnoringPauseGate(params.providerId, params.tenant);
     const resolvedConfig = await buildMicrosoftEmailProviderConfig(config);
     const adapter = new MicrosoftGraphAdapter(resolvedConfig);
-    const result = await this.reconcileMissedMessages(adapter, resolvedConfig, false, new Date(params.since));
-    return { queuedMessages: result.queuedMessages, truncated: result.truncated };
+    const result = await this.reconcileMissedMessages(
+      adapter,
+      resolvedConfig,
+      false,
+      new Date(params.since),
+      params.handedOffIds
+    );
+    return {
+      queuedMessages: result.queuedMessages,
+      moreRemaining: Boolean(result.moreRemaining),
+      enqueuedMessageIds: result.enqueuedMessageIds || [],
+    };
   }
 
   /** Like findActiveMicrosoftProviders but tenant-scoped, exact-provider, and without the paused gate. */
@@ -653,7 +676,8 @@ export class EmailWebhookMaintenanceService {
     adapter: MicrosoftGraphAdapter,
     config: EmailProviderConfig,
     detectWebhookSilence: boolean,
-    sinceOverride?: Date
+    sinceOverride?: Date,
+    handedOffIds?: Set<string>
   ): Promise<ReconciliationResult> {
     const knex = await getAdminConnection();
     const db = tenantDb(knex, config.tenant);
@@ -668,28 +692,13 @@ export class EmailWebhookMaintenanceService {
       ? new Date(reconciliationState.last_reconciliation_at).getTime() - RECONCILE_SAFETY_MARGIN_MS
       : Date.now() - RECONCILE_WINDOW_CAP_MS;
     // An explicit boundary (auth-pause recovery) keeps the same safety margin
-    // and window cap as the renewal-driven path.
-    const sinceFloorMs = sinceOverride
-      ? sinceOverride.getTime() - RECONCILE_SAFETY_MARGIN_MS
-      : lastReconciliationMs;
-    const since = new Date(Math.max(sinceFloorMs, Date.now() - RECONCILE_WINDOW_CAP_MS));
-    // No silent gaps: when the requested boundary predates the window cap,
-    // the reconciliation physically cannot cover the full paused interval —
-    // report truncation so the recovery result surfaces a partial status and
-    // logs what was left behind.
-    const windowClamped = sinceOverride
-      ? since.getTime() > sinceOverride.getTime()
-      : false;
-    if (windowClamped) {
-      logger.error('Microsoft reconciliation window clamped; older paused-interval mail will NOT be covered', {
-        tenant: config.tenant,
-        providerId: config.id,
-        requestedSince: sinceOverride!.toISOString(),
-        effectiveSince: since.toISOString(),
-        windowCapMs: RECONCILE_WINDOW_CAP_MS,
-        remediation: 'Run a mailbox resync for this provider to import the remaining paused-interval mail.',
-      });
-    }
+    // but is NOT clamped by the renewal window cap: the recovery contract
+    // requires the full paused interval to be reconciled, and multi-pass
+    // paging (the recovery loop) plus durable dedupe make re-enqueueing safe.
+    // The cap remains the default floor for renewal-driven reconciliation.
+    const since = sinceOverride
+      ? new Date(sinceOverride.getTime() - RECONCILE_SAFETY_MARGIN_MS)
+      : new Date(Math.max(lastReconciliationMs, Date.now() - RECONCILE_WINDOW_CAP_MS));
     const maxCount = Math.max(
       1,
       Number(config.provider_config?.max_emails_per_sync || DEFAULT_RECONCILE_MAX_MESSAGES)
@@ -697,7 +706,7 @@ export class EmailWebhookMaintenanceService {
     let fetchLimit = maxCount;
     let messages: Array<{ id: string; receivedDateTime?: string }> = [];
     let unprocessedMessages: Array<{ id: string; receivedDateTime?: string }> = [];
-    const processedMessageIds = new Set<string>();
+    const processedMessageIds = new Set<string>(handedOffIds || []);
     const checkedMessageIds = new Set<string>();
 
     // A capped oldest-first query can initially contain only messages from the
@@ -715,14 +724,18 @@ export class EmailWebhookMaintenanceService {
           .where({ provider_id: config.id })
           .whereIn('message_id', uncheckedMessageIds)
           .select('message_id');
-        // Durable mode: a message whose source is already durably staged
-        // (`inbound_email_ingress.status = 'staged'`) is covered even though it
-        // may not have reached the legacy audit table yet. Its deterministic
-        // ingress key is `message:<graph-id>`.
-        let stagedRows: Array<{ ingress_key: string }> = [];
+        // Durable mode: a message with ANY ingress row has been handed to the
+        // durable pipeline (received/staging = claimed by a worker,
+        // retryable_failed = owned by its backoff + recovery sweep,
+        // staged/terminal = settled) and must not be re-enqueued by
+        // reconciliation. Previously only `staged` counted, which made
+        // consecutive recovery passes re-see freshly enqueued rows and
+        // prevented the paused interval from being paged through in enforce
+        // mode.
+        let handedOffRows: Array<{ ingress_key: string }> = [];
         try {
-          stagedRows = await db.table('inbound_email_ingress')
-            .where({ tenant: config.tenant, provider_id: config.id, status: 'staged' })
+          handedOffRows = await db.table('inbound_email_ingress')
+            .where({ tenant: config.tenant, provider_id: config.id })
             .whereIn('ingress_key', uncheckedMessageIds.map((id) => `message:${id}`))
             .select('ingress_key');
         } catch {
@@ -730,7 +743,7 @@ export class EmailWebhookMaintenanceService {
         }
         for (const messageId of uncheckedMessageIds) checkedMessageIds.add(messageId);
         for (const row of processedRows) processedMessageIds.add(String(row.message_id));
-        for (const row of stagedRows) {
+        for (const row of handedOffRows) {
           const key = String(row.ingress_key);
           if (key.startsWith('message:')) processedMessageIds.add(key.slice('message:'.length));
         }
@@ -748,9 +761,14 @@ export class EmailWebhookMaintenanceService {
       : null;
     const completedAt = new Date().toISOString();
     const completedAtMs = new Date(completedAt).getTime();
-    const graphBatchMayHaveOverflow = unprocessedMessages.length >= maxCount && messages.length >= fetchLimit;
+    // The pass stopped at the per-pass enqueue cap while Graph still listed a
+    // full batch: more of the window may remain unprocessed. Multi-pass
+    // recovery callers must sweep again; the renewal path simply relies on its
+    // next scheduled run.
+    const moreRemaining = unprocessedMessages.length >= maxCount && messages.length >= fetchLimit;
+    const enqueuedMessageIds = unprocessedMessages.map((message) => message.id);
     let nextReconciliationAt = completedAt;
-    if (graphBatchMayHaveOverflow) {
+    if (moreRemaining) {
       const newestQueuedAtMs = Math.max(...unprocessedMessages.map((message) => {
         const receivedAtMs = message.receivedDateTime
           ? new Date(message.receivedDateTime).getTime()
@@ -867,13 +885,13 @@ export class EmailWebhookMaintenanceService {
         tenant: config.tenant,
         observedLastReconciliationAt: reconciliationState?.last_reconciliation_at || null,
       });
-      return { queuedMessages: 0, switchedToPolling: false, truncated: windowClamped };
+      return { queuedMessages: 0, switchedToPolling: false, moreRemaining: false, enqueuedMessageIds: [] };
     }
 
     const { queuedMessages, silenceEvidenceCount } = enqueueResult;
 
     if (!detectWebhookSilence || silenceEvidenceCount === 0) {
-      return { queuedMessages, switchedToPolling: false, truncated: windowClamped };
+      return { queuedMessages, switchedToPolling: false, moreRemaining, enqueuedMessageIds };
     }
 
     const silenceUpdate = db.table('microsoft_email_provider_config')
@@ -895,14 +913,14 @@ export class EmailWebhookMaintenanceService {
       updated_at: completedAt,
     });
     if (Number(updatedSilenceRows) !== 1) {
-      return { queuedMessages, switchedToPolling: false, truncated: windowClamped };
+      return { queuedMessages, switchedToPolling: false, moreRemaining, enqueuedMessageIds };
     }
     const latestSilenceState = await db.table('microsoft_email_provider_config')
       .where({ email_provider_id: config.id })
       .first('webhook_silent_runs');
     const silentRuns = Number(latestSilenceState?.webhook_silent_runs || 0);
     if (silentRuns < WEBHOOK_SILENT_RUN_THRESHOLD) {
-      return { queuedMessages, switchedToPolling: false, truncated: windowClamped };
+      return { queuedMessages, switchedToPolling: false, moreRemaining, enqueuedMessageIds };
     }
 
     const nextProbeAt = new Date(Date.now() + SUBSCRIPTION_PROBE_INTERVAL_MS).toISOString();
@@ -929,7 +947,7 @@ export class EmailWebhookMaintenanceService {
     if (Number(transitionedRows) !== 1) {
       // A webhook reset or another mode transition won the race after the
       // increment. Never delete the subscription from stale state.
-      return { queuedMessages, switchedToPolling: false, truncated: windowClamped };
+      return { queuedMessages, switchedToPolling: false, moreRemaining, enqueuedMessageIds };
     }
 
     const reason = `${silentRuns} reconciliation runs imported messages without a webhook delivery`;
@@ -958,7 +976,7 @@ export class EmailWebhookMaintenanceService {
       reason,
       nextProbeAt,
     });
-    return { queuedMessages, switchedToPolling: true, truncated: windowClamped };
+    return { queuedMessages, switchedToPolling: true, moreRemaining, enqueuedMessageIds };
   }
 
   private async updateProviderConnectionStatus(

--- a/shared/services/email/EmailWebhookMaintenanceService.ts
+++ b/shared/services/email/EmailWebhookMaintenanceService.ts
@@ -30,6 +30,8 @@ interface RenewalResult {
 interface ReconciliationResult {
   queuedMessages: number;
   switchedToPolling: boolean;
+  /** True when the effective `since` was clamped by the window cap and the requested interval was not fully covered. */
+  truncated?: boolean;
 }
 
 /**
@@ -584,12 +586,12 @@ export class EmailWebhookMaintenanceService {
     providerId: string;
     tenant: string;
     since: string | Date;
-  }): Promise<{ queuedMessages: number }> {
+  }): Promise<{ queuedMessages: number; truncated?: boolean }> {
     const config = await this.loadMicrosoftProviderIgnoringPauseGate(params.providerId, params.tenant);
     const resolvedConfig = await buildMicrosoftEmailProviderConfig(config);
     const adapter = new MicrosoftGraphAdapter(resolvedConfig);
     const result = await this.reconcileMissedMessages(adapter, resolvedConfig, false, new Date(params.since));
-    return { queuedMessages: result.queuedMessages };
+    return { queuedMessages: result.queuedMessages, truncated: result.truncated };
   }
 
   /** Like findActiveMicrosoftProviders but tenant-scoped, exact-provider, and without the paused gate. */
@@ -671,6 +673,23 @@ export class EmailWebhookMaintenanceService {
       ? sinceOverride.getTime() - RECONCILE_SAFETY_MARGIN_MS
       : lastReconciliationMs;
     const since = new Date(Math.max(sinceFloorMs, Date.now() - RECONCILE_WINDOW_CAP_MS));
+    // No silent gaps: when the requested boundary predates the window cap,
+    // the reconciliation physically cannot cover the full paused interval —
+    // report truncation so the recovery result surfaces a partial status and
+    // logs what was left behind.
+    const windowClamped = sinceOverride
+      ? since.getTime() > sinceOverride.getTime()
+      : false;
+    if (windowClamped) {
+      logger.error('Microsoft reconciliation window clamped; older paused-interval mail will NOT be covered', {
+        tenant: config.tenant,
+        providerId: config.id,
+        requestedSince: sinceOverride!.toISOString(),
+        effectiveSince: since.toISOString(),
+        windowCapMs: RECONCILE_WINDOW_CAP_MS,
+        remediation: 'Run a mailbox resync for this provider to import the remaining paused-interval mail.',
+      });
+    }
     const maxCount = Math.max(
       1,
       Number(config.provider_config?.max_emails_per_sync || DEFAULT_RECONCILE_MAX_MESSAGES)
@@ -848,13 +867,13 @@ export class EmailWebhookMaintenanceService {
         tenant: config.tenant,
         observedLastReconciliationAt: reconciliationState?.last_reconciliation_at || null,
       });
-      return { queuedMessages: 0, switchedToPolling: false };
+      return { queuedMessages: 0, switchedToPolling: false, truncated: windowClamped };
     }
 
     const { queuedMessages, silenceEvidenceCount } = enqueueResult;
 
     if (!detectWebhookSilence || silenceEvidenceCount === 0) {
-      return { queuedMessages, switchedToPolling: false };
+      return { queuedMessages, switchedToPolling: false, truncated: windowClamped };
     }
 
     const silenceUpdate = db.table('microsoft_email_provider_config')
@@ -876,14 +895,14 @@ export class EmailWebhookMaintenanceService {
       updated_at: completedAt,
     });
     if (Number(updatedSilenceRows) !== 1) {
-      return { queuedMessages, switchedToPolling: false };
+      return { queuedMessages, switchedToPolling: false, truncated: windowClamped };
     }
     const latestSilenceState = await db.table('microsoft_email_provider_config')
       .where({ email_provider_id: config.id })
       .first('webhook_silent_runs');
     const silentRuns = Number(latestSilenceState?.webhook_silent_runs || 0);
     if (silentRuns < WEBHOOK_SILENT_RUN_THRESHOLD) {
-      return { queuedMessages, switchedToPolling: false };
+      return { queuedMessages, switchedToPolling: false, truncated: windowClamped };
     }
 
     const nextProbeAt = new Date(Date.now() + SUBSCRIPTION_PROBE_INTERVAL_MS).toISOString();
@@ -910,7 +929,7 @@ export class EmailWebhookMaintenanceService {
     if (Number(transitionedRows) !== 1) {
       // A webhook reset or another mode transition won the race after the
       // increment. Never delete the subscription from stale state.
-      return { queuedMessages, switchedToPolling: false };
+      return { queuedMessages, switchedToPolling: false, truncated: windowClamped };
     }
 
     const reason = `${silentRuns} reconciliation runs imported messages without a webhook delivery`;
@@ -939,7 +958,7 @@ export class EmailWebhookMaintenanceService {
       reason,
       nextProbeAt,
     });
-    return { queuedMessages, switchedToPolling: true };
+    return { queuedMessages, switchedToPolling: true, truncated: windowClamped };
   }
 
   private async updateProviderConnectionStatus(
@@ -949,7 +968,29 @@ export class EmailWebhookMaintenanceService {
     errorMessage: string | null
   ): Promise<void> {
     const knex = await getAdminConnection();
-    await tenantDb(knex, tenant).table('email_providers')
+    const db = tenantDb(knex, tenant);
+
+    if (status === 'error') {
+      // The token-health failure may have just triggered the atomic
+      // auth-failure auto-pause, which already wrote the curated
+      // reconnect-required message. Overwriting it with the raw refresh-error
+      // text would leak provider error bodies onto the provider row and bury
+      // the actionable instruction.
+      const current = await db.table('email_providers')
+        .where({ id: providerId })
+        .first('inbound_paused_at', 'inbound_pause_reason') as
+        | { inbound_paused_at: string | null; inbound_pause_reason: string | null }
+        | undefined;
+      if (current?.inbound_paused_at && current.inbound_pause_reason === 'auth_failure') {
+        logger.info('Skipping connection-status overwrite for auth-failure auto-paused provider', {
+          providerId,
+          tenant,
+        });
+        return;
+      }
+    }
+
+    await db.table('email_providers')
       .where({ id: providerId })
       .update({
         status,

--- a/shared/services/email/EmailWebhookMaintenanceService.ts
+++ b/shared/services/email/EmailWebhookMaintenanceService.ts
@@ -924,7 +924,21 @@ export class EmailWebhookMaintenanceService {
         tenant: config.tenant,
         observedLastReconciliationAt: reconciliationState?.last_reconciliation_at || null,
       });
-      return { queuedMessages: 0, switchedToPolling: false, moreRemaining: false, enqueuedMessageIds: [] };
+      // A cursor-lock mismatch means another actor moved/held the Graph
+      // cursor during this pass: THIS pass handed off nothing and proves
+      // nothing about coverage of the window it read. A recovery pass must
+      // report remaining work so the multi-pass recovery caller keeps the
+      // pause (or re-drives) instead of declaring the paused interval
+      // exhausted over messages that were never handed off — the next pass
+      // re-reads the cursor and picks up from the saved boundary. Renewal
+      // passes keep the historical clean-skip semantics: their next
+      // scheduled run re-covers the window.
+      return {
+        queuedMessages: 0,
+        switchedToPolling: false,
+        moreRemaining: recoveryPass ? true : false,
+        enqueuedMessageIds: [],
+      };
     }
 
     const { queuedMessages, silenceEvidenceCount } = enqueueResult;

--- a/shared/services/email/InboundEmailAuthFailurePolicy.ts
+++ b/shared/services/email/InboundEmailAuthFailurePolicy.ts
@@ -1,0 +1,135 @@
+/**
+ * Strict, provider-neutral classification of inbound source-access failures.
+ *
+ * Only explicitly terminal credential failures count toward the automatic
+ * auth-failure pause. Everything else — throttling (429), server errors (5xx),
+ * timeouts, DNS/socket failures, Graph permission (403) / not-found (404)
+ * errors, webhook validation failures, MIME parsing errors, and downstream
+ * ticket-processing exceptions — must NEVER advance the pause counter.
+ *
+ * Classification reads structured adapter error metadata only:
+ *   - `error.status` / `error.response.status`
+ *   - `error.responseBody` / `error.response.data`
+ *   - IMAP explicit auth-rejection flags (`authenticationFailed`,
+ *     `serverResponseCode`, `responseStatus`/`responseText`)
+ *
+ * It must not do broad substring matching on messages (e.g. "401" or "auth"):
+ * the only allowlisted message-level token is the explicit AADSTS code for a
+ * revoked/expired Microsoft grant.
+ */
+
+/** Consecutive strictly-classified failures required to auto-pause a provider. */
+export const INBOUND_AUTH_FAILURE_PAUSE_THRESHOLD = 3;
+
+export type InboundAuthFailureClassification =
+  | { kind: 'unrecoverable_auth'; code: string }
+  | { kind: 'not_unrecoverable' };
+
+export type InboundAuthFailureProviderType = 'microsoft' | 'google' | 'imap';
+
+const NOT_UNRECOVERABLE: InboundAuthFailureClassification = { kind: 'not_unrecoverable' };
+
+/** Microsoft token-endpoint OAuth errors that cannot recover on their own. */
+const MICROSOFT_TOKEN_ERROR_ALLOWLIST = new Set(['invalid_client', 'invalid_grant']);
+
+/** Google token-endpoint OAuth errors that cannot recover on their own. */
+const GOOGLE_TOKEN_ERROR_ALLOWLIST = new Set(['invalid_grant']);
+
+/** IMAP OAuth token-endpoint OAuth errors that cannot recover on their own. */
+const IMAP_TOKEN_ERROR_ALLOWLIST = new Set(['invalid_client', 'invalid_grant']);
+
+/** Microsoft error_description token for a revoked or expired refresh grant. */
+const MICROSOFT_REVOKED_GRANT_TOKEN = 'AADSTS50173';
+
+function asTrimmedLowerString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim().toLowerCase();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function readOAuthErrorBody(error: any): {
+  error: string | null;
+  errorDescription: string;
+  errorSubtype: string | null;
+} {
+  const body = error?.responseBody ?? error?.response?.data;
+  if (!body || typeof body !== 'object') {
+    return { error: null, errorDescription: '', errorSubtype: null };
+  }
+  return {
+    error: asTrimmedLowerString((body as any).error),
+    errorDescription:
+      typeof (body as any).error_description === 'string' ? (body as any).error_description : '',
+    errorSubtype: asTrimmedLowerString((body as any).error_subtype),
+  };
+}
+
+function isImapAuthenticationRejection(error: any): boolean {
+  if (error?.authenticationFailed === true) return true;
+
+  const serverCode = String(error?.serverResponseCode || '').toUpperCase();
+  if (serverCode.includes('AUTHENTICATIONFAILED')) return true;
+
+  const responseStatus = String(error?.responseStatus || '').toUpperCase();
+  if (responseStatus === 'NO' && /invalid credentials/i.test(String(error?.responseText || ''))) {
+    return true;
+  }
+
+  return false;
+}
+
+/** Reduce a classified reason to a safe, bounded code (never error text). */
+function toSafeCode(code: string): string {
+  const sanitized = code.toLowerCase().replace(/[^a-z0-9_:-]/g, '').slice(0, 100);
+  return sanitized.length > 0 ? sanitized : 'unrecoverable_auth';
+}
+
+export function classifyInboundAuthFailure(params: {
+  providerType: InboundAuthFailureProviderType;
+  error: unknown;
+}): InboundAuthFailureClassification {
+  const error: any = params.error;
+  if (!error) return NOT_UNRECOVERABLE;
+
+  const { error: oauthError, errorDescription, errorSubtype } = readOAuthErrorBody(error);
+
+  if (params.providerType === 'microsoft') {
+    if (oauthError && MICROSOFT_TOKEN_ERROR_ALLOWLIST.has(oauthError)) {
+      return { kind: 'unrecoverable_auth', code: toSafeCode(`microsoft:${oauthError}`) };
+    }
+    if (errorDescription.includes(MICROSOFT_REVOKED_GRANT_TOKEN)) {
+      return {
+        kind: 'unrecoverable_auth',
+        code: toSafeCode('microsoft:invalid_grant:aadsts50173'),
+      };
+    }
+    return NOT_UNRECOVERABLE;
+  }
+
+  if (params.providerType === 'google') {
+    if (oauthError && GOOGLE_TOKEN_ERROR_ALLOWLIST.has(oauthError)) {
+      return {
+        kind: 'unrecoverable_auth',
+        code: toSafeCode(
+          errorSubtype ? `google:${oauthError}:${errorSubtype}` : `google:${oauthError}`
+        ),
+      };
+    }
+    return NOT_UNRECOVERABLE;
+  }
+
+  // IMAP: OAuth token-endpoint terminal errors, then explicit protocol-level
+  // authentication rejections (password or OAuth login rejected by the server).
+  if (oauthError && IMAP_TOKEN_ERROR_ALLOWLIST.has(oauthError)) {
+    return {
+      kind: 'unrecoverable_auth',
+      code: toSafeCode(
+        errorSubtype ? `imap:${oauthError}:${errorSubtype}` : `imap:${oauthError}`
+      ),
+    };
+  }
+  if (isImapAuthenticationRejection(error)) {
+    return { kind: 'unrecoverable_auth', code: toSafeCode('imap:authentication_failed') };
+  }
+  return NOT_UNRECOVERABLE;
+}

--- a/shared/services/email/__tests__/InboundEmailAuthFailurePolicy.test.ts
+++ b/shared/services/email/__tests__/InboundEmailAuthFailurePolicy.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from 'vitest';
+import {
+  INBOUND_AUTH_FAILURE_PAUSE_THRESHOLD,
+  classifyInboundAuthFailure,
+} from '../InboundEmailAuthFailurePolicy';
+
+/**
+ * Sanitized error shape produced by MicrosoftGraphAdapter.toSanitizedGraphError
+ * after a token-endpoint rejection (invalid_grant, incl. AADSTS50173).
+ */
+function msTokenEndpointError(error: string, errorDescription: string, status = 400) {
+  const e: any = new Error(`Error in refreshAccessToken: Request failed with status code ${status} (code: ${status})`);
+  e.status = status;
+  e.code = String(status);
+  e.responseBody = { error, error_description: errorDescription, error_codes: [50173] };
+  return e;
+}
+
+/** Axios error shape thrown raw by the IMAP OAuth refresh path. */
+function axiosTokenError(error: string, status = 400) {
+  const e: any = new Error('Request failed with status code 400');
+  e.response = { status, data: { error } };
+  return e;
+}
+
+/** Gmail error shape produced by BaseEmailAdapter.handleError wrapping a gaxios error. */
+function gmailHandleErrorError(body: Record<string, unknown>, status = 400) {
+  const e: any = new Error('Error in refreshAccessToken: invalid_grant');
+  e.status = status;
+  e.code = status;
+  e.responseBody = body;
+  return e;
+}
+
+describe('InboundEmailAuthFailurePolicy', () => {
+  it('exports a fixed, testable threshold', () => {
+    expect(INBOUND_AUTH_FAILURE_PAUSE_THRESHOLD).toBe(3);
+  });
+
+  describe('Microsoft allowlist', () => {
+    it('classifies token-endpoint invalid_grant (AADSTS50173 revoked grant)', () => {
+      const result = classifyInboundAuthFailure({
+        providerType: 'microsoft',
+        error: msTokenEndpointError(
+          'invalid_grant',
+          'AADSTS50173: The provided grant has expired or was revoked.'
+        ),
+      });
+      expect(result).toEqual({ kind: 'unrecoverable_auth', code: 'microsoft:invalid_grant' });
+    });
+
+    it('classifies token-endpoint invalid_client at status 401', () => {
+      const result = classifyInboundAuthFailure({
+        providerType: 'microsoft',
+        error: msTokenEndpointError('invalid_client', 'AADSTS7000215: invalid client secret', 401),
+      });
+      expect(result).toEqual({ kind: 'unrecoverable_auth', code: 'microsoft:invalid_client' });
+    });
+
+    it('classifies AADSTS50173 even when the error field is missing', () => {
+      const e = msTokenEndpointError('invalid_grant', 'AADSTS50173: expired grant');
+      delete (e.responseBody as any).error;
+      const result = classifyInboundAuthFailure({ providerType: 'microsoft', error: e });
+      expect(result).toEqual({
+        kind: 'unrecoverable_auth',
+        code: 'microsoft:invalid_grant:aadsts50173',
+      });
+    });
+
+    it('does NOT classify Graph permission errors (403 ErrorAccessDenied)', () => {
+      const e: any = new Error('Error in downloadMessageSource: Access is denied (code: ErrorAccessDenied)');
+      e.status = 403;
+      e.code = 'ErrorAccessDenied';
+      e.responseBody = { error: { code: 'ErrorAccessDenied', message: 'Access is denied.' } };
+      expect(classifyInboundAuthFailure({ providerType: 'microsoft', error: e })).toEqual({
+        kind: 'not_unrecoverable',
+      });
+    });
+
+    it('does NOT classify Graph 404 ResourceNotFound', () => {
+      const e: any = new Error('Error in downloadMessageSource: ResourceNotFound');
+      e.status = 404;
+      e.code = 'ResourceNotFound';
+      e.responseBody = { error: { code: 'ResourceNotFound' } };
+      expect(classifyInboundAuthFailure({ providerType: 'microsoft', error: e })).toEqual({
+        kind: 'not_unrecoverable',
+      });
+    });
+
+    it('does NOT classify webhook validation failures', () => {
+      const e: any = new Error('Subscription validation request failed');
+      e.code = 'ValidationError';
+      e.responseBody = { error: { code: 'ValidationError' } };
+      expect(classifyInboundAuthFailure({ providerType: 'microsoft', error: e })).toEqual({
+        kind: 'not_unrecoverable',
+      });
+    });
+  });
+
+  describe('Google allowlist', () => {
+    it('classifies invalid_grant and preserves error_subtype as the safe code', () => {
+      const result = classifyInboundAuthFailure({
+        providerType: 'google',
+        error: gmailHandleErrorError({
+          error: 'invalid_grant',
+          error_description: 'Token has been expired or revoked.',
+        }),
+      });
+      expect(result).toEqual({ kind: 'unrecoverable_auth', code: 'google:invalid_grant' });
+    });
+
+    it('preserves error_subtype such as invalid_rapt', () => {
+      const result = classifyInboundAuthFailure({
+        providerType: 'google',
+        error: gmailHandleErrorError({
+          error: 'invalid_grant',
+          error_subtype: 'invalid_rapt',
+        }),
+      });
+      expect(result).toEqual({
+        kind: 'unrecoverable_auth',
+        code: 'google:invalid_grant:invalid_rapt',
+      });
+    });
+
+    it('does NOT classify API-level auth errors (error is an object, not a token error string)', () => {
+      const result = classifyInboundAuthFailure({
+        providerType: 'google',
+        error: gmailHandleErrorError({
+          error: { code: 401, message: 'Invalid Credentials', errors: [{ reason: 'authError' }] },
+        }, 401),
+      });
+      expect(result).toEqual({ kind: 'not_unrecoverable' });
+    });
+
+    it('does NOT classify quota-exceeded (rateLimitExceeded) even at the token endpoint', () => {
+      const result = classifyInboundAuthFailure({
+        providerType: 'google',
+        error: gmailHandleErrorError({ error: 'rate_limit_exceeded' }, 429),
+      });
+      expect(result).toEqual({ kind: 'not_unrecoverable' });
+    });
+  });
+
+  describe('IMAP allowlist', () => {
+    it('classifies explicit imapflow authenticationFailed flag', () => {
+      const e: any = new Error('Authentication failed');
+      e.authenticationFailed = true;
+      expect(classifyInboundAuthFailure({ providerType: 'imap', error: e })).toEqual({
+        kind: 'unrecoverable_auth',
+        code: 'imap:authentication_failed',
+      });
+    });
+
+    it('classifies serverResponseCode AUTHENTICATIONFAILED', () => {
+      const e: any = new Error('AUTHENTICATIONFAILED');
+      e.serverResponseCode = 'AUTHENTICATIONFAILED';
+      expect(classifyInboundAuthFailure({ providerType: 'imap', error: e })).toEqual({
+        kind: 'unrecoverable_auth',
+        code: 'imap:authentication_failed',
+      });
+    });
+
+    it('classifies NO + invalid credentials response', () => {
+      const e: any = new Error('NO');
+      e.responseStatus = 'NO';
+      e.responseText = 'INVALID CREDENTIALS';
+      expect(classifyInboundAuthFailure({ providerType: 'imap', error: e })).toEqual({
+        kind: 'unrecoverable_auth',
+        code: 'imap:authentication_failed',
+      });
+    });
+
+    it('classifies OAuth token-endpoint invalid_grant from the raw axios error', () => {
+      const result = classifyInboundAuthFailure({
+        providerType: 'imap',
+        error: axiosTokenError('invalid_grant'),
+      });
+      expect(result).toEqual({ kind: 'unrecoverable_auth', code: 'imap:invalid_grant' });
+    });
+
+    it('classifies OAuth token-endpoint invalid_client', () => {
+      const result = classifyInboundAuthFailure({
+        providerType: 'imap',
+        error: axiosTokenError('invalid_client', 401),
+      });
+      expect(result).toEqual({ kind: 'unrecoverable_auth', code: 'imap:invalid_client' });
+    });
+
+    it('does NOT classify generic connection failures', () => {
+      const e: any = new Error('connect ECONNREFUSED 203.0.113.7:993');
+      e.code = 'ECONNREFUSED';
+      expect(classifyInboundAuthFailure({ providerType: 'imap', error: e })).toEqual({
+        kind: 'not_unrecoverable',
+      });
+    });
+  });
+
+  describe('transient shapes never count', () => {
+    const transientErrors: Array<[string, any]> = [
+      ['throttling 429', { status: 429, code: '429', responseBody: { error: { code: '429' } } }],
+      ['server error 503', { status: 503, code: '503', responseBody: { error: { code: '503' } } }],
+      ['axios timeout', { code: 'ECONNABORTED', message: 'timeout of 30000ms exceeded' }],
+      ['dns failure', { code: 'ENOTFOUND' }],
+      ['socket hangup', { code: 'ECONNRESET' }],
+      ['mime parse timeout', new Error('timeout:microsoft_mime_parse:30000')],
+      ['plain message with 401 substring', new Error('Request failed with status code 401')],
+      ['plain message with auth substring', new Error('authorization header problem')],
+      ['downstream processing failure', new Error('ticket processing exploded')],
+    ];
+
+    for (const providerType of ['microsoft', 'google', 'imap'] as const) {
+      it.each(transientErrors)('does not classify %s for %s', (_label, error) => {
+        expect(classifyInboundAuthFailure({ providerType, error })).toEqual({
+          kind: 'not_unrecoverable',
+        });
+      });
+    }
+
+    it('classifies nothing for missing errors', () => {
+      expect(classifyInboundAuthFailure({ providerType: 'microsoft', error: undefined })).toEqual({
+        kind: 'not_unrecoverable',
+      });
+    });
+  });
+
+  it('sanitizes unsafe code content out of reason codes', () => {
+    const e: any = new Error('x');
+    e.responseBody = { error: 'Invalid_Grant <script>alert(1)</script>' };
+    const result = classifyInboundAuthFailure({ providerType: 'microsoft', error: e });
+    // The allowlist is exact-match lowercase, so a decorated variant must not
+    // classify at all — codes only ever come from the fixed allowlist.
+    expect(result).toEqual({ kind: 'not_unrecoverable' });
+  });
+});

--- a/shared/services/email/__tests__/imapSyncCursor.test.ts
+++ b/shared/services/email/__tests__/imapSyncCursor.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { resolveImapSyncStartUid } from '../imapSyncCursor';
+
+describe('resolveImapSyncStartUid (IMAP cursor semantics)', () => {
+  it('resumes incrementally from a truthy cursor', () => {
+    expect(resolveImapSyncStartUid('417', 500, 5)).toBe(418);
+  });
+
+  it("treats the '0' recovery marker as a full covering rescan from UID 1", () => {
+    // The auth-pause recovery contract: last_uid = '0' must scan from the
+    // beginning of the mailbox so the entire paused interval is covered —
+    // not resume from the most recent window.
+    expect(resolveImapSyncStartUid('0', 10_000, 5)).toBe(1);
+  });
+
+  it('starts from the most recent window on a missing cursor (initial connect)', () => {
+    expect(resolveImapSyncStartUid(undefined, 10_000, 5)).toBe(9_995);
+    expect(resolveImapSyncStartUid(undefined, 3, 5)).toBe(1);
+    expect(resolveImapSyncStartUid(undefined, undefined, 5)).toBe(1);
+  });
+});

--- a/shared/services/email/__tests__/inboundAuthPauseEventNotifier.test.ts
+++ b/shared/services/email/__tests__/inboundAuthPauseEventNotifier.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  clearInboundAuthPauseNotifier,
+  dispatchInboundAuthPauseNotification,
+  isInboundAuthPauseNotifierRegistered,
+} from '../inboundAuthPauseNotifier';
+
+const publishEventMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@alga-psa/event-bus/publishers', () => ({
+  publishEvent: (...args: unknown[]) => publishEventMock(...args),
+}));
+
+const {
+  registerInboundAuthPauseEventPublisher,
+  publishInboundAuthPauseEvent,
+} = await import('../inboundAuthPauseEventNotifier');
+
+const params = {
+  tenant: '11111111-1111-4111-8111-111111111111',
+  providerId: '22222222-2222-4222-8222-222222222222',
+  providerName: 'Worker Mailbox',
+  mailbox: 'worker@example.com',
+  providerType: 'microsoft' as const,
+  authFailureCode: 'microsoft:invalid_grant',
+  pausedAt: '2026-08-15T12:00:00.000Z',
+};
+
+describe('inboundAuthPauseEventNotifier', () => {
+  afterEach(() => {
+    clearInboundAuthPauseNotifier();
+    publishEventMock.mockReset();
+  });
+
+  it('registers a notifier that publishes INBOUND_EMAIL_PROVIDER_AUTO_PAUSED', async () => {
+    expect(isInboundAuthPauseNotifierRegistered()).toBe(false);
+
+    registerInboundAuthPauseEventPublisher();
+    expect(isInboundAuthPauseNotifierRegistered()).toBe(true);
+
+    await dispatchInboundAuthPauseNotification(params);
+
+    expect(publishEventMock).toHaveBeenCalledTimes(1);
+    const event = publishEventMock.mock.calls[0][0];
+    expect(event.eventType).toBe('INBOUND_EMAIL_PROVIDER_AUTO_PAUSED');
+    expect(event.payload).toMatchObject({
+      tenantId: params.tenant,
+      providerId: params.providerId,
+      providerName: params.providerName,
+      mailbox: params.mailbox,
+      providerType: params.providerType,
+      authFailureCode: params.authFailureCode,
+      pausedAt: params.pausedAt,
+      actorType: 'SYSTEM',
+    });
+    // No credential material may ride on the event.
+    expect(JSON.stringify(event)).not.toMatch(/refresh|secret|token/i);
+  });
+
+  it('dispatch failures are contained (never propagate to the pause path)', async () => {
+    registerInboundAuthPauseEventPublisher();
+    publishEventMock.mockRejectedValueOnce(new Error('bus unavailable'));
+
+    await expect(dispatchInboundAuthPauseNotification(params)).resolves.toBeUndefined();
+  });
+
+  it('publishInboundAuthPauseEvent propagates publish errors to its caller', async () => {
+    publishEventMock.mockRejectedValueOnce(new Error('bus unavailable'));
+    await expect(publishInboundAuthPauseEvent(params)).rejects.toThrow(/bus unavailable/);
+  });
+});

--- a/shared/services/email/imapOauthToken.ts
+++ b/shared/services/email/imapOauthToken.ts
@@ -1,0 +1,97 @@
+/**
+ * IMAP OAuth token refresh, shared by the inbound queue processor and the
+ * provider lifecycle recovery path. Extracted so both callers use the same
+ * secret resolution and persistence behavior without import cycles.
+ */
+
+import axios from 'axios';
+import { tenantDb } from '@alga-psa/db';
+import type { getAdminConnection } from '@alga-psa/db/admin';
+import { getSecretProviderInstance } from '@alga-psa/core/secrets';
+
+function asNonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export async function getImapOauthSecrets(provider: {
+  id: string;
+  tenant: string;
+}): Promise<{ clientSecret: string | null; refreshToken: string | null }> {
+  const secretProvider = await getSecretProviderInstance();
+  const clientSecret =
+    (await secretProvider.getTenantSecret(provider.tenant, `imap_oauth_client_secret_${provider.id}`)) ?? null;
+  const refreshToken =
+    (await secretProvider.getTenantSecret(provider.tenant, `imap_refresh_token_${provider.id}`)) ?? null;
+  return { clientSecret, refreshToken };
+}
+
+export async function refreshImapAccessToken(params: {
+  provider: {
+    id: string;
+    tenant: string;
+    oauth_token_url?: string | null;
+    oauth_client_id?: string | null;
+    oauth_client_secret?: string | null;
+    refresh_token?: string | null;
+    access_token?: string | null;
+    token_expires_at?: string | null;
+  };
+  db: Awaited<ReturnType<typeof getAdminConnection>>;
+}): Promise<string> {
+  const { provider, db } = params;
+  if (!provider.oauth_token_url || !provider.oauth_client_id) {
+    throw new Error('IMAP OAuth token URL or client ID missing');
+  }
+
+  const { clientSecret, refreshToken } = await getImapOauthSecrets({
+    id: provider.id,
+    tenant: provider.tenant,
+  });
+  const effectiveRefreshToken = refreshToken || provider.refresh_token;
+  const effectiveClientSecret = clientSecret || provider.oauth_client_secret;
+  if (!effectiveRefreshToken) {
+    throw new Error('IMAP OAuth refresh token missing');
+  }
+
+  const paramsBody = new URLSearchParams();
+  paramsBody.append('grant_type', 'refresh_token');
+  paramsBody.append('refresh_token', effectiveRefreshToken);
+  paramsBody.append('client_id', provider.oauth_client_id);
+  if (effectiveClientSecret) {
+    paramsBody.append('client_secret', effectiveClientSecret);
+  }
+
+  const response = await axios.post(provider.oauth_token_url, paramsBody, {
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+  });
+  const accessToken = asNonEmptyString(response?.data?.access_token);
+  if (!accessToken) {
+    throw new Error('IMAP OAuth refresh returned no access token');
+  }
+
+  const expiresInSeconds = Number(response?.data?.expires_in || 3600);
+  const expiresAt = new Date(
+    Date.now() + (Number.isFinite(expiresInSeconds) ? expiresInSeconds : 3600) * 1000
+  ).toISOString();
+
+  await tenantDb(db, provider.tenant).table('imap_email_provider_config')
+    .where({ email_provider_id: provider.id })
+    .update({
+      access_token: accessToken,
+      token_expires_at: expiresAt,
+      updated_at: db.fn.now(),
+    });
+
+  provider.access_token = accessToken;
+  provider.token_expires_at = expiresAt;
+  console.info('[ImapOauthToken] refreshed IMAP OAuth access token', {
+    event: 'imap_oauth_refresh',
+    tenantId: provider.tenant,
+    providerId: provider.id,
+    expiresAt,
+  });
+
+  return accessToken;
+}

--- a/shared/services/email/imapSyncCursor.ts
+++ b/shared/services/email/imapSyncCursor.ts
@@ -1,0 +1,33 @@
+/**
+ * IMAP incremental-sync cursor semantics, shared by the standalone
+ * email-service listener loop.
+ *
+ * The auth-pause recovery path (EmailProviderLifecycleService) arms
+ * `last_uid = '0'` after credentials re-validate; this module defines what
+ * each cursor shape means when the listener resolves its next scan start.
+ */
+
+/**
+ * Resolve the first UID an incremental sync should scan from.
+ *
+ * - a truthy `lastUid` resumes from `Number(lastUid) + 1` — including the
+ *   explicit `'0'` marker (auth-pause recovery resync contract), which scans
+ *   from UID 1 so the WHOLE paused interval is covered; dedupe suppresses
+ *   already-processed mail;
+ * - a missing cursor (initial connect) starts from the most recent window
+ *   (`uidNext - maxEmailsPerSync`) instead of replaying the entire mailbox
+ *   from UID 1.
+ */
+export function resolveImapSyncStartUid(
+  lastUid: string | undefined,
+  uidNext: number | undefined,
+  maxEmailsPerSync: number
+): number {
+  if (lastUid) {
+    return Number(lastUid) + 1;
+  }
+  if (uidNext && Number(uidNext) > 1) {
+    return Math.max(1, Number(uidNext) - maxEmailsPerSync);
+  }
+  return 1;
+}

--- a/shared/services/email/inboundAuthPauseEventNotifier.ts
+++ b/shared/services/email/inboundAuthPauseEventNotifier.ts
@@ -1,0 +1,47 @@
+/**
+ * Event-publisher notifier for runtimes that cannot load the
+ * @alga-psa/notifications vertical (the standalone email-service container and
+ * the Temporal worker, whose build graphs deliberately exclude that package's
+ * transitive UI dependencies).
+ *
+ * Registers a notifier into the shared lifecycle hook that publishes
+ * INBOUND_EMAIL_PROVIDER_AUTO_PAUSED through the event bus; a server-side
+ * subscriber (server/src/lib/eventBus/subscribers/
+ * inboundAuthPauseNotificationSubscriber.ts) receives it and creates the admin
+ * notifications where the domain graph loads. Mirrors the established
+ * MAINTENANCE_JOB_REQUESTED worker→server hand-off. The paused provider row
+ * itself (inbound_paused_at + inbound_pause_reason='auth_failure') is the
+ * durable fallback evidence if the event is lost.
+ *
+ * The event-bus import is lazy (same pattern as inboundEmailOutboxDispatcher)
+ * so importing this module never couples module initialization to the bus.
+ */
+
+import {
+  registerInboundAuthPauseNotifier,
+  type InboundAuthPauseNotificationParams,
+} from './inboundAuthPauseNotifier';
+
+export async function publishInboundAuthPauseEvent(
+  params: InboundAuthPauseNotificationParams
+): Promise<void> {
+  const { publishEvent } = await import('@alga-psa/event-bus/publishers');
+  await publishEvent({
+    eventType: 'INBOUND_EMAIL_PROVIDER_AUTO_PAUSED',
+    payload: {
+      tenantId: params.tenant,
+      occurredAt: new Date().toISOString(),
+      actorType: 'SYSTEM',
+      providerId: params.providerId,
+      providerName: params.providerName,
+      mailbox: params.mailbox,
+      providerType: params.providerType,
+      authFailureCode: params.authFailureCode,
+      pausedAt: params.pausedAt,
+    },
+  });
+}
+
+export function registerInboundAuthPauseEventPublisher(): void {
+  registerInboundAuthPauseNotifier((params) => publishInboundAuthPauseEvent(params));
+}

--- a/shared/services/email/inboundAuthPauseNotifier.ts
+++ b/shared/services/email/inboundAuthPauseNotifier.ts
@@ -36,6 +36,34 @@ export function clearInboundAuthPauseNotifier(): void {
   registeredNotifier = null;
 }
 
+/**
+ * Whether a notifier implementation is registered in this process. Every
+ * runtime that can trigger the auto-pause (Next server, bin consumer,
+ * email-service container, Temporal worker) must register one at startup —
+ * a silent pause with no admin notification and no durable signal is the
+ * failure mode this feature exists to prevent.
+ */
+export function isInboundAuthPauseNotifierRegistered(): boolean {
+  return registeredNotifier !== null;
+}
+
+/**
+ * Startup guard for pause-triggering entrypoints: logs a loud error (never
+ * throws — startup must not depend on the notifier) when no notifier is
+ * registered, so a mis-wired deployment surfaces immediately in logs.
+ */
+export function assertInboundAuthPauseNotifierRegistered(entrypoint: string): boolean {
+  if (isInboundAuthPauseNotifierRegistered()) {
+    return true;
+  }
+  console.error('[EmailProviderLifecycle] NO inbound auth-pause notifier registered; auto-pauses would be silent', {
+    event: 'inbound_auth_pause_notifier_missing',
+    entrypoint,
+    remediation: 'Register a notifier (direct or event-publisher) at startup of every pause-triggering runtime.',
+  });
+  return false;
+}
+
 export async function dispatchInboundAuthPauseNotification(
   params: InboundAuthPauseNotificationParams
 ): Promise<void> {

--- a/shared/services/email/inboundAuthPauseNotifier.ts
+++ b/shared/services/email/inboundAuthPauseNotifier.ts
@@ -1,0 +1,61 @@
+/**
+ * Registration point for inbound auth-pause admin notifications.
+ *
+ * `shared/` cannot depend on `@alga-psa/notifications` (that would create a
+ * package cycle), so the lifecycle service exposes this tiny dispatch hook.
+ * The server process registers the real implementation (which creates
+ * `system-announcement` internal notifications for active tenant admins) at
+ * startup; other runtimes simply have no notifier and rely on the persistent
+ * settings banner as the durable fallback.
+ *
+ * Delivery is best-effort and must never roll back the pause itself.
+ */
+
+export interface InboundAuthPauseNotificationParams {
+  tenant: string;
+  providerId: string;
+  providerName: string;
+  mailbox: string;
+  providerType: 'microsoft' | 'google' | 'imap';
+  /** Safe, sanitized reason code (e.g. `microsoft:invalid_grant`). Never raw error text. */
+  authFailureCode: string;
+  pausedAt: string;
+}
+
+export type InboundAuthPauseNotifier = (
+  params: InboundAuthPauseNotificationParams
+) => Promise<void>;
+
+let registeredNotifier: InboundAuthPauseNotifier | null = null;
+
+export function registerInboundAuthPauseNotifier(notifier: InboundAuthPauseNotifier): void {
+  registeredNotifier = notifier;
+}
+
+export function clearInboundAuthPauseNotifier(): void {
+  registeredNotifier = null;
+}
+
+export async function dispatchInboundAuthPauseNotification(
+  params: InboundAuthPauseNotificationParams
+): Promise<void> {
+  if (!registeredNotifier) {
+    console.info('[EmailProviderLifecycle] no inbound auth-pause notifier registered', {
+      tenant: params.tenant,
+      providerId: params.providerId,
+      authFailureCode: params.authFailureCode,
+    });
+    return;
+  }
+
+  try {
+    await registeredNotifier(params);
+  } catch (error) {
+    console.warn('[EmailProviderLifecycle] inbound auth-pause notification delivery failed', {
+      tenant: params.tenant,
+      providerId: params.providerId,
+      authFailureCode: params.authFailureCode,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/shared/services/email/inboundEmailAuthOutcomeRecorder.ts
+++ b/shared/services/email/inboundEmailAuthOutcomeRecorder.ts
@@ -1,0 +1,120 @@
+/**
+ * Shared source-access auth-outcome recorder for inbound email runtimes
+ * outside the V1 queue processor (the standalone IMAP email-service listener
+ * loop and the durable-V2 ingress staging worker).
+ *
+ * Semantics are identical to the V1 boundary in
+ * `unifiedInboundEmailQueueJobProcessor.processUnifiedInboundEmailQueueJob`:
+ *
+ * - only strictly classified terminal credential failures advance the
+ *   consecutive-failure counter (and can trip the automatic pause);
+ * - any successful provider source access resets the counter;
+ * - recording/resetting failures are logged and never fatal — the caller's
+ *   own error handling and retry policy stay authoritative;
+ * - downstream (ticket/artifact/outbox) processing must never call this.
+ *
+ * The lifecycle service is lazy-imported so importing this module never
+ * changes a runtime's static module graph (it is loaded from inside the
+ * email-service IMAP listener, which must not pull the adapter stack at
+ * module-load time).
+ */
+
+import {
+  classifyInboundAuthFailure,
+  type InboundAuthFailureProviderType,
+} from './InboundEmailAuthFailurePolicy';
+
+export interface RecordInboundSourceAuthOutcomeParams {
+  tenant: string;
+  providerId: string;
+  providerType: InboundAuthFailureProviderType;
+  error: unknown;
+  /** Log label for the calling runtime, e.g. 'imap-email-service'. */
+  source: string;
+}
+
+export interface RecordInboundSourceAuthOutcomeResult {
+  unrecoverable: boolean;
+  autoPaused: boolean;
+}
+
+export interface RecordInboundSourceAccessSuccessParams {
+  tenant: string;
+  providerId: string;
+  /** Log label for the calling runtime. */
+  source: string;
+}
+
+/**
+ * Reset the consecutive auth-failure counter after a successful provider
+ * source access (including a fetch that returned no new messages).
+ * Best-effort: logged, never thrown.
+ */
+export async function recordInboundSourceAccessSuccess(
+  params: RecordInboundSourceAccessSuccessParams
+): Promise<void> {
+  try {
+    const { EmailProviderLifecycleService } = await import('./EmailProviderLifecycleService');
+    await new EmailProviderLifecycleService().recordSourceAccessSuccess(
+      params.providerId,
+      params.tenant
+    );
+  } catch (error) {
+    console.warn('[InboundEmailAuthOutcome] failed to reset auth-failure counter', {
+      event: 'inbound_email_auth_failure_reset_failed',
+      source: params.source,
+      tenantId: params.tenant,
+      providerId: params.providerId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
+ * Classify a source-access failure strictly and, when it is a terminal
+ * credential failure, advance the provider's auth-failure counter (which may
+ * atomically trip the automatic pause and dispatch the admin notification).
+ * Never throws and never mutates the original error's propagation.
+ */
+export async function recordInboundSourceAuthFailure(
+  params: RecordInboundSourceAuthOutcomeParams
+): Promise<RecordInboundSourceAuthOutcomeResult> {
+  const classification = classifyInboundAuthFailure({
+    providerType: params.providerType,
+    error: params.error,
+  });
+  if (classification.kind !== 'unrecoverable_auth') {
+    return { unrecoverable: false, autoPaused: false };
+  }
+
+  try {
+    const { EmailProviderLifecycleService } = await import('./EmailProviderLifecycleService');
+    const outcome = await new EmailProviderLifecycleService().recordUnrecoverableAuthFailure(
+      params.providerId,
+      params.tenant,
+      classification.code
+    );
+    if (outcome.autoPaused) {
+      console.info('[InboundEmailAuthOutcome] provider auto-paused after repeated auth failures', {
+        event: 'inbound_email_provider_auto_paused',
+        source: params.source,
+        tenantId: params.tenant,
+        providerId: params.providerId,
+        providerType: params.providerType,
+        authFailureCode: classification.code,
+        count: outcome.count,
+      });
+    }
+    return { unrecoverable: true, autoPaused: outcome.autoPaused };
+  } catch (error) {
+    console.warn('[InboundEmailAuthOutcome] failed to record auth failure', {
+      event: 'inbound_email_auth_failure_record_failed',
+      source: params.source,
+      tenantId: params.tenant,
+      providerId: params.providerId,
+      authFailureCode: classification.code,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { unrecoverable: true, autoPaused: false };
+  }
+}

--- a/shared/services/email/inboundEmailDurableStore.ts
+++ b/shared/services/email/inboundEmailDurableStore.ts
@@ -203,14 +203,23 @@ export async function claimIngress(db: DurableDb, params: {
     // Over-cap due retryable rows are dead-lettered into a queryable terminal
     // failure state rather than looping forever — unless the provider is
     // ingestion-paused: attempts that accrued while the credential was dead
-    // must not terminalize a paused-interval message. The row stays
-    // retryable and is re-driven after the pause clears.
+    // must not terminalize a paused-interval message. The early pause read
+    // leaves an already-paused provider's row untouched, and deadletterIngress
+    // re-checks the pause state atomically with the terminal write itself, so
+    // a pause landing between the two still cannot terminalize the row (it is
+    // parked there instead).
     if (isDue(current.next_attempt_at, now) && current.attempt_count >= maxAttempts) {
       if (await isInboundProviderPaused(db, params.tenant, current.provider_id)) {
         return { claimed: false, reason: 'not_due' };
       }
-      await deadletterIngress(db, current);
-      return { claimed: false, reason: 'terminal' };
+      const outcome = await deadletterIngress(db, current);
+      if (outcome === 'deadlettered') {
+        return { claimed: false, reason: 'terminal' };
+      }
+      // The pause raced this decision and the row was parked (or a
+      // concurrent transition won): not due now; the recovery sweep re-drives
+      // the row after the pause clears.
+      return { claimed: false, reason: 'not_due' };
     }
     return { claimed: false, reason: 'not_due' };
   }
@@ -316,10 +325,38 @@ export async function reclaimIngress(db: DurableDb, params: {
   return { claimed: false, reason: 'already_claimed' };
 }
 
-/** Dead-letter an over-cap due retryable ingress row into `terminal_failed`. */
-export async function deadletterIngress(db: DurableDb, row: InboundIngressRecord): Promise<boolean> {
+export type IngressDeadletterOutcome = 'deadlettered' | 'parked_while_paused' | 'noop';
+
+/** Backoff for a dead-letter attempt parked because the provider is paused.
+ * Short on purpose: the pause gate (not the backoff) suppresses re-drives
+ * while paused, matching parkIngressWhilePaused. */
+const PAUSED_DEADLETTER_PARK_BACKOFF_MS = 30_000;
+
+/**
+ * Dead-letter an over-cap due retryable ingress row into `terminal_failed`.
+ *
+ * The terminal transition is guarded at the WRITE ITSELF by the provider's
+ * live pause state (a NOT EXISTS subquery over the paused provider row in the
+ * same single UPDATE statement), so a provider that becomes paused between
+ * any earlier pause check/snapshot and this decision can never have an
+ * over-cap row terminalized: single-statement Postgres semantics make the
+ * guard and the write one atomic act. When the guard blocks the write because
+ * the provider is paused at decision time, the row is PARKED instead — the
+ * same non-terminal semantics as the staging-worker park (`retryable_failed`,
+ * attempt budget voided, short backoff) — so the recovery sweep re-drives it
+ * with a full retry budget once the pause clears.
+ */
+export async function deadletterIngress(
+  db: DurableDb,
+  row: InboundIngressRecord
+): Promise<IngressDeadletterOutcome> {
+  const notPausedWhileTerminal = db.raw(
+    'NOT EXISTS (SELECT 1 FROM email_providers ep WHERE ep.tenant = ? AND ep.id = ? AND ep.inbound_paused_at IS NOT NULL)',
+    [row.tenant, row.provider_id]
+  );
   const updated = await tenantDb(db, row.tenant).table('inbound_email_ingress')
     .where({ tenant: row.tenant, ingress_id: row.ingress_id, status: 'retryable_failed' })
+    .where(notPausedWhileTerminal)
     .update({
       status: 'terminal_failed',
       completed_at: db.fn.now(),
@@ -330,7 +367,27 @@ export async function deadletterIngress(db: DurableDb, row: InboundIngressRecord
       last_error: row.last_error ?? 'max_attempts_exhausted',
       updated_at: db.fn.now(),
     });
-  return updated > 0;
+  if (updated > 0) return 'deadlettered';
+
+  // Zero rows: either the row was transitioned concurrently (noop) or the
+  // pause guard blocked the terminal write. Park only when the provider is
+  // paused at this decision point — a fresh read, not a sweep-time snapshot.
+  if (!(await isInboundProviderPaused(db, row.tenant, row.provider_id))) {
+    return 'noop';
+  }
+  const parked = await tenantDb(db, row.tenant).table('inbound_email_ingress')
+    .where({ tenant: row.tenant, ingress_id: row.ingress_id, status: 'retryable_failed' })
+    .update({
+      attempt_count: 0,
+      lease_owner: null,
+      lease_token: null,
+      lease_expires_at: null,
+      next_attempt_at: db.raw("now() + (? || ' milliseconds')::interval", [PAUSED_DEADLETTER_PARK_BACKOFF_MS]),
+      last_error: row.last_error ?? 'max_attempts_exhausted',
+      error_details: JSON.stringify({ phase: 'deadletter', parkedWhilePaused: true }),
+      updated_at: db.fn.now(),
+    });
+  return parked > 0 ? 'parked_while_paused' : 'noop';
 }
 
 export async function getIngress(db: DurableDb, tenant: string, ingressId: string): Promise<InboundIngressRecord | null> {
@@ -1644,13 +1701,28 @@ export interface DueScanOptions {
   tenant: string;
   limit?: number;
   now?: Date;
+  /**
+   * Provider ids to exclude from the row-selection predicate ITSELF, before
+   * the cap is applied. Used by the recovery sweep for ingestion-paused
+   * providers' ingress rows: a paused provider's due rows must never occupy
+   * slots inside the cap window, or they would starve unpaused providers'
+   * due work. Only ingress staging requires live credentials, so only
+   * findDueIngress consumes this.
+   */
+  excludeProviderIds?: string[];
 }
 
 export async function findDueIngress(db: DurableDb, options: DueScanOptions): Promise<InboundIngressRecord[]> {
   const limit = Math.max(1, options.limit ?? 20);
   const now = options.now ?? new Date();
-  const rows = await tenantDb(db, options.tenant).table('inbound_email_ingress')
-    .where({ tenant: options.tenant })
+  const query = tenantDb(db, options.tenant).table('inbound_email_ingress')
+    .where({ tenant: options.tenant });
+  // The paused-provider filter is part of the selection predicate so the cap
+  // only ever applies to eligible (unpaused) work.
+  if (options.excludeProviderIds && options.excludeProviderIds.length > 0) {
+    query.whereNotIn('provider_id', options.excludeProviderIds);
+  }
+  const rows = await query
     .andWhere(function (this: any) {
       this.where({ status: 'received' })
         .orWhere((inner: any) => {

--- a/shared/services/email/inboundEmailDurableStore.ts
+++ b/shared/services/email/inboundEmailDurableStore.ts
@@ -82,6 +82,22 @@ function isDue(nextAttemptAt: Date | string | null | undefined, now: Date): bool
 // Ingress
 // ---------------------------------------------------------------------------
 
+/**
+ * True when the provider's inbound ingestion is paused (any reason). Durable
+ * work that requires provider source access must wait out the pause instead of
+ * burning attempts against dead credentials: a message that arrived during an
+ * auth pause must survive, non-terminal, until the resume reconciliation and
+ * the recovery sweep hand it off. Ingestion gating here is the durable-mode
+ * equivalent of the `inbound_paused_at` filters in the queue/maintenance
+ * loaders.
+ */
+export async function isInboundProviderPaused(db: DurableDb, tenant: string, providerId: string): Promise<boolean> {
+  const row = await tenantDb(db, tenant).table('email_providers')
+    .where({ tenant, id: providerId })
+    .first('inbound_paused_at');
+  return Boolean(row?.inbound_paused_at);
+}
+
 export interface InboundIngressInsert {
   tenant: string;
   provider_id: string;
@@ -185,14 +201,84 @@ export async function claimIngress(db: DurableDb, params: {
   }
   if (current.status === 'retryable_failed') {
     // Over-cap due retryable rows are dead-lettered into a queryable terminal
-    // failure state rather than looping forever.
+    // failure state rather than looping forever — unless the provider is
+    // ingestion-paused: attempts that accrued while the credential was dead
+    // must not terminalize a paused-interval message. The row stays
+    // retryable and is re-driven after the pause clears.
     if (isDue(current.next_attempt_at, now) && current.attempt_count >= maxAttempts) {
+      if (await isInboundProviderPaused(db, params.tenant, current.provider_id)) {
+        return { claimed: false, reason: 'not_due' };
+      }
       await deadletterIngress(db, current);
       return { claimed: false, reason: 'terminal' };
     }
     return { claimed: false, reason: 'not_due' };
   }
   return { claimed: false, reason: 'already_claimed' };
+}
+
+/**
+ * Park a claimed ingress row whose provider is ingestion-paused: fenced
+ * transition to `retryable_failed` with the attempt budget VOIDED. The pause
+ * owns the delay — the row's attempts were burned against a dead credential,
+ * not an unhealthy message — so after the pause clears the row gets a full
+ * retry budget and the recovery sweep re-drives it. Never terminal.
+ */
+export async function parkIngressWhilePaused(db: DurableDb, params: {
+  tenant: string;
+  ingress_id: string;
+  owner: string;
+  token: string;
+  version: number;
+  backoffMs: number;
+  error?: string | null;
+}): Promise<boolean> {
+  const updated = await tenantDb(db, params.tenant).table('inbound_email_ingress')
+    .where({
+      tenant: params.tenant,
+      ingress_id: params.ingress_id,
+      status: 'staging',
+      lease_owner: params.owner,
+      lease_token: params.token,
+      lease_version: params.version,
+    })
+    .update({
+      status: 'retryable_failed',
+      attempt_count: 0,
+      lease_owner: null,
+      lease_token: null,
+      lease_expires_at: null,
+      next_attempt_at: db.raw("now() + (? || ' milliseconds')::interval", [params.backoffMs]),
+      ...(params.error !== undefined ? { last_error: params.error } : {}),
+      error_details: JSON.stringify({ phase: 'staging', parkedWhilePaused: true }),
+      updated_at: db.fn.now(),
+    });
+  return updated > 0;
+}
+
+/**
+ * Revive a `terminal_failed` ingress row back to `received` with a fresh
+ * attempt budget. Used by the auth-pause recovery reconciliation when it
+ * re-hands-off a paused-interval message whose prior ingress terminalized
+ * (e.g. attempts burned against the dead credential): a terminal row is NOT a
+ * durable hand-off, and an explicit new hand-off must result in processing.
+ * Conditional on the still-terminal status so concurrent revives are safe.
+ */
+export async function reviveTerminalIngress(db: DurableDb, tenant: string, ingressId: string): Promise<boolean> {
+  const updated = await tenantDb(db, tenant).table('inbound_email_ingress')
+    .where({ tenant, ingress_id: ingressId, status: 'terminal_failed' })
+    .update({
+      status: 'received',
+      attempt_count: 0,
+      lease_owner: null,
+      lease_token: null,
+      lease_expires_at: null,
+      next_attempt_at: null,
+      completed_at: null,
+      error_details: JSON.stringify({ revivedBy: 'auth-pause-reconcile' }),
+      updated_at: db.fn.now(),
+    });
+  return updated > 0;
 }
 
 /**

--- a/shared/services/email/inboundEmailIngressStagingWorker.ts
+++ b/shared/services/email/inboundEmailIngressStagingWorker.ts
@@ -21,6 +21,8 @@ import {
   getDurableMaxAttempts,
   getInboundDurableMode,
   getIngress,
+  isInboundProviderPaused,
+  parkIngressWhilePaused,
   reclaimIngress,
   transitionIngress,
   upsertIngress,
@@ -45,6 +47,11 @@ function boundedBackoffMs(attemptCount: number): number {
   return Math.min(base + jitter, 5 * 60 * 1000);
 }
 
+/** Backoff for a parked-while-paused ingress row. Short on purpose: the pause
+ * gate (not the backoff) suppresses re-drives while paused, so after the pause
+ * clears the row becomes due quickly for the recovery sweep to re-enqueue. */
+const PAUSED_INGRESS_PARK_BACKOFF_MS = 30_000;
+
 export async function processIngressStageJob(
   job: UnifiedInboundEmailQueueJobV2,
   ctx: InboundV2JobContext
@@ -53,6 +60,23 @@ export async function processIngressStageJob(
   const owner = `ingress-stager-${job.jobId}`;
   const ttl = getDurableLeaseTtlMs();
   const maxAttempts = getDurableMaxAttempts();
+
+  // Pause gate BEFORE claiming: staging requires live provider credentials, so
+  // while the provider is ingestion-paused a wake-up must not claim the row
+  // (which would burn an attempt against the dead credential) and must not
+  // terminalize it. The row stays `received`/`retryable_failed` — non-terminal
+  // — and the recovery sweep re-drives it once the pause clears. Acking drops
+  // the wake-up; the durable row, not this job, is the unit of recovery.
+  const preClaim = await getIngress(db, job.tenantId, job.recordId);
+  if (preClaim && (await isInboundProviderPaused(db, job.tenantId, preClaim.provider_id))) {
+    console.info('[InboundIngressStagingWorker] ingress staging deferred: provider ingestion paused', {
+      event: 'inbound_email_ingress_paused_gate',
+      tenantId: job.tenantId,
+      providerId: preClaim.provider_id,
+      ingressId: preClaim.ingress_id,
+    });
+    return { disposition: 'ack', outcome: 'paused', reason: 'provider_ingestion_paused' };
+  }
 
   let claim = await claimIngress(db, {
     tenant: job.tenantId,
@@ -110,14 +134,27 @@ export async function processIngressStageJob(
   try {
     let stagedInboxes: string[];
     try {
-      stagedInboxes = await stageIngressSources(db, ingress);
+      stagedInboxes = await stageIngressSources(db, ingress, {
+        // Any successful provider source access — including an empty fetch —
+        // resets the consecutive auth-failure counter IMMEDIATELY, before the
+        // downstream staging work (object upload, inbox insert, cursor
+        // advance). A storage/inbox failure after a healthy fetch must not
+        // leave a stale counter armed: a later transient blip mixed with one
+        // real auth error could then mis-trip the automatic pause.
+        onSourceAccessSuccess: () =>
+          recordInboundSourceAccessSuccess({
+            tenant: ingress.tenant,
+            providerId: ingress.provider_id,
+            source: 'v2-ingress-staging',
+          }),
+      });
     } catch (error) {
       // Source-access auth accounting with the same semantics as the V1
       // processor boundary: only strictly classified terminal credential
       // failures count (the classifier never matches staging/storage errors),
       // a Google history notification with no messages is a successful empty
       // fetch, and the original error still propagates so the ingress
-      // retry/terminal policy above stays authoritative.
+      // retry/terminal policy below stays authoritative.
       if ((error as any)?.message === 'google_history_no_messages') {
         await recordInboundSourceAccessSuccess({
           tenant: ingress.tenant,
@@ -135,14 +172,6 @@ export async function processIngressStageJob(
       }
       throw error;
     }
-
-    // Any successful source access — including an empty fetch — resets the
-    // consecutive auth-failure counter before downstream inbox processing.
-    await recordInboundSourceAccessSuccess({
-      tenant: ingress.tenant,
-      providerId: ingress.provider_id,
-      source: 'v2-ingress-staging',
-    });
 
     const written = await transitionIngress(db, {
       tenant: ingress.tenant,
@@ -179,6 +208,26 @@ export async function processIngressStageJob(
     return { disposition: 'ack' };
   } catch (error: any) {
     const message = error?.message || String(error);
+    // Pause raced the claim (the pause tripped between the pre-claim gate and
+    // the fetch, e.g. a concurrent job crossed the threshold): the failure was
+    // measured against a dead credential, so park the row non-terminal with a
+    // voided attempt budget instead of terminalizing it. A paused-interval
+    // message must survive until the resume reconciliation hands it off.
+    if (await isInboundProviderPaused(db, ingress.tenant, ingress.provider_id)) {
+      const parked = await parkIngressWhilePaused(db, {
+        tenant: ingress.tenant,
+        ingress_id: ingress.ingress_id,
+        owner,
+        token,
+        version,
+        backoffMs: PAUSED_INGRESS_PARK_BACKOFF_MS,
+        error: message,
+      });
+      if (!parked) {
+        return { disposition: 'retry', error: 'ingress_fence_superseded' };
+      }
+      return { disposition: 'ack', outcome: 'paused', reason: `parked_while_paused:${message}` };
+    }
     const retryable = isRetryableStageError(message);
     // Terminal attempt cap: exhausted retries land in a queryable terminal
     // failure state instead of looping forever.
@@ -199,11 +248,25 @@ export async function processIngressStageJob(
   }
 }
 
-async function stageIngressSources(db: any, ingress: InboundIngressRecord): Promise<string[]> {  const providerType = ingress.provider_type;
+interface StageIngressSourcesContext {
+  /**
+   * Fired the moment provider source access is proven successful (fetch,
+   * listing, or download returned) — BEFORE any downstream staging work, so
+   * storage/insert failures cannot strand a stale auth-failure counter.
+   */
+  onSourceAccessSuccess: () => Promise<void>;
+}
+
+async function stageIngressSources(
+  db: any,
+  ingress: InboundIngressRecord,
+  ctx: StageIngressSourcesContext
+): Promise<string[]> {
+  const providerType = ingress.provider_type;
   const pointer = ingress.provider_pointer ?? {};
 
   if (providerType === 'google') {
-    return stageGoogleSources(db, ingress);
+    return stageGoogleSources(db, ingress, ctx);
   }
 
   const v1Job = buildV1JobFromIngress(ingress);
@@ -217,6 +280,9 @@ async function stageIngressSources(db: any, ingress: InboundIngressRecord): Prom
   } else {
     throw new Error(`unsupported_provider_type:${providerType}`);
   }
+  // Source fetch (download + parse) succeeded: reset the auth counter now —
+  // everything below is local staging work, not credential access.
+  await ctx.onSourceAccessSuccess();
 
   const rawMime = maybeExtractRawMimeFromEmailData(emailData);
   if (!rawMime) {
@@ -271,7 +337,7 @@ async function maybeAdvanceMicrosoftReconcileCursor(db: any, ingress: InboundIng
   }
 }
 
-async function stageGoogleSources(db: any, ingress: InboundIngressRecord): Promise<string[]> {
+async function stageGoogleSources(db: any, ingress: InboundIngressRecord, ctx: StageIngressSourcesContext): Promise<string[]> {
   const v1Job = buildV1JobFromIngress(ingress);
   const { fetchGoogleProviderConfig } = await import('./unifiedInboundEmailQueueJobProcessor');
   const { provider, googleConfig, config } = await fetchGoogleProviderConfig(v1Job);
@@ -286,13 +352,27 @@ async function stageGoogleSources(db: any, ingress: InboundIngressRecord): Promi
     googleConfig.history_id || Math.max((Number(ingress.provider_pointer?.historyId) || 1) - 1, 1)
   );
   const messageIds = explicitMessageIds.length > 0 ? explicitMessageIds : await adapter.listMessagesSince(startHistoryId);
+  if (explicitMessageIds.length === 0) {
+    // The history listing itself is the source access (an empty result is a
+    // successful empty fetch and throws below, handled by the caller's
+    // success-recording catch). Reset before any download/staging work.
+    await ctx.onSourceAccessSuccess();
+  }
   if (!messageIds.length) {
     throw new Error('google_history_no_messages');
   }
 
   const inboxIds: string[] = [];
+  let explicitSourceProven = explicitMessageIds.length === 0;
   for (const messageId of messageIds) {
     const rawMime = await adapter.downloadMessageSource(messageId);
+    if (!explicitSourceProven) {
+      // Pointer carried explicit discovered ids (no listing ran): the first
+      // successful download proves credential health. Reset immediately;
+      // remaining downloads + all staging work are downstream of the access.
+      explicitSourceProven = true;
+      await ctx.onSourceAccessSuccess();
+    }
     const emailData: any = {
       id: messageId,
       provider: 'google',
@@ -314,8 +394,18 @@ async function stageGoogleSources(db: any, ingress: InboundIngressRecord): Promi
   // durable: only after all inbox rows are inserted do we move the history
   // cursor to the notification's historyId. If any message failed to stage,
   // the caller marks the ingress retryable and this update is skipped.
+  // Monotonic (numeric GREATEST): a replayed/stale pointer must never regress
+  // the cursor below the persisted watch cursor — mirroring the Microsoft
+  // reconcile cursor's GREATEST advance.
   const cursorHistoryId = String(ingress.provider_pointer?.historyId ?? googleConfig.history_id ?? startHistoryId);
-  if (cursorHistoryId) {
+  const currentHistoryIdNum = Number(googleConfig.history_id);
+  const cursorHistoryIdNum = Number(cursorHistoryId);
+  const cursorAdvances =
+    !googleConfig.history_id ||
+    (Number.isFinite(cursorHistoryIdNum) &&
+      Number.isFinite(currentHistoryIdNum) &&
+      cursorHistoryIdNum > currentHistoryIdNum);
+  if (cursorHistoryId && cursorAdvances) {
     const { tenantDb } = await import('@alga-psa/db');
     await tenantDb(db, ingress.tenant).table('google_email_provider_config')
       .where({ email_provider_id: ingress.provider_id })

--- a/shared/services/email/inboundEmailIngressStagingWorker.ts
+++ b/shared/services/email/inboundEmailIngressStagingWorker.ts
@@ -394,21 +394,24 @@ async function stageGoogleSources(db: any, ingress: InboundIngressRecord, ctx: S
   // durable: only after all inbox rows are inserted do we move the history
   // cursor to the notification's historyId. If any message failed to stage,
   // the caller marks the ingress retryable and this update is skipped.
-  // Monotonic (numeric GREATEST): a replayed/stale pointer must never regress
-  // the cursor below the persisted watch cursor — mirroring the Microsoft
-  // reconcile cursor's GREATEST advance.
+  // Monotonic AT THE DATABASE WRITE ITSELF: the conditional UPDATE compares
+  // against the CURRENT row, not the googleConfig snapshot read at the start
+  // of staging, so no application-level read-compare-write window exists —
+  // a slower concurrent worker holding an older historyId can never overwrite
+  // a newer cursor another worker already persisted. history_id is a varchar
+  // column holding Gmail's numeric historyId strings, so the comparison casts
+  // both sides to bigint; a NULL (never-set) baseline always accepts the
+  // write, and a non-numeric legacy value is left untouched (the candidate
+  // must itself be numeric for the write to run at all).
   const cursorHistoryId = String(ingress.provider_pointer?.historyId ?? googleConfig.history_id ?? startHistoryId);
-  const currentHistoryIdNum = Number(googleConfig.history_id);
-  const cursorHistoryIdNum = Number(cursorHistoryId);
-  const cursorAdvances =
-    !googleConfig.history_id ||
-    (Number.isFinite(cursorHistoryIdNum) &&
-      Number.isFinite(currentHistoryIdNum) &&
-      cursorHistoryIdNum > currentHistoryIdNum);
-  if (cursorHistoryId && cursorAdvances) {
+  if (cursorHistoryId && /^\d+$/.test(cursorHistoryId)) {
     const { tenantDb } = await import('@alga-psa/db');
     await tenantDb(db, ingress.tenant).table('google_email_provider_config')
       .where({ email_provider_id: ingress.provider_id })
+      .whereRaw(
+        '(history_id IS NULL OR (history_id ~ ? AND history_id::bigint < ?::bigint))',
+        ['^[0-9]+$', cursorHistoryId]
+      )
       .update({
         history_id: cursorHistoryId,
         updated_at: db.fn.now(),

--- a/shared/services/email/inboundEmailIngressStagingWorker.ts
+++ b/shared/services/email/inboundEmailIngressStagingWorker.ts
@@ -32,6 +32,10 @@ import { maybeExtractRawMimeFromEmailData } from './inboundEmailArtifactHelpers'
 import { buildIngressKey } from './inboundEmailIdentity';
 import { enqueueInboundEmailDurableJob } from './unifiedInboundEmailQueueV2';
 import { GmailAdapter } from './providers/GmailAdapter';
+import {
+  recordInboundSourceAccessSuccess,
+  recordInboundSourceAuthFailure,
+} from './inboundEmailAuthOutcomeRecorder';
 
 const TERMINAL_INGRESS_STATUSES = new Set(['staged', 'terminal_failed']);
 
@@ -104,7 +108,42 @@ export async function processIngressStageJob(
   const version = Number(ingress.lease_version);
 
   try {
-    const stagedInboxes = await stageIngressSources(db, ingress);
+    let stagedInboxes: string[];
+    try {
+      stagedInboxes = await stageIngressSources(db, ingress);
+    } catch (error) {
+      // Source-access auth accounting with the same semantics as the V1
+      // processor boundary: only strictly classified terminal credential
+      // failures count (the classifier never matches staging/storage errors),
+      // a Google history notification with no messages is a successful empty
+      // fetch, and the original error still propagates so the ingress
+      // retry/terminal policy above stays authoritative.
+      if ((error as any)?.message === 'google_history_no_messages') {
+        await recordInboundSourceAccessSuccess({
+          tenant: ingress.tenant,
+          providerId: ingress.provider_id,
+          source: 'v2-ingress-staging',
+        });
+      } else {
+        await recordInboundSourceAuthFailure({
+          tenant: ingress.tenant,
+          providerId: ingress.provider_id,
+          providerType: ingress.provider_type,
+          error,
+          source: 'v2-ingress-staging',
+        });
+      }
+      throw error;
+    }
+
+    // Any successful source access — including an empty fetch — resets the
+    // consecutive auth-failure counter before downstream inbox processing.
+    await recordInboundSourceAccessSuccess({
+      tenant: ingress.tenant,
+      providerId: ingress.provider_id,
+      source: 'v2-ingress-staging',
+    });
+
     const written = await transitionIngress(db, {
       tenant: ingress.tenant,
       ingress_id: ingress.ingress_id,

--- a/shared/services/email/inboundEmailProducer.ts
+++ b/shared/services/email/inboundEmailProducer.ts
@@ -10,7 +10,7 @@
 
 import { getInboundDurableMode } from './inboundEmailDurableStore';
 import { enqueueInboundEmailDurableJob } from './unifiedInboundEmailQueueV2';
-import { upsertIngress } from './inboundEmailDurableStore';
+import { reviveTerminalIngress, upsertIngress } from './inboundEmailDurableStore';
 import { buildIngressKey } from './inboundEmailIdentity';
 import { stageIngressFromReadySource } from './inboundEmailIngressStagingWorker';
 
@@ -49,6 +49,14 @@ export async function persistIngressPointer(params: {
   providerId: string;
   providerType: InboundProviderPointer['providerType'];
   pointer: InboundProviderPointer;
+  /**
+   * Auth-pause recovery only: when the deterministic ingress key already has a
+   * `terminal_failed` row (e.g. attempts burned against the dead credential),
+   * revive it to `received` with a fresh attempt budget so the explicit
+   * re-hand-off actually results in processing. A terminal row is not a
+   * durable hand-off.
+   */
+  reviveTerminal?: boolean;
 }): Promise<PersistIngressResult> {
   const mode = getInboundDurableMode();
   if (mode === 'off') {
@@ -90,6 +98,10 @@ export async function persistIngressPointer(params: {
       uid: params.pointer.uid ?? null,
     },
   });
+
+  if (params.reviveTerminal && ingress.status === 'terminal_failed') {
+    await reviveTerminalIngress(db, params.tenant, ingress.ingress_id);
+  }
 
   try {
     await enqueueInboundEmailDurableJob({

--- a/shared/services/email/inboundEmailRecovery.ts
+++ b/shared/services/email/inboundEmailRecovery.ts
@@ -55,11 +55,29 @@ export interface RecoverySweepResult {
 
 export async function sweepTenantDurableWork(tenant: string, limit: number = 10): Promise<RecoverySweepResult> {
   const db = await (await import('@alga-psa/db/admin')).getAdminConnection();
+  const { tenantDb } = await import('@alga-psa/db');
   const result: RecoverySweepResult = { enqueued: { ingress: 0, inbox: 0, artifact: 0, outbox: 0, deliveries: 0 } };
   const maxAttempts = getDurableMaxAttempts();
 
+  // Ingress staging requires live provider credentials. While a provider is
+  // ingestion-paused (auth_failure or manual), its ingress rows are left
+  // untouched: no wake-up (which would burn attempts against the dead
+  // credential) and no over-cap dead-letter (attempts accrued during the pause
+  // must not terminalize a paused-interval message). Once the pause clears,
+  // the next sweep re-drives every still-non-terminal row. Inbox/artifact/
+  // outbox rows process staged sources only — no credential access — and stay
+  // eligible during a pause.
+  const pausedProviderIds = new Set<string>(
+    ((await tenantDb(db, tenant).table('email_providers')
+      .whereNotNull('inbound_paused_at')
+      .select('id')) as Array<{ id: string }>).map((row) => row.id)
+  );
+
   const ingressRows = await findDueIngress(db, { tenant, limit });
   for (const row of ingressRows) {
+    if (pausedProviderIds.has(row.provider_id)) {
+      continue;
+    }
     // Exhausted retryable rows dead-letter into a queryable terminal state
     // instead of being re-woken forever.
     if (row.status === 'retryable_failed' && row.attempt_count >= maxAttempts) {

--- a/shared/services/email/inboundEmailRecovery.ts
+++ b/shared/services/email/inboundEmailRecovery.ts
@@ -63,25 +63,43 @@ export async function sweepTenantDurableWork(tenant: string, limit: number = 10)
   // ingestion-paused (auth_failure or manual), its ingress rows are left
   // untouched: no wake-up (which would burn attempts against the dead
   // credential) and no over-cap dead-letter (attempts accrued during the pause
-  // must not terminalize a paused-interval message). Once the pause clears,
-  // the next sweep re-drives every still-non-terminal row. Inbox/artifact/
-  // outbox rows process staged sources only — no credential access — and stay
-  // eligible during a pause.
+  // must not terminalize a paused-interval message). The paused ids are passed
+  // INTO the capped due-row query so paused rows never consume cap slots that
+  // belong to unpaused providers' due work; a provider that pauses AFTER the
+  // snapshot is still safe because the dead-letter decision re-checks the
+  // pause state at the write itself (see deadletterIngress). Once the pause
+  // clears, the next sweep re-drives every still-non-terminal row.
+  // Inbox/artifact/outbox rows process staged sources only — no credential
+  // access — and stay eligible during a pause.
   const pausedProviderIds = new Set<string>(
     ((await tenantDb(db, tenant).table('email_providers')
       .whereNotNull('inbound_paused_at')
       .select('id')) as Array<{ id: string }>).map((row) => row.id)
   );
 
-  const ingressRows = await findDueIngress(db, { tenant, limit });
+  const ingressRows = await findDueIngress(db, {
+    tenant,
+    limit,
+    excludeProviderIds: [...pausedProviderIds],
+  });
   for (const row of ingressRows) {
     if (pausedProviderIds.has(row.provider_id)) {
       continue;
     }
     // Exhausted retryable rows dead-letter into a queryable terminal state
-    // instead of being re-woken forever.
+    // instead of being re-woken forever. The terminal write is pause-guarded
+    // at the SQL level: a provider paused between the snapshot above and this
+    // decision has its row PARKED (retryable, attempt budget voided), never
+    // terminalized.
     if (row.status === 'retryable_failed' && row.attempt_count >= maxAttempts) {
-      await deadletterIngress(db, row);
+      const outcome = await deadletterIngress(db, row);
+      if (outcome === 'parked_while_paused') {
+        console.info('[InboundEmailRecovery] over-cap ingress parked: provider paused at dead-letter decision', {
+          event: 'inbound_email_recovery_ingress_parked_while_paused',
+          tenantId: tenant,
+          ingressId: row.ingress_id,
+        });
+      }
       continue;
     }
     try {

--- a/shared/services/email/providers/GmailAdapter.ts
+++ b/shared/services/email/providers/GmailAdapter.ts
@@ -314,7 +314,19 @@ This indicates a problem with the OAuth token saving process.`;
       
       this.config.provider_config.watch_expiration = expirationISO || undefined;
 
-      // Save updated history_id and watch_expiration to database
+      // Save updated history_id and watch_expiration to database.
+      // INTENTIONALLY AUTHORITATIVE (not monotonic): a freshly registered
+      // watch's historyId is Gmail's own authoritative snapshot of the current
+      // mailbox state at watch creation — the baseline every subsequent
+      // notification advances from — so it must replace any prior cursor,
+      // including the older one a watch re-establishment after historyId
+      // invalidation (attemptWatchRecovery) is recovering from. Guarding this
+      // write with a monotonic predicate would strand that dead cursor
+      // forever. The only possible regression is against a NEWER
+      // notification-derived cursor persisted concurrently after the watch
+      // call; replaying from the watch baseline is the safe direction (the
+      // durable inbox dedupe re-covers already-staged messages, and the next
+      // notification re-advances the cursor).
       try {
         const knex = await getAdminConnection();
         await tenantDb(knex, this.config.tenant).table('google_email_provider_config')

--- a/shared/services/email/providers/GmailAdapter.ts
+++ b/shared/services/email/providers/GmailAdapter.ts
@@ -497,9 +497,15 @@ This indicates a problem with the OAuth token saving process.`;
    * Fallback reconciliation path when the saved history cursor has been
    * invalidated (e.g. after a pause long enough for Gmail to expire it): a
    * mailbox query bounded by the pause timestamp instead of silently
-   * accepting a gap. Capped by `maxResults`.
+   * accepting a gap. Capped by `maxResults`, or fully paginated when
+   * `options.paginateAll` is set (auth-pause recovery must cover the whole
+   * paused interval, never a truncated prefix).
    */
-  async listMessageIdsSinceTime(since: Date, maxResults = 200): Promise<string[]> {
+  async listMessageIdsSinceTime(
+    since: Date,
+    maxResults = 200,
+    options?: { paginateAll?: boolean }
+  ): Promise<string[]> {
     await this.ensureValidToken();
     const ids: string[] = [];
     let pageToken: string | undefined;
@@ -508,7 +514,7 @@ This indicates a problem with the OAuth token saving process.`;
       const response: any = await this.gmail.users.messages.list({
         userId: 'me',
         q: `after:${Math.floor(since.getTime() / 1000)}`,
-        maxResults: Math.min(100, Math.max(1, maxResults - ids.length)),
+        maxResults: options?.paginateAll ? 500 : Math.min(100, Math.max(1, maxResults - ids.length)),
         pageToken,
       });
       for (const message of response?.data?.messages || []) {
@@ -517,7 +523,7 @@ This indicates a problem with the OAuth token saving process.`;
         }
       }
       pageToken = response?.data?.nextPageToken || undefined;
-    } while (pageToken && ids.length < maxResults);
+    } while (pageToken && (options?.paginateAll || ids.length < maxResults));
 
     // users.messages.list returns newest-first; reconcile oldest-first.
     return ids.reverse();

--- a/shared/services/email/providers/GmailAdapter.ts
+++ b/shared/services/email/providers/GmailAdapter.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
-import { BaseEmailAdapter } from './base/BaseEmailAdapter';
+import { BaseEmailAdapter, type AdapterConnectionTestResult } from './base/BaseEmailAdapter';
 import { EmailMessageDetails, EmailProviderConfig } from '../../../interfaces/inbound-email.interfaces';
 import { getSecretProviderInstance } from '@alga-psa/core/secrets';
 import { google } from 'googleapis';
@@ -182,7 +182,19 @@ export class GmailAdapter extends BaseEmailAdapter {
   async connect(): Promise<void> {
     try {
       await this.loadCredentials();
-      await this.testConnection();
+      const connection = await this.testConnection();
+      if (!connection.success) {
+        // Preserve structured failure metadata (status, code, responseBody)
+        // so callers can classify terminal OAuth errors instead of parsing
+        // the human-readable message.
+        const failure = new Error(connection.error || 'Gmail connection test failed');
+        Object.assign(failure, {
+          status: (connection as any).status,
+          code: (connection as any).code,
+          responseBody: (connection as any).responseBody,
+        });
+        throw failure;
+      }
       this.log('info', 'Connected to Gmail API successfully');
     } catch (error) {
       throw this.handleError(error, 'connect');
@@ -479,8 +491,39 @@ This indicates a problem with the OAuth token saving process.`;
     }
   }
 
-  private isHistoryIdNotFoundError(error: any): boolean {
-    if (!error) return false;
+  /**
+   * List Gmail message ids received after a point in time, oldest first.
+   *
+   * Fallback reconciliation path when the saved history cursor has been
+   * invalidated (e.g. after a pause long enough for Gmail to expire it): a
+   * mailbox query bounded by the pause timestamp instead of silently
+   * accepting a gap. Capped by `maxResults`.
+   */
+  async listMessageIdsSinceTime(since: Date, maxResults = 200): Promise<string[]> {
+    await this.ensureValidToken();
+    const ids: string[] = [];
+    let pageToken: string | undefined;
+
+    do {
+      const response: any = await this.gmail.users.messages.list({
+        userId: 'me',
+        q: `after:${Math.floor(since.getTime() / 1000)}`,
+        maxResults: Math.min(100, Math.max(1, maxResults - ids.length)),
+        pageToken,
+      });
+      for (const message of response?.data?.messages || []) {
+        if (message?.id && !ids.includes(message.id)) {
+          ids.push(String(message.id));
+        }
+      }
+      pageToken = response?.data?.nextPageToken || undefined;
+    } while (pageToken && ids.length < maxResults);
+
+    // users.messages.list returns newest-first; reconcile oldest-first.
+    return ids.reverse();
+  }
+
+  private isHistoryIdNotFoundError(error: any): boolean {    if (!error) return false;
     const status = error?.response?.status || error?.status;
     if (status !== 404) return false;
 
@@ -689,11 +732,11 @@ This indicates a problem with the OAuth token saving process.`;
   /**
    * Test the connection to Gmail API
    */
-  async testConnection(): Promise<{ success: boolean; error?: string; }> {
+  async testConnection(): Promise<AdapterConnectionTestResult> {
     try {
       // Try to get the user's profile
       const profile = await this.gmail.users.getProfile({ userId: 'me' });
-      
+
       if (profile.data.emailAddress !== this.config.mailbox) {
         return {
           success: false,
@@ -703,9 +746,15 @@ This indicates a problem with the OAuth token saving process.`;
 
       return { success: true };
     } catch (error: any) {
+      // Preserve structured failure metadata (status, code, responseBody) so
+      // callers can classify terminal OAuth errors instead of parsing the
+      // human-readable message.
       return {
         success: false,
-        error: error.message || 'Failed to connect to Gmail API'
+        error: error.message || 'Failed to connect to Gmail API',
+        status: error?.response?.status ?? error?.status,
+        code: error?.response?.data?.error?.code ?? error?.code,
+        responseBody: error?.response?.data ?? error?.responseBody,
       };
     }
   }

--- a/shared/services/email/providers/MicrosoftGraphAdapter.ts
+++ b/shared/services/email/providers/MicrosoftGraphAdapter.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance, AxiosResponse } from 'axios';
 import { randomUUID } from 'crypto';
-import { BaseEmailAdapter } from './base/BaseEmailAdapter';
+import { BaseEmailAdapter, type AdapterConnectionTestResult } from './base/BaseEmailAdapter';
 import { EmailMessageDetails, EmailProviderConfig } from '../../../interfaces/inbound-email.interfaces';
 import type {
   Microsoft365DiagnosticsOptions,
@@ -454,7 +454,16 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
       await this.loadAuthenticatedUserEmail();
       const connection = await this.testConnection();
       if (!connection.success) {
-        throw new Error(connection.error || 'Microsoft Graph connection test failed');
+        // Preserve structured failure metadata (status, code, responseBody)
+        // so callers can classify terminal OAuth errors instead of parsing
+        // the human-readable message.
+        const failure = new Error(connection.error || 'Microsoft Graph connection test failed');
+        Object.assign(failure, {
+          status: (connection as any).status,
+          code: (connection as any).code,
+          responseBody: (connection as any).responseBody,
+        });
+        throw failure;
       }
       this.log('info', 'Connected to Microsoft Graph API successfully');
     } catch (error) {
@@ -876,7 +885,7 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
   /**
    * Test the connection to Microsoft Graph
    */
-  async testConnection(): Promise<{ success: boolean; error?: string }> {
+  async testConnection(): Promise<AdapterConnectionTestResult> {
     try {
       const mailboxBase = this.getMailboxBasePath();
       // Test mail-data access rather than reading the mailbox's user object:
@@ -901,6 +910,9 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
         error: detail
           ? `${failure.message} (${detail})`
           : failure.message || 'Connection test failed',
+        status: failure.status,
+        code: failure.code,
+        responseBody: failure.responseBody,
       };
     }
   }
@@ -940,8 +952,11 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
     responseBody?: unknown;
   } {
     const res = error?.response;
-    const status = res?.status;
-    const graphErr = res?.data?.error || res?.data;
+    // Already-sanitized errors (e.g. from token refresh inside the request
+    // interceptor) carry status/code/responseBody at the top level.
+    const status = res?.status ?? error?.status;
+    const body = res?.data ?? error?.responseBody;
+    const graphErr = body?.error || body;
     const message =
       graphErr?.message ||
       error?.message ||
@@ -954,7 +969,7 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
       message,
       requestId: ids.requestId,
       clientRequestId: ids.clientRequestId,
-      responseBody: res?.data,
+      responseBody: body,
     };
   }
 
@@ -971,6 +986,7 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
       status: failure.status,
       code: failure.code,
       requestId: failure.requestId,
+      responseBody: failure.responseBody,
     });
     return wrapped;
   }

--- a/shared/services/email/providers/base/BaseEmailAdapter.ts
+++ b/shared/services/email/providers/base/BaseEmailAdapter.ts
@@ -2,6 +2,18 @@ import { EmailProviderAdapter } from '../../../../interfaces/emailProvider.inter
 import { EmailProviderConfig, EmailMessageDetails } from '../../../../interfaces/inbound-email.interfaces';
 
 /**
+ * Connection-test outcome with structured failure metadata so callers can
+ * classify terminal OAuth errors without parsing the human-readable message.
+ */
+export interface AdapterConnectionTestResult {
+  success: boolean;
+  error?: string;
+  status?: number;
+  code?: string;
+  responseBody?: unknown;
+}
+
+/**
  * Base abstract class for email provider adapters
  * Provides common functionality and enforces interface implementation
  */
@@ -91,12 +103,16 @@ export abstract class BaseEmailAdapter implements EmailProviderAdapter {
     const errorMessage = `Error in ${context}: ${error.message || error}${details}`;
     this.log('error', errorMessage, error);
     const wrapped = new Error(errorMessage);
-    // Propagate metadata for outer catch blocks
+    // Propagate metadata for outer catch blocks. Already-sanitized errors
+    // (thrown by token refresh paths) carry status/code/responseBody at the
+    // top level and no axios `response`; keep those instead of stripping them.
     try {
-      (wrapped as any).status = res?.status;
-      (wrapped as any).code = (res?.data?.error?.code || res?.status) ?? undefined;
-      (wrapped as any).requestId = res?.headers?.['request-id'] || res?.headers?.['client-request-id'];
-      (wrapped as any).responseBody = res?.data;
+      (wrapped as any).status = res?.status ?? error?.status;
+      (wrapped as any).code = (res?.data?.error?.code || res?.status || error?.code) ?? undefined;
+      (wrapped as any).requestId = res?.headers?.['request-id']
+        || res?.headers?.['client-request-id']
+        || error?.requestId;
+      (wrapped as any).responseBody = res?.data ?? error?.responseBody;
     } catch { /* no-op */ }
     return wrapped;
   }
@@ -109,6 +125,6 @@ export abstract class BaseEmailAdapter implements EmailProviderAdapter {
   abstract markMessageProcessed(messageId: string): Promise<void>;
   abstract getMessageDetails(messageId: string): Promise<EmailMessageDetails>;
   abstract downloadMessageSource(messageId: string): Promise<Buffer>;
-  abstract testConnection(): Promise<{ success: boolean; error?: string; }>;
+  abstract testConnection(): Promise<AdapterConnectionTestResult>;
   abstract disconnect(): Promise<void>;
 }

--- a/shared/services/email/unifiedInboundEmailQueueJobProcessor.ts
+++ b/shared/services/email/unifiedInboundEmailQueueJobProcessor.ts
@@ -691,8 +691,19 @@ async function persistGoogleHistoryCursor(job: UnifiedInboundEmailQueueJob): Pro
   if (!historyId) return;
 
   const db = await getAdminConnection();
+  // Monotonic AT THE DATABASE WRITE ITSELF (compare-and-set): the predicate
+  // compares against the CURRENT row, so a slower job holding an older
+  // pointer historyId can never overwrite a newer cursor another worker
+  // already persisted — there is no application-level read-compare-write
+  // window. history_id is a varchar column of Gmail numeric historyId
+  // strings, so both sides cast to bigint; a NULL baseline always accepts,
+  // and a non-numeric legacy value is left untouched.
   await tenantDb(db, job.tenantId).table('google_email_provider_config')
     .where({ email_provider_id: job.providerId })
+    .whereRaw(
+      '(history_id IS NULL OR (history_id ~ ? AND history_id::bigint < ?::bigint))',
+      ['^[0-9]+$', historyId]
+    )
     .update({
       history_id: historyId,
       updated_at: db.fn.now(),

--- a/shared/services/email/unifiedInboundEmailQueueJobProcessor.ts
+++ b/shared/services/email/unifiedInboundEmailQueueJobProcessor.ts
@@ -2,7 +2,6 @@ import { ImapFlow } from 'imapflow';
 import { simpleParser } from 'mailparser';
 import { tenantDb } from '@alga-psa/db';
 import { getAdminConnection } from '@alga-psa/db/admin';
-import axios from 'axios';
 import type {
   EmailMessageDetails,
   EmailProviderConfig,
@@ -18,6 +17,9 @@ import { GmailAdapter } from '@alga-psa/shared/services/email/providers/GmailAda
 import { getSecretProviderInstance } from '@alga-psa/core/secrets';
 import { resolveListRewriteSender } from '@alga-psa/shared/lib/email/listRewriteSender';
 import { extractRelevantInboundHeaders } from '@alga-psa/shared/lib/email/automatedMessage';
+import { classifyInboundAuthFailure } from '@alga-psa/shared/services/email/InboundEmailAuthFailurePolicy';
+import { EmailProviderLifecycleService } from '@alga-psa/shared/services/email/EmailProviderLifecycleService';
+import { refreshImapAccessToken } from '@alga-psa/shared/services/email/imapOauthToken';
 
 export class SourceMessageUnavailableError extends Error {
   public readonly reason: string;
@@ -185,87 +187,6 @@ function isImapAuthenticationError(error: any): boolean {
   }
 
   return false;
-}
-
-async function getImapOauthSecrets(provider: {
-  id: string;
-  tenant: string;
-}): Promise<{ clientSecret: string | null; refreshToken: string | null }> {
-  const secretProvider = await getSecretProviderInstance();
-  const clientSecret =
-    (await secretProvider.getTenantSecret(provider.tenant, `imap_oauth_client_secret_${provider.id}`)) ?? null;
-  const refreshToken =
-    (await secretProvider.getTenantSecret(provider.tenant, `imap_refresh_token_${provider.id}`)) ?? null;
-  return { clientSecret, refreshToken };
-}
-
-async function refreshImapAccessToken(params: {
-  provider: {
-    id: string;
-    tenant: string;
-    oauth_token_url?: string | null;
-    oauth_client_id?: string | null;
-    oauth_client_secret?: string | null;
-    refresh_token?: string | null;
-    access_token?: string | null;
-    token_expires_at?: string | null;
-  };
-  db: Awaited<ReturnType<typeof getAdminConnection>>;
-}): Promise<string> {
-  const { provider, db } = params;
-  if (!provider.oauth_token_url || !provider.oauth_client_id) {
-    throw new Error('IMAP OAuth token URL or client ID missing');
-  }
-
-  const { clientSecret, refreshToken } = await getImapOauthSecrets({
-    id: provider.id,
-    tenant: provider.tenant,
-  });
-  const effectiveRefreshToken = refreshToken || provider.refresh_token;
-  const effectiveClientSecret = clientSecret || provider.oauth_client_secret;
-  if (!effectiveRefreshToken) {
-    throw new Error('IMAP OAuth refresh token missing');
-  }
-
-  const paramsBody = new URLSearchParams();
-  paramsBody.append('grant_type', 'refresh_token');
-  paramsBody.append('refresh_token', effectiveRefreshToken);
-  paramsBody.append('client_id', provider.oauth_client_id);
-  if (effectiveClientSecret) {
-    paramsBody.append('client_secret', effectiveClientSecret);
-  }
-
-  const response = await axios.post(provider.oauth_token_url, paramsBody, {
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-  });
-  const accessToken = asNonEmptyString(response?.data?.access_token);
-  if (!accessToken) {
-    throw new Error('IMAP OAuth refresh returned no access token');
-  }
-
-  const expiresInSeconds = Number(response?.data?.expires_in || 3600);
-  const expiresAt = new Date(
-    Date.now() + (Number.isFinite(expiresInSeconds) ? expiresInSeconds : 3600) * 1000
-  ).toISOString();
-
-  await tenantDb(db, provider.tenant).table('imap_email_provider_config')
-    .where({ email_provider_id: provider.id })
-    .update({
-      access_token: accessToken,
-      token_expires_at: expiresAt,
-      updated_at: db.fn.now(),
-    });
-
-  provider.access_token = accessToken;
-  provider.token_expires_at = expiresAt;
-  console.info('[UnifiedInboundEmailQueueJobProcessor] refreshed IMAP OAuth access token', {
-    event: 'imap_oauth_refresh',
-    tenantId: provider.tenant,
-    providerId: provider.id,
-    expiresAt,
-  });
-
-  return accessToken;
 }
 
 export async function fetchMicrosoftProviderConfig(job: UnifiedInboundEmailQueueJob): Promise<EmailProviderConfig> {
@@ -972,7 +893,59 @@ export async function processUnifiedInboundEmailQueueJob(
         reason: `source_unavailable:${error.reason}`,
       };
     }
+
+    // Only strictly classified terminal credential failures advance the
+    // consecutive auth-failure counter; everything else (throttling, server
+    // errors, timeouts, transport failures, downstream processing) does not.
+    // The original error still propagates: the existing queue retry policy
+    // stays authoritative, and once the threshold trips, the pause gate above
+    // stops the next attempt.
+    const classification = classifyInboundAuthFailure({
+      providerType: job.provider,
+      error,
+    });
+    if (classification.kind === 'unrecoverable_auth') {
+      try {
+        const outcome = await new EmailProviderLifecycleService().recordUnrecoverableAuthFailure(
+          job.providerId,
+          job.tenantId,
+          classification.code
+        );
+        if (outcome.autoPaused) {
+          console.info('[UnifiedInboundEmailQueueJobProcessor] provider auto-paused after repeated auth failures', {
+            event: 'inbound_email_provider_auto_paused',
+            tenantId: job.tenantId,
+            providerId: job.providerId,
+            provider: job.provider,
+            authFailureCode: classification.code,
+            count: outcome.count,
+          });
+        }
+      } catch (recordError) {
+        console.warn('[UnifiedInboundEmailQueueJobProcessor] failed to record auth failure', {
+          event: 'inbound_email_auth_failure_record_failed',
+          tenantId: job.tenantId,
+          providerId: job.providerId,
+          authFailureCode: classification.code,
+          error: recordError instanceof Error ? recordError.message : String(recordError),
+        });
+      }
+    }
     throw error;
+  }
+
+  // Any successful source access — including an empty fetch — resets the
+  // consecutive auth-failure counter before downstream ticket processing,
+  // so application failures never inflate the credential-failure count.
+  try {
+    await new EmailProviderLifecycleService().recordSourceAccessSuccess(job.providerId, job.tenantId);
+  } catch (resetError) {
+    console.warn('[UnifiedInboundEmailQueueJobProcessor] failed to reset auth-failure counter', {
+      event: 'inbound_email_auth_failure_reset_failed',
+      tenantId: job.tenantId,
+      providerId: job.providerId,
+      error: resetError instanceof Error ? resetError.message : String(resetError),
+    });
   }
 
   if (payloads.length === 0) {


### PR DESCRIPTION
## Auto-pause inbound email providers on repeated auth failures

When an inbound email provider's credentials become permanently invalid — a Microsoft rotated/expired client secret (`invalid_client` 401), a revoked MS grant (`AADSTS50173`), a Google `invalid_grant`, or an IMAP authentication rejection — the mailbox silently goes dark: the Graph subscription / Gmail watch lapses, alerts stop, and nobody notices. This change adds an **automatic trigger** on top of the existing pause machinery (`email_providers.inbound_paused_at` / `inbound_pause_reason`, `EmailProviderLifecycleService.pause/resumeProvider`) so the system detects the failure class, pauses the provider, tells the tenant admins, and backfills the missed window on reconnect.

### What it does

- **Classify, don't count blindly.** `shared/services/email/InboundEmailAuthFailurePolicy.ts` classifies failures strictly from structured adapter error metadata (status/response body, IMAP auth-rejection flags, the single allowlisted `AADSTS50173` token). Only *unrecoverable* auth failures advance the counter. Transient failures — 429, 5xx, timeouts, DNS/socket errors, 403/404, webhook-validation and MIME-parse errors, and any downstream ticket-processing exception — **never** pause a provider.
- **Count at the source-fetch boundary.** Consecutive terminal auth failures are recorded at the unified provider source-fetch boundary (`inboundEmailAuthOutcomeRecorder.ts`, wired through `unifiedInboundEmailQueueJobProcessor.ts`, the V2 ingress staging worker, and the adapters). Three consecutive classified failures auto-pause; **any** successful source access — including an empty fetch — resets the counter to 0. The V2 staging path resets the counter immediately after a successful fetch, before object upload / inbox insert, so a downstream staging failure can never strand a stale count.
- **Atomic, idempotent pause.** The transition sets `inbound_pause_reason = auth_failure`, tears down the delivery subscription exactly once, and dispatches exactly one in-app notification per active tenant admin. Manual pause semantics are unchanged. New tracking columns (`inbound_auth_failure_count/_last_at/_code`) and a widened `email_providers_inbound_pause_reason_check` CHECK ship in migration `20260815120000` (additive ALTERs, Citus-safe).
- **Notifications that survive process topology.** `shared/` can't import `@alga-psa/notifications` (package cycle) and the queue processor / temporal worker runtimes don't call server `initializeApp`, so admin notifications go over an event (`INBOUND_EMAIL_PROVIDER_AUTO_PAUSED`) published by `inboundAuthPauseEventNotifier.ts` and delivered by the server-side `inboundAuthPauseNotificationSubscriber` / `inboundAuthPauseNotificationService`, with the standalone consumer registering the direct implementation.
- **Reconnect, not bare Resume.** An auth-failure pause has no plain Resume: the settings card carries a **persistent reconnect banner** (`EmailProviderCard.tsx`) explaining the mailbox is disconnected and that mail is retained and will be backfilled. Recovery (`recoverAuthPausedProvider` in `EmailProviderLifecycleService.ts`) validates the corrected credential, re-establishes delivery, clears the pause/counter, and **durably reconciles the pause window** via `EmailWebhookMaintenanceService.reconcileMissedMessages` before reporting success. Google recovery snapshots `history_id` *before* watch registration so the paused interval isn't dropped; MS/Google recovery counts coverage only from monotonic markers so multi-pass recovery terminates.
- **Durable-V2 survival.** Ingress staging is pause-gated pre-claim; a failure racing the pause parks the ingress row non-terminal (`retryable_failed`, backoff) instead of terminalizing it, and sweeps / over-cap dead-letter skip paused providers, so the first post-resume sweep re-drives parked work.
- **Reconnect UI correctness (mitigation round).** `skipAutomation` keeps its original meaning — skip *transport* automation (Gmail Pub/Sub, MS webhook init) — but no longer gates auth-pause lifecycle recovery: the IMAP and Microsoft `recoverAuthPausedProvider` branches run on **every** credential-bearing save while the provider is auth_failure-paused, and Microsoft only claims `credentialsValidated`/`deliveryEstablished` when webhook init actually ran (else recovery self-validates). `updateEmailProvider` re-reads the provider row after recovery so the returned state (pause fields, status, counters) reflects post-recovery reality, and `setupError` is honoured by the reconnect forms — the drawer stays open on failure and the paused-state banner persists. Gmail OAuth reconnect failures no longer masquerade as success: for an auth_failure-paused provider, both `configureGmailProvider` exits that skip watch registration now report `authFailureRecovery = failed`, and a Google fallback runs recovery whenever automation did not run; both Gmail form copies return on `setupError` (drawer stays open). New locale key `forms.common.messages.setupIncomplete` across all 10 packs.

### Tests

New integration and unit coverage: policy classification, auto-pause threshold, migration CHECK, recovery/backfill, durable-inbox survival, notification subscriber/topology, and the queue-processor auth-failure path. Six focused regression tests cover the three concurrency defects fixed in the later commits (starvation, snapshot race, Google CAS cursor, MS lock-mismatch, lifecycle listing race, V1 cursor). The reconnect-save integration suite (8 tests) and Gmail form unit tests (both CE and EE copies) cover the `skipAutomation`/`setupError`/false-success fixes with pre-fix stash-proofs. See `docs/plans/auth-pause-review-guide.md` for the bounded review guide.

---

## Smoke test: **PASS — all ten flows, zero product defects**

Independent live smoke of auto-pause-on-auth-failure on the real stack (compose `alga-psa-local-test`, app on :3466 built from this worktree at HEAD `a17bdee9aa`, Postgres :6472, Redis :6380, repo GreenMail SMTP 3025/IMAP 3143, host-run `services/email-service` from worktree code). Evidence directory: `/tmp/alga-smoke-evidence/auto-pause-inbound-auth-20260816T194119Z`.

1. **BASELINE (regression guard):** healthy email → ticket in 18s — normal ingestion intact.
2. **TRANSIENT:** 11× ECONNREFUSED (dead port) → status=error but counter stayed 0, no pause, no notifications. Failure-class trigger confirmed.
3. **THREE-STRIKE AUTO-PAUSE:** overwrote the real IMAP secret file (credential-death simulation against real GreenMail LOGIN rejection) + restarted email-service → counter 1→2→3 at 2s/4s backoff, atomic pause landed at 19:56:12.263Z with `reason=auth_failure`, `code=imap:authentication_failed`, listener stopped (`listener_stop_inbound_paused`), and **ZERO** queue/webhook activity during the 5-min pause window — the local equivalent of the dead-letter alert stopping its flapping.
4. **NOTIFICATIONS:** exactly 4 in-app `internal_notifications`, one per active tenant admin (all 4 enumerated), naming provider + mailbox `imap_user@localhost`, "reconnection required", mail-not-lost wording, deep link to email settings. No extra notifications from transient or backfill phases (idempotent).
5. **BANNER:** `#provider-auth-failure-banner-<id>` renders persistently on `/msp/settings/email` with title/description/Reconnect action (screenshot).
6. **PAUSE GATE:** email delivered while paused created no ticket and no queue activity — mail waited in GreenMail.
7. **UI RECONNECT:** banner → Reconnect → drawer → correct password → save → drawer closed with no `setupError` (the `skipAutomation` bypass from the earlier round is fixed in the running build), banner gone, provider Connected; DB shows pause fields NULL, counter reset 0.
8. **BACKFILL:** pause-window message became ticket TIC001059 at 20:07:58Z via the guaranteed recovery resync — cursor reset to 0, whole 67-message fixture mailbox re-walked with message-id dedupe (0 new duplicate tickets; the one duplicate pair found dates from Aug 8, pre-existing). Honest caveat: backfill latency scales with **TOTAL mailbox size**, not pause-window size (~5 UIDs/10s throttle → ~7 min for the 67-msg fixture).
9. **STEADY STATE:** fresh post-reconnect email → ticket TIC001060 in 16s.
10. **Cross-cutting:** exactly one notification per admin; manual-pause semantics untouched.

**Fidelity compromises / disclosures:** (a) alga-dev browser panes still reject commands from `ts:robert-Desktop` ("belongs to a different host") even though `space-new-tab` succeeds — drove the real UI via local Playwright + system Chrome against the real app instead; (b) credential death was simulated by overwriting the real filesystem secret (`secrets/tenants/<tenant>/imap_password_<providerId>`) rather than rotating the password inside GreenMail — equivalent from the product's perspective since real LOGIN attempts really were rejected; (c) the "no bare Resume action for auth_failure pauses" dropdown guard was verified in code (`EmailProviderCard.tsx:263`) + unit test (`authFailure.test.tsx:120`) but not live-screenshotted (would have required a second full pause/reconnect cycle); (d) Microsoft/Google OAuth pause paths were not live-testable locally (no real IdP) — covered only by the branch's integration suites. No mocks were used anywhere in the live path.

**Operational notes:** a concurrent board-run agent (codex) was mid-smoke when the session started; waited for it to exit before running flows to avoid state corruption, and it had restored the fixture clean. The dev server rebooted twice during the session; every Next dev worker completing `initializeApp` rotates glinda's dev password mid-session — reset via the repo's script pattern and verified the hash round-trip before login. Environment left healthy: provider connected/unpaused/counter 0, secret file correct, git tree clean, email-service left running, full service logs preserved under `evidence/logs/`.
