### PR TITLE
docs: RMM scheduled device sync (2026-08-18)

### DIFF
--- a/docs/integrations/tactical-rmm.md
+++ b/docs/integrations/tactical-rmm.md
@@ -73,6 +73,32 @@ last-seen time and cached vitals such as current user, uptime, and LAN/WAN IP wh
 Tactical reports them. When an agent disappears from Tactical, AlgaPSA leaves its
 asset in place rather than deactivating it.
 
+## Scheduled device sync
+
+In addition to the manual **Sync Devices** button, AlgaPSA can keep device records
+current on a recurring schedule. Configure this in the **Device sync** section of
+the Tactical RMM integration panel:
+
+- **Enable scheduled sync** — toggle the recurring job on or off. The toggle
+  defaults to off; turn it on to start automatic sync.
+- **Interval** — how often (in minutes) AlgaPSA polls Tactical for device changes.
+  Set a value between 15 and 1440 minutes (one day). The default is 60 minutes;
+  use a lower interval for estates where endpoint churn is frequent and a higher
+  one for stable fleets where nightly sync is sufficient.
+
+Once enabled, AlgaPSA creates a recurring job keyed to this integration. The job
+runs at the configured cadence and updates asset records to match the current state
+in Tactical. The **Last synced** line under the toggle shows when the most recent
+scheduled run completed. If the last run encountered an error, the error message
+appears alongside it so you can investigate. A failed run does not disable the
+schedule — the job retries at the next interval.
+
+Disabling the toggle or deactivating the integration cancels the recurring job
+within a few minutes. Changing the interval recreates the job at the new cadence.
+
+The manual **Sync Devices** button continues to work independently of the schedule
+and always performs a full sync immediately.
+
 ## Receive alerts
 
 Tactical pushes alerts to AlgaPSA over a webhook. In the **Webhooks** section, copy


### PR DESCRIPTION
## Source PR

- [#3179 Rmm scheduled sync](https://github.com/Nine-Minds/alga-psa/pull/3179) — merged 2026-08-17

## Files edited

| File | Rationale |
|------|-----------|
| `docs/integrations/tactical-rmm.md` | Added "Scheduled device sync" section explaining the new per-integration recurring job: how to enable it, set the interval (15–1440 min, default 60), read the last-synced timestamp and error state, and how manual Sync Devices still works alongside it. The previous doc described device sync as manual-only. |

## What changed (source PR)

PR #3179 added automatic scheduled device sync for all supported RMM providers (NinjaOne, Level.io, TacticalRMM, Tanium). Before this PR, device sync in every provider required a human to click "Sync Devices". After this PR, operators can configure a recurring job per integration — with a toggle (off by default), an interval in minutes (15–1440, default 60), and real-time display of last-synced time and sync errors. Failed runs retry at the next interval rather than cancelling the schedule. Incremental sync (delta since last run) is used where the provider supports it.

## Needs human review

- **OpenAPI spec is stale.** The PR updated `sdk/docs/openapi/alga-openapi.{ce,ee,}.{json,yaml}` (the generated specs), which are in-scope but generated artifacts. Please regen via the repo's standard `openapi:generate` script and confirm the output is current. These files were not edited here.
- **`docs/api/api_overview.md` — new `/api/v1/integrations/rmm/**` API group not listed.** The PR added four new REST endpoints under `/api/v1/integrations/rmm/` with full OpenAPI documentation (`server/src/lib/api/openapi/routes/rmmIntegrations.ts`, +157 lines). Section 6 of `api_overview.md` lists available CE API groups; the RMM Integration API is not mentioned. A human familiar with the endpoint contracts should decide whether and how to describe it there.
- **No existing docs cover NinjaOne, Level.io, or Tanium scheduled sync in alga-psa.** The `/docs/integrations/` directory only has `tactical-rmm.md` for RMM providers; scheduled sync sections for other providers would require new files or additions verified against each provider's actual UI.

---
_Generated by [Claude Code](https://claude.ai/code/session_0182AWirRERbQwQbm3oGozAS)_