### PR TITLE
Seed tenant location from Stripe; hide placeholder address values

### DIFF
--- a/ee/temporal-workflows/src/activities/stripe-activities.ts
+++ b/ee/temporal-workflows/src/activities/stripe-activities.ts
@@ -47,6 +47,16 @@ export interface FetchStripeDetailsInput {
   checkoutSessionId: string;
 }
 
+export interface StripeBillingAddress {
+  line1?: string;
+  line2?: string;
+  city?: string;
+  state?: string;
+  postalCode?: string;
+  countryCode?: string; // ISO-3166 alpha-2
+  phone?: string;
+}
+
 export interface FetchStripeDetailsResult {
   stripeCustomerId: string;
   stripeSubscriptionId?: string;
@@ -55,6 +65,23 @@ export interface FetchStripeDetailsResult {
   stripeBaseItemId?: string;          // Base fee item (multi-item only)
   stripeBasePriceId?: string;         // Base fee price (multi-item only)
   licenseCount?: number;
+  billingAddress?: StripeBillingAddress;
+}
+
+function toBillingAddress(
+  address: Stripe.Address | null | undefined,
+  phone?: string | null
+): StripeBillingAddress | undefined {
+  const result: StripeBillingAddress = {
+    line1: address?.line1 ?? undefined,
+    line2: address?.line2 ?? undefined,
+    city: address?.city ?? undefined,
+    state: address?.state ?? undefined,
+    postalCode: address?.postal_code ?? undefined,
+    countryCode: address?.country ?? undefined,
+    phone: phone ?? undefined,
+  };
+  return Object.values(result).some(v => v) ? result : undefined;
 }
 
 /**
@@ -98,7 +125,27 @@ export async function fetchStripeDetailsFromCheckout(
 
     const result: FetchStripeDetailsResult = {
       stripeCustomerId: session.customer as string,
+      billingAddress: toBillingAddress(
+        session.customer_details?.address,
+        session.customer_details?.phone
+      ),
     };
+
+    // Checkout collected no address (e.g. trial without payment method) —
+    // fall back to the address stored on the Stripe customer, if any.
+    if (!result.billingAddress?.countryCode) {
+      try {
+        const customer = await stripe.customers.retrieve(result.stripeCustomerId);
+        if (!customer.deleted) {
+          result.billingAddress = toBillingAddress(customer.address, customer.phone) ?? result.billingAddress;
+        }
+      } catch (customerError) {
+        log.warn('Failed to fetch Stripe customer for billing address fallback', {
+          customerId: result.stripeCustomerId,
+          error: customerError instanceof Error ? customerError.message : 'Unknown error',
+        });
+      }
+    }
 
     // If this was a subscription checkout, fetch subscription details
     if (session.subscription) {

--- a/ee/temporal-workflows/src/db/tenant-operations.ts
+++ b/ee/temporal-workflows/src/db/tenant-operations.ts
@@ -334,8 +334,27 @@ export async function createTenantInDB(
         clientId = clientResult[0].client_id;
         log.info('Client created', { clientId, clientName, tenantId });
         
-        // Create default location for the MSP client with email from the tenant setup
-        // Insert minimal required fields to satisfy NOT NULL constraints
+        // Create default location for the MSP client with email from the tenant
+        // setup and the billing address captured from Stripe when available.
+        // Fields still unknown fall back to placeholders ('N/A'/'XX'/'Unknown')
+        // to satisfy NOT NULL constraints; the onboarding wizard lets the user
+        // correct them.
+        const billing = input.billingAddress;
+        let countryCode = 'XX';
+        let countryName = 'Unknown';
+        if (billing?.countryCode) {
+          const country = await tenantScopedDb.table('countries')
+            .where({ code: billing.countryCode.toUpperCase() })
+            .first('code', 'name');
+          if (country) {
+            countryCode = country.code;
+            countryName = country.name;
+          } else {
+            log.warn('Stripe billing country not found in countries table', {
+              countryCode: billing.countryCode,
+            });
+          }
+        }
         await tenantScopedDb.table('client_locations')
           .insert({
             location_id: knex.raw('gen_random_uuid()'),
@@ -343,17 +362,25 @@ export async function createTenantInDB(
             tenant: tenantId,
             location_name: 'Main Office',
             email: input.email.toLowerCase(), // default contact email (lowercased)
-            phone: '',
-            address_line1: 'N/A', // required, placeholder per migration convention
-            city: 'N/A', // required by schema
-            country_code: 'XX', // required by schema (ISO-3166 alpha-2)
-            country_name: 'Unknown', // required by schema
+            phone: billing?.phone || '',
+            address_line1: billing?.line1 || 'N/A',
+            address_line2: billing?.line2 || null,
+            city: billing?.city || 'N/A',
+            state_province: billing?.state || null,
+            postal_code: billing?.postalCode || null,
+            country_code: countryCode,
+            country_name: countryName,
             is_default: true,
             is_active: true,
             created_at: knex.fn.now(),
             updated_at: knex.fn.now()
           });
-        log.info('Default location created', { clientId, email: input.email });
+        log.info('Default location created', {
+          clientId,
+          email: input.email,
+          hasBillingAddress: !!billing,
+          countryCode,
+        });
         
         // Note: Not updating tenant with client_id as column doesn't exist in schema
       }

--- a/ee/temporal-workflows/src/types/workflow-types.ts
+++ b/ee/temporal-workflows/src/types/workflow-types.ts
@@ -3,6 +3,18 @@ export type ISO8601String = string;
 
 export type BillingSource = 'stripe' | 'apple_iap' | 'manual';
 
+// Billing address captured from Stripe (checkout session customer_details or
+// the customer record), used to seed the default client location.
+export interface TenantBillingAddress {
+  line1?: string;
+  line2?: string;
+  city?: string;
+  state?: string;
+  postalCode?: string;
+  countryCode?: string; // ISO-3166 alpha-2
+  phone?: string;
+}
+
 export interface AppleIapTenantInput {
   originalTransactionId: string;
   productId: string;
@@ -58,6 +70,10 @@ export interface TenantCreationInput {
   stripeBaseItemId?: string;        // Base fee subscription item ID (si_...) — multi-item only
   stripeBasePriceId?: string;       // Base fee price ID (price_...) — multi-item only
 
+  // Billing address for the default client location; normally fetched from the
+  // checkout session, but callers may pass it directly.
+  billingAddress?: TenantBillingAddress;
+
   // Add-ons purchased with this subscription
   addons?: string[];                // Add-on codes (e.g. ['ai-addon'])
 }
@@ -103,6 +119,9 @@ export interface CreateTenantActivityInput {
   stripePriceId?: string;           // Per-user price ID (price_...)
   stripeBaseItemId?: string;        // Base fee subscription item ID (si_...) — multi-item only
   stripeBasePriceId?: string;       // Base fee price ID (price_...) — multi-item only
+
+  // Billing address from Stripe used to seed the default client location.
+  billingAddress?: TenantBillingAddress;
 
   // Add-ons purchased with this subscription
   addons?: string[];                // Add-on codes (e.g. ['ai-addon'])

--- a/ee/temporal-workflows/src/workflows/shared/tenant-creation-steps.ts
+++ b/ee/temporal-workflows/src/workflows/shared/tenant-creation-steps.ts
@@ -18,6 +18,7 @@ import type {
   SendWelcomeEmailActivityResult,
   CreatePortalUserActivityInput,
   CreatePortalUserActivityResult,
+  TenantBillingAddress,
 } from '../../types/workflow-types.js';
 
 const activities = proxyActivities<{
@@ -47,6 +48,7 @@ const activities = proxyActivities<{
     stripePriceId?: string;
     stripeBaseItemId?: string;
     stripeBasePriceId?: string;
+    billingAddress?: TenantBillingAddress;
     addons?: string[];
   }): Promise<CreateTenantActivityResult>;
   createAdminUser(input: {
@@ -104,6 +106,7 @@ const activities = proxyActivities<{
     stripeBaseItemId?: string;
     stripeBasePriceId?: string;
     licenseCount?: number;
+    billingAddress?: TenantBillingAddress;
   }>;
 }>({
   startToCloseTimeout: '5m',
@@ -164,7 +167,16 @@ export async function runTenantCreationOrchestration(
     log.info('Starting tenant creation workflow', { input });
 
     // Step 0.5: Fetch Stripe details from checkout session if provided
-    let stripeDetails = {
+    let stripeDetails: {
+      stripeCustomerId?: string;
+      stripeSubscriptionId?: string;
+      stripeSubscriptionItemId?: string;
+      stripePriceId?: string;
+      stripeBaseItemId?: string;
+      stripeBasePriceId?: string;
+      licenseCount?: number;
+      billingAddress?: TenantBillingAddress;
+    } = {
       stripeCustomerId: input.stripeCustomerId,
       stripeSubscriptionId: input.stripeSubscriptionId,
       stripeSubscriptionItemId: input.stripeSubscriptionItemId,
@@ -172,6 +184,7 @@ export async function runTenantCreationOrchestration(
       stripeBaseItemId: input.stripeBaseItemId,
       stripeBasePriceId: input.stripeBasePriceId,
       licenseCount: input.licenseCount,
+      billingAddress: input.billingAddress,
     };
 
     if (input.checkoutSessionId && !input.stripeCustomerId) {
@@ -190,6 +203,7 @@ export async function runTenantCreationOrchestration(
         stripeDetails = {
           ...stripeDetails,
           ...fetchedStripeDetails,
+          billingAddress: fetchedStripeDetails.billingAddress ?? stripeDetails.billingAddress,
         };
 
         log.info('Stripe details fetched successfully', {
@@ -236,6 +250,7 @@ export async function runTenantCreationOrchestration(
       stripeSubscriptionId: stripeDetails.stripeSubscriptionId,
       stripeSubscriptionItemId: stripeDetails.stripeSubscriptionItemId,
       stripePriceId: stripeDetails.stripePriceId,
+      billingAddress: stripeDetails.billingAddress,
       stripeBaseItemId: stripeDetails.stripeBaseItemId,
       stripeBasePriceId: stripeDetails.stripeBasePriceId,
       addons: input.addons,

--- a/packages/assets/src/lib/formatClientLocation.ts
+++ b/packages/assets/src/lib/formatClientLocation.ts
@@ -1,3 +1,5 @@
+import { displayAddressField, displayCountry } from '@alga-psa/core';
+
 export interface ClientLocationLike {
     location_name?: string | null;
     address_line1?: string | null;
@@ -11,11 +13,11 @@ export interface ClientLocationLike {
 export function formatClientLocation(location: ClientLocationLike): string {
     return [
         location.location_name,
-        location.address_line1,
-        location.address_line2,
-        location.city,
-        location.state_province,
-        location.postal_code,
-        location.country_name,
+        displayAddressField(location.address_line1),
+        displayAddressField(location.address_line2),
+        displayAddressField(location.city),
+        displayAddressField(location.state_province),
+        displayAddressField(location.postal_code),
+        displayCountry(location.country_name),
     ].filter(Boolean).join(', ');
 }

--- a/packages/billing/src/actions/invoiceQueries.ts
+++ b/packages/billing/src/actions/invoiceQueries.ts
@@ -10,7 +10,7 @@ import {
   IInvoiceCharge
 } from '@alga-psa/types';
 import { createTenantKnex } from '@alga-psa/db';
-import { toPlainDate } from '@alga-psa/core';
+import { toPlainDate, displayAddressField, displayCountry } from '@alga-psa/core';
 import Invoice from '@alga-psa/billing/models/invoice';
 import { getClientContractPurchaseOrderContext, getPurchaseOrderConsumedCents } from '@alga-psa/billing/services/purchaseOrderService';
 import { withAuth } from '@alga-psa/auth';
@@ -513,13 +513,14 @@ export const fetchInvoicesPaginated = withAuth(async (
 
         // Format location address
         const addressParts: string[] = [];
-        if (invoice.address_line1) addressParts.push(invoice.address_line1);
+        const addressLine1 = displayAddressField(invoice.address_line1);
+        if (addressLine1) addressParts.push(addressLine1);
         if (invoice.address_line2) addressParts.push(invoice.address_line2);
-        if (invoice.city || invoice.state_province || invoice.postal_code) {
-          const cityStateZip = [invoice.city, invoice.state_province, invoice.postal_code].filter(Boolean).join(', ');
-          addressParts.push(cityStateZip);
-        }
-        if (invoice.country_name) addressParts.push(invoice.country_name);
+        const cityStateZip = [displayAddressField(invoice.city), invoice.state_province, invoice.postal_code]
+          .filter(Boolean).join(', ');
+        if (cityStateZip) addressParts.push(cityStateZip);
+        const countryName = displayCountry(invoice.country_name);
+        if (countryName) addressParts.push(countryName);
 
         return getBasicInvoiceViewModel(invoice, {
           client_name: invoice.client_name,
@@ -656,13 +657,14 @@ export const fetchInvoicesByClient = withAuth(async (
       
       // Format location address
       const addressParts: string[] = [];
-      if (invoice.address_line1) addressParts.push(invoice.address_line1);
+      const addressLine1 = displayAddressField(invoice.address_line1);
+      if (addressLine1) addressParts.push(addressLine1);
       if (invoice.address_line2) addressParts.push(invoice.address_line2);
-      if (invoice.city || invoice.state_province || invoice.postal_code) {
-        const cityStateZip = [invoice.city, invoice.state_province, invoice.postal_code].filter(Boolean).join(', ');
-        addressParts.push(cityStateZip);
-      }
-      if (invoice.country_name) addressParts.push(invoice.country_name);
+      const cityStateZip = [displayAddressField(invoice.city), invoice.state_province, invoice.postal_code]
+        .filter(Boolean).join(', ');
+      if (cityStateZip) addressParts.push(cityStateZip);
+      const countryName = displayCountry(invoice.country_name);
+      if (countryName) addressParts.push(countryName);
       
       return getBasicInvoiceViewModel(invoice, {
         client_name: invoice.client_name,

--- a/packages/billing/src/lib/adapters/invoiceAdapters.server.ts
+++ b/packages/billing/src/lib/adapters/invoiceAdapters.server.ts
@@ -5,22 +5,21 @@ import type {
 } from '@alga-psa/types';
 import type { Knex } from 'knex';
 import { buildInvoiceLocationGroups } from './invoiceAdapters';
-
-const asTrimmedString = (value: unknown): string => (typeof value === 'string' ? value.trim() : '');
+import { displayAddressField, displayCountry } from '@alga-psa/core';
 
 const buildLocationAddressBlock = (location: WasmInvoiceLineItemLocation | null): string | null => {
   if (!location) return null;
   const lines: string[] = [];
   for (const field of [location.address_line1, location.address_line2, location.address_line3]) {
-    const trimmed = asTrimmedString(field);
+    const trimmed = displayAddressField(field);
     if (trimmed) lines.push(trimmed);
   }
   const cityLine = [location.city, location.state_province, location.postal_code]
-    .map(asTrimmedString)
+    .map(displayAddressField)
     .filter((value) => value.length > 0)
     .join(', ');
   if (cityLine) lines.push(cityLine);
-  const country = asTrimmedString(location.country_name) || asTrimmedString(location.country_code);
+  const country = displayCountry(location.country_name, location.country_code);
   if (country) lines.push(country);
   return lines.length > 0 ? lines.join('\n') : null;
 };

--- a/packages/billing/src/lib/adapters/invoiceAdapters.ts
+++ b/packages/billing/src/lib/adapters/invoiceAdapters.ts
@@ -11,6 +11,7 @@ import type {
   DateValue,
 } from '@alga-psa/types';
 import { Temporal } from '@js-temporal/polyfill';
+import { displayAddressField, displayCountry } from '@alga-psa/core';
 // toPlainDate is likely not needed here as we format to string for Wasm
 
 // Helper function to convert DateValue (Date or ISO string or Temporal) to ISO string for Wasm
@@ -197,15 +198,15 @@ const buildLocationAddressBlock = (location: WasmInvoiceLineItemLocation | null)
   if (!location) return null;
   const lines: string[] = [];
   for (const field of [location.address_line1, location.address_line2, location.address_line3]) {
-    const trimmed = asTrimmedString(field);
+    const trimmed = displayAddressField(field);
     if (trimmed) lines.push(trimmed);
   }
   const cityLine = [location.city, location.state_province, location.postal_code]
-    .map(asTrimmedString)
+    .map(displayAddressField)
     .filter((value) => value.length > 0)
     .join(', ');
   if (cityLine) lines.push(cityLine);
-  const country = asTrimmedString(location.country_name) || asTrimmedString(location.country_code);
+  const country = displayCountry(location.country_name, location.country_code);
   if (country) lines.push(country);
   return lines.length > 0 ? lines.join('\n') : null;
 };

--- a/packages/billing/src/lib/adapters/quoteAdapters.ts
+++ b/packages/billing/src/lib/adapters/quoteAdapters.ts
@@ -5,6 +5,7 @@ import { tenantDb } from '@alga-psa/db';
 
 import Quote from '../../models/quote';
 import { fetchTenantParty } from './tenantPartyAdapter';
+import { displayAddressField, displayCountry } from '@alga-psa/core';
 
 type QuoteItemGroupSummary = {
   items: QuoteViewModelLineItem[];
@@ -47,17 +48,16 @@ const buildAddress = (record: Record<string, unknown> | null | undefined): strin
   }
 
   const parts = [
-    record.address_line1,
-    record.address_line2,
-    record.address_line3,
-    record.city,
-    record.state_province,
-    record.postal_code,
-    record.country_name,
-    record.location_address,
-    record.address,
+    displayAddressField(record.address_line1),
+    displayAddressField(record.address_line2),
+    displayAddressField(record.address_line3),
+    displayAddressField(record.city),
+    displayAddressField(record.state_province),
+    displayAddressField(record.postal_code),
+    displayCountry(record.country_name),
+    displayAddressField(record.location_address),
+    displayAddressField(record.address),
   ]
-    .map(asTrimmedString)
     .filter((value, index, collection) => value.length > 0 && collection.indexOf(value) === index);
 
   return parts.length > 0 ? parts.join(', ') : null;
@@ -104,15 +104,15 @@ const buildLocationAddress = (location: QuoteViewModelLocation | null): string |
   if (!location) return null;
   const lines: string[] = [];
   for (const field of [location.address_line1, location.address_line2, location.address_line3]) {
-    const trimmed = asTrimmedString(field);
+    const trimmed = displayAddressField(field);
     if (trimmed) lines.push(trimmed);
   }
   const cityLine = [location.city, location.state_province, location.postal_code]
-    .map(asTrimmedString)
+    .map(displayAddressField)
     .filter((v) => v.length > 0)
     .join(', ');
   if (cityLine) lines.push(cityLine);
-  const country = asTrimmedString(location.country_name) || asTrimmedString(location.country_code);
+  const country = displayCountry(location.country_name, location.country_code);
   if (country) lines.push(country);
   return lines.length > 0 ? lines.join('\n') : null;
 };

--- a/packages/billing/src/lib/adapters/salesOrderAdapters.ts
+++ b/packages/billing/src/lib/adapters/salesOrderAdapters.ts
@@ -2,6 +2,7 @@ import type { Knex } from 'knex';
 import type { SalesOrderDocumentParty, SalesOrderViewModel } from '@alga-psa/types';
 
 import { fetchTenantParty } from './tenantPartyAdapter';
+import { displayAddressField, displayCountry } from '@alga-psa/core';
 import {
   asTrimmedString,
   assembleSalesOrderViewModel,
@@ -24,15 +25,14 @@ export {
 const buildAddress = (record: Record<string, unknown> | null | undefined): string | null => {
   if (!record) return null;
   const parts = [
-    record.address_line1,
-    record.address_line2,
-    record.address_line3,
-    record.city,
-    record.state_province,
-    record.postal_code,
-    record.country_name,
+    displayAddressField(record.address_line1),
+    displayAddressField(record.address_line2),
+    displayAddressField(record.address_line3),
+    displayAddressField(record.city),
+    displayAddressField(record.state_province),
+    displayAddressField(record.postal_code),
+    displayCountry(record.country_name),
   ]
-    .map(asTrimmedString)
     .filter((value, index, collection) => value.length > 0 && collection.indexOf(value) === index);
   return parts.length > 0 ? parts.join(', ') : null;
 };

--- a/packages/billing/src/lib/adapters/tenantPartyAdapter.ts
+++ b/packages/billing/src/lib/adapters/tenantPartyAdapter.ts
@@ -1,6 +1,7 @@
 import type { Knex } from 'knex';
 import { tenantDb } from '@alga-psa/db';
 import { getClientLogoUrl } from '@alga-psa/formatting/avatarUtils';
+import { displayAddressField, displayCountry } from '@alga-psa/core';
 
 const asTrimmedString = (value: unknown): string => (typeof value === 'string' ? value.trim() : '');
 
@@ -10,17 +11,16 @@ const buildAddress = (record: Record<string, unknown> | null | undefined): strin
   }
 
   const parts = [
-    record.address_line1,
-    record.address_line2,
-    record.address_line3,
-    record.city,
-    record.state_province,
-    record.postal_code,
-    record.country_name,
-    record.location_address,
-    record.address,
+    displayAddressField(record.address_line1),
+    displayAddressField(record.address_line2),
+    displayAddressField(record.address_line3),
+    displayAddressField(record.city),
+    displayAddressField(record.state_province),
+    displayAddressField(record.postal_code),
+    displayCountry(record.country_name),
+    displayAddressField(record.location_address),
+    displayAddressField(record.address),
   ]
-    .map(asTrimmedString)
     .filter((value, index, collection) => value.length > 0 && collection.indexOf(value) === index);
 
   return parts.length > 0 ? parts.join(', ') : null;

--- a/packages/billing/src/models/invoice.ts
+++ b/packages/billing/src/models/invoice.ts
@@ -440,12 +440,12 @@ const Invoice = {
           'c.client_name',
           'c.properties',
           knexOrTrx.raw(`CONCAT_WS(', ',
-            cl.address_line1,
+            NULLIF(cl.address_line1, 'N/A'),
             cl.address_line2,
-            cl.city,
+            NULLIF(cl.city, 'N/A'),
             cl.state_province,
             cl.postal_code,
-            cl.country_name
+            NULLIF(cl.country_name, 'Unknown')
           ) as location_address`)
         )
         .where({
@@ -463,12 +463,12 @@ const Invoice = {
           'tc.client_id',
           'c.client_name',
           knexOrTrx.raw(`CONCAT_WS(', ',
-            cl.address_line1,
+            NULLIF(cl.address_line1, 'N/A'),
             cl.address_line2,
-            cl.city,
+            NULLIF(cl.city, 'N/A'),
             cl.state_province,
             cl.postal_code,
-            cl.country_name
+            NULLIF(cl.country_name, 'Unknown')
           ) as location_address`)
         )
         .where({

--- a/packages/client-portal/src/components/billing/QuoteDetailPage.tsx
+++ b/packages/client-portal/src/components/billing/QuoteDetailPage.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { displayAddressField, displayCountry } from '@alga-psa/core';
 import { useCurrencyFormat } from '@alga-psa/ui/lib';
 import { useRouter } from 'next/navigation';
 import { Badge, type BadgeVariant } from '@alga-psa/ui/components/Badge';
@@ -103,13 +104,14 @@ function formatClientPortalLocationLines(location: ClientPortalLocationSummary |
   if (!location) return [];
   const lines: string[] = [];
   for (const field of [location.address_line1, location.address_line2, location.address_line3]) {
-    if (typeof field === 'string' && field.trim().length > 0) lines.push(field.trim());
+    const trimmed = displayAddressField(field);
+    if (trimmed) lines.push(trimmed);
   }
   const parts = [location.city, location.state_province, location.postal_code]
-    .map((v) => (typeof v === 'string' ? v.trim() : ''))
+    .map(displayAddressField)
     .filter((v) => v.length > 0);
   if (parts.length > 0) lines.push(parts.join(', '));
-  const country = (location.country_name || location.country_code || '').trim();
+  const country = displayCountry(location.country_name, location.country_code);
   if (country) lines.push(country);
   return lines;
 }

--- a/packages/clients/src/components/clients/ClientLocations.tsx
+++ b/packages/clients/src/components/clients/ClientLocations.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
+import { displayAddressField, displayCountry } from '@alga-psa/core';
 import type { IClientLocation } from '@alga-psa/types';
 import { 
   getClientLocations, 
@@ -699,18 +700,19 @@ export default function ClientLocations({ clientId, isEditing }: ClientLocations
     
     // Combine address lines (address_line1, address_line2, address_line3)
     const addressLines = [
-      location.address_line1,
+      displayAddressField(location.address_line1),
       location.address_line2,
       location.address_line3
     ].filter(Boolean);
-    
+
     if (addressLines.length > 0) {
       addressParts.push(addressLines.join(', '));
     }
-    
+
     // Add city if present
-    if (location.city) {
-      addressParts.push(location.city);
+    const cityDisplay = displayAddressField(location.city);
+    if (cityDisplay) {
+      addressParts.push(cityDisplay);
     }
     
     // Add state/province and postal code together (space-separated, not comma-separated)
@@ -725,9 +727,10 @@ export default function ClientLocations({ clientId, isEditing }: ClientLocations
       addressParts.push(statePostalParts.join(' '));
     }
     
-    // Add country if present
-    if (location.country_name) {
-      addressParts.push(location.country_name);
+    // Add country if present (placeholder 'Unknown'/'XX' is omitted)
+    const countryDisplay = displayCountry(location.country_name, location.country_code);
+    if (countryDisplay) {
+      addressParts.push(countryDisplay);
     }
     
     // Join all major address components with comma-space

--- a/packages/clients/src/components/clients/ClientSideDetails.tsx
+++ b/packages/clients/src/components/clients/ClientSideDetails.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { displayAddressField, displayCountry } from '@alga-psa/core';
 import type { IClient } from '@alga-psa/types';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 
@@ -20,17 +21,20 @@ const ClientSideDetails = ({ client }: ClientSideDetailsProps) => {
     // Format location address
     const formatAddress = () => {
         const parts: string[] = [];
-        if (client.address_line1) parts.push(client.address_line1);
+        const addressLine1 = displayAddressField(client.address_line1);
+        if (addressLine1) parts.push(addressLine1);
         if (client.address_line2) parts.push(client.address_line2);
-        
+
         const cityStateZip: string[] = [];
-        if (client.city) cityStateZip.push(client.city);
+        const city = displayAddressField(client.city);
+        if (city) cityStateZip.push(city);
         if (client.state_province) cityStateZip.push(client.state_province);
         if (client.postal_code) cityStateZip.push(client.postal_code);
-        
+
         if (cityStateZip.length > 0) parts.push(cityStateZip.join(', '));
-        if (client.country_name) parts.push(client.country_name);
-        
+        const country = displayCountry(client.country_name);
+        if (country) parts.push(country);
+
         return parts.join('\n');
     };
 

--- a/packages/core/src/lib/formatters.ts
+++ b/packages/core/src/lib/formatters.ts
@@ -87,3 +87,26 @@ export function formatBytes(bytes: number, decimals: number = 2): string {
   return Number.parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
 }
 
+// Placeholder values stamped on client_locations rows whose real address is
+// unknown (tenant provisioning, the company→location migration). Storage keeps
+// them to satisfy NOT NULL constraints; rendered addresses must omit them.
+export const ADDRESS_PLACEHOLDER = 'N/A';
+export const COUNTRY_CODE_PLACEHOLDER = 'XX';
+export const COUNTRY_NAME_PLACEHOLDER = 'Unknown';
+
+/** Address field for display: trimmed, with the 'N/A' placeholder blanked. */
+export function displayAddressField(value?: unknown): string {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  return trimmed === ADDRESS_PLACEHOLDER ? '' : trimmed;
+}
+
+/** Country for display: empty when only the XX/Unknown placeholder is stored. */
+export function displayCountry(countryName?: unknown, countryCode?: unknown): string {
+  const name = typeof countryName === 'string' ? countryName.trim() : '';
+  const code = typeof countryCode === 'string' ? countryCode.trim() : '';
+  if (name === COUNTRY_NAME_PLACEHOLDER || code.toUpperCase() === COUNTRY_CODE_PLACEHOLDER) {
+    return '';
+  }
+  return name || code;
+}
+

--- a/packages/onboarding/src/actions/onboarding-actions/onboardingActions.ts
+++ b/packages/onboarding/src/actions/onboarding-actions/onboardingActions.ts
@@ -5,6 +5,7 @@ import { revalidatePath } from 'next/cache';
 import { withTransaction } from '@alga-psa/db';
 import { Knex } from 'knex';
 import { hashPassword } from '@alga-psa/core/encryption';
+import { randomUUID } from 'crypto';
 import { isValidEmail } from '@alga-psa/core';
 import { createClient as createClientInternal } from '@alga-psa/clients/actions/clientActions';
 import { createClientContact } from '@alga-psa/clients/actions/contact-actions/contactActions';
@@ -26,6 +27,15 @@ export interface ClientInfoData {
   tenantName: string;
   email: string;
   newPassword?: string;
+  // MSP company address (default location on the MSP's own client record)
+  companyLocationId?: string;
+  companyAddressLine1?: string;
+  companyAddressLine2?: string;
+  companyCity?: string;
+  companyStateProvince?: string;
+  companyPostalCode?: string;
+  companyCountryCode?: string;
+  companyCountryName?: string;
 }
 
 export interface TeamMember {
@@ -138,6 +148,74 @@ export const saveClientInfo = withAuth(async (
             setting_value: true,
             updated_at: new Date()
           });
+        }
+      }
+
+      // Persist the MSP company address on the default location of the MSP's
+      // own client record (seeded from Stripe at tenant creation). Address
+      // lives in client_locations, not in onboarding progress — the DB row is
+      // the source of truth the wizard prefills from.
+      const hasAddressInput = [
+        data.companyAddressLine1,
+        data.companyAddressLine2,
+        data.companyCity,
+        data.companyStateProvince,
+        data.companyPostalCode,
+        data.companyCountryCode,
+      ].some(v => v !== undefined);
+
+      if (hasAddressInput) {
+        const mspClient = await tenantDb(trx, tenant).table('clients')
+          .where({ is_inactive: false })
+          .orderBy('created_at', 'asc')
+          .first('client_id');
+
+        if (mspClient) {
+          let countryCode = data.companyCountryCode?.toUpperCase() || '';
+          let countryName = '';
+          if (countryCode) {
+            const country = await tenantDb(trx, tenant).table('countries')
+              .where({ code: countryCode })
+              .first('code', 'name');
+            countryCode = country?.code || '';
+            countryName = country?.name || '';
+          }
+
+          const locationFields = {
+            address_line1: data.companyAddressLine1 || 'N/A',
+            address_line2: data.companyAddressLine2 || null,
+            city: data.companyCity || 'N/A',
+            state_province: data.companyStateProvince || null,
+            postal_code: data.companyPostalCode || null,
+            // Keep the not-null placeholders when no country was chosen —
+            // never silently default to a real country.
+            country_code: countryCode || 'XX',
+            country_name: countryName || 'Unknown',
+            updated_at: new Date()
+          };
+
+          const defaultLocation = await tenantDb(trx, tenant).table('client_locations')
+            .where({ client_id: mspClient.client_id, is_default: true })
+            .first('location_id');
+
+          if (defaultLocation) {
+            await tenantDb(trx, tenant).table('client_locations')
+              .where({ location_id: defaultLocation.location_id })
+              .update(locationFields);
+          } else {
+            await tenantDb(trx, tenant).table('client_locations').insert({
+              location_id: randomUUID(),
+              client_id: mspClient.client_id,
+              tenant,
+              location_name: 'Main Office',
+              email: currentUser.email?.toLowerCase() || '',
+              phone: '',
+              ...locationFields,
+              is_default: true,
+              is_active: true,
+              created_at: new Date()
+            });
+          }
         }
       }
 
@@ -1209,13 +1287,43 @@ export const getOnboardingInitialData = withAuth(async (
       .orderBy('created_at', 'asc')
       .first();
 
+    // Default location of the MSP's own client (seeded from the Stripe billing
+    // address at tenant creation). Placeholder values ('N/A'/'XX'/'Unknown')
+    // are blanked so the wizard shows empty editable fields instead.
+    let location: Record<string, any> | undefined;
+    if (client) {
+      location = await tenantDb(knex, tenant).table('client_locations')
+        .where({ client_id: client.client_id, is_default: true })
+        .first(
+          'location_id',
+          'address_line1',
+          'address_line2',
+          'city',
+          'state_province',
+          'postal_code',
+          'country_code',
+          'country_name'
+        );
+    }
+    const blankPlaceholder = (value: string | null | undefined) =>
+      !value || value === 'N/A' ? '' : value;
+    const hasRealCountry = location?.country_code && location.country_code !== 'XX';
+
     return {
       success: true,
       data: {
         firstName: currentUser.first_name || '',
         lastName: currentUser.last_name || '',
         email: currentUser.email || '',
-        tenantName: client?.client_name || tenant // Use tenant name as fallback
+        tenantName: client?.client_name || tenant, // Use tenant name as fallback
+        companyLocationId: location?.location_id,
+        companyAddressLine1: blankPlaceholder(location?.address_line1),
+        companyAddressLine2: blankPlaceholder(location?.address_line2),
+        companyCity: blankPlaceholder(location?.city),
+        companyStateProvince: blankPlaceholder(location?.state_province),
+        companyPostalCode: blankPlaceholder(location?.postal_code),
+        companyCountryCode: hasRealCountry ? location!.country_code : '',
+        companyCountryName: hasRealCountry ? location!.country_name : ''
       }
     };
   } catch (error) {

--- a/packages/onboarding/src/components/OnboardingWizard.tsx
+++ b/packages/onboarding/src/components/OnboardingWizard.tsx
@@ -184,7 +184,13 @@ export function OnboardingWizard({
             lastName: wizardData.lastName,
             tenantName: wizardData.tenantName,
             email: wizardData.email,
-            newPassword: wizardData.newPassword
+            newPassword: wizardData.newPassword,
+            companyAddressLine1: wizardData.companyAddressLine1,
+            companyAddressLine2: wizardData.companyAddressLine2,
+            companyCity: wizardData.companyCity,
+            companyStateProvince: wizardData.companyStateProvince,
+            companyPostalCode: wizardData.companyPostalCode,
+            companyCountryCode: wizardData.companyCountryCode
           });
           if (!clientResult.success) {
             setErrors(prev => ({ ...prev, [stepIndex]: clientResult.error || t('onboardingWizard.errors.saveClientInfo', {

--- a/packages/onboarding/src/components/steps/ClientInfoStep.tsx
+++ b/packages/onboarding/src/components/steps/ClientInfoStep.tsx
@@ -6,10 +6,12 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { Input } from '@alga-psa/ui/components/Input';
 import { Label } from '@alga-psa/ui/components/Label';
 import CustomSelect, { SelectOption } from '@alga-psa/ui/components/CustomSelect';
+import CountryPicker from '@alga-psa/ui/components/CountryPicker';
 import { Eye, EyeOff } from 'lucide-react';
 import type { StepProps } from '@alga-psa/types';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { validateEmailAddress } from '@alga-psa/validation';
+import { getAllCountries, type ICountry } from '@alga-psa/clients/actions';
 import { useTranslation, useI18n } from '@alga-psa/ui/lib/i18n/client';
 import {
   LOCALE_CONFIG,
@@ -30,6 +32,125 @@ export function ClientInfoStep({ data, updateData, isRevisit = false }: ClientIn
   const [passwordStrength, setPasswordStrength] = useState<'weak' | 'medium' | 'strong' | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [isLocaleChanging, setIsLocaleChanging] = useState(false);
+  const [countries, setCountries] = useState<ICountry[]>([]);
+
+  useEffect(() => {
+    getAllCountries()
+      .then(setCountries)
+      .catch((error) => console.error('Failed to load countries:', error));
+  }, []);
+
+  const companyAddressSection = (
+    <div className="space-y-4 pt-4 border-t">
+      <div className="space-y-1">
+        <h3 className="text-lg font-medium">
+          {t('clientInfoStep.address.title', {
+            defaultValue: 'Company Address'
+          })}
+        </h3>
+        <p className="text-sm text-gray-600">
+          {t('clientInfoStep.address.description', {
+            defaultValue: 'Prefilled from your billing details — review and correct if needed. This address appears on your invoices and quotes.'
+          })}
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="companyAddressLine1">
+          {t('clientInfoStep.address.fields.addressLine1.label', {
+            defaultValue: 'Address Line 1'
+          })}
+        </Label>
+        <Input
+          id="companyAddressLine1"
+          value={data.companyAddressLine1 || ''}
+          onChange={(e) => updateData({ companyAddressLine1: e.target.value })}
+          placeholder={t('clientInfoStep.address.fields.addressLine1.placeholder', {
+            defaultValue: '123 Main St'
+          })}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="companyAddressLine2">
+          {t('clientInfoStep.address.fields.addressLine2.label', {
+            defaultValue: 'Address Line 2'
+          })}
+        </Label>
+        <Input
+          id="companyAddressLine2"
+          value={data.companyAddressLine2 || ''}
+          onChange={(e) => updateData({ companyAddressLine2: e.target.value })}
+          placeholder={t('clientInfoStep.address.fields.addressLine2.placeholder', {
+            defaultValue: 'Suite 100'
+          })}
+        />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <div className="space-y-2">
+          <Label htmlFor="companyCity">
+            {t('clientInfoStep.address.fields.city.label', {
+              defaultValue: 'City'
+            })}
+          </Label>
+          <Input
+            id="companyCity"
+            value={data.companyCity || ''}
+            onChange={(e) => updateData({ companyCity: e.target.value })}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="companyStateProvince">
+            {t('clientInfoStep.address.fields.stateProvince.label', {
+              defaultValue: 'State/Province'
+            })}
+          </Label>
+          <Input
+            id="companyStateProvince"
+            value={data.companyStateProvince || ''}
+            onChange={(e) => updateData({ companyStateProvince: e.target.value })}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="companyPostalCode">
+            {t('clientInfoStep.address.fields.postalCode.label', {
+              defaultValue: 'Postal Code'
+            })}
+          </Label>
+          <Input
+            id="companyPostalCode"
+            value={data.companyPostalCode || ''}
+            onChange={(e) => updateData({ companyPostalCode: e.target.value })}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="company-country-picker">
+          {t('clientInfoStep.address.fields.country.label', {
+            defaultValue: 'Country'
+          })}
+        </Label>
+        <CountryPicker
+          id="company-country-picker"
+          data-automation-id="company-country-picker"
+          value={data.companyCountryCode || ''}
+          onValueChange={(countryCode, countryName) =>
+            updateData({ companyCountryCode: countryCode, companyCountryName: countryName })
+          }
+          countries={countries}
+          labelStyle="none"
+          buttonWidth="full"
+          placeholder={t('clientInfoStep.address.fields.country.placeholder', {
+            defaultValue: 'Select Country'
+          })}
+        />
+      </div>
+    </div>
+  );
 
   const visibleLocales = useMemo(
     () => filterPseudoLocales(LOCALE_CONFIG.supportedLocales),
@@ -191,6 +312,8 @@ export function ClientInfoStep({ data, updateData, isRevisit = false }: ClientIn
           </p>
         </div>
 
+        {companyAddressSection}
+
         <Alert variant="info">
           <AlertDescription>
             <span className="font-semibold">
@@ -336,6 +459,8 @@ export function ClientInfoStep({ data, updateData, isRevisit = false }: ClientIn
           })}
         </p>
       </div>
+
+      {companyAddressSection}
 
       <div className="space-y-4 pt-4 border-t">
         <Alert variant="warning" className="mb-4">

--- a/packages/types/src/lib/onboardingWizard.ts
+++ b/packages/types/src/lib/onboardingWizard.ts
@@ -8,6 +8,17 @@ export interface WizardData {
   confirmPassword?: string;
   locale?: string;
 
+  // MSP company location (default location on the MSP's own client record,
+  // seeded from the Stripe billing address at tenant creation)
+  companyLocationId?: string;
+  companyAddressLine1?: string;
+  companyAddressLine2?: string;
+  companyCity?: string;
+  companyStateProvince?: string;
+  companyPostalCode?: string;
+  companyCountryCode?: string;
+  companyCountryName?: string;
+
   // Team Members
   teamMembers: TeamMember[];
   createdTeamMemberEmails?: string[]; // Track which team members have been created

--- a/server/public/locales/de/msp/onboarding.json
+++ b/server/public/locales/de/msp/onboarding.json
@@ -329,6 +329,33 @@
         "help": "Wird zum Organisationsstandard für alle: MSP-Mitarbeiter und Client-Portal-Benutzer. Einzelne Benutzer und Kunden können ihn später überschreiben."
       }
     },
+    "address": {
+      "title": "Firmenadresse",
+      "description": "Aus Ihren Rechnungsdaten vorausgefüllt — bitte prüfen und bei Bedarf korrigieren. Diese Adresse erscheint auf Ihren Rechnungen und Angeboten.",
+      "fields": {
+        "addressLine1": {
+          "label": "Adresszeile 1",
+          "placeholder": "Hauptstraße 123"
+        },
+        "addressLine2": {
+          "label": "Adresszeile 2",
+          "placeholder": "Büro 100"
+        },
+        "city": {
+          "label": "Stadt"
+        },
+        "stateProvince": {
+          "label": "Bundesland/Provinz"
+        },
+        "postalCode": {
+          "label": "Postleitzahl"
+        },
+        "country": {
+          "label": "Land",
+          "placeholder": "Land auswählen"
+        }
+      }
+    },
     "password": {
       "resetRequired": {
         "title": "Passwort zurücksetzen erforderlich",

--- a/server/public/locales/en/msp/onboarding.json
+++ b/server/public/locales/en/msp/onboarding.json
@@ -329,6 +329,33 @@
         "help": "Becomes the organization default for everyone: MSP staff and client portal users. Individual users and clients can override it later."
       }
     },
+    "address": {
+      "title": "Company Address",
+      "description": "Prefilled from your billing details — review and correct if needed. This address appears on your invoices and quotes.",
+      "fields": {
+        "addressLine1": {
+          "label": "Address Line 1",
+          "placeholder": "123 Main St"
+        },
+        "addressLine2": {
+          "label": "Address Line 2",
+          "placeholder": "Suite 100"
+        },
+        "city": {
+          "label": "City"
+        },
+        "stateProvince": {
+          "label": "State/Province"
+        },
+        "postalCode": {
+          "label": "Postal Code"
+        },
+        "country": {
+          "label": "Country",
+          "placeholder": "Select Country"
+        }
+      }
+    },
     "password": {
       "resetRequired": {
         "title": "Password Reset Required",

--- a/server/public/locales/es/msp/onboarding.json
+++ b/server/public/locales/es/msp/onboarding.json
@@ -331,7 +331,7 @@
     },
     "address": {
       "title": "Dirección de la empresa",
-      "description": "Precargada con sus datos de facturación: revísela y corríjala si es necesario. Esta dirección aparece en sus facturas y presupuestos.",
+      "description": "Precargada con sus datos de facturación: revísela y corríjala si es necesario. Esta dirección aparece en sus facturas y cotizaciones.",
       "fields": {
         "addressLine1": {
           "label": "Dirección línea 1",

--- a/server/public/locales/es/msp/onboarding.json
+++ b/server/public/locales/es/msp/onboarding.json
@@ -329,6 +329,33 @@
         "help": "Se convierte en el idioma predeterminado de la organización para todos: personal MSP y usuarios del portal del cliente. Los usuarios individuales y los clientes pueden anularlo más tarde."
       }
     },
+    "address": {
+      "title": "Dirección de la empresa",
+      "description": "Precargada con sus datos de facturación: revísela y corríjala si es necesario. Esta dirección aparece en sus facturas y presupuestos.",
+      "fields": {
+        "addressLine1": {
+          "label": "Dirección línea 1",
+          "placeholder": "Calle Mayor 123"
+        },
+        "addressLine2": {
+          "label": "Dirección línea 2",
+          "placeholder": "Oficina 100"
+        },
+        "city": {
+          "label": "Ciudad"
+        },
+        "stateProvince": {
+          "label": "Estado/Provincia"
+        },
+        "postalCode": {
+          "label": "Código postal"
+        },
+        "country": {
+          "label": "País",
+          "placeholder": "Seleccionar país"
+        }
+      }
+    },
     "password": {
       "resetRequired": {
         "title": "Se requiere restablecer la contraseña",

--- a/server/public/locales/fr/msp/onboarding.json
+++ b/server/public/locales/fr/msp/onboarding.json
@@ -329,6 +329,33 @@
         "help": "Devient la valeur par défaut de l'organisation pour tout le monde : personnel MSP et utilisateurs du portail client. Les utilisateurs individuels et les clients peuvent la remplacer plus tard."
       }
     },
+    "address": {
+      "title": "Adresse de l'entreprise",
+      "description": "Préremplie à partir de vos informations de facturation — vérifiez et corrigez si nécessaire. Cette adresse figure sur vos factures et devis.",
+      "fields": {
+        "addressLine1": {
+          "label": "Adresse ligne 1",
+          "placeholder": "123 rue Principale"
+        },
+        "addressLine2": {
+          "label": "Adresse ligne 2",
+          "placeholder": "Bureau 100"
+        },
+        "city": {
+          "label": "Ville"
+        },
+        "stateProvince": {
+          "label": "État/Province"
+        },
+        "postalCode": {
+          "label": "Code postal"
+        },
+        "country": {
+          "label": "Pays",
+          "placeholder": "Sélectionner un pays"
+        }
+      }
+    },
     "password": {
       "resetRequired": {
         "title": "Réinitialisation du mot de passe requise",

--- a/server/public/locales/it/msp/onboarding.json
+++ b/server/public/locales/it/msp/onboarding.json
@@ -329,6 +329,33 @@
         "help": "Diventa l'impostazione predefinita dell'organizzazione per tutti: personale MSP e utenti del portale cliente. I singoli utenti e i clienti possono sovrascriverla in seguito."
       }
     },
+    "address": {
+      "title": "Indirizzo dell'azienda",
+      "description": "Precompilato dai dati di fatturazione — controlla e correggi se necessario. Questo indirizzo compare su fatture e preventivi.",
+      "fields": {
+        "addressLine1": {
+          "label": "Indirizzo riga 1",
+          "placeholder": "Via Principale 123"
+        },
+        "addressLine2": {
+          "label": "Indirizzo riga 2",
+          "placeholder": "Interno 100"
+        },
+        "city": {
+          "label": "Città"
+        },
+        "stateProvince": {
+          "label": "Stato/Provincia"
+        },
+        "postalCode": {
+          "label": "Codice postale"
+        },
+        "country": {
+          "label": "Paese",
+          "placeholder": "Seleziona paese"
+        }
+      }
+    },
     "password": {
       "resetRequired": {
         "title": "Reimpostazione password richiesta",

--- a/server/public/locales/nl/msp/onboarding.json
+++ b/server/public/locales/nl/msp/onboarding.json
@@ -339,7 +339,7 @@
         },
         "addressLine2": {
           "label": "Adresregel 2",
-          "placeholder": "Suite 100"
+          "placeholder": "3e verdieping"
         },
         "city": {
           "label": "Plaats"

--- a/server/public/locales/nl/msp/onboarding.json
+++ b/server/public/locales/nl/msp/onboarding.json
@@ -329,6 +329,33 @@
         "help": "Wordt de organisatiestandaard voor iedereen: MSP-personeel en klantportaalgebruikers. Individuele gebruikers en klanten kunnen dit later overschrijven."
       }
     },
+    "address": {
+      "title": "Bedrijfsadres",
+      "description": "Vooraf ingevuld op basis van uw factuurgegevens — controleer en corrigeer indien nodig. Dit adres verschijnt op uw facturen en offertes.",
+      "fields": {
+        "addressLine1": {
+          "label": "Adresregel 1",
+          "placeholder": "Hoofdstraat 123"
+        },
+        "addressLine2": {
+          "label": "Adresregel 2",
+          "placeholder": "Suite 100"
+        },
+        "city": {
+          "label": "Plaats"
+        },
+        "stateProvince": {
+          "label": "Staat/Provincie"
+        },
+        "postalCode": {
+          "label": "Postcode"
+        },
+        "country": {
+          "label": "Land",
+          "placeholder": "Land selecteren"
+        }
+      }
+    },
     "password": {
       "resetRequired": {
         "title": "Wachtwoord opnieuw instellen vereist",

--- a/server/public/locales/pl/msp/onboarding.json
+++ b/server/public/locales/pl/msp/onboarding.json
@@ -331,6 +331,33 @@
         "help": "Staje się domyślnym językiem organizacji dla wszystkich: personelu MSP i użytkowników portalu klienta. Poszczególni użytkownicy i klienci mogą go później nadpisać."
       }
     },
+    "address": {
+      "title": "Adres firmy",
+      "description": "Wstępnie wypełniony na podstawie danych rozliczeniowych — sprawdź i popraw w razie potrzeby. Ten adres pojawia się na fakturach i wycenach.",
+      "fields": {
+        "addressLine1": {
+          "label": "Adres wiersz 1",
+          "placeholder": "ul. Główna 123"
+        },
+        "addressLine2": {
+          "label": "Adres wiersz 2",
+          "placeholder": "Lokal 100"
+        },
+        "city": {
+          "label": "Miasto"
+        },
+        "stateProvince": {
+          "label": "Województwo/Region"
+        },
+        "postalCode": {
+          "label": "Kod pocztowy"
+        },
+        "country": {
+          "label": "Kraj",
+          "placeholder": "Wybierz kraj"
+        }
+      }
+    },
     "password": {
       "resetRequired": {
         "title": "Wymagany reset hasła",

--- a/server/public/locales/pt/msp/onboarding.json
+++ b/server/public/locales/pt/msp/onboarding.json
@@ -329,6 +329,33 @@
         "help": "Torna-se o padrão da organização para todos: funcionários do MSP e usuários do portal do cliente. Usuários e clientes individuais podem substituí-lo posteriormente."
       }
     },
+    "address": {
+      "title": "Endereço da empresa",
+      "description": "Preenchido com os seus dados de faturação — reveja e corrija se necessário. Este endereço aparece nas suas faturas e orçamentos.",
+      "fields": {
+        "addressLine1": {
+          "label": "Endereço linha 1",
+          "placeholder": "Rua Principal 123"
+        },
+        "addressLine2": {
+          "label": "Endereço linha 2",
+          "placeholder": "Sala 100"
+        },
+        "city": {
+          "label": "Cidade"
+        },
+        "stateProvince": {
+          "label": "Estado/Província"
+        },
+        "postalCode": {
+          "label": "Código postal"
+        },
+        "country": {
+          "label": "País",
+          "placeholder": "Selecionar país"
+        }
+      }
+    },
     "password": {
       "resetRequired": {
         "title": "Redefinição de senha necessária",

--- a/server/public/locales/xx/msp/onboarding.json
+++ b/server/public/locales/xx/msp/onboarding.json
@@ -329,6 +329,33 @@
         "help": "11111"
       }
     },
+    "address": {
+      "title": "11111",
+      "description": "11111",
+      "fields": {
+        "addressLine1": {
+          "label": "11111",
+          "placeholder": "11111"
+        },
+        "addressLine2": {
+          "label": "11111",
+          "placeholder": "11111"
+        },
+        "city": {
+          "label": "11111"
+        },
+        "stateProvince": {
+          "label": "11111"
+        },
+        "postalCode": {
+          "label": "11111"
+        },
+        "country": {
+          "label": "11111",
+          "placeholder": "11111"
+        }
+      }
+    },
     "password": {
       "resetRequired": {
         "title": "11111",

--- a/server/public/locales/yy/msp/onboarding.json
+++ b/server/public/locales/yy/msp/onboarding.json
@@ -329,6 +329,33 @@
         "help": "55555"
       }
     },
+    "address": {
+      "title": "55555",
+      "description": "55555",
+      "fields": {
+        "addressLine1": {
+          "label": "55555",
+          "placeholder": "55555"
+        },
+        "addressLine2": {
+          "label": "55555",
+          "placeholder": "55555"
+        },
+        "city": {
+          "label": "55555"
+        },
+        "stateProvince": {
+          "label": "55555"
+        },
+        "postalCode": {
+          "label": "55555"
+        },
+        "country": {
+          "label": "55555",
+          "placeholder": "55555"
+        }
+      }
+    },
     "password": {
       "resetRequired": {
         "title": "55555",

--- a/server/src/app/msp/onboarding/page.tsx
+++ b/server/src/app/msp/onboarding/page.tsx
@@ -60,12 +60,31 @@ export default function OnboardingPage() {
           };
         }
       } else {
-        // For returning users, just prefill company name from tenant data
+        // For returning users, just prefill company name and address from tenant data
         const initialDataResult = await getOnboardingInitialData();
-        if (initialDataResult.success && initialDataResult.data?.tenantName) {
+        if (initialDataResult.success && initialDataResult.data) {
+          const {
+            tenantName,
+            companyLocationId,
+            companyAddressLine1,
+            companyAddressLine2,
+            companyCity,
+            companyStateProvince,
+            companyPostalCode,
+            companyCountryCode,
+            companyCountryName,
+          } = initialDataResult.data;
           data = {
             ...data,
-            tenantName: initialDataResult.data.tenantName
+            ...(tenantName ? { tenantName } : {}),
+            companyLocationId,
+            companyAddressLine1,
+            companyAddressLine2,
+            companyCity,
+            companyStateProvince,
+            companyPostalCode,
+            companyCountryCode,
+            companyCountryName,
           };
         }
       }

--- a/server/src/lib/api/services/InvoiceService.ts
+++ b/server/src/lib/api/services/InvoiceService.ts
@@ -343,13 +343,13 @@ export class InvoiceService extends BaseService<IInvoice> {
           .select(
             'cl.client_id',
             'cl.tenant',
-            trx.raw(`CONCAT_WS(', ', 
-              cl.address_line1, 
-              cl.address_line2, 
-              cl.city, 
-              cl.state_province, 
-              cl.postal_code, 
-              cl.country_name
+            trx.raw(`CONCAT_WS(', ',
+              NULLIF(cl.address_line1, 'N/A'),
+              cl.address_line2,
+              NULLIF(cl.city, 'N/A'),
+              cl.state_province,
+              cl.postal_code,
+              NULLIF(cl.country_name, 'Unknown')
             ) as formatted_address`)
           )
           .where(function() {
@@ -2345,7 +2345,7 @@ export class InvoiceService extends BaseService<IInvoice> {
         'c.client_id',
         'c.client_name',
         'c.billing_email as email',
-        trx.raw(`CONCAT_WS(', ', cl.address_line1, cl.address_line2, cl.city, cl.state_province, cl.postal_code, cl.country_name) as billing_address`),
+        trx.raw(`CONCAT_WS(', ', NULLIF(cl.address_line1, 'N/A'), cl.address_line2, NULLIF(cl.city, 'N/A'), cl.state_province, cl.postal_code, NULLIF(cl.country_name, 'Unknown')) as billing_address`),
         'cl.phone as phone_no'
       )
       .orderByRaw('cl.is_billing_address DESC, cl.is_default DESC')

--- a/server/src/lib/eventBus/subscribers/ticketEmailSubscriber.ts
+++ b/server/src/lib/eventBus/subscribers/ticketEmailSubscriber.ts
@@ -12,6 +12,7 @@ import {
 import { sendEventEmail, SendEmailParams } from '../../notifications/sendEventEmail';
 import { EventEmailRetryQueue } from '../../notifications/EventEmailRetryQueue';
 import logger from '@alga-psa/core/logger';
+import { displayAddressField, displayCountry } from '@alga-psa/core';
 import { getConnection } from '../../db/db';
 import { getSecret } from '../../utils/getSecret';
 import { createTenantKnex } from '../../db';
@@ -1073,9 +1074,9 @@ async function handleTicketCreated(event: TicketCreatedEvent): Promise<void> {
     if (locationName) {
       locationSegments.push(locationName);
     }
-    const addressLines = [safeString(ticket.address_line1), safeString(ticket.address_line2)].filter(Boolean);
-    const cityState = [safeString(ticket.city), safeString(ticket.state_province)].filter(Boolean).join(', ');
-    const postalCountry = [safeString(ticket.postal_code), safeString(ticket.country_code)].filter(Boolean).join(' ');
+    const addressLines = [displayAddressField(safeString(ticket.address_line1)), safeString(ticket.address_line2)].filter(Boolean);
+    const cityState = [displayAddressField(safeString(ticket.city)), safeString(ticket.state_province)].filter(Boolean).join(', ');
+    const postalCountry = [safeString(ticket.postal_code), displayCountry(undefined, safeString(ticket.country_code))].filter(Boolean).join(' ');
     const locationDetailsParts = [...addressLines];
     if (cityState) {
       locationDetailsParts.push(cityState);
@@ -1390,9 +1391,9 @@ async function handleTicketUpdated(event: TicketUpdatedEvent): Promise<void> {
     if (locationName) {
       locationSegments.push(locationName);
     }
-    const addressLines = [safeString(ticket.address_line1), safeString(ticket.address_line2)].filter(Boolean);
-    const cityState = [safeString(ticket.city), safeString(ticket.state_province)].filter(Boolean).join(', ');
-    const postalCountry = [safeString(ticket.postal_code), safeString(ticket.country_code)].filter(Boolean).join(' ');
+    const addressLines = [displayAddressField(safeString(ticket.address_line1)), safeString(ticket.address_line2)].filter(Boolean);
+    const cityState = [displayAddressField(safeString(ticket.city)), safeString(ticket.state_province)].filter(Boolean).join(', ');
+    const postalCountry = [safeString(ticket.postal_code), displayCountry(undefined, safeString(ticket.country_code))].filter(Boolean).join(' ');
     const locationDetailsParts = [...addressLines];
     if (cityState) {
       locationDetailsParts.push(cityState);
@@ -1792,9 +1793,9 @@ export async function handleAccumulatedTicketUpdates(notification: PendingNotifi
     if (locationName) {
       locationSegments.push(locationName);
     }
-    const addressLines = [safeString(ticket.address_line1), safeString(ticket.address_line2)].filter(Boolean);
-    const cityState = [safeString(ticket.city), safeString(ticket.state_province)].filter(Boolean).join(', ');
-    const postalCountry = [safeString(ticket.postal_code), safeString(ticket.country_code)].filter(Boolean).join(' ');
+    const addressLines = [displayAddressField(safeString(ticket.address_line1)), safeString(ticket.address_line2)].filter(Boolean);
+    const cityState = [displayAddressField(safeString(ticket.city)), safeString(ticket.state_province)].filter(Boolean).join(', ');
+    const postalCountry = [safeString(ticket.postal_code), displayCountry(undefined, safeString(ticket.country_code))].filter(Boolean).join(' ');
     const locationDetailsParts = [...addressLines];
     if (cityState) {
       locationDetailsParts.push(cityState);
@@ -2131,9 +2132,9 @@ async function sendTicketAssignedNotifications(
     if (locationName) {
       locationSegments.push(locationName);
     }
-    const addressLines = [safeString(ticket.address_line1), safeString(ticket.address_line2)].filter(Boolean);
-    const cityState = [safeString(ticket.city), safeString(ticket.state_province)].filter(Boolean).join(', ');
-    const postalCountry = [safeString(ticket.postal_code), safeString(ticket.country_code)].filter(Boolean).join(' ');
+    const addressLines = [displayAddressField(safeString(ticket.address_line1)), safeString(ticket.address_line2)].filter(Boolean);
+    const cityState = [displayAddressField(safeString(ticket.city)), safeString(ticket.state_province)].filter(Boolean).join(', ');
+    const postalCountry = [safeString(ticket.postal_code), displayCountry(undefined, safeString(ticket.country_code))].filter(Boolean).join(' ');
     const locationDetailsParts = [...addressLines];
     if (cityState) {
       locationDetailsParts.push(cityState);
@@ -2573,9 +2574,9 @@ async function handleTicketCommentAdded(event: TicketCommentAddedEvent): Promise
     if (locationName) {
       locationSegments.push(locationName);
     }
-    const addressLines = [safeString(ticket.address_line1), safeString(ticket.address_line2)].filter(Boolean);
-    const cityState = [safeString(ticket.city), safeString(ticket.state_province)].filter(Boolean).join(', ');
-    const postalCountry = [safeString(ticket.postal_code), safeString(ticket.country_code)].filter(Boolean).join(' ');
+    const addressLines = [displayAddressField(safeString(ticket.address_line1)), safeString(ticket.address_line2)].filter(Boolean);
+    const cityState = [displayAddressField(safeString(ticket.city)), safeString(ticket.state_province)].filter(Boolean).join(', ');
+    const postalCountry = [safeString(ticket.postal_code), displayCountry(undefined, safeString(ticket.country_code))].filter(Boolean).join(' ');
     const locationDetailsParts = [...addressLines];
     if (cityState) {
       locationDetailsParts.push(cityState);
@@ -3030,9 +3031,9 @@ async function handleTicketClosed(event: TicketClosedEvent): Promise<void> {
     if (locationName) {
       locationSegments.push(locationName);
     }
-    const addressLines = [safeString(ticket.address_line1), safeString(ticket.address_line2)].filter(Boolean);
-    const cityState = [safeString(ticket.city), safeString(ticket.state_province)].filter(Boolean).join(', ');
-    const postalCountry = [safeString(ticket.postal_code), safeString(ticket.country_code)].filter(Boolean).join(' ');
+    const addressLines = [displayAddressField(safeString(ticket.address_line1)), safeString(ticket.address_line2)].filter(Boolean);
+    const cityState = [displayAddressField(safeString(ticket.city)), safeString(ticket.state_province)].filter(Boolean).join(', ');
+    const postalCountry = [safeString(ticket.postal_code), displayCountry(undefined, safeString(ticket.country_code))].filter(Boolean).join(' ');
     const locationDetailsParts = [...addressLines];
     if (cityState) {
       locationDetailsParts.push(cityState);


### PR DESCRIPTION
Tenant creation now captures the billing address from the Stripe checkout session (with a customer-record fallback) and writes it to the MSP client's default location instead of the N/A/XX/Unknown placeholders. The onboarding wizard's first step displays the address prefil
saves edits back to it, with country resolved against the countries table (never silently defaulting to US). New displayA
helpers in @alga-psa/core strip the placeholders from every rendered address — invoice/quote/sales-order adapters, t
CONCAT_WS builders (via NULLIF), client portal, ticket emails, and client detail views — while leaving stored data untouc

"Toto, I've a feeling we're not in country 'XX'
as displayCountry() swept the curtain aside and revealed there was no great and powerful 'Unknown' at all — just a hu
Stripe, clicking its NULLIF slippers three times: there's no place like Main Office. 🌪️👠📍