### PR TITLE
Unify invoice credit reversal (void/unfinalize/hard-delete)

### DIFF
--- a/docs/plans/2026-08-16-unify-invoice-credit-reversal-plan.md
+++ b/docs/plans/2026-08-16-unify-invoice-credit-reversal-plan.md
@@ -1,0 +1,81 @@
+# Unified invoice credit reversal implementation plan
+
+## Goal
+
+Make invoice credit reversal one transactional ledger operation shared by void, unfinalize, and hard-delete. A draft invoice carries no applied credit; re-finalization may apply credit again under the then-current draw-down policy.
+
+## Current behavior and constraints
+
+- `packages/billing/src/actions/voidInvoiceActions.ts` owns `reverseCreditApplicationsForInvoice`. It reads every `credit_application` transaction for the invoice, restores the `metadata.applied_credits` amounts to `credit_tracking`, writes `credit_adjustment` audit transactions, and zeros `invoices.credit_applied`.
+- `unfinalizeInvoice` in `packages/billing/src/actions/invoiceModification.ts` currently performs no ordinary credit reversal.
+- `hardDeleteInvoice` uses `credit_tracking_usage`, which has no writers, only handles the first application transaction, and then deletes that transaction. This can permanently lose customer credit.
+- The branch inherits the invoice-row-then-credit-rows lock order from the parent branch. Preserve it everywhere: lock the invoice first, then deterministically lock the affected `credit_tracking` rows before reading or changing balances.
+- Existing allocation rows are append-only evidence. Do not infer the active amount from their gross historical sum.
+- Reversal must be repeat-safe. Unfinalize can be followed by re-finalize and another unfinalize, so the primitive must not restore an already-reversed historical application a second time.
+
+## Design
+
+### 1. Turn reversal into the canonical primitive
+
+Move the reusable primitive to a neutral billing module if importing it from `voidInvoiceActions.ts` would create a server-action cycle; otherwise retain the export with a clear dependency direction. Give it a lifecycle-neutral contract such as:
+
+```ts
+reverseCreditApplicationsForInvoice(trx, tenant, invoiceId, actorUserId, reason)
+```
+
+The caller must already be inside a transaction and must have locked the invoice row. The primitive:
+
+1. Reads all `credit_application` transactions for the invoice, not only the first.
+2. Excludes applications already reversed by finding completed `credit_adjustment` transactions whose metadata identifies `reversal_of` that application transaction. This is the idempotency boundary needed for repeated unfinalize/re-finalize cycles.
+3. Validates and flattens each active application's `metadata.applied_credits`; fail the transaction on malformed or missing provenance rather than silently losing credit.
+4. Locks the referenced `credit_tracking` rows in stable `credit_id` order with `FOR UPDATE`, then restores each amount.
+5. Writes one auditable reversal record per application (or another deterministic shape that retains `reversal_of`, reason, actor, and restored credit ids/amounts).
+6. Sets `invoices.credit_applied` to zero before returning a structured result with restored totals/application ids.
+
+Do not delete historical `credit_application`, `credit_adjustment`, or `credit_allocations` rows in this primitive. They are ledger evidence; active-versus-reversed state is determined by the explicit reversal link.
+
+### 2. Make all three lifecycle actions use it
+
+- **Void:** lock the invoice row at the start of the transaction, re-run the relevant guards against that locked truth, and call the primitive for a standard invoice before marking it cancelled. Keep the separate issued-credit-note clawback behavior, including its consumed-credit guard.
+- **Unfinalize:** inside its existing transaction, select the invoice with `FOR UPDATE`, call the primitive before clearing `finalized_at`/setting draft, and retain the existing project-deposit rollback. A subsequent finalization starts from `credit_applied = 0` and may create a new application under current policy.
+- **Hard delete:** lock the invoice first, call the primitive before deleting dependent records, and remove the entire `credit_tracking_usage` restore/delete block. Continue deleting invoice-owned transaction rows later as part of hard deletion, but only after restoration has completed. Preserve existing payment reversal, negative-invoice issued-credit protection, recurring-period guards, and resource-release behavior.
+
+### 3. Preserve transaction and lock semantics
+
+- Every caller performs invoice `FOR UPDATE` before any credit-row lock.
+- The primitive locks all credit rows in a deterministic order to avoid application-vs-reversal and multi-credit deadlocks.
+- All restoration, audit writes, invoice credit reset, and lifecycle mutation commit or roll back together.
+- Concurrent apply must either finish before reversal reads active applications or wait until the lifecycle transaction completes; no interleaving may leave `credit_applied`, `remaining_amount`, and ledger history disagreeing.
+
+## Behavioral tests
+
+Add database-backed tests using committed setup rows and one client per test, following `creditDrawdownConcurrentApply.test.ts` rather than source-string assertions.
+
+1. **Unfinalize reverses:** apply multiple credits/transactions, unfinalize, and assert draft status, `credit_applied = 0`, exact restoration of every `credit_tracking.remaining_amount`, and linked reversal audit rows.
+2. **Re-finalize cycle is repeat-safe:** apply, unfinalize, re-finalize/apply again, unfinalize again; assert the first application is not restored twice and balances never exceed their original amounts.
+3. **Hard delete restores all applications:** use more than one application transaction and more than one underlying credit, delete, and assert exact credit restoration plus invoice removal without relying on `credit_tracking_usage`.
+4. **Void regression:** preserve the existing correct outcome for multiple applications and verify a second invocation cannot duplicate restoration.
+5. **Concurrent apply versus each reversal path:** hold a committed application/reversal at the lock boundary and prove serialization with authoritative post-commit balances. Assert invoice-first then credit-row locking and no deadlock.
+6. **Atomic failure:** inject a malformed/missing application provenance or failed credit update and prove the invoice lifecycle state and all balances remain unchanged.
+7. Retain tests for consumed credit-note guards, project-deposit rollback, exported-invoice restrictions, payments, and recurring-service-period hard-delete guards.
+
+## Deliberately out of scope
+
+- No new UI or feature flag surface.
+- No redesign of credit application ordering/eligibility policy.
+- No backfill of the dead `credit_tracking_usage` table; remove its reversal dependency instead.
+- No deletion or compaction of historical allocation/application ledger rows outside the existing hard-delete transaction cleanup.
+
+## Implementation order
+
+1. Add repeat-safe canonical primitive and focused unit/database coverage.
+2. Convert void while preserving credit-note behavior.
+3. Convert unfinalize and add re-finalize-cycle coverage.
+4. Convert hard-delete and delete the dead usage-table path.
+5. Run the focused billing action suites, concurrency suite serially, billing/server typechecks, then a live smoke covering apply → unfinalize → re-finalize and apply → hard-delete with database balance inspection.
+
+## Review risks
+
+- The existing primitive currently re-reads every historical application; simply calling it from unfinalize would over-credit on a second lifecycle cycle. The explicit `reversal_of` idempotency filter is mandatory.
+- Hard-delete later removes transaction history; reversal must finish before that cleanup, and tests must prove restoration does not depend on rows already deleted.
+- Lock acquisition hidden in helper calls can reintroduce credit-first ordering. Review every call site and test real overlap, not only isolated final values.

--- a/packages/billing/src/actions/creditActions.ts
+++ b/packages/billing/src/actions/creditActions.ts
@@ -818,6 +818,11 @@ export async function applyCreditToInvoiceInternal(
         // (finalize auto-apply, the manual applyCreditToInvoice action, and
         // the REST services) funnels through this function, which always owns
         // this transaction, so this is the single serialization point.
+        //
+        // It also honours the shared lock order every credit writer follows —
+        // invoice row first, then credit rows in stable credit_id order — so
+        // application serializes against a concurrent void/unfinalize/
+        // hard-delete reversal instead of interleaving with it.
         const invoice = await tenantScopedTable(trx, tenant, 'invoices')
             .where({
                 invoice_id: invoiceId,
@@ -1024,23 +1029,42 @@ export async function applyCreditToInvoiceInternal(
             return;
         }
 
+        // Lock the candidate credit rows in stable credit_id order (the same
+        // order the reversal primitive uses after locking the invoice row) and
+        // re-read remaining_amount under the lock: a concurrent apply or
+        // reversal that committed between the unlocked candidate scan above
+        // and this point must be visible before any balance is drawn down, or
+        // the pool could be over-drawn / a restore lost.
+        const candidateCreditIds = creditEntries
+            .map((credit) => String(credit.credit_id))
+            .sort();
+        const lockedCreditRows = await tenantScopedTable(trx, tenant, 'credit_tracking')
+            .whereIn('credit_id', candidateCreditIds)
+            .orderBy('credit_id', 'asc')
+            .forUpdate()
+            .select('credit_id', 'remaining_amount');
+        const lockedRemainingByCreditId = new Map<string, number>(
+            lockedCreditRows.map((row) => [String(row.credit_id), Number(row.remaining_amount)])
+        );
+
         let remainingRequestedAmount = requestedAmount;
         let totalAppliedAmount = 0;
         const appliedCredits: { creditId: string, amount: number, transactionId: string }[] = [];
-        
+
         // Apply credits in order of expiration date until the requested amount is fulfilled
         for (const credit of creditEntries) {
             if (remainingRequestedAmount <= 0) break;
-            
+
+            const lockedRemainingAmount = lockedRemainingByCreditId.get(String(credit.credit_id)) ?? 0;
             const amountToApplyFromCredit = Math.min(
                 remainingRequestedAmount,
-                Number(credit.remaining_amount)
+                lockedRemainingAmount
             );
-            
+
             if (amountToApplyFromCredit <= 0) continue;
-            
+
             // Update the credit tracking entry
-            const newRemainingAmount = Number(credit.remaining_amount) - amountToApplyFromCredit;
+            const newRemainingAmount = lockedRemainingAmount - amountToApplyFromCredit;
             await tenantScopedTable(trx, tenant, 'credit_tracking')
                 .where({ credit_id: credit.credit_id })
                 .update({

--- a/packages/billing/src/actions/invoiceModification.ts
+++ b/packages/billing/src/actions/invoiceModification.ts
@@ -10,6 +10,7 @@ import { toISODate } from '@alga-psa/core';
 // import { auditLog } from '@alga-psa/db';
 import { applyCreditToInvoice, resolveCreditExpirationDate, resolveCreditDrawdownPolicy } from './creditActions';
 import { getAvailableCredit } from '../lib/creditBalance';
+import { reverseCreditApplicationsForInvoice } from '../lib/creditReversal';
 import { IInvoiceCharge, InvoiceViewModel, DiscountType } from '@alga-psa/types';
 import { BillingEngine } from '../lib/billing/billingEngine';
 import ProjectBillingCapUsage from '../models/projectBillingCapUsage';
@@ -1469,12 +1470,13 @@ export const unfinalizeInvoice = withAuth(async (
 
   try {
     await withTransaction(knex, async (trx: Knex.Transaction) => {
-      // Check if invoice exists and is finalized. FOR UPDATE: this
-      // transaction later deletes credit_tracking rows (project-deposit
-      // rollback) and then writes the invoice row — locking the invoice row
-      // first matches applyCreditToInvoiceInternal's invoice-then-credit
-      // lock order, so a concurrent credit application queues here instead
-      // of deadlocking against the rollback's credit-row locks.
+      // Check if invoice exists and is finalized. Lock the invoice row first
+      // (invoice row, then credit rows — the shared lock order every credit
+      // writer follows) so the credit reversal below cannot interleave with a
+      // concurrent apply/void on the same invoice. This also matches
+      // applyCreditToInvoiceInternal's invoice-then-credit lock order, so a
+      // concurrent credit application queues here instead of deadlocking
+      // against the rollback's credit-row locks.
       const invoice = await tenantScopedTable(trx, tenant, 'invoices')
       .where({ invoice_id: invoiceId })
       .forUpdate()
@@ -1503,6 +1505,12 @@ export const unfinalizeInvoice = withAuth(async (
     // Hour blocks minted by this invoice follow it back to draft — unused
     // blocks return to pending; used blocks abort the whole unfinalization.
     await deactivateHourBlocksForUnfinalizedInvoice(trx, tenant, invoiceId, user.user_id);
+
+    // A draft invoice carries no applied credit: reverse the credit
+    // applications (repeat-safe — already-reversed applications are skipped)
+    // so re-finalizing re-applies credit under the then-current draw-down
+    // policy, symmetric with finalize auto-apply.
+    await reverseCreditApplicationsForInvoice(trx, tenant, invoiceId, user.user_id, 'invoice_unfinalized');
 
     // When unfinalizing make sure the invoice returns to draft status even if some
     // environments only toggle the status flag without storing finalized_at.
@@ -2032,10 +2040,12 @@ export const hardDeleteInvoice = withAuth(async (
 
   await withTransaction(knex, async (trx: Knex.Transaction) => {
     const now = new Date().toISOString();
-    // 1. Get invoice details. FOR UPDATE: deletion rolls back project-deposit
-    // credit_tracking rows before deleting the invoice row — taking the
-    // invoice row lock first preserves the invoice-then-credit lock order
-    // applyCreditToInvoiceInternal relies on (deadlock avoidance).
+    // 1. Get invoice details. Lock the invoice row first (invoice row, then
+    // credit rows — the shared lock order every credit writer follows) so the
+    // credit reversal below cannot interleave with a concurrent apply/void.
+    // The lock also preserves the invoice-then-credit lock order that
+    // applyCreditToInvoiceInternal relies on before the deletion's
+    // project-deposit credit_tracking rollback.
     const invoice = await tenantScopedTable(trx, tenant, 'invoices')
       .where({
         invoice_id: invoiceId,
@@ -2102,41 +2112,11 @@ export const hardDeleteInvoice = withAuth(async (
        // TODO: Recalculate client balance after reversals
     }
 
-    // 3. Handle credit applied to this invoice
-    if (invoice.credit_applied > 0) {
-        // Find the credit application transaction
-        const creditAppTransaction = await tenantScopedTable(trx, tenant, 'transactions')
-            .where({
-                invoice_id: invoiceId,
-                type: 'credit_application',
-                tenant: tenant
-            })
-            .first();
-
-        // Find related credit tracking entries that were used
-        const creditTrackingUsed = await tenantScopedTable(trx, tenant, 'credit_tracking_usage')
-            .where({ transaction_id: creditAppTransaction?.transaction_id })
-            .select('credit_id', 'amount_used');
-
-        // Restore the used amounts back to the original credit_tracking entries
-        for (const usage of creditTrackingUsed) {
-            await tenantScopedTable(trx, tenant, 'credit_tracking')
-                .where({ credit_id: usage.credit_id })
-                .increment('remaining_amount', usage.amount_used)
-                .update({ updated_at: new Date().toISOString() }); // Update timestamp
-        }
-
-        // Delete the credit tracking usage records
-        await tenantScopedTable(trx, tenant, 'credit_tracking_usage')
-            .where({ transaction_id: creditAppTransaction?.transaction_id })
-            .delete();
-
-        // Delete the credit application transaction itself. The restored
-        // remaining_amounts above put the credit back in the derived balance.
-        await tenantScopedTable(trx, tenant, 'transactions')
-            .where({ transaction_id: creditAppTransaction?.transaction_id })
-            .delete();
-    }
+    // 3. Handle credit applied to this invoice: restore every application's
+    // credits to the pool through the canonical primitive (repeat-safe, all
+    // application transactions, credit rows locked in stable order) BEFORE the
+    // transaction-history cleanup below deletes the provenance it reads.
+    await reverseCreditApplicationsForInvoice(trx, tenant, invoiceId, user.user_id, 'invoice_deleted');
 
     // Handle credit issued *from* this invoice (if it was negative)
     const creditIssuanceTransaction = await tenantScopedTable(trx, tenant, 'transactions')
@@ -2213,14 +2193,24 @@ export const hardDeleteInvoice = withAuth(async (
       )
       .update({ invoiced: false });
 
-    // 6. Delete other transactions related to the invoice (e.g., invoice_generated, price_adjustment)
+    // 6. Delete other transactions related to the invoice (e.g., invoice_generated,
+    // price_adjustment, and the credit_application/credit_adjustment ledger rows —
+    // restoration already completed above, so this cleanup no longer loses credit).
+    // Allocation rows FK the application transactions, so they go first.
+    await tenantScopedTable(trx, tenant, 'credit_allocations')
+      .where({
+        invoice_id: invoiceId,
+        tenant
+      })
+      .delete();
+
     await tenantScopedTable(trx, tenant, 'transactions')
       .where({
         invoice_id: invoiceId,
         tenant
       })
-      // Exclude types already handled (payment, payment_reversal, credit_application, credit_issuance...)
-      .whereNotIn('type', ['payment', 'payment_reversal', 'credit_application', 'credit_issuance_from_negative_invoice'])
+      // Exclude types already handled (payment, payment_reversal, credit_issuance...)
+      .whereNotIn('type', ['payment', 'payment_reversal', 'credit_issuance_from_negative_invoice'])
       .delete();
 
     // 7. Delete join records

--- a/packages/billing/src/actions/voidInvoiceActions.test.ts
+++ b/packages/billing/src/actions/voidInvoiceActions.test.ts
@@ -30,191 +30,11 @@ vi.mock('../services/accountingSync/invoiceTerminalStatusHandlers', () => ({
   listPendingInvoicePaymentLinks: vi.fn(),
 }));
 
-import { reverseCreditApplicationsForInvoice, voidInvoice } from './voidInvoiceActions';
+import { voidInvoice } from './voidInvoiceActions';
 import { createTenantKnex } from '@alga-psa/db';
 import { notifyInvoiceTerminalStatus } from '../services/accountingSync/invoiceTerminalStatusHandlers';
 
-// ── Helper: build a fake transaction (knex-like) ────────────────────────────
-
-function makeQueryBuilder(returnValue: any = null) {
-  const builder: any = {};
-  builder.where = vi.fn(() => builder);
-  builder.whereIn = vi.fn(() => builder);
-  builder.first = vi.fn(async (..._args: any[]) => returnValue);
-  builder.select = vi.fn(() => builder);
-  builder.increment = vi.fn(() => builder);
-  builder.decrement = vi.fn(() => builder);
-  builder.forUpdate = vi.fn(() => builder);
-  builder.update = vi.fn(async () => 1);
-  builder.insert = vi.fn(async () => [{}]);
-  builder.sum = vi.fn(() => builder);
-  return builder;
-}
-
-function makeTrx(tableMap: Record<string, any> = {}) {
-  const trx = vi.fn((tableName: string) => {
-    return tableMap[tableName] ?? makeQueryBuilder(null);
-  }) as any;
-  trx.raw = vi.fn((sql: string) => sql);
-  return trx;
-}
-
-describe('reverseCreditApplicationsForInvoice', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('does nothing when no credit_application transactions exist', async () => {
-    const transactionsQb = makeQueryBuilder([]);
-    transactionsQb.select = vi.fn(() => ({ ...transactionsQb, then: undefined }));
-    // Override where+select chain to return empty array
-    const whereResult = {
-      where: vi.fn(() => whereResult),
-      select: vi.fn(async () => []),
-      // Make it thenable so await works
-    };
-    whereResult.select = vi.fn().mockResolvedValue([]);
-
-    const trx = vi.fn((tableName: string) => {
-      if (tableName === 'transactions') {
-        return {
-          where: vi.fn(() => ({ select: vi.fn().mockResolvedValue([]) }))
-        };
-      }
-      return makeQueryBuilder(null);
-    }) as any;
-
-    // Should complete without error
-    await expect(
-      reverseCreditApplicationsForInvoice(trx, 'tenant-1', 'inv-1', 'user-1')
-    ).resolves.toBeUndefined();
-  });
-
-  it('restores credit balance and writes reversal transaction when credit_application exists', async () => {
-    const txnRecord = {
-      transaction_id: 'txn-1',
-      client_id: 'client-1',
-      invoice_id: 'inv-1',
-      tenant: 'tenant-1',
-      metadata: {
-        applied_credits: [
-          { creditId: 'credit-1', amount: 50 },
-          { creditId: 'credit-2', amount: 30 }
-        ]
-      }
-    };
-
-    const creditTrackingQb = makeQueryBuilder(null);
-    const clientsQb = makeQueryBuilder(null);
-    const invoicesQb = makeQueryBuilder(null);
-    const insertTxnQb = makeQueryBuilder(null);
-
-    const callLog: string[] = [];
-
-    const trx = vi.fn((tableName: string) => {
-      if (tableName === 'transactions') {
-        return {
-          where: vi.fn(() => ({
-            select: vi.fn().mockResolvedValue([txnRecord])
-          })),
-          insert: vi.fn(async () => {
-            callLog.push('transactions.insert');
-          })
-        };
-      }
-      if (tableName === 'credit_tracking') {
-        return {
-          where: vi.fn(() => ({
-            increment: vi.fn(() => ({
-              update: vi.fn(async () => {
-                callLog.push('credit_tracking.update');
-              })
-            }))
-          }))
-        };
-      }
-      if (tableName === 'clients') {
-        return {
-          where: vi.fn(() => ({
-            increment: vi.fn(async () => {
-              callLog.push('clients.increment');
-            })
-          }))
-        };
-      }
-      if (tableName === 'invoices') {
-        return {
-          where: vi.fn(() => ({
-            update: vi.fn(async () => {
-              callLog.push('invoices.update');
-            })
-          }))
-        };
-      }
-      return makeQueryBuilder(null);
-    }) as any;
-
-    await reverseCreditApplicationsForInvoice(trx, 'tenant-1', 'inv-1', 'user-1');
-
-    // credit_tracking should have been updated for each applied credit (2 credits)
-    const creditTrackingUpdates = callLog.filter((e) => e === 'credit_tracking.update');
-    expect(creditTrackingUpdates).toHaveLength(2);
-
-    // Balance derives from the ledger (a3ef7392a1): restoring
-    // remaining_amount IS the balance restore — no clients write.
-    expect(callLog).not.toContain('clients.increment');
-
-    // A reversal transaction should have been inserted
-    expect(callLog).toContain('transactions.insert');
-
-    // Invoice credit_applied should have been zeroed
-    expect(callLog).toContain('invoices.update');
-  });
-
-  it('does not increment clients or insert transaction when totalRestored is 0', async () => {
-    const txnRecord = {
-      transaction_id: 'txn-2',
-      client_id: 'client-2',
-      invoice_id: 'inv-2',
-      tenant: 'tenant-1',
-      metadata: { applied_credits: [] } // no credits applied
-    };
-
-    const callLog: string[] = [];
-
-    const trx = vi.fn((tableName: string) => {
-      if (tableName === 'transactions') {
-        return {
-          where: vi.fn(() => ({
-            select: vi.fn().mockResolvedValue([txnRecord])
-          })),
-          insert: vi.fn(async () => {
-            callLog.push('transactions.insert');
-          })
-        };
-      }
-      if (tableName === 'invoices') {
-        return {
-          where: vi.fn(() => ({
-            update: vi.fn(async () => {
-              callLog.push('invoices.update');
-            })
-          }))
-        };
-      }
-      return makeQueryBuilder(null);
-    }) as any;
-
-    await reverseCreditApplicationsForInvoice(trx, 'tenant-1', 'inv-2', 'user-1');
-
-    // With no applied_credits, no reversal transaction should be inserted
-    expect(callLog).not.toContain('transactions.insert');
-    // But invoices.update still runs (credit_applied zeroed) since creditAppTxns.length > 0
-    expect(callLog).toContain('invoices.update');
-  });
-});
-
-// ── voidInvoice: credit-note claw-back ──────────────────────────────────────
+// ── voidInvoice harness ─────────────────────────────────────────────────────
 
 interface VoidHarnessOptions {
   /** Some of the issued credit was already spent (trips the guard). */
@@ -225,38 +45,99 @@ interface VoidHarnessOptions {
    * window where a concurrent application commits between the two reads.
    */
   consumedUnderLockOnly?: boolean;
+  /** Standard-invoice mode: positive invoice with these applied credits. */
+  standardInvoice?: {
+    creditApplied: number;
+    applications: Array<{
+      transactionId: string;
+      appliedCredits: Array<{ creditId: string; amount: number }>;
+    }>;
+    /** Pre-existing completed credit_adjustment reversal links. */
+    reversedTransactionIds?: string[];
+  };
 }
 
 /**
- * Fake knex for the voidInvoice credit-note path. The issuance transaction is
+ * Fake knex for voidInvoice. Credit-note mode: the issuance transaction is
  * typed 'credit_issuance_from_negative_invoice' — the type real credit notes
  * write — which the pre-fix code missed entirely (it queried only
  * 'credit_issuance'), leaving phantom spendable credit after a void.
+ * Standard mode: drives the shared reversal primitive end to end against the
+ * fake tables (voidInvoice → reverseCreditApplicationsForInvoice).
  */
 function makeVoidHarness(options: VoidHarnessOptions = {}) {
   const log: Array<{ table: string; op: string; args: any }> = [];
   const issuanceTxn = { transaction_id: 'txn-iss-1', client_id: 'client-1', amount: 1800 };
-  const invoiceRow = {
-    invoice_id: 'inv-cn-1',
-    tenant: 'tenant-1',
-    finalized_at: '2026-06-01T00:00:00.000Z',
-    status: 'sent',
-    invoice_type: 'credit_note',
-    total_amount: -1800,
-    client_id: 'client-1',
-    is_prepayment: false,
-    credit_applied: 0
-  };
+  const standard = options.standardInvoice;
+  const invoiceRow = standard
+    ? {
+        invoice_id: 'inv-std-1',
+        tenant: 'tenant-1',
+        finalized_at: '2026-06-01T00:00:00.000Z',
+        status: 'sent',
+        invoice_type: 'standard',
+        total_amount: 5000,
+        client_id: 'client-1',
+        is_prepayment: false,
+        credit_applied: standard.creditApplied
+      }
+    : {
+        invoice_id: 'inv-cn-1',
+        tenant: 'tenant-1',
+        finalized_at: '2026-06-01T00:00:00.000Z',
+        status: 'sent',
+        invoice_type: 'credit_note',
+        total_amount: -1800,
+        client_id: 'client-1',
+        is_prepayment: false,
+        credit_applied: 0
+      };
 
   const knex: any = vi.fn((tableName: string) => {
     const builder: any = {};
     const filters: Array<[string, any[]]> = [];
-    builder.where = vi.fn((...args: any[]) => { filters.push(['where', args]); return builder; });
-    builder.whereIn = vi.fn((...args: any[]) => { filters.push(['whereIn', args]); return builder; });
-    builder.sum = vi.fn(() => builder);
+    const record = (method: string) => vi.fn((...args: any[]) => {
+      filters.push([method, args]);
+      return builder;
+    });
+    builder.where = record('where');
+    builder.whereIn = record('whereIn');
+    builder.orderBy = record('orderBy');
+    builder.forUpdate = record('forUpdate');
+    builder.sum = record('sum');
+    builder.increment = record('increment');
     builder.select = vi.fn(async () => {
-      if (tableName === 'transactions') return [issuanceTxn];
+      if (tableName === 'transactions') {
+        if (standard) {
+          const typeFilter = filters
+            .filter(([method]) => method === 'where')
+            .map(([, args]) => args[0]?.type)
+            .find(Boolean);
+          if (typeFilter === 'credit_application') {
+            return standard.applications.map((app) => ({
+              transaction_id: app.transactionId,
+              client_id: 'client-1',
+              invoice_id: invoiceRow.invoice_id,
+              tenant: 'tenant-1',
+              metadata: { applied_credits: app.appliedCredits }
+            }));
+          }
+          if (typeFilter === 'credit_adjustment') {
+            return (standard.reversedTransactionIds ?? []).map((id, index) => ({
+              transaction_id: `adj-${index}`,
+              metadata: { reversal_of: id }
+            }));
+          }
+          return [];
+        }
+        return [issuanceTxn];
+      }
       if (tableName === 'credit_tracking') {
+        if (standard) {
+          // The primitive's FOR UPDATE lock read: echo back the requested ids.
+          const requested: string[] = filters.find(([method]) => method === 'whereIn')?.[1]?.[1] ?? [];
+          return requested.map((id) => ({ credit_id: id }));
+        }
         // In-transaction consumed re-check (post-FOR UPDATE): the note's
         // credit rows as the locks reveal them.
         return options.consumedUnderLockOnly
@@ -285,8 +166,6 @@ function makeVoidHarness(options: VoidHarnessOptions = {}) {
       log.push({ table: tableName, op: 'decrement', args: { column, amount } });
       return builder;
     });
-    builder.increment = vi.fn(() => builder);
-    builder.forUpdate = vi.fn(() => builder);
     return builder;
   });
   knex.raw = vi.fn((sql: string) => sql);
@@ -374,5 +253,67 @@ describe('voidInvoice (credit note)', () => {
 
     // Nothing was mutated.
     expect(log.every((e) => e.op !== 'insert' && e.op !== 'update')).toBe(true);
+  });
+});
+
+describe('voidInvoice (standard invoice)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reverses every credit application through the shared primitive before cancelling', async () => {
+    const { knex, log } = makeVoidHarness({
+      standardInvoice: {
+        creditApplied: 80,
+        applications: [
+          { transactionId: 'txn-app-1', appliedCredits: [{ creditId: 'credit-1', amount: 50 }] },
+          { transactionId: 'txn-app-2', appliedCredits: [{ creditId: 'credit-2', amount: 30 }] },
+        ],
+      },
+    });
+    vi.mocked(createTenantKnex).mockResolvedValue({ knex, tenant: 'tenant-1' } as any);
+
+    const result = await (voidInvoice as any)(
+      { user_id: 'user-1' },
+      { tenant: 'tenant-1' },
+      'inv-std-1',
+      'billing error'
+    );
+    expect(result).toEqual({ success: true });
+
+    // Both applications restored…
+    expect(log.filter((e) => e.table === 'credit_tracking' && e.op === 'update')).toHaveLength(2);
+    // …with one linked reversal record each…
+    const adjustments = log.filter((e) => e.table === 'transactions' && e.op === 'insert' && e.args.type === 'credit_adjustment');
+    expect(adjustments.map((e) => e.args.metadata.reversal_of).sort()).toEqual(['txn-app-1', 'txn-app-2']);
+    expect(adjustments.every((e) => e.args.metadata.reason === 'invoice_voided')).toBe(true);
+    // …credit_applied zeroed, then the document cancelled.
+    expect(log.some((e) => e.table === 'invoices' && e.op === 'update' && e.args.credit_applied === 0)).toBe(true);
+    expect(log.some((e) => e.table === 'invoices' && e.op === 'update' && e.args.status === 'cancelled')).toBe(true);
+  });
+
+  it('does not restore applications already reversed (repeat-safe)', async () => {
+    const { knex, log } = makeVoidHarness({
+      standardInvoice: {
+        creditApplied: 0,
+        applications: [
+          { transactionId: 'txn-app-1', appliedCredits: [{ creditId: 'credit-1', amount: 50 }] },
+        ],
+        reversedTransactionIds: ['txn-app-1'],
+      },
+    });
+    vi.mocked(createTenantKnex).mockResolvedValue({ knex, tenant: 'tenant-1' } as any);
+
+    const result = await (voidInvoice as any)(
+      { user_id: 'user-1' },
+      { tenant: 'tenant-1' },
+      'inv-std-1',
+      'second void attempt'
+    );
+    expect(result).toEqual({ success: true });
+
+    // No restore, no new adjustment — only the cancel writes.
+    expect(log.filter((e) => e.table === 'credit_tracking')).toHaveLength(0);
+    expect(log.filter((e) => e.table === 'transactions' && e.op === 'insert' && e.args.type === 'credit_adjustment')).toHaveLength(0);
   });
 });

--- a/packages/billing/src/actions/voidInvoiceActions.ts
+++ b/packages/billing/src/actions/voidInvoiceActions.ts
@@ -7,68 +7,9 @@ import { Knex } from 'knex';
 import { v4 as uuidv4 } from 'uuid';
 import { withAuth } from '@alga-psa/auth';
 import { hasPermission } from '@alga-psa/auth/rbac';
+import { reverseCreditApplicationsForInvoice } from '../lib/creditReversal';
 import { enqueueInvoiceVoid } from '../services/accountingSync/syncProducers';
 import { notifyInvoiceTerminalStatus } from '../services/accountingSync/invoiceTerminalStatusHandlers';
-
-// Exported for testing
-export async function reverseCreditApplicationsForInvoice(
-  trx: Knex.Transaction,
-  tenant: string,
-  invoiceId: string,
-  userId: string
-): Promise<void> {
-  // Find all credit_application transactions for this invoice
-  const creditAppTxns = await tenantDb(trx, tenant).table('transactions')
-    .where({ invoice_id: invoiceId, type: 'credit_application' })
-    .select('*');
-
-  for (const txn of creditAppTxns) {
-    const appliedCredits: Array<{ creditId: string; amount: number }> =
-      (txn.metadata as any)?.applied_credits ?? [];
-
-    let totalRestored = 0;
-
-    for (const applied of appliedCredits) {
-      // Restore the credit tracking pool
-      await tenantDb(trx, tenant).table('credit_tracking')
-        .where({ credit_id: applied.creditId })
-        .increment('remaining_amount', applied.amount)
-        .update({ updated_at: new Date().toISOString() });
-
-      totalRestored += applied.amount;
-    }
-
-    if (totalRestored > 0) {
-      // The restored remaining_amounts above put the credit back in the
-      // derived balance; only the reversing transaction is left to write.
-
-      // Write reversing transaction
-      await tenantDb(trx, tenant).table('transactions').insert({
-        transaction_id: uuidv4(),
-        client_id: txn.client_id,
-        invoice_id: invoiceId,
-        amount: totalRestored,
-        type: 'credit_adjustment',
-        status: 'completed',
-        description: `Credit reversal due to invoice void`,
-        created_at: new Date().toISOString(),
-        balance_after: null,
-        tenant,
-        metadata: {
-          reversal_of: txn.transaction_id,
-          reason: 'invoice_voided'
-        }
-      });
-    }
-  }
-
-  // Zero out credit_applied on the invoice
-  if (creditAppTxns.length > 0) {
-    await tenantDb(trx, tenant).table('invoices')
-      .where({ invoice_id: invoiceId })
-      .update({ credit_applied: 0, updated_at: new Date().toISOString() });
-  }
-}
 
 export type VoidInvoiceResult =
   | { success: true }
@@ -264,9 +205,11 @@ export const voidInvoice = withAuth(async (
       // Standard invoice: reverse any credit applications. Decided from the
       // locked row, not the pre-transaction snapshot — a concurrent
       // application committing between the two reads is invisible to the
-      // snapshot but must still be reversed.
+      // snapshot but must still be reversed. The canonical primitive
+      // (packages/billing/src/lib/creditReversal.ts) is repeat-safe and
+      // restores every application.
       if (Number(lockedInvoice.credit_applied ?? 0) > 0) {
-        await reverseCreditApplicationsForInvoice(trx, tenant, invoiceId, user.user_id);
+        await reverseCreditApplicationsForInvoice(trx, tenant, invoiceId, user.user_id, 'invoice_voided');
       }
     }
 

--- a/packages/billing/src/lib/creditReversal.test.ts
+++ b/packages/billing/src/lib/creditReversal.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('@alga-psa/db', () => ({
+  // Facade passthrough: the fakes below dispatch by table name; tenant
+  // scoping is the real facade's concern, not this test's.
+  tenantDb: (conn: any, _tenant: string) => ({ table: (name: string) => conn(name) })
+}));
+
+import { reverseCreditApplicationsForInvoice } from './creditReversal';
+
+// ── Fake transaction ────────────────────────────────────────────────────────
+//
+// One builder per trx(tableName) call; chained filters are recorded so the
+// dispatch can distinguish e.g. the credit_application read from the
+// credit_adjustment read on the same table.
+
+interface FakeTables {
+  creditApplications?: any[];
+  creditAdjustments?: any[];
+  /** credit_id values the FOR UPDATE lock query finds. */
+  lockedCreditIds?: string[];
+}
+
+function makeTrx(tables: FakeTables) {
+  const log: Array<{ table: string; op: string; args: any; filters: any[] }> = [];
+
+  const trx = vi.fn((tableName: string) => {
+    const filters: Array<{ method: string; args: any[] }> = [];
+    const builder: any = {};
+    const chain = (method: string) =>
+      vi.fn((...args: any[]) => {
+        filters.push({ method, args });
+        return builder;
+      });
+    builder.where = chain('where');
+    builder.whereIn = chain('whereIn');
+    builder.orderBy = chain('orderBy');
+    builder.forUpdate = chain('forUpdate');
+    builder.increment = chain('increment');
+    builder.select = vi.fn(async (..._args: any[]) => {
+      if (tableName === 'transactions') {
+        const typeFilter = filters.find(
+          (f) => f.method === 'where' && f.args[0]?.type
+        )?.args[0]?.type;
+        if (typeFilter === 'credit_application') return tables.creditApplications ?? [];
+        if (typeFilter === 'credit_adjustment') return tables.creditAdjustments ?? [];
+        return [];
+      }
+      if (tableName === 'credit_tracking') {
+        const requested: string[] = filters.find((f) => f.method === 'whereIn')?.args[1] ?? [];
+        const available = new Set(tables.lockedCreditIds ?? requested);
+        return requested.filter((id) => available.has(id)).map((id) => ({ credit_id: id }));
+      }
+      return [];
+    });
+    builder.update = vi.fn(async (args: any) => {
+      log.push({ table: tableName, op: 'update', args, filters: [...filters] });
+      return 1;
+    });
+    builder.insert = vi.fn(async (args: any) => {
+      log.push({ table: tableName, op: 'insert', args, filters: [...filters] });
+    });
+    return builder;
+  }) as any;
+  trx.raw = vi.fn((sql: string) => sql);
+
+  return { trx, log };
+}
+
+function application(
+  transactionId: string,
+  appliedCredits: Array<{ creditId: string; amount: number }> | undefined,
+  overrides: Record<string, unknown> = {}
+) {
+  return {
+    transaction_id: transactionId,
+    client_id: 'client-1',
+    invoice_id: 'inv-1',
+    tenant: 'tenant-1',
+    metadata: appliedCredits === undefined ? {} : { applied_credits: appliedCredits },
+    ...overrides,
+  };
+}
+
+describe('reverseCreditApplicationsForInvoice', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('zeroes credit_applied and restores nothing when no applications exist', async () => {
+    const { trx, log } = makeTrx({ creditApplications: [] });
+
+    const result = await reverseCreditApplicationsForInvoice(trx, 'tenant-1', 'inv-1', 'user-1', 'invoice_voided');
+
+    expect(result.totalRestored).toBe(0);
+    expect(result.reversedApplications).toEqual([]);
+    expect(log.filter((e) => e.table === 'credit_tracking')).toHaveLength(0);
+    expect(log.filter((e) => e.table === 'transactions' && e.op === 'insert')).toHaveLength(0);
+    // The invariant holds even for a no-op: a reversed invoice carries no credit.
+    const invoiceUpdate = log.find((e) => e.table === 'invoices' && e.op === 'update');
+    expect(invoiceUpdate?.args.credit_applied).toBe(0);
+  });
+
+  it('restores every application (not only the first) and writes one reversal per application', async () => {
+    const { trx, log } = makeTrx({
+      creditApplications: [
+        application('txn-1', [
+          { creditId: 'credit-1', amount: 50 },
+          { creditId: 'credit-2', amount: 30 },
+        ]),
+        application('txn-2', [{ creditId: 'credit-2', amount: 20 }]),
+      ],
+    });
+
+    const result = await reverseCreditApplicationsForInvoice(trx, 'tenant-1', 'inv-1', 'user-1', 'invoice_voided');
+
+    expect(result.totalRestored).toBe(100);
+    expect(result.reversedApplications.map((r) => r.transactionId)).toEqual(['txn-1', 'txn-2']);
+
+    const restores = log.filter((e) => e.table === 'credit_tracking' && e.op === 'update');
+    expect(restores).toHaveLength(3);
+
+    const adjustments = log.filter((e) => e.table === 'transactions' && e.op === 'insert');
+    expect(adjustments).toHaveLength(2);
+    expect(adjustments[0].args.type).toBe('credit_adjustment');
+    expect(adjustments[0].args.metadata.reversal_of).toBe('txn-1');
+    expect(adjustments[0].args.metadata.reason).toBe('invoice_voided');
+    expect(adjustments[0].args.metadata.reversed_by).toBe('user-1');
+    expect(adjustments[0].args.amount).toBe(80);
+    expect(adjustments[1].args.metadata.reversal_of).toBe('txn-2');
+    expect(adjustments[1].args.amount).toBe(20);
+
+    const invoiceUpdate = log.find((e) => e.table === 'invoices' && e.op === 'update');
+    expect(invoiceUpdate?.args.credit_applied).toBe(0);
+  });
+
+  it('skips applications already reversed by a completed credit_adjustment (repeat-safe)', async () => {
+    const { trx, log } = makeTrx({
+      creditApplications: [
+        application('txn-1', [{ creditId: 'credit-1', amount: 50 }]),
+        application('txn-2', [{ creditId: 'credit-1', amount: 25 }]),
+      ],
+      creditAdjustments: [
+        { transaction_id: 'adj-1', metadata: { reversal_of: 'txn-1', reason: 'invoice_unfinalized' } },
+      ],
+    });
+
+    const result = await reverseCreditApplicationsForInvoice(trx, 'tenant-1', 'inv-1', 'user-1', 'invoice_unfinalized');
+
+    // Only the not-yet-reversed application restores.
+    expect(result.totalRestored).toBe(25);
+    expect(result.reversedApplications.map((r) => r.transactionId)).toEqual(['txn-2']);
+    const adjustments = log.filter((e) => e.table === 'transactions' && e.op === 'insert');
+    expect(adjustments).toHaveLength(1);
+    expect(adjustments[0].args.metadata.reversal_of).toBe('txn-2');
+  });
+
+  it('is a no-op (besides the credit_applied reset) when every application is already reversed', async () => {
+    const { trx, log } = makeTrx({
+      creditApplications: [application('txn-1', [{ creditId: 'credit-1', amount: 50 }])],
+      creditAdjustments: [{ transaction_id: 'adj-1', metadata: { reversal_of: 'txn-1' } }],
+    });
+
+    const result = await reverseCreditApplicationsForInvoice(trx, 'tenant-1', 'inv-1', 'user-1', 'invoice_unfinalized');
+
+    expect(result.totalRestored).toBe(0);
+    expect(log.filter((e) => e.table === 'credit_tracking')).toHaveLength(0);
+    expect(log.filter((e) => e.table === 'transactions' && e.op === 'insert')).toHaveLength(0);
+  });
+
+  it('fails fast on missing applied_credits provenance instead of silently losing credit', async () => {
+    const { trx, log } = makeTrx({
+      creditApplications: [application('txn-1', undefined)],
+    });
+
+    await expect(
+      reverseCreditApplicationsForInvoice(trx, 'tenant-1', 'inv-1', 'user-1', 'invoice_voided')
+    ).rejects.toThrow(/no applied_credits provenance/);
+    // Nothing mutated before the failure.
+    expect(log).toHaveLength(0);
+  });
+
+  it('fails fast on malformed applied_credits entries', async () => {
+    const { trx } = makeTrx({
+      creditApplications: [application('txn-1', [{ creditId: '', amount: 10 } as any])],
+    });
+
+    await expect(
+      reverseCreditApplicationsForInvoice(trx, 'tenant-1', 'inv-1', 'user-1', 'invoice_voided')
+    ).rejects.toThrow(/missing a creditId/);
+  });
+
+  it('fails fast when a referenced credit_tracking row no longer exists', async () => {
+    const { trx, log } = makeTrx({
+      creditApplications: [
+        application('txn-1', [
+          { creditId: 'credit-1', amount: 50 },
+          { creditId: 'credit-gone', amount: 10 },
+        ]),
+      ],
+      lockedCreditIds: ['credit-1'],
+    });
+
+    await expect(
+      reverseCreditApplicationsForInvoice(trx, 'tenant-1', 'inv-1', 'user-1', 'invoice_deleted')
+    ).rejects.toThrow(/credit_tracking rows missing for credit id\(s\) credit-gone/);
+    // Nothing mutated before the failure.
+    expect(log).toHaveLength(0);
+  });
+
+  it('parses string metadata (driver variance) and still reverses', async () => {
+    const { trx, log } = makeTrx({
+      creditApplications: [
+        application('txn-1', undefined, {
+          metadata: JSON.stringify({ applied_credits: [{ creditId: 'credit-1', amount: 40 }] }),
+        }),
+      ],
+    });
+
+    const result = await reverseCreditApplicationsForInvoice(trx, 'tenant-1', 'inv-1', 'user-1', 'invoice_voided');
+
+    expect(result.totalRestored).toBe(40);
+    expect(log.filter((e) => e.table === 'credit_tracking' && e.op === 'update')).toHaveLength(1);
+  });
+
+  it('tolerates an empty applied_credits array without writing a reversal row', async () => {
+    const { trx, log } = makeTrx({
+      creditApplications: [application('txn-1', [])],
+    });
+
+    const result = await reverseCreditApplicationsForInvoice(trx, 'tenant-1', 'inv-1', 'user-1', 'invoice_voided');
+
+    expect(result.totalRestored).toBe(0);
+    expect(log.filter((e) => e.table === 'transactions' && e.op === 'insert')).toHaveLength(0);
+    // credit_applied is still zeroed.
+    expect(log.some((e) => e.table === 'invoices' && e.op === 'update' && e.args.credit_applied === 0)).toBe(true);
+  });
+});

--- a/packages/billing/src/lib/creditReversal.ts
+++ b/packages/billing/src/lib/creditReversal.ts
@@ -1,0 +1,240 @@
+import { tenantDb } from '@alga-psa/db';
+import type { Knex } from 'knex';
+import { v4 as uuidv4 } from 'uuid';
+
+/**
+ * Canonical reversal of the credits applied to an invoice — the single
+ * primitive behind void, unfinalize, and hard-delete. The ledger is the
+ * source of truth: `credit_application` transactions carry
+ * `metadata.applied_credits` provenance, and a reversal restores those exact
+ * amounts to `credit_tracking` and writes one auditable `credit_adjustment`
+ * per application with `metadata.reversal_of` linking back.
+ *
+ * Contract:
+ * - The caller must already be inside a transaction and must have locked the
+ *   invoice row (`SELECT … FOR UPDATE` on `invoices`) before calling. The
+ *   primitive then locks the referenced `credit_tracking` rows in stable
+ *   `credit_id` order — the shared invoice-row-then-credit-rows lock order
+ *   that every writer of these tables follows to avoid deadlocks.
+ * - Repeat-safe: applications already reversed (a completed
+ *   `credit_adjustment` whose `metadata.reversal_of` names the application
+ *   transaction) are skipped, so unfinalize → re-finalize → unfinalize cycles
+ *   never restore the same application twice.
+ * - All application transactions are reversed, not only the first.
+ * - Historical `credit_application` / `credit_adjustment` / `credit_allocations`
+ *   rows are never deleted here — they are ledger evidence. Active-versus-
+ *   reversed state is determined by the explicit `reversal_of` link.
+ * - Malformed or missing provenance fails the transaction instead of silently
+ *   losing customer credit.
+ * - `invoices.credit_applied` is set to zero before returning: a draft,
+ *   cancelled, or deleted invoice carries no applied credit.
+ */
+
+export interface RestoredCredit {
+  creditId: string;
+  amount: number;
+}
+
+export interface ReversedCreditApplication {
+  /** The `credit_application` transaction that was reversed. */
+  transactionId: string;
+  /** Sum restored to the credit pool for this application. */
+  restoredAmount: number;
+  /** Per-credit restored amounts (mirrors the application's provenance). */
+  restoredCredits: RestoredCredit[];
+}
+
+export interface CreditReversalResult {
+  reversedApplications: ReversedCreditApplication[];
+  totalRestored: number;
+}
+
+function parseTransactionMetadata(
+  metadata: unknown,
+  transactionId: string
+): Record<string, unknown> | null {
+  if (metadata == null) {
+    return null;
+  }
+  if (typeof metadata === 'string') {
+    try {
+      return JSON.parse(metadata) as Record<string, unknown>;
+    } catch {
+      throw new Error(
+        `Credit transaction ${transactionId} has unparseable metadata; refusing to reverse without provenance`
+      );
+    }
+  }
+  if (typeof metadata === 'object') {
+    return metadata as Record<string, unknown>;
+  }
+  return null;
+}
+
+/**
+ * Validate and flatten one application's `metadata.applied_credits`. Fails
+ * fast on missing or malformed provenance — restoring a guessed amount (or
+ * silently restoring nothing) would permanently lose or invent customer
+ * credit.
+ */
+function extractAppliedCredits(txn: {
+  transaction_id: string;
+  metadata: unknown;
+}): RestoredCredit[] {
+  const metadata = parseTransactionMetadata(txn.metadata, txn.transaction_id);
+  const appliedCredits = metadata?.applied_credits;
+  if (!Array.isArray(appliedCredits)) {
+    throw new Error(
+      `Credit application transaction ${txn.transaction_id} has no applied_credits provenance; refusing to reverse it blind`
+    );
+  }
+
+  return appliedCredits.map((entry: any, index: number): RestoredCredit => {
+    const creditId = entry?.creditId;
+    const amount = Number(entry?.amount);
+    if (typeof creditId !== 'string' || creditId.length === 0) {
+      throw new Error(
+        `Credit application transaction ${txn.transaction_id} applied_credits[${index}] is missing a creditId`
+      );
+    }
+    if (!Number.isFinite(amount) || amount < 0) {
+      throw new Error(
+        `Credit application transaction ${txn.transaction_id} applied_credits[${index}] has an invalid amount (${String(entry?.amount)})`
+      );
+    }
+    return { creditId, amount };
+  });
+}
+
+export async function reverseCreditApplicationsForInvoice(
+  trx: Knex.Transaction,
+  tenant: string,
+  invoiceId: string,
+  userId: string,
+  reason: string
+): Promise<CreditReversalResult> {
+  const now = new Date().toISOString();
+  const db = tenantDb(trx, tenant);
+
+  // Every credit_application for this invoice — not only the first.
+  // Deterministic order keeps reversal audit rows reproducible.
+  const creditAppTxns = await db
+    .table('transactions')
+    .where({ invoice_id: invoiceId, type: 'credit_application' })
+    .orderBy([
+      { column: 'created_at', order: 'asc' },
+      { column: 'transaction_id', order: 'asc' },
+    ])
+    .select('*');
+
+  // Idempotency boundary: an application already reversed by a completed
+  // credit_adjustment (metadata.reversal_of) must not be restored again, or
+  // repeated unfinalize/re-finalize cycles would over-credit the client.
+  let alreadyReversedIds = new Set<string>();
+  if (creditAppTxns.length > 0) {
+    const adjustments = await db
+      .table('transactions')
+      .where({ invoice_id: invoiceId, type: 'credit_adjustment', status: 'completed' })
+      .select('transaction_id', 'metadata');
+    alreadyReversedIds = new Set(
+      adjustments
+        .map((adj: any) => parseTransactionMetadata(adj.metadata, adj.transaction_id)?.reversal_of)
+        .filter((id: unknown): id is string => typeof id === 'string' && id.length > 0)
+    );
+  }
+
+  // Validate provenance for every active application up front so nothing is
+  // mutated when any of them would fail.
+  const activeApplications = creditAppTxns
+    .filter((txn: any) => !alreadyReversedIds.has(txn.transaction_id))
+    .map((txn: any) => ({ txn, appliedCredits: extractAppliedCredits(txn) }));
+
+  // Lock the referenced credit rows in stable credit_id order (the invoice row
+  // is already locked by the caller — invoice first, then credit rows). A
+  // missing credit row means the provenance points at credit we can no longer
+  // restore; fail rather than silently dropping it.
+  const creditIds = Array.from(
+    new Set(
+      activeApplications.flatMap(({ appliedCredits }) =>
+        appliedCredits.filter((c) => c.amount > 0).map((c) => c.creditId)
+      )
+    )
+  ).sort();
+
+  if (creditIds.length > 0) {
+    const lockedRows = await db
+      .table('credit_tracking')
+      .whereIn('credit_id', creditIds)
+      .orderBy('credit_id', 'asc')
+      .forUpdate()
+      .select('credit_id');
+    if (lockedRows.length !== creditIds.length) {
+      const found = new Set(lockedRows.map((row: any) => String(row.credit_id)));
+      const missing = creditIds.filter((id) => !found.has(id));
+      throw new Error(
+        `Cannot reverse credit applications for invoice ${invoiceId}: credit_tracking rows missing for credit id(s) ${missing.join(', ')}`
+      );
+    }
+  }
+
+  const reversedApplications: ReversedCreditApplication[] = [];
+  let totalRestored = 0;
+
+  for (const { txn, appliedCredits } of activeApplications) {
+    let restoredForApplication = 0;
+
+    for (const applied of appliedCredits) {
+      if (applied.amount === 0) {
+        continue;
+      }
+      // Restore the credit pool. The derived client balance comes from
+      // credit_tracking.remaining_amount, so this IS the balance restore.
+      await db
+        .table('credit_tracking')
+        .where({ credit_id: applied.creditId })
+        .increment('remaining_amount', applied.amount)
+        .update({ updated_at: now });
+      restoredForApplication += applied.amount;
+    }
+
+    if (restoredForApplication > 0) {
+      // One auditable reversal record per application; reversal_of is the
+      // idempotency link consulted above.
+      await db.table('transactions').insert({
+        transaction_id: uuidv4(),
+        client_id: txn.client_id,
+        invoice_id: invoiceId,
+        amount: restoredForApplication,
+        type: 'credit_adjustment',
+        status: 'completed',
+        description: `Credit application reversed (${reason})`,
+        created_at: now,
+        balance_after: null,
+        tenant,
+        metadata: {
+          reversal_of: txn.transaction_id,
+          reason,
+          reversed_by: userId,
+          restored_credits: appliedCredits,
+        },
+        currency_code: txn.currency_code ?? null,
+      });
+
+      reversedApplications.push({
+        transactionId: txn.transaction_id,
+        restoredAmount: restoredForApplication,
+        restoredCredits: appliedCredits,
+      });
+      totalRestored += restoredForApplication;
+    }
+  }
+
+  // A reversed invoice carries no applied credit — unconditionally, so drift
+  // between credit_applied and the ledger heals rather than persists.
+  await db
+    .table('invoices')
+    .where({ invoice_id: invoiceId })
+    .update({ credit_applied: 0, updated_at: now });
+
+  return { reversedApplications, totalRestored };
+}

--- a/server/src/test/infrastructure/billing/credits/invoiceCreditReversalConcurrency.test.ts
+++ b/server/src/test/infrastructure/billing/credits/invoiceCreditReversalConcurrency.test.ts
@@ -1,0 +1,405 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import '../../../../../test-utils/nextApiMock';
+import type { Knex } from 'knex';
+import { v4 as uuidv4 } from 'uuid';
+
+/**
+ * Real-concurrency regression tests for the unified credit reversal
+ * primitive: committed rows on a plain connection, one dedicated knex client
+ * per concurrent actor, REAL transactions (no withTransaction identity mock).
+ * These prove the invoice-row-then-credit-rows lock order actually
+ * serializes apply against reversal instead of asserting on source strings.
+ */
+
+process.env.DB_PORT = process.env.DB_PORT === '6432' ? '5432' : process.env.DB_PORT;
+process.env.DB_HOST = process.env.DB_HOST === 'pgbouncer' ? 'localhost' : process.env.DB_HOST;
+
+let mockedTenantId = '11111111-1111-1111-1111-111111111111';
+let mockedUserId = 'mock-user-id';
+
+vi.mock('server/src/lib/analytics/posthog', () => ({
+  analytics: {
+    capture: vi.fn(),
+    identify: vi.fn(),
+    trackPerformance: vi.fn(),
+    getClient: () => null,
+  },
+}));
+
+vi.mock('@alga-psa/core/logger', () => {
+  const noop = vi.fn();
+  const logger = {
+    info: noop,
+    warn: noop,
+    error: noop,
+    debug: noop,
+    child: vi.fn(() => logger),
+  };
+  return { default: logger };
+});
+
+vi.mock('@alga-psa/users/actions', () => ({
+  getCurrentUser: vi.fn(() =>
+    Promise.resolve({
+      user_id: mockedUserId,
+      tenant: mockedTenantId,
+      username: 'mock-user',
+      first_name: 'Mock',
+      last_name: 'User',
+      email: 'mock.user@example.com',
+      user_type: 'internal',
+      roles: [],
+    })
+  ),
+}));
+
+vi.mock('@alga-psa/auth', async () => {
+  const { createAuthModuleMock } = await import('../../../../../test-utils/authModuleMock');
+  return createAuthModuleMock();
+});
+
+vi.mock('@alga-psa/auth/rbac', () => ({
+  hasPermission: vi.fn(() => Promise.resolve(true)),
+}));
+
+vi.mock('@alga-psa/event-bus/publishers', () => ({
+  publishWorkflowEvent: vi.fn(async () => undefined),
+}));
+
+import { createTestDbConnection } from '../../../../../test-utils/dbConfig';
+import { createClient } from '../../../../../test-utils/testDataFactory';
+import { currentUserRef } from '../../../../../test-utils/authModuleMock';
+import { reverseCreditApplicationsForInvoice } from '@alga-psa/billing/lib/creditReversal';
+import { applyCreditToInvoiceInternal } from '@alga-psa/billing/actions/creditActions';
+import { unfinalizeInvoice } from '@alga-psa/billing/actions/invoiceModification';
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+let db: Knex;
+/** One dedicated client per concurrent actor ("one client per test"). */
+let actorA: Knex;
+let actorB: Knex;
+let tenant: string;
+
+interface SeededCredit {
+  creditId: string;
+  transactionId: string;
+  amount: number;
+}
+
+async function newTestClient(name: string): Promise<string> {
+  return createClient(db, tenant, name, {
+    billing_cycle: 'monthly',
+    is_tax_exempt: false,
+    credit_balance: 0,
+  });
+}
+
+async function seedCredit(clientId: string, amount: number): Promise<SeededCredit> {
+  const transactionId = uuidv4();
+  const creditId = uuidv4();
+  const now = new Date().toISOString();
+  await db('transactions').insert({
+    transaction_id: transactionId,
+    tenant,
+    client_id: clientId,
+    invoice_id: null,
+    amount,
+    type: 'credit_issuance',
+    status: 'completed',
+    description: 'Concurrency test credit issuance',
+    created_at: now,
+    balance_after: null,
+    currency_code: 'USD',
+  });
+  await db('credit_tracking').insert({
+    credit_id: creditId,
+    tenant,
+    client_id: clientId,
+    transaction_id: transactionId,
+    amount,
+    remaining_amount: amount,
+    created_at: now,
+    is_expired: false,
+    updated_at: now,
+    currency_code: 'USD',
+  });
+  return { creditId, transactionId, amount };
+}
+
+interface SeededInvoice {
+  invoiceId: string;
+  applicationTransactionIds: string[];
+}
+
+/**
+ * Seed a committed finalized invoice, optionally with credit applications
+ * already drawn (matching what applyCreditToInvoiceInternal writes: the
+ * application transaction with applied_credits provenance, the allocation
+ * row, drained credit_tracking balances, and invoices.credit_applied).
+ */
+async function seedFinalizedInvoice(options: {
+  clientId: string;
+  total: number;
+  applications?: Array<Array<{ credit: SeededCredit; amount: number }>>;
+}): Promise<SeededInvoice> {
+  const invoiceId = uuidv4();
+  const now = new Date().toISOString();
+  await db('invoices').insert({
+    invoice_id: invoiceId,
+    tenant,
+    client_id: options.clientId,
+    invoice_number: `CONC-${invoiceId.slice(0, 8)}`,
+    invoice_date: now,
+    due_date: now,
+    total_amount: options.total,
+    subtotal: options.total,
+    tax: 0,
+    status: 'sent',
+    finalized_at: now,
+    credit_applied: 0,
+    is_manual: false,
+    is_prepayment: false,
+    currency_code: 'USD',
+    invoice_type: 'standard',
+  });
+  await db('invoice_charges').insert({
+    item_id: uuidv4(),
+    tenant,
+    invoice_id: invoiceId,
+    description: 'Concurrency test charge',
+    quantity: 1,
+    unit_price: options.total,
+    net_amount: options.total,
+    total_price: options.total,
+    tax_amount: 0,
+    tax_rate: 0,
+    is_manual: false,
+  });
+
+  const applicationTransactionIds: string[] = [];
+  for (const draws of options.applications ?? []) {
+    const transactionId = uuidv4();
+    const total = draws.reduce((sum, draw) => sum + draw.amount, 0);
+    for (const draw of draws) {
+      await db('credit_tracking')
+        .where({ credit_id: draw.credit.creditId, tenant })
+        .decrement('remaining_amount', draw.amount);
+    }
+    await db('transactions').insert({
+      transaction_id: transactionId,
+      tenant,
+      client_id: options.clientId,
+      invoice_id: invoiceId,
+      amount: -total,
+      type: 'credit_application',
+      status: 'completed',
+      description: `Applied credit to invoice ${invoiceId}`,
+      created_at: new Date().toISOString(),
+      balance_after: null,
+      currency_code: 'USD',
+      metadata: JSON.stringify({
+        applied_credits: draws.map((draw) => ({ creditId: draw.credit.creditId, amount: draw.amount })),
+      }),
+    });
+    await db('credit_allocations').insert({
+      allocation_id: uuidv4(),
+      tenant,
+      transaction_id: transactionId,
+      invoice_id: invoiceId,
+      amount: total,
+      created_at: new Date().toISOString(),
+    });
+    await db('invoices')
+      .where({ invoice_id: invoiceId, tenant })
+      .increment('credit_applied', total);
+    applicationTransactionIds.push(transactionId);
+  }
+
+  return { invoiceId, applicationTransactionIds };
+}
+
+async function remainingAmount(creditId: string): Promise<number> {
+  const row = await db('credit_tracking').where({ credit_id: creditId, tenant }).first('remaining_amount');
+  return Number(row?.remaining_amount ?? 0);
+}
+
+async function invoiceCreditApplied(invoiceId: string): Promise<number> {
+  const row = await db('invoices').where({ invoice_id: invoiceId, tenant }).first('credit_applied');
+  return Number(row?.credit_applied ?? 0);
+}
+
+async function adjustmentsFor(invoiceId: string) {
+  return db('transactions')
+    .where({ invoice_id: invoiceId, type: 'credit_adjustment', tenant })
+    .select('*');
+}
+
+/** A caller-shaped reversal: invoice row FOR UPDATE first, then the primitive. */
+async function runReversal(
+  client: Knex,
+  invoiceId: string,
+  options: { holdMsAfterReversal?: number; beforeCommit?: () => void | Promise<void> } = {}
+): Promise<void> {
+  await client.transaction(async (trx) => {
+    await trx('invoices').where({ invoice_id: invoiceId, tenant }).forUpdate().first();
+    await reverseCreditApplicationsForInvoice(trx, tenant, invoiceId, mockedUserId, 'invoice_unfinalized');
+    if (options.holdMsAfterReversal) {
+      await sleep(options.holdMsAfterReversal);
+    }
+    if (options.beforeCommit) {
+      await options.beforeCommit();
+    }
+  });
+}
+
+describe('invoice credit reversal — real concurrency', () => {
+  beforeAll(async () => {
+    db = await createTestDbConnection({ runSeeds: true });
+    const tenantRow = await db('tenants').first('tenant');
+    if (!tenantRow) {
+      throw new Error('Seeded tenant not found');
+    }
+    tenant = String(tenantRow.tenant);
+    mockedTenantId = tenant;
+    currentUserRef.user.tenant = tenant;
+    currentUserRef.user.user_id = mockedUserId;
+
+    actorA = await createTestDbConnection({ recreate: false });
+    actorB = await createTestDbConnection({ recreate: false });
+
+    // Warm the app-side pool createTenantKnex hands to the real actions so the
+    // in-flight timing assertions below don't measure pool spin-up.
+    const warmupClientId = await newTestClient('Warmup Client');
+    const warmup = await seedFinalizedInvoice({ clientId: warmupClientId, total: 100 });
+    await applyCreditToInvoiceInternal(tenant, mockedUserId, warmupClientId, warmup.invoiceId, 0);
+  }, 180000);
+
+  afterAll(async () => {
+    await actorA?.destroy();
+    await actorB?.destroy();
+    await db?.destroy();
+  }, 30000);
+
+  it('two concurrent reversals restore the application exactly once', async () => {
+    const clientId = await newTestClient('Double Reversal Client');
+    const credit = await seedCredit(clientId, 10000);
+    const { invoiceId, applicationTransactionIds } = await seedFinalizedInvoice({
+      clientId,
+      total: 8000,
+      applications: [[{ credit, amount: 5000 }]],
+    });
+    expect(await remainingAmount(credit.creditId)).toBe(5000);
+
+    await Promise.all([
+      runReversal(actorA, invoiceId),
+      runReversal(actorB, invoiceId),
+    ]);
+
+    // The second reverser waited on the invoice lock, re-read the ledger, saw
+    // the reversal_of link, and restored nothing.
+    expect(await remainingAmount(credit.creditId)).toBe(10000);
+    expect(await invoiceCreditApplied(invoiceId)).toBe(0);
+    const adjustments = await adjustmentsFor(invoiceId);
+    expect(adjustments).toHaveLength(1);
+    expect(adjustments[0].metadata.reversal_of).toBe(applicationTransactionIds[0]);
+  });
+
+  it('a concurrent apply blocks on the invoice lock until the reversal commits, then draws from restored balances', async () => {
+    const clientId = await newTestClient('Apply vs Reversal Client');
+    const credit = await seedCredit(clientId, 10000);
+    const { invoiceId } = await seedFinalizedInvoice({
+      clientId,
+      total: 8000,
+      applications: [[{ credit, amount: 5000 }]],
+    });
+
+    let applyFinished = false;
+    let applyPromise: Promise<{ appliedAmount: number }> | undefined;
+
+    await runReversal(actorA, invoiceId, {
+      beforeCommit: async () => {
+        // Launch the real apply path while the reversal still holds the
+        // invoice row lock; its first statement is the invoices FOR UPDATE.
+        applyPromise = applyCreditToInvoiceInternal(tenant, mockedUserId, clientId, invoiceId, 2000)
+          .then((result) => {
+            applyFinished = true;
+            return result;
+          });
+        await sleep(500);
+        // Still blocked — apply must not interleave with the uncommitted reversal.
+        expect(applyFinished).toBe(false);
+      },
+    });
+
+    const applyResult = await applyPromise!;
+    expect(applyResult.appliedAmount).toBe(2000);
+
+    // Serialized outcome: restore (+5000) fully visible before the draw (−2000).
+    expect(await remainingAmount(credit.creditId)).toBe(8000);
+    expect(await invoiceCreditApplied(invoiceId)).toBe(2000);
+
+    // Ledger agrees: one reversed application, one new active application.
+    const adjustments = await adjustmentsFor(invoiceId);
+    expect(adjustments).toHaveLength(1);
+    const applications = await db('transactions')
+      .where({ invoice_id: invoiceId, type: 'credit_application', tenant })
+      .select('transaction_id');
+    expect(applications).toHaveLength(2);
+  });
+
+  it('reversal and apply on different invoices over the same credit pool complete without deadlock', async () => {
+    const clientId = await newTestClient('Cross Invoice Client');
+    const credit1 = await seedCredit(clientId, 10000);
+    const credit2 = await seedCredit(clientId, 10000);
+    const invoiceA = await seedFinalizedInvoice({
+      clientId,
+      total: 8000,
+      applications: [[
+        { credit: credit1, amount: 3000 },
+        { credit: credit2, amount: 3000 },
+      ]],
+    });
+    const invoiceB = await seedFinalizedInvoice({ clientId, total: 8000 });
+
+    // Overlap: the reversal holds its locks for a while as the apply runs.
+    const [, applyResult] = await Promise.all([
+      runReversal(actorA, invoiceA.invoiceId, { holdMsAfterReversal: 300 }),
+      applyCreditToInvoiceInternal(tenant, mockedUserId, clientId, invoiceB.invoiceId, 6000),
+    ]);
+
+    expect(applyResult.appliedAmount).toBe(6000);
+    expect(await invoiceCreditApplied(invoiceA.invoiceId)).toBe(0);
+    expect(await invoiceCreditApplied(invoiceB.invoiceId)).toBe(6000);
+
+    // Conservation across the pool: 20000 issued, 6000 applied to B, rest in the pool.
+    const total = (await remainingAmount(credit1.creditId)) + (await remainingAmount(credit2.creditId));
+    expect(total).toBe(14000);
+  });
+
+  it('a failed reversal rolls back atomically: lifecycle state and balances unchanged', async () => {
+    const clientId = await newTestClient('Atomic Failure Client');
+    const credit = await seedCredit(clientId, 10000);
+    const { invoiceId, applicationTransactionIds } = await seedFinalizedInvoice({
+      clientId,
+      total: 8000,
+      applications: [[{ credit, amount: 5000 }]],
+    });
+
+    // Break the provenance the reversal depends on.
+    await db('transactions')
+      .where({ transaction_id: applicationTransactionIds[0], tenant })
+      .update({ metadata: JSON.stringify({}) });
+
+    // Real action, real transaction, real rollback.
+    const result = await unfinalizeInvoice(invoiceId);
+    expect(result).toEqual({ actionError: expect.any(String) });
+
+    const invoice = await db('invoices').where({ invoice_id: invoiceId, tenant }).first();
+    expect(invoice.status).toBe('sent');
+    expect(invoice.finalized_at).not.toBeNull();
+    expect(Number(invoice.credit_applied)).toBe(5000);
+    expect(await remainingAmount(credit.creditId)).toBe(5000);
+    expect(await adjustmentsFor(invoiceId)).toHaveLength(0);
+  });
+});

--- a/server/src/test/infrastructure/billing/credits/invoiceCreditReversalLifecycle.test.ts
+++ b/server/src/test/infrastructure/billing/credits/invoiceCreditReversalLifecycle.test.ts
@@ -1,0 +1,562 @@
+import { describe, it, expect, beforeAll, afterEach, beforeEach, afterAll, vi } from 'vitest';
+import '../../../../../test-utils/nextApiMock';
+import { setupCommonMocks } from '../../../../../test-utils/testMocks';
+import { tenantDb } from '@alga-psa/db';
+import { TestContext } from '../../../../../test-utils/testContext';
+import {
+  createPrepaymentInvoice,
+  applyCreditToInvoice,
+} from '@alga-psa/billing/actions/creditActions';
+import {
+  finalizeInvoice,
+  unfinalizeInvoice,
+  hardDeleteInvoice,
+} from '@alga-psa/billing/actions/invoiceModification';
+import { voidInvoice } from '@alga-psa/billing/actions/voidInvoiceActions';
+import { createInvoiceFromBillingResult } from '@alga-psa/billing/actions/invoiceGeneration';
+import {
+  createTestService,
+  createFixedPlanAssignment,
+  setupClientTaxConfiguration,
+  assignServiceTaxRate,
+} from '../../../../../test-utils/billingTestHelpers';
+import type { IBillingCharge, IBillingResult } from 'server/src/interfaces/billing.interfaces';
+import { v4 as uuidv4 } from 'uuid';
+import { Temporal } from '@js-temporal/polyfill';
+import { createTestDate } from '../../../test-utils/dateUtils';
+import { createClient } from '../../../../../test-utils/testDataFactory';
+
+let mockedTenantId = '11111111-1111-1111-1111-111111111111';
+let mockedUserId = 'mock-user-id';
+
+process.env.DB_PORT = process.env.DB_PORT === '6432' ? '5432' : process.env.DB_PORT;
+process.env.DB_HOST = process.env.DB_HOST === 'pgbouncer' ? 'localhost' : process.env.DB_HOST;
+
+vi.mock('server/src/lib/analytics/posthog', () => ({
+  analytics: {
+    capture: vi.fn(),
+    identify: vi.fn(),
+    trackPerformance: vi.fn(),
+    getClient: () => null,
+  },
+}));
+
+vi.mock('@alga-psa/db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@alga-psa/db')>();
+  return {
+    ...actual,
+    withTransaction: vi.fn(async (knex, callback) => callback(knex)),
+    withAdminTransaction: vi.fn(async (callback, existingConnection) => callback(existingConnection as any)),
+  };
+});
+
+vi.mock('@alga-psa/core/logger', () => {
+  const noop = vi.fn();
+  const logger = {
+    info: noop,
+    warn: noop,
+    error: noop,
+    debug: noop,
+    child: vi.fn(() => logger),
+  };
+  return { default: logger };
+});
+
+vi.mock('@alga-psa/users/actions', () => ({
+  getCurrentUser: vi.fn(() =>
+    Promise.resolve({
+      user_id: mockedUserId,
+      tenant: mockedTenantId,
+      username: 'mock-user',
+      first_name: 'Mock',
+      last_name: 'User',
+      email: 'mock.user@example.com',
+      user_type: 'internal',
+      roles: [],
+    })
+  ),
+}));
+
+vi.mock('@alga-psa/auth', async () => {
+  const { createAuthModuleMock } = await import('../../../../../test-utils/authModuleMock');
+  return createAuthModuleMock();
+});
+
+vi.mock('server/src/lib/auth/rbac', () => ({
+  hasPermission: vi.fn(() => Promise.resolve(true)),
+}));
+
+const {
+  beforeAll: setupContext,
+  beforeEach: resetContext,
+  afterEach: rollbackContext,
+  afterAll: cleanupContext,
+} = TestContext.createHelpers();
+
+let context: TestContext;
+
+function tenantTable<Row extends object = Record<string, unknown>>(
+  context: TestContext,
+  tableExpression: string
+) {
+  return tenantDb(context.db, context.tenantId).table<Row>(tableExpression);
+}
+
+async function ensureClientBillingSettings(
+  clientId: string,
+  overrides: Record<string, unknown> = {}
+) {
+  await tenantTable(context, 'client_billing_settings')
+    .where({ client_id: clientId, tenant: context.tenantId })
+    .del();
+
+  const now = new Date().toISOString();
+  await tenantTable(context, 'client_billing_settings').insert({
+    client_id: clientId,
+    tenant: context.tenantId,
+    zero_dollar_invoice_handling: 'normal',
+    suppress_zero_dollar_invoices: false,
+    enable_credit_expiration: false,
+    created_at: now,
+    updated_at: now,
+    ...overrides,
+  });
+}
+
+async function createBillingCycle(
+  clientId: string,
+  startDate: string,
+  endDate: string
+): Promise<string> {
+  return context.createEntity(
+    'client_billing_cycles',
+    {
+      client_id: clientId,
+      billing_cycle: 'monthly',
+      period_start_date: startDate,
+      period_end_date: endDate,
+      effective_date: startDate,
+    },
+    'billing_cycle_id'
+  );
+}
+
+async function generateInvoiceFromChargesForClient(
+  clientId: string,
+  billingCycleId: string,
+  charges: IBillingCharge[]
+) {
+  const cycleRecord = await tenantTable(context, 'client_billing_cycles')
+    .where({ billing_cycle_id: billingCycleId, tenant: context.tenantId })
+    .first();
+
+  if (!cycleRecord) {
+    throw new Error(`Billing cycle ${billingCycleId} not found`);
+  }
+
+  for (const charge of charges) {
+    if (!(charge as { config_id?: string }).config_id) {
+      (charge as { config_id?: string }).config_id = uuidv4();
+    }
+    const usageId = (charge as { usageId?: string }).usageId;
+    if (charge.type === 'usage' && usageId) {
+      await tenantTable(context, 'usage_tracking')
+        .insert({
+          tenant: context.tenantId,
+          usage_id: usageId,
+          service_id: (charge as { serviceId?: string }).serviceId,
+          client_id: clientId,
+          usage_date: (charge as { servicePeriodStart?: string }).servicePeriodStart ?? cycleRecord.period_start_date,
+          quantity: (charge as { quantity?: number }).quantity ?? 1,
+          invoiced: false,
+        })
+        .onConflict(['tenant', 'usage_id'])
+        .ignore();
+    }
+  }
+
+  const totalAmount = charges.reduce((sum, charge) => sum + Number(charge.total ?? 0), 0);
+
+  const billingResult: IBillingResult = {
+    tenant: context.tenantId,
+    charges,
+    discounts: [],
+    adjustments: [],
+    totalAmount,
+    finalAmount: totalAmount,
+  };
+
+  const createdInvoice = await createInvoiceFromBillingResult(
+    billingResult,
+    clientId,
+    cycleRecord.period_start_date ?? cycleRecord.effective_date,
+    cycleRecord.period_end_date ?? cycleRecord.effective_date,
+    billingCycleId,
+    context.userId
+  );
+
+  return createdInvoice.invoice_id as string;
+}
+
+async function setupDefaultTax(clientId?: string) {
+  await setupClientTaxConfiguration(context, {
+    clientId,
+    regionCode: 'US-NY',
+    regionName: 'New York',
+    description: 'NY State Tax',
+    startDate: '2020-01-01T00:00:00.000Z',
+    taxPercentage: 10.0,
+  });
+  await assignServiceTaxRate(context, '*', 'US-NY', { onlyUnset: true });
+}
+
+function makeCharge(
+  serviceId: string,
+  serviceName: string,
+  total: number,
+  periodStart: string,
+  periodEnd: string
+): IBillingCharge {
+  return {
+    tenant: context.tenantId,
+    type: 'usage',
+    serviceId,
+    serviceName,
+    quantity: 1,
+    rate: total,
+    total,
+    tax_amount: 0,
+    tax_rate: 0,
+    tax_region: 'US-NY',
+    is_taxable: false,
+    usageId: uuidv4(),
+    servicePeriodStart: periodStart,
+    servicePeriodEnd: periodEnd,
+    billingTiming: 'arrears',
+  };
+}
+
+/** Full drawdown scaffold: client + service + billing cycle + one invoice. */
+async function setupCreditedClientInvoice(options: {
+  clientName: string;
+  invoiceTotal: number;
+  prepayments: number[];
+  autoApply?: boolean;
+}) {
+  const clientId = await createClient(context.db, context.tenantId, options.clientName, {
+    billing_cycle: 'monthly',
+    region_code: 'US-NY',
+    is_tax_exempt: false,
+    credit_balance: 0,
+  });
+
+  await setupDefaultTax(clientId);
+  await ensureClientBillingSettings(clientId, {
+    credit_auto_apply_enabled: options.autoApply ?? true,
+  });
+
+  const now = createTestDate();
+  const periodStart = Temporal.PlainDate.from(now).subtract({ months: 1 }).toString();
+  const periodEnd = Temporal.PlainDate.from(now).toString();
+
+  const anchorServiceId = await createTestService(context, {
+    service_name: 'Contract Line Anchor Service',
+  });
+  await createFixedPlanAssignment(context, anchorServiceId, {
+    clientId,
+    startDate: periodStart,
+    planName: 'Credit Reversal Test Plan',
+  });
+
+  const serviceId = await createTestService(context, {
+    service_name: 'Standard Service',
+    billing_method: 'fixed',
+    default_rate: options.invoiceTotal,
+    tax_region: 'US-NY',
+  });
+
+  const billingCycleId = await createBillingCycle(clientId, periodStart, periodEnd);
+
+  for (const amount of options.prepayments) {
+    const prepaymentInvoice = await createPrepaymentInvoice(clientId, amount);
+    await finalizeInvoice(prepaymentInvoice.invoice_id);
+  }
+
+  const invoiceId = await generateInvoiceFromChargesForClient(clientId, billingCycleId, [
+    makeCharge(serviceId, 'Standard Service', options.invoiceTotal, periodStart, periodEnd),
+  ]);
+
+  return { clientId, invoiceId };
+}
+
+async function creditTrackingRows(clientId: string) {
+  return tenantTable(context, 'credit_tracking')
+    .where({ client_id: clientId, tenant: context.tenantId })
+    .orderBy('created_at', 'asc')
+    .select('credit_id', 'amount', 'remaining_amount');
+}
+
+async function invoiceRow(invoiceId: string) {
+  return tenantTable(context, 'invoices')
+    .where({ invoice_id: invoiceId, tenant: context.tenantId })
+    .first();
+}
+
+async function transactionsOfType(invoiceId: string, type: string) {
+  return tenantTable(context, 'transactions')
+    .where({ invoice_id: invoiceId, type, tenant: context.tenantId })
+    .orderBy('created_at', 'asc')
+    .select('*');
+}
+
+describe('Unified invoice credit reversal (void / unfinalize / hard-delete)', () => {
+  beforeAll(async () => {
+    context = await setupContext({
+      runSeeds: true,
+      cleanupTables: [
+        'invoice_charges',
+        'invoices',
+        'transactions',
+        'credit_tracking',
+        'credit_allocations',
+        'client_billing_cycles',
+        'client_contract_lines',
+        'service_catalog',
+        'service_types',
+        'contract_lines',
+        'tax_rates',
+        'tax_regions',
+        'client_tax_settings',
+        'client_tax_rates',
+        'client_billing_settings',
+        'default_billing_settings',
+      ],
+      clientName: 'Credit Reversal Client',
+      userType: 'internal',
+    });
+
+    const mockContext = setupCommonMocks({
+      tenantId: context.tenantId,
+      userId: context.userId,
+      permissionCheck: () => true,
+    });
+
+    mockedTenantId = mockContext.tenantId;
+    mockedUserId = mockContext.userId;
+  }, 120000);
+
+  beforeEach(async () => {
+    context = await resetContext();
+
+    const mockContext = setupCommonMocks({
+      tenantId: context.tenantId,
+      userId: context.userId,
+      permissionCheck: () => true,
+    });
+
+    mockedTenantId = mockContext.tenantId;
+    mockedUserId = mockContext.userId;
+  }, 30000);
+
+  afterEach(async () => {
+    await rollbackContext();
+  }, 30000);
+
+  afterAll(async () => {
+    await cleanupContext();
+  }, 30000);
+
+  it('unfinalize reverses applied credit: draft carries credit_applied = 0 and the pool is restored', async () => {
+    const { clientId, invoiceId } = await setupCreditedClientInvoice({
+      clientName: 'Unfinalize Reversal Client',
+      invoiceTotal: 10000,
+      prepayments: [5000],
+    });
+
+    await finalizeInvoice(invoiceId);
+
+    const afterFinalize = await invoiceRow(invoiceId);
+    expect(Number(afterFinalize.credit_applied)).toBe(5000);
+    let credits = await creditTrackingRows(clientId);
+    expect(Number(credits[0].remaining_amount)).toBe(0);
+
+    const result = await unfinalizeInvoice(invoiceId);
+    expect(result).toEqual({ success: true });
+
+    const afterUnfinalize = await invoiceRow(invoiceId);
+    expect(afterUnfinalize.status).toBe('draft');
+    expect(afterUnfinalize.finalized_at).toBeNull();
+    expect(Number(afterUnfinalize.credit_applied)).toBe(0);
+
+    credits = await creditTrackingRows(clientId);
+    expect(Number(credits[0].remaining_amount)).toBe(5000);
+
+    // One linked, auditable reversal per application.
+    const applications = await transactionsOfType(invoiceId, 'credit_application');
+    expect(applications).toHaveLength(1);
+    const adjustments = await transactionsOfType(invoiceId, 'credit_adjustment');
+    expect(adjustments).toHaveLength(1);
+    expect(adjustments[0].metadata.reversal_of).toBe(applications[0].transaction_id);
+    expect(adjustments[0].metadata.reason).toBe('invoice_unfinalized');
+
+    // Historical ledger evidence survives the reversal.
+    const allocations = await tenantTable(context, 'credit_allocations')
+      .where({ invoice_id: invoiceId, tenant: context.tenantId })
+      .select('allocation_id');
+    expect(allocations).toHaveLength(1);
+  });
+
+  it('unfinalize → re-finalize → unfinalize cycle is repeat-safe: no application restores twice', async () => {
+    const { clientId, invoiceId } = await setupCreditedClientInvoice({
+      clientName: 'Cycle Repeat-Safe Client',
+      invoiceTotal: 10000,
+      prepayments: [5000],
+    });
+
+    await finalizeInvoice(invoiceId);
+    expect(Number((await invoiceRow(invoiceId)).credit_applied)).toBe(5000);
+
+    await unfinalizeInvoice(invoiceId);
+    expect(Number((await creditTrackingRows(clientId))[0].remaining_amount)).toBe(5000);
+
+    // Re-finalize: credit re-applies under the current policy (auto-apply on).
+    await finalizeInvoice(invoiceId);
+    const afterRefinalize = await invoiceRow(invoiceId);
+    expect(Number(afterRefinalize.credit_applied)).toBe(5000);
+    expect(Number((await creditTrackingRows(clientId))[0].remaining_amount)).toBe(0);
+
+    await unfinalizeInvoice(invoiceId);
+
+    // The first (already reversed) application must not restore again: the
+    // pool ends exactly at its original amount, never above it.
+    const credits = await creditTrackingRows(clientId);
+    expect(Number(credits[0].remaining_amount)).toBe(5000);
+    expect(Number(credits[0].remaining_amount)).toBeLessThanOrEqual(Number(credits[0].amount));
+    expect(Number((await invoiceRow(invoiceId)).credit_applied)).toBe(0);
+
+    // Two applications, each reversed exactly once.
+    const applications = await transactionsOfType(invoiceId, 'credit_application');
+    expect(applications).toHaveLength(2);
+    const adjustments = await transactionsOfType(invoiceId, 'credit_adjustment');
+    expect(adjustments).toHaveLength(2);
+    const reversedIds = adjustments.map((adj: any) => adj.metadata.reversal_of).sort();
+    expect(reversedIds).toEqual(applications.map((app: any) => app.transaction_id).sort());
+  });
+
+  it('hard delete restores every application across multiple credits without credit_tracking_usage', async () => {
+    const { clientId, invoiceId } = await setupCreditedClientInvoice({
+      clientName: 'Hard Delete Restore Client',
+      invoiceTotal: 10000,
+      prepayments: [3000, 4000],
+      autoApply: false,
+    });
+
+    await finalizeInvoice(invoiceId);
+    expect(Number((await invoiceRow(invoiceId)).credit_applied)).toBe(0);
+
+    // Two separate manual applications → two application transactions; the
+    // second draws across the remaining pool.
+    await applyCreditToInvoice(clientId, invoiceId, 2000);
+    await applyCreditToInvoice(clientId, invoiceId, 4000);
+    expect(Number((await invoiceRow(invoiceId)).credit_applied)).toBe(6000);
+
+    const applications = await transactionsOfType(invoiceId, 'credit_application');
+    expect(applications).toHaveLength(2);
+    const drainedCredits = await creditTrackingRows(clientId);
+    const drainedTotal = drainedCredits.reduce((sum: number, row: any) => sum + Number(row.remaining_amount), 0);
+    expect(drainedTotal).toBe(1000);
+
+    // The invoice generator records canonical recurring detail periods for the
+    // usage charges; a real hard-delete candidate (manual/non-recurring) has
+    // none, and the recurring guard is out of scope here — neutralize it.
+    await tenantTable(context, 'invoice_charge_details')
+      .whereIn(
+        'item_id',
+        tenantTable(context, 'invoice_charges').select('item_id').where({ invoice_id: invoiceId, tenant: context.tenantId })
+      )
+      .update({ service_period_start: null, service_period_end: null });
+
+    const result = await hardDeleteInvoice(invoiceId);
+    expect(result).toEqual({ success: true });
+
+    // Every application restored — full pool back.
+    const restoredCredits = await creditTrackingRows(clientId);
+    for (const row of restoredCredits) {
+      expect(Number(row.remaining_amount)).toBe(Number(row.amount));
+    }
+
+    // Invoice and its ledger rows are gone.
+    expect(await invoiceRow(invoiceId)).toBeUndefined();
+    const remainingTxns = await tenantTable(context, 'transactions')
+      .where({ invoice_id: invoiceId, tenant: context.tenantId })
+      .select('transaction_id');
+    expect(remainingTxns).toHaveLength(0);
+    const allocations = await tenantTable(context, 'credit_allocations')
+      .where({ invoice_id: invoiceId, tenant: context.tenantId })
+      .select('allocation_id');
+    expect(allocations).toHaveLength(0);
+  });
+
+  it('void reverses all applications and a repeated void cannot duplicate the restoration', async () => {
+    const { clientId, invoiceId } = await setupCreditedClientInvoice({
+      clientName: 'Void Regression Client',
+      invoiceTotal: 10000,
+      prepayments: [3000, 4000],
+      autoApply: false,
+    });
+
+    await finalizeInvoice(invoiceId);
+    await applyCreditToInvoice(clientId, invoiceId, 2000);
+    await applyCreditToInvoice(clientId, invoiceId, 4000);
+    expect(Number((await invoiceRow(invoiceId)).credit_applied)).toBe(6000);
+
+    const voidResult = await voidInvoice(invoiceId, 'billing error');
+    expect(voidResult).toEqual({ success: true });
+
+    const afterVoid = await invoiceRow(invoiceId);
+    expect(afterVoid.status).toBe('cancelled');
+    expect(Number(afterVoid.credit_applied)).toBe(0);
+    const restoredCredits = await creditTrackingRows(clientId);
+    for (const row of restoredCredits) {
+      expect(Number(row.remaining_amount)).toBe(Number(row.amount));
+    }
+    const adjustments = await transactionsOfType(invoiceId, 'credit_adjustment');
+    expect(adjustments).toHaveLength(2);
+
+    // Second invocation: blocked by the cancelled guard, nothing restored twice.
+    const secondVoid = await voidInvoice(invoiceId, 'again');
+    expect(secondVoid).toEqual({ success: false, error: 'Invoice is already voided.' });
+    const creditsAfterSecond = await creditTrackingRows(clientId);
+    for (const row of creditsAfterSecond) {
+      expect(Number(row.remaining_amount)).toBe(Number(row.amount));
+    }
+    expect(await transactionsOfType(invoiceId, 'credit_adjustment')).toHaveLength(2);
+  });
+
+  it('malformed application provenance fails the unfinalize and leaves state untouched', async () => {
+    const { clientId, invoiceId } = await setupCreditedClientInvoice({
+      clientName: 'Malformed Provenance Client',
+      invoiceTotal: 10000,
+      prepayments: [5000],
+    });
+
+    await finalizeInvoice(invoiceId);
+    const applications = await transactionsOfType(invoiceId, 'credit_application');
+    expect(applications).toHaveLength(1);
+
+    // Corrupt the provenance the reversal depends on.
+    await tenantTable(context, 'transactions')
+      .where({ transaction_id: applications[0].transaction_id, tenant: context.tenantId })
+      .update({ metadata: JSON.stringify({}) });
+
+    const result = await unfinalizeInvoice(invoiceId);
+    expect(result).toEqual({ actionError: expect.any(String) });
+
+    // Validation precedes mutation: lifecycle and balances unchanged.
+    const invoice = await invoiceRow(invoiceId);
+    expect(invoice.status).not.toBe('draft');
+    expect(Number(invoice.credit_applied)).toBe(5000);
+    expect(Number((await creditTrackingRows(clientId))[0].remaining_amount)).toBe(0);
+    expect(await transactionsOfType(invoiceId, 'credit_adjustment')).toHaveLength(0);
+  });
+});

--- a/server/src/test/unit/billing/creditActions.applyCredit.postDrop.test.ts
+++ b/server/src/test/unit/billing/creditActions.applyCredit.postDrop.test.ts
@@ -161,8 +161,12 @@ function createCreditApplicationTrx() {
         where: vi.fn((_criteriaOrColumn: any, _value?: any, _extra?: any) => builder),
         andWhere: vi.fn((_criteriaOrColumn: any, _value?: any, _extra?: any) => builder),
         whereNot: vi.fn(() => builder),
+        whereIn: vi.fn(() => builder),
         orderBy: vi.fn(() => builder),
         forUpdate: vi.fn(() => builder),
+        // The stable-order lock read (whereIn → orderBy → forUpdate → select)
+        // resolves through the thenable below to the same credit entries.
+        select: vi.fn(() => builder),
         sum: vi.fn(() => { summing = true; return builder; }),
         first: vi.fn(async () =>
           summing

--- a/server/src/test/unit/docs/servicePeriodFirstBillingPlan.contract.test.ts
+++ b/server/src/test/unit/docs/servicePeriodFirstBillingPlan.contract.test.ts
@@ -221,6 +221,7 @@ const servicePeriodPostInventoryRefs = new Set([
   // service-period columns in its fixtures.
   'server/src/test/infrastructure/billing/credits/creditDrawdownPolicy.test.ts',
   'server/src/test/infrastructure/billing/credits/creditServiceTypeRestrictionMode.test.ts',
+  'server/src/test/infrastructure/billing/credits/invoiceCreditReversalLifecycle.test.ts',
   'server/src/test/unit/contractReportActions.sharedContractResults.test.ts',
   // Batched fixed-charge preview loader suite seeds persisted service-period
   // rows in its fixtures; it landed after the pass-0 snapshot.


### PR DESCRIPTION
## Summary

Unifies credit reversal logic across the three invoice paths that can undo a finalized invoice's credit application — **unfinalize**, **void**, and **hard delete** — behind a single canonical primitive, `reverseCreditApplicationsForInvoice` in `packages/billing/src/lib/creditReversal.ts`.

Previously, unfinalize left applied credit stuck on the now-draft invoice (never restored to the client's pool), and hard-delete of a credited invoice threw because it queried a `credit_tracking_usage` table that doesn't exist anywhere in the schema — silently losing the customer's credit on any credited invoice deletion. Void already reversed credit correctly and is now expressed via the same shared primitive.

Key properties of the new primitive:
- **Repeat-safe**: only reverses `credit_application` transactions not already linked by a prior `credit_adjustment.metadata.reversal_of`, so cycling finalize → unfinalize → finalize → unfinalize never over-credits the pool.
- **Deadlock-safe locking**: every caller locks the invoice row `FOR UPDATE` first, then locks the referenced `credit_tracking` rows in stable `credit_id` order — matching `applyCreditToInvoiceInternal`'s lock order so apply and reversal can never deadlock against each other.
- Draft invoices now always carry `credit_applied = 0` — credit is only ever attached to a finalized invoice.

### Restacking note
This branch was originally stacked on `feature/credit-drawdown-policy-controls` (PR #3172) and merged there as PR #3178. #3172 merged to `main` a few seconds *before* #3178 landed on the feature branch, so #3178's merge commit never made it into `main` (diverged: 176 vs 3 commits) and could not be reopened. This PR rebases the branch's 3 commits directly onto current `origin/main` and retargets to `main`. One real conflict surfaced during the rebase in `invoiceModification.ts`'s `unfinalizeInvoice`: `main` had independently added an hour-block deactivation step in the same spot this branch adds credit reversal. Resolved by keeping both — they're independent, order-insensitive side effects of unfinalizing an invoice.

## Changes
- `packages/billing/src/lib/creditReversal.ts` (new): canonical `reverseCreditApplicationsForInvoice` primitive plus supporting lock/lookup helpers.
- `packages/billing/src/actions/invoiceModification.ts`: `unfinalizeInvoice` now reverses credit (alongside the pre-existing hour-block deactivation); hard-delete path now reverses credit correctly instead of hitting the nonexistent `credit_tracking_usage` table.
- `packages/billing/src/actions/voidInvoiceActions.ts`: void's ad hoc reversal logic replaced with a call to the shared primitive.
- `packages/billing/src/actions/creditActions.ts`: `applyCreditToInvoiceInternal` now takes the invoice `FOR UPDATE` lock, then `credit_tracking` locks in `credit_id` order, matching the reversal side's lock order.
- New test coverage: `creditReversal.test.ts` (unit), `invoiceCreditReversalLifecycle.test.ts` and `invoiceCreditReversalConcurrency.test.ts` (DB-backed integration, real transactions/real concurrency), plus updates to existing `voidInvoiceActions.test.ts` and `creditActions.applyCredit.postDrop.test.ts`.
- `docs/plans/2026-08-16-unify-invoice-credit-reversal-plan.md`: design plan for this work.

## Smoke test results

**SMOKE PASSED** — unified invoice credit reversal verified end-to-end through the real running product (next dev on `:3928` wired to the `alga-psa-local-test` Postgres at `127.0.0.1:6472`, tenant `dd8cb218`), driving the real UI (billing dashboard Drafts/Finalized kebab menus, invoice preview panel buttons, Credits page Add Credit dialog) with real signin as `glinda@emeraldcity.oz`. Every outcome was proven at the DB level (`invoices`/`credit_tracking`/`transactions`/`credit_allocations`), not just by toasts.

**Flows exercised** (client "Smoke Credit Reversal Co", $500 credit pool, all amounts in cents internally):
- **Setup**: client created via `/msp/clients`; $500 credit via Credits > Add Credit (`grantCredit`) → `credit_tracking` 50000/50000.
- **A (headline fix, unfinalize reverses)**: manual invoice INV-000027 $318 ($300+tax) → Finalize auto-applied $318 (`credit_applied`=31800, pool 18200, `credit_application` txn with `applied_credits` provenance) → Unfinalize → draft, `credit_applied`=0, pool restored EXACTLY to 50000, `credit_adjustment` +31800 with `metadata.reversal_of` linking the application txn, reason=`invoice_unfinalized`. On main this flow left the credit attached to the draft.
- **B (repeat-safety, the over-credit trap)**: re-finalize re-applied $318 (second application txn, pool 18200) → second unfinalize restored pool to EXACTLY 50000 — the first application was NOT restored twice; the second adjustment links only the second application.
- **C (void preserved)**: third finalize → applied → Void with reason → cancelled, `credit_applied`=0, pool 50000, third adjustment reason=`invoice_voided`. Ledger ends with 3 clean application/adjustment pairs, each linked by `reversal_of`.
- **D (hard-delete, previously threw/lost credit)**: INV-000028 $159 → finalize (applied, pool 34100) → unfinalize (pool 50000) → Reverse Draft (hardDelete) → invoice row, charges, ALL its transactions (`invoice_generated`/`credit_application`/`credit_adjustment`) and `credit_allocations` deleted; pool exactly 50000; zero orphan `credit_allocations` tenant-wide. Pre-fix this path queried the nonexistent `credit_tracking_usage` table and lost the customer's credit.
- **R1 (nearby regression, no credit)**: $0 invoice finalize→unfinalize→finalize→void all clean with pool untouched (no phantom restore); second $0 draft hard-deleted cleanly.

**Fidelity**: no simulators, no mocks — real UI + real Postgres. Two disclosed setup-only deviations: (1) dev-login password had been rotated by a sibling worktree's reboot sharing this DB — set a known password hash directly using the repo's exact PBKDF2 scheme; (2) the new client had no billing location, so a billing `client_locations` row was inserted directly (same validation the Create Client form enforces).

**Not tested / gaps**: concurrent apply-vs-reversal locking is covered only by the branch's committed real-concurrency vitest suite (`invoiceCreditReversalConcurrency.test.ts`) — no live concurrent HTTP actors were injected during the UI smoke. Manual "Apply Credit" button wasn't clicked (after finalize auto-apply, either the pool or invoice balance is exhausted, so a meaningful manual-apply needs the parent card's auto-apply policy toggled off; it calls the same changed `applyCreditToInvoiceInternal` that auto-apply exercised twice). Hard-delete of a still-credited (finalized) invoice isn't reachable from the UI (Reverse Draft exists on drafts only, and drafts now always carry `credit_applied`=0 by design) — that exact scenario is covered by the DB-backed lifecycle test.

**Observations** (pre-existing, unrelated to this branch): `CreditExpirationInfo.tsx` fetches `/api/invoices/[id]/credit-allocations`, which has no route anywhere under `server/src/app/api` — the "Applied Credits" card 404s on every credited invoice on `main` too. Also noted: the manual-invoice form only commits typed line-item values on row collapse (a pre-existing UX/automation quirk, not introduced here).

Evidence: `/tmp/alga-smoke-evidence/unify-invoice-credit-reversal-20260816-175603`

## Test plan
- [x] `creditReversal.test.ts` unit tests
- [x] `invoiceCreditReversalLifecycle.test.ts` DB-backed integration test
- [x] `invoiceCreditReversalConcurrency.test.ts` real-concurrency DB-backed test
- [x] `voidInvoiceActions.test.ts` updated for shared primitive
- [x] Manual UI smoke (see above) — unfinalize/void/hard-delete flows against real Postgres