### PR TITLE
Fix Entra direct connect: use beta Graph endpoint

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -75,7 +75,7 @@ These images link directly to screenshots from the [AlgaPSA feature tour](https:
   </thead>
   <tbody>
     <tr>
-      <td width="50%"><img src="https://www.nineminds.com/imported-media/Ticketing-1.gif" alt="AlgaPSA ticketing screen" width="420"></td>
+      <td width="50%"><img src="https://www.nineminds.com/imported-media/tickets-assignment-tracking.png" alt="AlgaPSA ticketing screen" width="420"></td>
       <td width="50%"><img src="https://www.nineminds.com/imported-media/Billing%20Cycles.png" alt="AlgaPSA billing dashboard" width="420"></td>
     </tr>
     <tr>

--- a/docker-compose.ee.yaml
+++ b/docker-compose.ee.yaml
@@ -57,6 +57,9 @@ services:
       MICROSOFT_CLIENT_SECRET: ${MICROSOFT_CLIENT_SECRET:-}
       MICROSOFT_LOGIN_BASE_URL: ${MICROSOFT_LOGIN_BASE_URL:-}
       MICROSOFT_GRAPH_BASE_URL: ${MICROSOFT_GRAPH_BASE_URL:-}
+      # managedTenants (beta-only API) has its own emulator hook; without it,
+      # emulator-pointed Entra testing silently hits real Graph.
+      MICROSOFT_GRAPH_BETA_BASE_URL: ${MICROSOFT_GRAPH_BETA_BASE_URL:-}
       # Secret provider configuration (EE edition - for local dev, vault is disabled by default)
       # For production with vault, set SECRET_READ_CHAIN=env,filesystem,vault in your environment
       SECRET_READ_CHAIN: ${SECRET_READ_CHAIN:-env,filesystem}
@@ -487,6 +490,7 @@ services:
       - MICROSOFT_CLIENT_SECRET=${MICROSOFT_CLIENT_SECRET:-}
       - MICROSOFT_LOGIN_BASE_URL=${MICROSOFT_LOGIN_BASE_URL:-}
       - MICROSOFT_GRAPH_BASE_URL=${MICROSOFT_GRAPH_BASE_URL:-}
+      - MICROSOFT_GRAPH_BETA_BASE_URL=${MICROSOFT_GRAPH_BETA_BASE_URL:-}
       # Smoke-only: defaults to unset so the worker uses the real GDAP endpoints. Override in
       # the compose invocation or shell env to test self-tenant mode without CSP/GDAP.
       - ENTRA_DIRECT_SMOKE_SELF_TENANT_MODE=${ENTRA_DIRECT_SMOKE_SELF_TENANT_MODE:-}

--- a/docs/inbound-email/setup/microsoft.md
+++ b/docs/inbound-email/setup/microsoft.md
@@ -127,6 +127,12 @@ Confirm all of the following:
    type.
 3. Under **Authentication**, add the callback from AlgaPSA as a **Web** redirect
    URI: `https://<your-host>/api/auth/microsoft/callback`.
+   If this app registration will also serve other AlgaPSA Microsoft integrations,
+   register their callbacks too — each flow has its own and Microsoft validates
+   them independently: `/api/auth/microsoft/email-setup/callback` (provider setup
+   wizard), `/api/auth/microsoft/calendar/callback` (calendar), and
+   `/api/auth/microsoft/entra/callback` (Entra Identity, EE). A missing entry
+   fails that flow with `AADSTS50011` after the consent screen.
 4. Under **API permissions**, add `Mail.Read`, `Mail.Read.Shared`, `Mail.Send`,
    and `offline_access` as delegated permissions.
 5. If your tenant policy requires administrator approval, select **Grant admin

--- a/ee/docs/guides/entra-integration-phase-1.md
+++ b/ee/docs/guides/entra-integration-phase-1.md
@@ -20,6 +20,19 @@ All user-visible Entra surfaces are feature-flag gated.
   - View endpoints/actions: `system_settings.read`
   - Connect/map/sync/resolve endpoints/actions: `system_settings.update`
 
+For the `direct` connection type, Microsoft-side prerequisites also apply:
+
+- The MSP's partner tenant must be onboarded to **Microsoft 365 Lighthouse** with active
+  **GDAP** relationships to its customer tenants. The integration reads the managed tenant
+  list from the Lighthouse `managedTenants` Graph API; a partner tenant without Lighthouse
+  gets an empty or failing tenant list no matter how the OAuth app is configured.
+- The person clicking through the connect flow must be able to grant **admin consent** in
+  the MSP tenant: `ManagedTenants.Read.All` and `Directory.Read.All` are admin-consent
+  scopes, so a non-admin hits Microsoft's "needs admin approval" screen.
+- The `managedTenants` API is a **beta** Graph API (`https://graph.microsoft.com/beta`);
+  it does not exist on v1.0. Alga targets the beta endpoint for these calls and v1.0 for
+  everything else — a version regression fails every Direct connect with a Graph 400.
+
 ## Connection Path Decision Guide
 
 Choose one connection type per tenant:
@@ -80,6 +93,33 @@ For direct Microsoft OAuth credentials, resolution order is:
 1. Tenant secrets (`microsoft_client_id` + `microsoft_client_secret`, optional `microsoft_tenant_id`)
 2. Environment variables (`MICROSOFT_CLIENT_ID`, `MICROSOFT_CLIENT_SECRET`, `MICROSOFT_TENANT_ID`)
 3. App secrets (`MICROSOFT_CLIENT_ID`, `MICROSOFT_CLIENT_SECRET`, `MICROSOFT_TENANT_ID`)
+
+## Azure App Registration Requirements (Direct)
+
+Whichever slot the credentials come from, the Azure app registration they name must have:
+
+- **Redirect URI** (Web platform): `https://<your-host>/api/auth/microsoft/entra/callback`.
+  The URI is built from `NEXT_PUBLIC_BASE_URL`/`NEXTAUTH_URL`, and Microsoft rejects any
+  URI not registered — the operator sees `AADSTS50011` after consenting.
+- **Delegated Microsoft Graph permissions** (from
+  `ee/server/src/lib/integrations/entra/auth/directScopes.ts`): `User.Read`,
+  `ManagedTenants.Read.All`, `Directory.Read.All`, plus `offline_access`. Grant admin
+  consent for the two admin-consent scopes.
+
+One app registration is often shared across every Alga Microsoft integration. Each flow
+has its own callback, and Microsoft validates them independently, so a shared app must
+register **all** of the callbacks it will serve:
+
+| Callback path | Used by |
+| --- | --- |
+| `/api/auth/microsoft/callback` | Email mailbox OAuth |
+| `/api/auth/microsoft/email-setup/callback` | M365 email provider setup wizard |
+| `/api/auth/microsoft/calendar/callback` | Calendar integration |
+| `/api/auth/microsoft/entra/callback` | Entra Identity direct connect |
+
+(The `/api/email/webhooks/microsoft` and `/api/calendar/webhooks/microsoft` paths are
+Graph change-notification webhooks, not OAuth redirects — they do not belong in the
+redirect URI list.)
 
 ## Feature Flags (Phase 1)
 

--- a/ee/server/src/__tests__/unit/directProviderAdapter.normalization.test.ts
+++ b/ee/server/src/__tests__/unit/directProviderAdapter.normalization.test.ts
@@ -79,7 +79,7 @@ describe('DirectProviderAdapter normalization', () => {
       sourceUserCount: 42,
     });
     expect(axiosGetMock).toHaveBeenCalledWith(
-      'https://graph.microsoft.com/v1.0/tenantRelationships/managedTenants/tenants?$top=999',
+      'https://graph.microsoft.com/beta/tenantRelationships/managedTenants/tenants?$top=999',
       expect.objectContaining({
         headers: { Authorization: 'Bearer access-token-direct' },
       })

--- a/ee/server/src/__tests__/unit/entraDirectProbe.test.ts
+++ b/ee/server/src/__tests__/unit/entraDirectProbe.test.ts
@@ -11,8 +11,10 @@ vi.mock('axios', () => ({
   isAxiosError: (error: unknown) => Boolean((error as { isAxiosError?: boolean } | null)?.isAxiosError),
 }));
 
+// managedTenants is a beta-only Graph API: v1.0 has no such segment and
+// answers 400, which is the bug this pin guards against regressing.
 const MANAGED_TENANTS_URL =
-  'https://graph.microsoft.com/v1.0/tenantRelationships/managedTenants/tenants?$top=1';
+  'https://graph.microsoft.com/beta/tenantRelationships/managedTenants/tenants?$top=1';
 
 describe('probeEntraDirectAccess', () => {
   const originalSmokeMode = process.env.ENTRA_DIRECT_SMOKE_SELF_TENANT_MODE;
@@ -76,9 +78,9 @@ describe('probeEntraDirectAccess', () => {
     });
   });
 
-  it('follows MICROSOFT_GRAPH_BASE_URL, so the emulator can be probed like Graph', async () => {
-    const originalBaseUrl = process.env.MICROSOFT_GRAPH_BASE_URL;
-    process.env.MICROSOFT_GRAPH_BASE_URL = 'http://127.0.0.1:4010/v1.0';
+  it('follows MICROSOFT_GRAPH_BETA_BASE_URL, so the emulator can be probed like Graph', async () => {
+    const originalBetaBaseUrl = process.env.MICROSOFT_GRAPH_BETA_BASE_URL;
+    process.env.MICROSOFT_GRAPH_BETA_BASE_URL = 'http://127.0.0.1:4010/beta';
     axiosGetMock.mockResolvedValue({ data: { value: [{ tenantId: 'a' }] } });
 
     try {
@@ -89,8 +91,29 @@ describe('probeEntraDirectAccess', () => {
 
       expect(result).toMatchObject({
         valid: true,
-        endpoint: 'http://127.0.0.1:4010/v1.0/tenantRelationships/managedTenants/tenants?$top=1',
+        endpoint: 'http://127.0.0.1:4010/beta/tenantRelationships/managedTenants/tenants?$top=1',
       });
+    } finally {
+      if (originalBetaBaseUrl === undefined) {
+        delete process.env.MICROSOFT_GRAPH_BETA_BASE_URL;
+      } else {
+        process.env.MICROSOFT_GRAPH_BETA_BASE_URL = originalBetaBaseUrl;
+      }
+    }
+  });
+
+  it('ignores MICROSOFT_GRAPH_BASE_URL: the v1.0 emulator hook must not drag managedTenants back to v1.0', async () => {
+    const originalBaseUrl = process.env.MICROSOFT_GRAPH_BASE_URL;
+    process.env.MICROSOFT_GRAPH_BASE_URL = 'http://127.0.0.1:4010/v1.0';
+    axiosGetMock.mockResolvedValue({ data: { value: [{ tenantId: 'a' }] } });
+
+    try {
+      const { probeEntraDirectAccess } = await import(
+        '@ee/lib/integrations/entra/providers/direct/directProbe'
+      );
+      const result = await probeEntraDirectAccess('token-1');
+
+      expect(result).toMatchObject({ valid: true, endpoint: MANAGED_TENANTS_URL });
     } finally {
       if (originalBaseUrl === undefined) {
         delete process.env.MICROSOFT_GRAPH_BASE_URL;
@@ -98,6 +121,32 @@ describe('probeEntraDirectAccess', () => {
         process.env.MICROSOFT_GRAPH_BASE_URL = originalBaseUrl;
       }
     }
+  });
+
+  it('carries Graph\'s error code and message as detail, so logs name the refusal', async () => {
+    const { probeEntraDirectAccess } = await import(
+      '@ee/lib/integrations/entra/providers/direct/directProbe'
+    );
+
+    axiosGetMock.mockRejectedValue({
+      isAxiosError: true,
+      response: {
+        status: 400,
+        data: {
+          error: {
+            code: 'BadRequest',
+            message: "Resource not found for the segment 'managedTenants'.",
+          },
+        },
+      },
+    });
+
+    await expect(probeEntraDirectAccess('token-1')).resolves.toMatchObject({
+      valid: false,
+      code: 'validation_failed',
+      status: 400,
+      detail: "BadRequest: Resource not found for the segment 'managedTenants'.",
+    });
   });
 
   it('probes the endpoint the adapter actually uses in self-tenant smoke mode', async () => {

--- a/ee/server/src/__tests__/unit/entraOAuthCallback.validation.test.ts
+++ b/ee/server/src/__tests__/unit/entraOAuthCallback.validation.test.ts
@@ -185,7 +185,7 @@ describe('Entra OAuth callback validation', () => {
 
     // The Graph probe runs on the freshly exchanged token, before anything is written.
     expect(axiosGetMock).toHaveBeenCalledWith(
-      'https://graph.microsoft.com/v1.0/tenantRelationships/managedTenants/tenants?$top=1',
+      'https://graph.microsoft.com/beta/tenantRelationships/managedTenants/tenants?$top=1',
       expect.objectContaining({
         headers: { Authorization: 'Bearer access-token-1' },
       })

--- a/ee/server/src/__tests__/unit/entraValidateDirectRoute.test.ts
+++ b/ee/server/src/__tests__/unit/entraValidateDirectRoute.test.ts
@@ -85,7 +85,7 @@ describe('validate-direct route', () => {
     });
 
     expect(axiosGetMock).toHaveBeenCalledWith(
-      'https://graph.microsoft.com/v1.0/tenantRelationships/managedTenants/tenants?$top=1',
+      'https://graph.microsoft.com/beta/tenantRelationships/managedTenants/tenants?$top=1',
       expect.objectContaining({
         headers: { Authorization: 'Bearer access-token-38' },
       })
@@ -95,6 +95,61 @@ describe('validate-direct route', () => {
       connectionType: 'direct',
       status: 'connected',
       snapshot: null,
+    });
+    expect(refreshEntraDirectTokenMock).not.toHaveBeenCalled();
+  });
+
+  it('persists validation_failed with the Graph detail and answers 502 when the probe fails', async () => {
+    requireEntraAccessMock.mockResolvedValue({
+      tenantId: 'tenant-39',
+      userId: 'user-39',
+    });
+    resolveMicrosoftCredentialsForTenantMock.mockResolvedValue({
+      clientId: 'client-id-39',
+      clientSecret: 'client-secret-39',
+      tenantId: null,
+      source: 'tenant-secret',
+    });
+
+    const getTenantSecretMock = vi
+      .fn()
+      .mockResolvedValueOnce('access-token-39')
+      .mockResolvedValueOnce(new Date(Date.now() + 3600_000).toISOString());
+    getSecretProviderInstanceMock.mockResolvedValue({
+      getTenantSecret: getTenantSecretMock,
+    });
+
+    // The exact production failure: a non-401/403 Graph refusal of the
+    // managed-tenant list. It must be recorded on the connection and surfaced
+    // as 502 — not swallowed, and not misfiled as a consent problem.
+    axiosGetMock.mockRejectedValue({
+      isAxiosError: true,
+      response: {
+        status: 400,
+        data: {
+          error: {
+            code: 'BadRequest',
+            message: "Resource not found for the segment 'managedTenants'.",
+          },
+        },
+      },
+    });
+
+    const { POST } = await import('@ee/app/api/integrations/entra/validate-direct/route');
+    const response = await POST();
+    const payload = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(payload.success).toBe(false);
+
+    expect(updateEntraConnectionValidationMock).toHaveBeenCalledWith({
+      tenant: 'tenant-39',
+      connectionType: 'direct',
+      status: 'validation_failed',
+      snapshot: expect.objectContaining({
+        code: 'upstream_error',
+        details: { graph: "BadRequest: Resource not found for the segment 'managedTenants'." },
+      }),
     });
     expect(refreshEntraDirectTokenMock).not.toHaveBeenCalled();
   });

--- a/ee/server/src/app/api/auth/microsoft/entra/callback/route.ts
+++ b/ee/server/src/app/api/auth/microsoft/entra/callback/route.ts
@@ -152,6 +152,7 @@ export async function GET(request: NextRequest) {
       console.error('[Entra OAuth] Direct connection rejected before persisting', {
         code: probe.code,
         status: probe.status,
+        detail: probe.detail,
       });
       return failureRedirect(probe.code, probe.error);
     }

--- a/ee/server/src/app/api/integrations/entra/validate-direct/route.ts
+++ b/ee/server/src/app/api/integrations/entra/validate-direct/route.ts
@@ -127,6 +127,7 @@ export async function POST(): Promise<Response> {
         message: probe.error,
         code: 'upstream_error',
         checkedAt: probe.checkedAt,
+        ...(probe.detail ? { details: { graph: probe.detail } } : {}),
       },
     });
     return new Response(

--- a/ee/server/src/components/settings/integrations/entra/ConnectionMethodChooser.tsx
+++ b/ee/server/src/components/settings/integrations/entra/ConnectionMethodChooser.tsx
@@ -21,6 +21,10 @@ interface ConnectionMethodChooserProps {
 
 const DIRECT_PREREQUISITE_KEYS = [
   'integrations.entra.setup.chooser.direct.prerequisites.partnerRelationship',
+  // GDAP alone is not enough: the managedTenants API answers only for partner
+  // tenants onboarded to Lighthouse, and a missing onboarding fails the
+  // connect after consent — the worst place to learn about it.
+  'integrations.entra.setup.chooser.direct.prerequisites.lighthouse',
   'integrations.entra.setup.chooser.direct.prerequisites.globalAdmin',
   'integrations.entra.setup.chooser.direct.prerequisites.appRegistration',
 ];

--- a/ee/server/src/components/settings/integrations/entra/entraCallbackErrors.ts
+++ b/ee/server/src/components/settings/integrations/entra/entraCallbackErrors.ts
@@ -10,6 +10,10 @@ export const buildEntraCallbackErrorKey = (errorCode: string | null | undefined)
     case 'consent_missing':
       return 'integrations.entra.settings.connection.callbackErrors.consentMissing';
     case 'auth_rejected':
+      return 'integrations.entra.settings.connection.callbackErrors.tokenRejected';
+    // Not a permission problem — those arrive as consent_missing. The remaining
+    // probe failures are almost always a partner tenant without Lighthouse/GDAP,
+    // and the message must not send the operator to the permissions screen.
     case 'validation_failed':
       return 'integrations.entra.settings.connection.callbackErrors.validationFailed';
     case 'expired_state':

--- a/ee/server/src/lib/integrations/entra/providers/direct/directProbe.ts
+++ b/ee/server/src/lib/integrations/entra/providers/direct/directProbe.ts
@@ -1,5 +1,8 @@
 import axios from 'axios';
-import { getMicrosoftGraphBaseUrl } from '@alga-psa/shared/services/email/microsoftGraphEndpoints';
+import {
+  getMicrosoftGraphBaseUrl,
+  getMicrosoftGraphBetaBaseUrl,
+} from '@alga-psa/shared/services/email/microsoftGraphEndpoints';
 
 /**
  * The Direct (GDAP) reachability probe, with no side effects of any kind: it
@@ -38,7 +41,32 @@ export type EntraDirectProbeResult =
       error: string;
       code: 'auth_rejected' | 'consent_missing' | 'validation_failed';
       status?: number;
+      /** Graph's own error code/message, for logs — never shown to the operator. */
+      detail?: string;
     };
+
+/**
+ * Graph's error body, compressed to one loggable line. A bare HTTP status hides
+ * the actual refusal ("status: 400" concealed a wrong-endpoint-version bug);
+ * the code and message name it.
+ */
+function graphErrorDetail(error: unknown): string | undefined {
+  if (!axios.isAxiosError(error)) {
+    return error instanceof Error ? error.message : undefined;
+  }
+
+  const body = error.response?.data as
+    | { error?: { code?: unknown; message?: unknown } }
+    | undefined;
+  const code = typeof body?.error?.code === 'string' ? body.error.code : null;
+  const message = typeof body?.error?.message === 'string' ? body.error.message : null;
+
+  if (code || message) {
+    return [code, message].filter(Boolean).join(': ');
+  }
+
+  return error.message || undefined;
+}
 
 /**
  * The endpoint whose readability defines a working Direct connection. Mirrors
@@ -46,17 +74,20 @@ export type EntraDirectProbeResult =
  * mode — probing an endpoint the adapter will never call would validate the
  * wrong thing, and would fail every smoke tenant at connect time.
  *
- * Resolved per call rather than at module load so pointing MICROSOFT_GRAPH_BASE_URL
- * at the Graph emulator moves the probe with the adapter.
+ * Resolved per call rather than at module load so pointing the emulator env
+ * overrides at the Graph emulator moves the probe with the adapter.
+ *
+ * managedTenants is beta-only: on v1.0 the segment does not exist and Graph
+ * answers 400, which failed every real Direct connect while the smoke-mode
+ * /organization path (valid on v1.0) kept passing.
  */
 export function entraDirectProbeEndpoint(): string {
-  const graphBaseUrl = getMicrosoftGraphBaseUrl();
   const isSelfTenantSmoke =
     (process.env.ENTRA_DIRECT_SMOKE_SELF_TENANT_MODE || '').toLowerCase() === 'true';
 
   return isSelfTenantSmoke
-    ? `${graphBaseUrl}/organization?$top=1`
-    : `${graphBaseUrl}/tenantRelationships/managedTenants/tenants?$top=1`;
+    ? `${getMicrosoftGraphBaseUrl()}/organization?$top=1`
+    : `${getMicrosoftGraphBetaBaseUrl()}/tenantRelationships/managedTenants/tenants?$top=1`;
 }
 
 export async function probeEntraDirectAccess(
@@ -80,6 +111,7 @@ export async function probeEntraDirectAccess(
     };
   } catch (error: unknown) {
     const status = axios.isAxiosError(error) ? error.response?.status : undefined;
+    const detail = graphErrorDetail(error);
 
     if (status === 401) {
       return {
@@ -88,6 +120,7 @@ export async function probeEntraDirectAccess(
         error: 'Microsoft rejected the access token for this connection.',
         code: 'auth_rejected',
         status,
+        detail,
       };
     }
 
@@ -100,6 +133,7 @@ export async function probeEntraDirectAccess(
           'A Global Administrator must grant admin consent for the requested permissions.',
         code: 'consent_missing',
         status,
+        detail,
       };
     }
 
@@ -109,6 +143,7 @@ export async function probeEntraDirectAccess(
       error: 'Unable to read the Microsoft Entra managed tenant list with this connection.',
       code: 'validation_failed',
       status,
+      detail,
     };
   }
 }

--- a/ee/server/src/lib/integrations/entra/providers/direct/directProviderAdapter.ts
+++ b/ee/server/src/lib/integrations/entra/providers/direct/directProviderAdapter.ts
@@ -1,6 +1,9 @@
 import axios, { AxiosError } from 'axios';
 import { getSecretProviderInstance } from '@alga-psa/core/secrets';
-import { getMicrosoftGraphBaseUrl } from '@alga-psa/shared/services/email/microsoftGraphEndpoints';
+import {
+  getMicrosoftGraphBaseUrl,
+  getMicrosoftGraphBetaBaseUrl,
+} from '@alga-psa/shared/services/email/microsoftGraphEndpoints';
 import {
   refreshEntraDirectAccessTokenForTenant,
   refreshEntraDirectToken,
@@ -24,8 +27,11 @@ const GRAPH_REQUEST_TIMEOUT_MS = 20_000;
 
 // Resolved per call: MICROSOFT_GRAPH_BASE_URL points the whole adapter at the
 // Graph emulator (test-harness/graph-emulator) so the integration can be walked
-// end to end without a CSP tenant.
+// end to end without a CSP tenant. The managedTenants endpoints live on the
+// beta base (the API is beta-only; v1.0 answers 400), with its own emulator
+// override MICROSOFT_GRAPH_BETA_BASE_URL.
 const graphBaseUrl = (): string => getMicrosoftGraphBaseUrl();
+const graphBetaBaseUrl = (): string => getMicrosoftGraphBetaBaseUrl();
 
 // Smoke-only: when enabled, swap the GDAP-backed managedTenants/* endpoints for
 // /organization and /users so the partner's own tenant acts as a single managed
@@ -319,7 +325,7 @@ export class DirectProviderAdapter implements EntraProviderAdapter {
 
     const tenants: EntraManagedTenantRecord[] = [];
     const seenTenantIds = new Set<string>();
-    let nextUrl = `${graphBaseUrl()}/tenantRelationships/managedTenants/tenants?$top=999`;
+    let nextUrl = `${graphBetaBaseUrl()}/tenantRelationships/managedTenants/tenants?$top=999`;
 
     while (nextUrl) {
       const payload = await this.graphGet(input.tenant, nextUrl);
@@ -376,7 +382,7 @@ export class DirectProviderAdapter implements EntraProviderAdapter {
     ].join(',');
 
     let nextUrl =
-      `${graphBaseUrl()}/tenantRelationships/managedTenants/users` +
+      `${graphBetaBaseUrl()}/tenantRelationships/managedTenants/users` +
       `?$filter=tenantId eq '${encodedTenant}'&$select=${select}&$top=999`;
 
     while (nextUrl) {

--- a/server/public/locales/de/msp/integrations.json
+++ b/server/public/locales/de/msp/integrations.json
@@ -722,7 +722,8 @@
             "consentMissing": "Microsoft hat Sie angemeldet, den Zugriff auf Ihre verwaltete Mandantenliste jedoch verweigert. Ein globaler Administrator muss die Administratorzustimmung für die angeforderten Berechtigungen erteilen. Es wurde nichts gespeichert – versuchen Sie es nach erteilter Zustimmung erneut.",
             "expired": "Der Verbindungsversuch ist abgelaufen, bevor er abgeschlossen war. Es wurde nichts gespeichert – starten Sie die Verbindung erneut.",
             "generic": "Microsoft Entra wurde nicht verbunden, und es wurde nichts gespeichert. Bitte versuchen Sie es erneut.",
-            "validationFailed": "Microsoft hat Sie angemeldet, aber Ihre verwaltete Mandantenliste konnte nicht gelesen werden, daher wurde nichts gespeichert. Prüfen Sie die Berechtigungen der Verbindung und versuchen Sie es erneut."
+            "validationFailed": "Microsoft hat Sie angemeldet, aber die verwaltete Mandantenliste konnte nicht gelesen werden; es wurde nichts gespeichert. Ihre Berechtigungen wurden akzeptiert — meist ist der Partner-Mandant nicht in Microsoft 365 Lighthouse eingebunden oder es bestehen keine aktiven GDAP-Beziehungen.",
+            "tokenRejected": "Microsoft hat das Zugriffstoken der Verbindung abgelehnt; es wurde nichts gespeichert. Starten Sie die Verbindung erneut."
           },
           "cippServerLabel": "CIPP-Server",
           "connectingSuffix": " (Verbindung wird hergestellt...)",
@@ -941,7 +942,8 @@
             "prerequisites": {
               "appRegistration": "Für diesen Mandanten konfigurierte Microsoft-OAuth-Anmeldedaten.",
               "globalAdmin": "Einen globalen Administrator, der die Berechtigungen genehmigen kann.",
-              "partnerRelationship": "Eine Partnerbeziehung (GDAP) mit den verwalteten Mandanten."
+              "partnerRelationship": "Eine Partnerbeziehung (GDAP) mit den verwalteten Mandanten.",
+              "lighthouse": "Microsoft 365 Lighthouse ist in Ihrem Partner-Mandanten eingerichtet."
             }
           },
           "directReassurance": "Sie sehen die Berechtigungsabfrage, bevor irgendetwas erteilt wird.",

--- a/server/public/locales/en/msp/integrations.json
+++ b/server/public/locales/en/msp/integrations.json
@@ -722,7 +722,8 @@
             "consentMissing": "Microsoft signed you in but refused access to your managed tenant list. A Global Administrator must grant admin consent for the requested permissions. Nothing was saved — try again once consent is granted.",
             "expired": "The connection attempt expired before it finished. Nothing was saved — start the connection again.",
             "generic": "Microsoft Entra was not connected, and nothing was saved. Please try again.",
-            "validationFailed": "Microsoft signed you in, but we could not read your managed tenant list, so nothing was saved. Check the connection's permissions and try again."
+            "validationFailed": "Microsoft signed you in, but the managed tenant list could not be read, so nothing was saved. Your permissions were accepted — this usually means the partner tenant is not onboarded to Microsoft 365 Lighthouse or has no active GDAP relationships.",
+            "tokenRejected": "Microsoft rejected the connection's access token, so nothing was saved. Start the connection again."
           },
           "cippServerLabel": "CIPP server",
           "connectingSuffix": " (Connecting...)",
@@ -941,7 +942,8 @@
             "prerequisites": {
               "appRegistration": "Microsoft OAuth credentials configured for this tenant.",
               "globalAdmin": "A Global Administrator who can approve the permissions.",
-              "partnerRelationship": "A partner relationship (GDAP) with the tenants you manage."
+              "partnerRelationship": "A partner relationship (GDAP) with the tenants you manage.",
+              "lighthouse": "Microsoft 365 Lighthouse onboarded in your partner tenant."
             }
           },
           "directReassurance": "You will review the permission prompt before anything is granted.",

--- a/server/public/locales/es/msp/integrations.json
+++ b/server/public/locales/es/msp/integrations.json
@@ -722,7 +722,8 @@
             "consentMissing": "Microsoft inició su sesión, pero denegó el acceso a su lista de inquilinos gestionados. Un administrador global debe conceder el consentimiento de administrador para los permisos solicitados. No se guardó nada: inténtelo de nuevo cuando se conceda el consentimiento.",
             "expired": "El intento de conexión caducó antes de completarse. No se guardó nada: inicie la conexión de nuevo.",
             "generic": "Microsoft Entra no se conectó y no se guardó nada. Inténtelo de nuevo.",
-            "validationFailed": "Microsoft inició su sesión, pero no se pudo leer su lista de inquilinos gestionados, por lo que no se guardó nada. Revise los permisos de la conexión e inténtelo de nuevo."
+            "validationFailed": "Microsoft inició su sesión, pero no se pudo leer la lista de inquilinos gestionados; no se guardó nada. Sus permisos fueron aceptados — normalmente significa que el inquilino de partner no está incorporado a Microsoft 365 Lighthouse o no tiene relaciones GDAP activas.",
+            "tokenRejected": "Microsoft rechazó el token de acceso de la conexión; no se guardó nada. Inicie la conexión de nuevo."
           },
           "cippServerLabel": "Servidor CIPP",
           "connectingSuffix": " (Conectando...)",
@@ -941,7 +942,8 @@
             "prerequisites": {
               "appRegistration": "Credenciales OAuth de Microsoft configuradas para este inquilino.",
               "globalAdmin": "Un administrador global que pueda aprobar los permisos.",
-              "partnerRelationship": "Una relación de partner (GDAP) con los inquilinos que gestiona."
+              "partnerRelationship": "Una relación de partner (GDAP) con los inquilinos que gestiona.",
+              "lighthouse": "Microsoft 365 Lighthouse incorporado en su inquilino de partner."
             }
           },
           "directReassurance": "Revisará la solicitud de permisos antes de conceder nada.",

--- a/server/public/locales/fr/msp/integrations.json
+++ b/server/public/locales/fr/msp/integrations.json
@@ -722,7 +722,8 @@
             "consentMissing": "Microsoft vous a connecté mais a refusé l'accès à votre liste de locataires gérés. Un administrateur général doit accorder le consentement administrateur pour les autorisations demandées. Rien n'a été enregistré — réessayez une fois le consentement accordé.",
             "expired": "La tentative de connexion a expiré avant de se terminer. Rien n'a été enregistré — relancez la connexion.",
             "generic": "Microsoft Entra n'a pas été connecté et rien n'a été enregistré. Veuillez réessayer.",
-            "validationFailed": "Microsoft vous a connecté, mais votre liste de locataires gérés n'a pas pu être lue, donc rien n'a été enregistré. Vérifiez les autorisations de la connexion et réessayez."
+            "validationFailed": "Microsoft vous a connecté, mais la liste des locataires gérés n'a pas pu être lue ; rien n'a été enregistré. Vos autorisations ont été acceptées — en général, le locataire partenaire n'est pas intégré à Microsoft 365 Lighthouse ou n'a aucune relation GDAP active.",
+            "tokenRejected": "Microsoft a rejeté le jeton d'accès de la connexion ; rien n'a été enregistré. Relancez la connexion."
           },
           "cippServerLabel": "Serveur CIPP",
           "connectingSuffix": " (Connexion...)",
@@ -941,7 +942,8 @@
             "prerequisites": {
               "appRegistration": "Des identifiants OAuth Microsoft configurés pour ce locataire.",
               "globalAdmin": "Un administrateur général capable d'approuver les autorisations.",
-              "partnerRelationship": "Une relation de partenaire (GDAP) avec les locataires que vous gérez."
+              "partnerRelationship": "Une relation de partenaire (GDAP) avec les locataires que vous gérez.",
+              "lighthouse": "Microsoft 365 Lighthouse intégré dans votre locataire partenaire."
             }
           },
           "directReassurance": "Vous verrez la demande d'autorisations avant que quoi que ce soit ne soit accordé.",

--- a/server/public/locales/it/msp/integrations.json
+++ b/server/public/locales/it/msp/integrations.json
@@ -722,7 +722,8 @@
             "consentMissing": "Microsoft ti ha autenticato ma ha negato l'accesso all'elenco dei tenant gestiti. Un amministratore globale deve concedere il consenso amministratore per le autorizzazioni richieste. Non è stato salvato nulla: riprova una volta concesso il consenso.",
             "expired": "Il tentativo di connessione è scaduto prima di completarsi. Non è stato salvato nulla: avvia di nuovo la connessione.",
             "generic": "Microsoft Entra non è stato connesso e non è stato salvato nulla. Riprova.",
-            "validationFailed": "Microsoft ti ha autenticato, ma non è stato possibile leggere l'elenco dei tenant gestiti, quindi non è stato salvato nulla. Controlla le autorizzazioni della connessione e riprova."
+            "validationFailed": "Microsoft ti ha autenticato, ma non è stato possibile leggere l'elenco dei tenant gestiti; non è stato salvato nulla. Le autorizzazioni sono state accettate — di solito il tenant partner non è integrato in Microsoft 365 Lighthouse o non ha relazioni GDAP attive.",
+            "tokenRejected": "Microsoft ha rifiutato il token di accesso della connessione; non è stato salvato nulla. Riavvia la connessione."
           },
           "cippServerLabel": "Server CIPP",
           "connectingSuffix": " (Connessione...)",
@@ -941,7 +942,8 @@
             "prerequisites": {
               "appRegistration": "Credenziali OAuth Microsoft configurate per questo tenant.",
               "globalAdmin": "Un amministratore globale che possa approvare le autorizzazioni.",
-              "partnerRelationship": "Una relazione di partner (GDAP) con i tenant che gestisci."
+              "partnerRelationship": "Una relazione di partner (GDAP) con i tenant che gestisci.",
+              "lighthouse": "Microsoft 365 Lighthouse integrato nel tenant partner."
             }
           },
           "directReassurance": "Vedrai la richiesta di autorizzazioni prima che venga concesso qualcosa.",

--- a/server/public/locales/nl/msp/integrations.json
+++ b/server/public/locales/nl/msp/integrations.json
@@ -722,7 +722,8 @@
             "consentMissing": "Microsoft heeft u aangemeld maar toegang tot uw lijst met beheerde tenants geweigerd. Een globale beheerder moet beheerderstoestemming verlenen voor de gevraagde machtigingen. Er is niets opgeslagen — probeer het opnieuw zodra de toestemming is verleend.",
             "expired": "De verbindingspoging is verlopen voordat deze was voltooid. Er is niets opgeslagen — start de verbinding opnieuw.",
             "generic": "Microsoft Entra is niet verbonden en er is niets opgeslagen. Probeer het opnieuw.",
-            "validationFailed": "Microsoft heeft u aangemeld, maar uw lijst met beheerde tenants kon niet worden gelezen, dus er is niets opgeslagen. Controleer de machtigingen van de verbinding en probeer het opnieuw."
+            "validationFailed": "Microsoft heeft u aangemeld, maar de lijst met beheerde tenants kon niet worden gelezen; er is niets opgeslagen. Uw machtigingen zijn geaccepteerd — meestal is de partnertenant niet aangesloten op Microsoft 365 Lighthouse of zijn er geen actieve GDAP-relaties.",
+            "tokenRejected": "Microsoft heeft het toegangstoken van de verbinding geweigerd; er is niets opgeslagen. Start de verbinding opnieuw."
           },
           "cippServerLabel": "CIPP-server",
           "connectingSuffix": " (Verbinden...)",
@@ -941,7 +942,8 @@
             "prerequisites": {
               "appRegistration": "Microsoft OAuth-gegevens die voor deze tenant zijn geconfigureerd.",
               "globalAdmin": "Een globale beheerder die de machtigingen kan goedkeuren.",
-              "partnerRelationship": "Een partnerrelatie (GDAP) met de tenants die u beheert."
+              "partnerRelationship": "Een partnerrelatie (GDAP) met de tenants die u beheert.",
+              "lighthouse": "Microsoft 365 Lighthouse ingericht in uw partnertenant."
             }
           },
           "directReassurance": "U ziet de toestemmingsvraag voordat er iets wordt verleend.",

--- a/server/public/locales/pl/msp/integrations.json
+++ b/server/public/locales/pl/msp/integrations.json
@@ -722,7 +722,7 @@
             "consentMissing": "Microsoft zalogował Cię, ale odmówił dostępu do listy zarządzanych dzierżaw. Administrator globalny musi udzielić zgody administratora na żądane uprawnienia. Nic nie zostało zapisane — spróbuj ponownie po udzieleniu zgody.",
             "expired": "Próba połączenia wygasła przed zakończeniem. Nic nie zostało zapisane — rozpocznij połączenie ponownie.",
             "generic": "Nie połączono z Microsoft Entra i nic nie zostało zapisane. Spróbuj ponownie.",
-            "validationFailed": "Microsoft zalogował Cię, ale nie udało się odczytać listy zarządzanych dzierżaw; nic nie zostało zapisane. Uprawnienia zostały zaakceptowane — zwykle oznacza to, że dzierżawa partnera nie jest wdrożona w Microsoft 365 Lighthouse lub nie ma aktywnych relacji GDAP.",
+            "validationFailed": "Microsoft zalogował Cię, ale nie udało się odczytać listy zarządzanych organizacji; nic nie zostało zapisane. Uprawnienia zostały zaakceptowane — zwykle oznacza to, że organizacja partnerska nie jest wdrożona w Microsoft 365 Lighthouse lub nie ma aktywnych relacji GDAP.",
             "tokenRejected": "Microsoft odrzucił token dostępu połączenia; nic nie zostało zapisane. Rozpocznij połączenie ponownie."
           },
           "cippServerLabel": "Serwer CIPP",
@@ -943,7 +943,7 @@
               "appRegistration": "Dane OAuth Microsoft skonfigurowane dla tej organizacji.",
               "globalAdmin": "Administratora globalnego, który zatwierdzi uprawnienia.",
               "partnerRelationship": "Relacja partnerska (GDAP) z zarządzanymi dzierżawami.",
-              "lighthouse": "Microsoft 365 Lighthouse wdrożony w dzierżawie partnera."
+              "lighthouse": "Microsoft 365 Lighthouse wdrożony w organizacji partnerskiej."
             }
           },
           "directReassurance": "Zobaczysz prośbę o uprawnienia, zanim cokolwiek zostanie przyznane.",

--- a/server/public/locales/pl/msp/integrations.json
+++ b/server/public/locales/pl/msp/integrations.json
@@ -722,7 +722,8 @@
             "consentMissing": "Microsoft zalogował Cię, ale odmówił dostępu do listy zarządzanych dzierżaw. Administrator globalny musi udzielić zgody administratora na żądane uprawnienia. Nic nie zostało zapisane — spróbuj ponownie po udzieleniu zgody.",
             "expired": "Próba połączenia wygasła przed zakończeniem. Nic nie zostało zapisane — rozpocznij połączenie ponownie.",
             "generic": "Nie połączono z Microsoft Entra i nic nie zostało zapisane. Spróbuj ponownie.",
-            "validationFailed": "Microsoft zalogował Cię, ale nie udało się odczytać listy zarządzanych dzierżaw, więc nic nie zostało zapisane. Sprawdź uprawnienia połączenia i spróbuj ponownie."
+            "validationFailed": "Microsoft zalogował Cię, ale nie udało się odczytać listy zarządzanych dzierżaw; nic nie zostało zapisane. Uprawnienia zostały zaakceptowane — zwykle oznacza to, że dzierżawa partnera nie jest wdrożona w Microsoft 365 Lighthouse lub nie ma aktywnych relacji GDAP.",
+            "tokenRejected": "Microsoft odrzucił token dostępu połączenia; nic nie zostało zapisane. Rozpocznij połączenie ponownie."
           },
           "cippServerLabel": "Serwer CIPP",
           "connectingSuffix": " (Łączenie...)",
@@ -941,7 +942,8 @@
             "prerequisites": {
               "appRegistration": "Dane OAuth Microsoft skonfigurowane dla tej organizacji.",
               "globalAdmin": "Administratora globalnego, który zatwierdzi uprawnienia.",
-              "partnerRelationship": "Relacja partnerska (GDAP) z zarządzanymi dzierżawami."
+              "partnerRelationship": "Relacja partnerska (GDAP) z zarządzanymi dzierżawami.",
+              "lighthouse": "Microsoft 365 Lighthouse wdrożony w dzierżawie partnera."
             }
           },
           "directReassurance": "Zobaczysz prośbę o uprawnienia, zanim cokolwiek zostanie przyznane.",

--- a/server/public/locales/pt/msp/integrations.json
+++ b/server/public/locales/pt/msp/integrations.json
@@ -722,7 +722,8 @@
             "consentMissing": "A Microsoft fez seu login, mas negou o acesso à lista de tenants gerenciados. Um administrador global deve conceder o consentimento de administrador para as permissões solicitadas. Nada foi salvo. Tente novamente depois que o consentimento for concedido.",
             "expired": "A tentativa de conexão expirou antes da conclusão. Nada foi salvo. Inicie a conexão novamente.",
             "generic": "O Microsoft Entra não foi conectado e nada foi salvo. Tente novamente.",
-            "validationFailed": "A Microsoft fez seu login, mas não foi possível ler a lista de tenants gerenciados, então nada foi salvo. Verifique as permissões da conexão e tente novamente."
+            "validationFailed": "A Microsoft fez seu login, mas a lista de tenants gerenciados não pôde ser lida; nada foi salvo. Suas permissões foram aceitas — geralmente significa que o tenant de parceiro não está integrado ao Microsoft 365 Lighthouse ou não tem relações GDAP ativas.",
+            "tokenRejected": "A Microsoft rejeitou o token de acesso da conexão; nada foi salvo. Inicie a conexão novamente."
           },
           "cippServerLabel": "Servidor CIPP",
           "connectingSuffix": "(Conectando...)",
@@ -941,7 +942,8 @@
             "prerequisites": {
               "appRegistration": "Credenciais OAuth da Microsoft configuradas para este tenant.",
               "globalAdmin": "Um administrador global que possa aprovar as permissões.",
-              "partnerRelationship": "Uma relação de parceiro (GDAP) com os tenants que você gerencia."
+              "partnerRelationship": "Uma relação de parceiro (GDAP) com os tenants que você gerencia.",
+              "lighthouse": "Microsoft 365 Lighthouse integrado no seu tenant de parceiro."
             }
           },
           "directReassurance": "Você poderá revisar as permissões solicitadas antes de concedê-las.",

--- a/server/public/locales/xx/msp/integrations.json
+++ b/server/public/locales/xx/msp/integrations.json
@@ -722,7 +722,8 @@
             "consentMissing": "11111",
             "expired": "11111",
             "generic": "11111",
-            "validationFailed": "11111"
+            "validationFailed": "11111",
+            "tokenRejected": "11111"
           },
           "cippServerLabel": "11111",
           "connectingSuffix": "11111",
@@ -941,7 +942,8 @@
             "prerequisites": {
               "appRegistration": "11111",
               "globalAdmin": "11111",
-              "partnerRelationship": "11111"
+              "partnerRelationship": "11111",
+              "lighthouse": "11111"
             }
           },
           "directReassurance": "11111",

--- a/server/public/locales/yy/msp/integrations.json
+++ b/server/public/locales/yy/msp/integrations.json
@@ -722,7 +722,8 @@
             "consentMissing": "55555",
             "expired": "55555",
             "generic": "55555",
-            "validationFailed": "55555"
+            "validationFailed": "55555",
+            "tokenRejected": "55555"
           },
           "cippServerLabel": "55555",
           "connectingSuffix": "55555",
@@ -941,7 +942,8 @@
             "prerequisites": {
               "appRegistration": "55555",
               "globalAdmin": "55555",
-              "partnerRelationship": "55555"
+              "partnerRelationship": "55555",
+              "lighthouse": "55555"
             }
           },
           "directReassurance": "55555",

--- a/server/src/test/unit/components/integrations/entraCallbackErrors.test.ts
+++ b/server/src/test/unit/components/integrations/entraCallbackErrors.test.ts
@@ -9,9 +9,11 @@ describe('buildEntraCallbackErrorKey', () => {
     );
   });
 
-  it('groups rejected tokens with failed validation', () => {
+  it('keeps a rejected token distinct from failed validation', () => {
+    // Lumping these together once pointed an operator at permissions when the
+    // real failure was a wrong Graph endpoint; each cause gets its own message.
     expect(buildEntraCallbackErrorKey('auth_rejected')).toBe(
-      'integrations.entra.settings.connection.callbackErrors.validationFailed'
+      'integrations.entra.settings.connection.callbackErrors.tokenRejected'
     );
     expect(buildEntraCallbackErrorKey('validation_failed')).toBe(
       'integrations.entra.settings.connection.callbackErrors.validationFailed'

--- a/shared/services/email/microsoftGraphEndpoints.ts
+++ b/shared/services/email/microsoftGraphEndpoints.ts
@@ -1,4 +1,7 @@
 export const DEFAULT_MICROSOFT_GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0';
+// The managedTenants (Microsoft 365 Lighthouse) API exists only on the beta
+// endpoint; requesting it on v1.0 returns 400 for the unknown segment.
+export const DEFAULT_MICROSOFT_GRAPH_BETA_BASE_URL = 'https://graph.microsoft.com/beta';
 export const DEFAULT_MICROSOFT_LOGIN_BASE_URL = 'https://login.microsoftonline.com';
 
 /**
@@ -26,6 +29,15 @@ function withoutTrailingSlash(value: string): string {
 export function getMicrosoftGraphBaseUrl(): string {
   return withoutTrailingSlash(
     (process.env.MICROSOFT_GRAPH_BASE_URL || '').trim() || DEFAULT_MICROSOFT_GRAPH_BASE_URL
+  );
+}
+
+// Separate override from MICROSOFT_GRAPH_BASE_URL: that variable is also the
+// Graph emulator hook, and beta callers pointed at the emulator must opt in
+// explicitly or they silently keep hitting real Graph.
+export function getMicrosoftGraphBetaBaseUrl(): string {
+  return withoutTrailingSlash(
+    (process.env.MICROSOFT_GRAPH_BETA_BASE_URL || '').trim() || DEFAULT_MICROSOFT_GRAPH_BETA_BASE_URL
   );
 }
 

--- a/test-harness/graph-emulator/README.md
+++ b/test-harness/graph-emulator/README.md
@@ -21,6 +21,7 @@ Point the Alga server at it with:
 ```bash
 MICROSOFT_LOGIN_BASE_URL=http://127.0.0.1:4010
 MICROSOFT_GRAPH_BASE_URL=http://127.0.0.1:4010/v1.0
+MICROSOFT_GRAPH_BETA_BASE_URL=http://127.0.0.1:4010/beta
 ```
 
 `npm test` starts isolated emulators and verifies the OAuth client pin, message
@@ -45,7 +46,7 @@ either way and produce the same clients and contacts:
 
 | Method | What it calls |
 | --- | --- |
-| Direct | `GET /v1.0/tenantRelationships/managedTenants/tenants`, `…/users?$filter=tenantId eq '…'` |
+| Direct | `GET /beta/tenantRelationships/managedTenants/tenants`, `…/users?$filter=tenantId eq '…'` (beta-only, as on real Graph — v1.0 answers 400) |
 | Direct, self-tenant smoke | `GET /v1.0/organization`, `GET /v1.0/users` |
 | CIPP | `GET /api/listtenants`, `GET /api/listusers?tenantId=…` |
 

--- a/test-harness/graph-emulator/entra.smoke.test.mjs
+++ b/test-harness/graph-emulator/entra.smoke.test.mjs
@@ -17,7 +17,9 @@ async function waitFor(url) {
 }
 
 async function graph(path, headers = {}) {
-  return fetch(`${base}/v1.0${path}`, {
+  // managedTenants lives on beta, as on real Graph; everything else on v1.0.
+  const version = path.startsWith('/tenantRelationships/managedTenants') ? 'beta' : 'v1.0';
+  return fetch(`${base}/${version}${path}`, {
     headers: { authorization: `Bearer ${accessToken}`, ...headers },
   });
 }
@@ -81,10 +83,19 @@ test('the probe endpoint answers before anything is persisted', async () => {
 });
 
 test('an unknown token is rejected, so a failed probe is reachable', async () => {
-  const response = await fetch(`${base}/v1.0/tenantRelationships/managedTenants/tenants`, {
+  const response = await fetch(`${base}/beta/tenantRelationships/managedTenants/tenants`, {
     headers: { authorization: 'Bearer not-a-token' },
   });
   assert.equal(response.status, 401);
+});
+
+test('managedTenants on v1.0 answers 400 like real Graph, so the endpoint-version bug stays dead', async () => {
+  const response = await fetch(`${base}/v1.0/tenantRelationships/managedTenants/tenants?$top=1`, {
+    headers: { authorization: `Bearer ${accessToken}` },
+  });
+  assert.equal(response.status, 400);
+  const payload = await response.json();
+  assert.equal(payload.error.code, 'BadRequest');
 });
 
 test('users come back per tenant, including the disabled account', async () => {
@@ -104,7 +115,7 @@ test('users come back per tenant, including the disabled account', async () => {
 
 test('pages with @odata.nextLink so the adapters have to follow it', async () => {
   const filter = encodeURIComponent(`tenantId eq '${CONTOSO}'`);
-  let url = `${base}/v1.0/tenantRelationships/managedTenants/users?$filter=${filter}&$top=2`;
+  let url = `${base}/beta/tenantRelationships/managedTenants/users?$filter=${filter}&$top=2`;
   const seen = [];
   let pages = 0;
 

--- a/test-harness/graph-emulator/seed.mjs
+++ b/test-harness/graph-emulator/seed.mjs
@@ -46,6 +46,7 @@ Point Alga at it:
 
   MICROSOFT_LOGIN_BASE_URL=${url}
   MICROSOFT_GRAPH_BASE_URL=${url}/v1.0
+  MICROSOFT_GRAPH_BETA_BASE_URL=${url}/beta
   MICROSOFT_CLIENT_ID=${clientId}
   MICROSOFT_CLIENT_SECRET=${clientSecret}
 

--- a/test-harness/graph-emulator/server.mjs
+++ b/test-harness/graph-emulator/server.mjs
@@ -234,10 +234,21 @@ async function handler(req, res) {
   // key, so it is handled before the Graph access-token gate.
   if (handleCippApi(req, res, url, json)) return;
 
-  if (!url.pathname.startsWith('/v1.0/')) return json(res, 404, { error: 'not_found' });
+  const versionMatch = url.pathname.match(/^\/(v1\.0|beta)\//);
+  if (!versionMatch) return json(res, 404, { error: 'not_found' });
   const access = requireAccess(req, res);
   if (!access) return;
-  const graphPath = url.pathname.slice('/v1.0'.length);
+  const graphPath = url.pathname.slice(versionMatch[1].length + 1);
+  // Faithful to real Graph: managedTenants (Microsoft 365 Lighthouse) exists
+  // only on beta. Serving it on v1.0 here is what let the v1.0 bug ship.
+  if (versionMatch[1] === 'v1.0' && graphPath.startsWith('/tenantRelationships/managedTenants')) {
+    return json(res, 400, {
+      error: {
+        code: 'BadRequest',
+        message: "Resource not found for the segment 'managedTenants'.",
+      },
+    });
+  }
   const fault = injectedFault(`${req.method} ${graphPath}`);
   if (fault) return json(res, fault.status, fault.body);
 


### PR DESCRIPTION
The managedTenants (Microsoft 365 Lighthouse) API exists only on Graph's beta endpoint; calling it on v1.0 returned 400 and failed every real Direct connect, while smoke mode's /organization probe kept passing. Route the probe and sync adapter through a new getMicrosoftGraphBetaBaseUrl() (own emulator override, MICROSOFT_GRAPH_BETA_BASE_URL), capture Graph's error body as a loggable detail, and make the emulator refuse managedTenants on v1.0 like real Graph so this class of bug can't ship again.

Also: split the auth_rejected UI message from validation_failed (which no longer blames permissions), list Lighthouse onboarding as a chooser prerequisite (all 8 locales + pseudo), and document the beta dependency, GDAP/Lighthouse prereqs, and all four Microsoft OAuth callback URIs for shared app registrations.

'Curiouser and curiouser!' cried the probe, having knocked at /v1.0's door for the seventh time only to find there was no such segment behind it — for as the Cheshire Graph explained, grinning from ear to /beta, 'managedTenants lives that way. We're all on different versions here.' 🐇🎩📡