### PR TITLE
Default ticket detail layout to Grid (bento)

### DIFF
--- a/.github/actions/install-ripgrep/action.yml
+++ b/.github/actions/install-ripgrep/action.yml
@@ -1,0 +1,45 @@
+name: Install ripgrep
+description: >-
+  Install the ripgrep (rg) binary from its GitHub release. A few contract tests
+  shell out to `rg` (execFileSync('rg', ...)) and it is not on the runner by
+  default. We deliberately avoid `apt-get`: the hosted runners' primary Ubuntu
+  mirror (azure.archive.ubuntu.com) is intermittently degraded, and both
+  `apt-get update` and the `.deb` download stall on it — that stall once hung a
+  job for ~6h until it was cancelled. Fetching the static musl binary from the
+  ripgrep release depends only on github.com, which the workflow already relies
+  on for checkout and actions.
+inputs:
+  version:
+    description: ripgrep release version to install (no leading v).
+    required: false
+    default: '14.1.1'
+runs:
+  using: composite
+  steps:
+    - name: Install ripgrep binary
+      shell: bash
+      run: |
+        set -euo pipefail
+        if command -v rg >/dev/null 2>&1; then
+          echo "ripgrep already present: $(rg --version | head -1)"
+          exit 0
+        fi
+        version='${{ inputs.version }}'
+        dir="ripgrep-${version}-x86_64-unknown-linux-musl"
+        url="https://github.com/BurntSushi/ripgrep/releases/download/${version}/${dir}.tar.gz"
+        ok=
+        for attempt in 1 2 3; do
+          if curl -fsSL --retry 3 --retry-all-errors --connect-timeout 30 --max-time 120 "$url" -o /tmp/rg.tar.gz; then
+            ok=1
+            break
+          fi
+          echo "ripgrep download attempt ${attempt} failed; retrying in 10s" >&2
+          sleep 10
+        done
+        if [ -z "$ok" ]; then
+          echo "failed to download ripgrep after 3 attempts" >&2
+          exit 1
+        fi
+        tar -xzf /tmp/rg.tar.gz -C /tmp
+        sudo install -m 0755 "/tmp/${dir}/rg" /usr/local/bin/rg
+        rg --version | head -1

--- a/.github/workflows/bidi-control-guard.yml
+++ b/.github/workflows/bidi-control-guard.yml
@@ -12,6 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install ripgrep
-        run: sudo apt-get update && sudo apt-get install -y ripgrep
+        uses: ./.github/actions/install-ripgrep
       - name: Check for bidirectional Unicode controls
         run: npm run guard:no-bidi-control-chars

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -60,23 +60,10 @@ jobs:
         run: npm ci
 
       # A few contract tests shell out to ripgrep (execFileSync('rg', ...)) to
-      # assert on source layout; it isn't on the runner by default.
-      # A hung apt mirror once stalled this seconds-long install until the 6h
-      # runner cap; bound each apt call and retry so a transient network flake
-      # fails fast instead of holding the job for hours.
-      # LEVERAGE: pattern install-ripgrep-with-retry — same block repeated in the coverage-report job and bidi-control-guard.yml
+      # assert on source layout; it isn't on the runner by default. Installed
+      # from its GitHub release, not apt — see the composite action for why.
       - name: Install ripgrep
-        timeout-minutes: 10
-        run: |
-          for attempt in 1 2 3; do
-            if sudo timeout 120 apt-get update && sudo timeout 120 apt-get install -y ripgrep; then
-              exit 0
-            fi
-            echo "ripgrep install attempt $attempt failed; retrying in 15s" >&2
-            sleep 15
-          done
-          echo "ripgrep install failed after 3 attempts" >&2
-          exit 1
+        uses: ./.github/actions/install-ripgrep
 
       # Build the shared infra libraries' dist before testing. Most package
       # vitest configs alias @alga-psa/<lib> to src, but a handful (auth, sla,
@@ -163,22 +150,11 @@ jobs:
         run: npm install -g npm@11
       - name: Install dependencies
         run: npm ci
-      # A few contract tests shell out to ripgrep; it isn't on the runner by default.
-      # Bounded + retried install: a hung apt mirror here stalled this job for
-      # ~6h (the failure this backstop and the job timeout above address).
-      # LEVERAGE: pattern install-ripgrep-with-retry — same block as the unit-tests job above and bidi-control-guard.yml
+      # A few contract tests shell out to ripgrep; it isn't on the runner by
+      # default. Installed from its GitHub release, not apt (the apt mirror hang
+      # here once stalled this job for ~6h). See the composite action for why.
       - name: Install ripgrep
-        timeout-minutes: 10
-        run: |
-          for attempt in 1 2 3; do
-            if sudo timeout 120 apt-get update && sudo timeout 120 apt-get install -y ripgrep; then
-              exit 0
-            fi
-            echo "ripgrep install attempt $attempt failed; retrying in 15s" >&2
-            sleep 15
-          done
-          echo "ripgrep install failed after 3 attempts" >&2
-          exit 1
+        uses: ./.github/actions/install-ripgrep
       # Package suites that real-import @alga-psa/* through native Node
       # resolution (onboarding seeds are .cjs) need the dists on disk; same
       # project set the nx job builds.

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -61,8 +61,22 @@ jobs:
 
       # A few contract tests shell out to ripgrep (execFileSync('rg', ...)) to
       # assert on source layout; it isn't on the runner by default.
+      # A hung apt mirror once stalled this seconds-long install until the 6h
+      # runner cap; bound each apt call and retry so a transient network flake
+      # fails fast instead of holding the job for hours.
+      # LEVERAGE: pattern install-ripgrep-with-retry — same block repeated in the coverage-report job and bidi-control-guard.yml
       - name: Install ripgrep
-        run: sudo apt-get update && sudo apt-get install -y ripgrep
+        timeout-minutes: 10
+        run: |
+          for attempt in 1 2 3; do
+            if sudo timeout 120 apt-get update && sudo timeout 120 apt-get install -y ripgrep; then
+              exit 0
+            fi
+            echo "ripgrep install attempt $attempt failed; retrying in 15s" >&2
+            sleep 15
+          done
+          echo "ripgrep install failed after 3 attempts" >&2
+          exit 1
 
       # Build the shared infra libraries' dist before testing. Most package
       # vitest configs alias @alga-psa/<lib> to src, but a handful (auth, sla,
@@ -134,6 +148,11 @@ jobs:
   coverage-report:
     name: Server unit suite + coverage
     runs-on: ubuntu-latest
+    # Backstop like the sibling unit-tests job: without this the 6h runner
+    # default applies, and a hung apt mirror in "Install ripgrep" once stalled
+    # this job for ~6h before it was cancelled. An hour comfortably covers the
+    # full server suite while still catching a hang 6x sooner.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -145,8 +164,21 @@ jobs:
       - name: Install dependencies
         run: npm ci
       # A few contract tests shell out to ripgrep; it isn't on the runner by default.
+      # Bounded + retried install: a hung apt mirror here stalled this job for
+      # ~6h (the failure this backstop and the job timeout above address).
+      # LEVERAGE: pattern install-ripgrep-with-retry — same block as the unit-tests job above and bidi-control-guard.yml
       - name: Install ripgrep
-        run: sudo apt-get update && sudo apt-get install -y ripgrep
+        timeout-minutes: 10
+        run: |
+          for attempt in 1 2 3; do
+            if sudo timeout 120 apt-get update && sudo timeout 120 apt-get install -y ripgrep; then
+              exit 0
+            fi
+            echo "ripgrep install attempt $attempt failed; retrying in 15s" >&2
+            sleep 15
+          done
+          echo "ripgrep install failed after 3 attempts" >&2
+          exit 1
       # Package suites that real-import @alga-psa/* through native Node
       # resolution (onboarding seeds are .cjs) need the dists on disk; same
       # project set the nx job builds.

--- a/packages/tickets/src/actions/ticketLayoutPreference.defaults.test.ts
+++ b/packages/tickets/src/actions/ticketLayoutPreference.defaults.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let currentUser: any;
+
+const userPreferencesGetMock = vi.fn();
+
+vi.mock('@alga-psa/auth', () => ({
+  withAuth: (action: any) => async (...args: any[]) =>
+    action(currentUser, { tenant: currentUser.tenant }, ...args),
+}));
+
+vi.mock('@alga-psa/db', () => ({
+  createTenantKnex: async () => ({ knex: {} }),
+  tenantDb: (conn: any, tenant: string) => ({
+    table: (table: string) => conn(table).where({ tenant }),
+  }),
+  withTransaction: async (_knex: unknown, callback: (trx: any) => Promise<unknown>) => {
+    // Minimal query-builder stand-in: the action only reads the current user row.
+    const builder: any = {
+      where: () => builder,
+      first: async () => ({ user_id: currentUser.user_id }),
+    };
+    const trx = (_table: string) => builder;
+    return callback(trx);
+  },
+  UserPreferences: {
+    get: (...args: any[]) => userPreferencesGetMock(...args),
+    upsert: vi.fn(),
+  },
+}));
+
+vi.mock('@alga-psa/ui/lib/errorHandling', () => ({
+  actionError: (message: string) => ({ error: message }),
+  permissionError: (message: string) => ({ error: message }),
+}));
+
+const { getTicketLayoutPreference } = await import('./ticketLayoutPreference');
+
+describe('getTicketLayoutPreference defaults', () => {
+  beforeEach(() => {
+    currentUser = { user_id: 'user-1', tenant: 'tenant-1', user_type: 'internal' };
+    userPreferencesGetMock.mockReset();
+  });
+
+  it('defaults to the Grid layout when the user has never chosen one', async () => {
+    userPreferencesGetMock.mockResolvedValue(undefined);
+
+    await expect(getTicketLayoutPreference()).resolves.toEqual({
+      layout: 'grid',
+      timelineOrder: 'asc',
+    });
+  });
+
+  it("keeps the Entry layout for a user who affirmatively stored 'entry'", async () => {
+    userPreferencesGetMock.mockImplementation(async (_trx: unknown, _userId: string, setting: string) =>
+      setting === 'ticket_detail_layout' ? { setting_value: '"entry"' } : undefined,
+    );
+
+    await expect(getTicketLayoutPreference()).resolves.toEqual({
+      layout: 'entry',
+      timelineOrder: 'asc',
+    });
+  });
+
+  it('falls back to Grid when the stored layout value is not a known layout', async () => {
+    userPreferencesGetMock.mockImplementation(async (_trx: unknown, _userId: string, setting: string) =>
+      setting === 'ticket_detail_layout' ? { setting_value: '"bento-deluxe"' } : undefined,
+    );
+
+    await expect(getTicketLayoutPreference()).resolves.toEqual({
+      layout: 'grid',
+      timelineOrder: 'asc',
+    });
+  });
+});

--- a/packages/tickets/src/actions/ticketLayoutPreference.ts
+++ b/packages/tickets/src/actions/ticketLayoutPreference.ts
@@ -15,7 +15,7 @@ export interface TicketLayoutPreference {
 }
 
 const DEFAULT_LAYOUT_PREFERENCE: TicketLayoutPreference = {
-  layout: 'entry',
+  layout: 'grid',
   timelineOrder: 'asc',
 };
 

--- a/packages/tickets/src/components/ticket/TicketDetails.tsx
+++ b/packages/tickets/src/components/ticket/TicketDetails.tsx
@@ -551,10 +551,10 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({
     }), [t]);
     const [ticketInfoDirtyFields, setTicketInfoDirtyFields] = useState<string[]>([]);
 
-    // Grid | Entry layout toggle (per-user preference). Entry is the default
-    // and renders the existing layout untouched.
+    // Grid | Entry layout toggle (per-user preference). Grid is the default;
+    // a stored 'entry' preference keeps the existing layout untouched.
     const [layoutMode, setLayoutMode] = useState<TicketDetailLayout>(
-        bootstrap?.layoutPreference?.layout ?? 'entry',
+        bootstrap?.layoutPreference?.layout ?? 'grid',
     );
     const [timelinePrefOrder, setTimelinePrefOrder] = useState<'asc' | 'desc'>(
         bootstrap?.layoutPreference?.timelineOrder ?? 'asc',

--- a/packages/tickets/src/components/ticket/__tests__/TicketDetails.liveTimerPolicy.test.tsx
+++ b/packages/tickets/src/components/ticket/__tests__/TicketDetails.liveTimerPolicy.test.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import TicketDetails from '../TicketDetails';
+import { entryLayoutBootstrap } from './entryLayoutBootstrap';
 
 const findBoardByIdMock = vi.fn();
 const getTicketByIdMock = vi.fn();
@@ -393,6 +394,7 @@ describe('TicketDetails live timer board policy', () => {
   it('skips live timer auto-start when the initial board disables the live timer', async () => {
     render(
       <TicketDetails
+        bootstrap={entryLayoutBootstrap}
         initialTicket={{ ...baseTicket, board_id: 'board-disabled' }}
         initialBoard={disabledBoard}
       />
@@ -411,6 +413,7 @@ describe('TicketDetails live timer board policy', () => {
 
     render(
       <TicketDetails
+        bootstrap={entryLayoutBootstrap}
         initialTicket={baseTicket}
         initialBoard={enabledBoard}
         onTicketUpdate={onTicketUpdateMock}
@@ -449,6 +452,7 @@ describe('TicketDetails live timer board policy', () => {
 
     render(
       <TicketDetails
+        bootstrap={entryLayoutBootstrap}
         initialTicket={baseTicket}
         initialBoard={enabledBoard}
         onTicketUpdate={onTicketUpdateMock}
@@ -483,6 +487,7 @@ describe('TicketDetails live timer board policy', () => {
 
     const { rerender } = render(
       <TicketDetails
+        bootstrap={entryLayoutBootstrap}
         initialTicket={baseTicket}
         initialBoard={enabledBoard}
       />
@@ -499,6 +504,7 @@ describe('TicketDetails live timer board policy', () => {
 
     rerender(
       <TicketDetails
+        bootstrap={entryLayoutBootstrap}
         initialTicket={baseTicket}
         initialBoard={enabledBoard}
       />
@@ -513,6 +519,7 @@ describe('TicketDetails live timer board policy', () => {
 
     rerender(
       <TicketDetails
+        bootstrap={entryLayoutBootstrap}
         initialTicket={baseTicket}
         initialBoard={enabledBoard}
       />
@@ -531,6 +538,7 @@ describe('TicketDetails live timer board policy', () => {
 
     const { rerender } = render(
       <TicketDetails
+        bootstrap={entryLayoutBootstrap}
         initialTicket={baseTicket}
         initialBoard={enabledBoard}
       />
@@ -545,6 +553,7 @@ describe('TicketDetails live timer board policy', () => {
 
     rerender(
       <TicketDetails
+        bootstrap={entryLayoutBootstrap}
         initialTicket={baseTicket}
         initialBoard={enabledBoard}
       />

--- a/packages/tickets/src/components/ticket/__tests__/TicketDetails.remoteUpdates.test.tsx
+++ b/packages/tickets/src/components/ticket/__tests__/TicketDetails.remoteUpdates.test.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, cleanup, render, screen } from '@testing-library/react';
 import TicketDetails from '../TicketDetails';
+import { entryLayoutBootstrap } from './entryLayoutBootstrap';
 
 const {
   routerPushMock,
@@ -416,6 +417,7 @@ const enabledBoard = {
 function renderTicketDetails() {
   return render(
     <TicketDetails
+      bootstrap={entryLayoutBootstrap}
       initialTicket={baseTicket}
       initialBoard={enabledBoard}
       statusOptions={[
@@ -477,6 +479,7 @@ describe('TicketDetails remote live updates', () => {
     act(() => {
       view.rerender(
         <TicketDetails
+          bootstrap={entryLayoutBootstrap}
           initialTicket={baseTicket}
           initialBoard={enabledBoard}
           statusOptions={[
@@ -523,6 +526,7 @@ describe('TicketDetails remote live updates', () => {
       act(() => {
         view.rerender(
           <TicketDetails
+            bootstrap={entryLayoutBootstrap}
             initialTicket={baseTicket}
             initialBoard={enabledBoard}
             statusOptions={[
@@ -578,6 +582,7 @@ describe('TicketDetails remote live updates', () => {
     act(() => {
       view.rerender(
         <TicketDetails
+          bootstrap={entryLayoutBootstrap}
           initialTicket={baseTicket}
           initialBoard={enabledBoard}
           statusOptions={[
@@ -627,6 +632,7 @@ describe('TicketDetails remote live updates', () => {
     act(() => {
       view.rerender(
         <TicketDetails
+          bootstrap={entryLayoutBootstrap}
           initialTicket={baseTicket}
           initialBoard={enabledBoard}
           statusOptions={[
@@ -676,6 +682,7 @@ describe('TicketDetails remote live updates', () => {
     act(() => {
       view.rerender(
         <TicketDetails
+          bootstrap={entryLayoutBootstrap}
           initialTicket={baseTicket}
           initialBoard={enabledBoard}
           statusOptions={[
@@ -729,6 +736,7 @@ describe('TicketDetails remote live updates', () => {
     act(() => {
       view.rerender(
         <TicketDetails
+          bootstrap={entryLayoutBootstrap}
           initialTicket={baseTicket}
           initialBoard={enabledBoard}
           statusOptions={[
@@ -775,6 +783,7 @@ describe('TicketDetails remote live updates', () => {
     act(() => {
       view.rerender(
         <TicketDetails
+          bootstrap={entryLayoutBootstrap}
           initialTicket={baseTicket}
           initialBoard={enabledBoard}
           statusOptions={[

--- a/packages/tickets/src/components/ticket/__tests__/TicketDetailsCreateTask.test.tsx
+++ b/packages/tickets/src/components/ticket/__tests__/TicketDetailsCreateTask.test.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import TicketDetails from '../TicketDetails';
+import { entryLayoutBootstrap } from './entryLayoutBootstrap';
 
 let lastTicketInfoProps: any = null;
 
@@ -300,6 +301,7 @@ describe('TicketDetails toolbar actions', () => {
 
     render(
       <TicketDetails
+        bootstrap={entryLayoutBootstrap}
         initialTicket={baseTicket as any}
         renderCreateProjectTask={renderCreateProjectTask}
       />
@@ -309,7 +311,7 @@ describe('TicketDetails toolbar actions', () => {
   });
 
   it('does not render create task button when renderCreateProjectTask is missing', () => {
-    render(<TicketDetails initialTicket={baseTicket as any} />);
+    render(<TicketDetails bootstrap={entryLayoutBootstrap} initialTicket={baseTicket as any} />);
 
     expect(lastTicketInfoProps.renderProjectTaskActions).toBeUndefined();
   });
@@ -317,6 +319,7 @@ describe('TicketDetails toolbar actions', () => {
   it('exposes the resolve-and-close action for an open ticket with a closed board status', () => {
     render(
       <TicketDetails
+        bootstrap={entryLayoutBootstrap}
         initialTicket={baseTicket as any}
         statusOptions={[
           { value: 'status-1', label: 'Open', board_id: 'board-1', is_closed: false },
@@ -332,6 +335,7 @@ describe('TicketDetails toolbar actions', () => {
   it('hides the resolve-and-close action after the ticket is closed', () => {
     render(
       <TicketDetails
+        bootstrap={entryLayoutBootstrap}
         initialTicket={{ ...baseTicket, status_id: 'status-closed' } as any}
         statusOptions={[
           { value: 'status-closed', label: 'Resolved', board_id: 'board-1', is_closed: true },

--- a/packages/tickets/src/components/ticket/__tests__/entryLayoutBootstrap.ts
+++ b/packages/tickets/src/components/ticket/__tests__/entryLayoutBootstrap.ts
@@ -1,0 +1,22 @@
+import type { TicketScreenBootstrap } from '../../../lib/ticketScreenBootstrap';
+
+/**
+ * Pins TicketDetails to the Entry layout for specs that assert against the
+ * Entry rendering (they read the props TicketDetails hands to <TicketInfo>,
+ * which the Grid/bento layout does not render).
+ *
+ * Grid is the default for a user with no stored `ticket_detail_layout`
+ * preference, so without this the specs would silently exercise the bento
+ * layout instead. Every other bootstrap field stays null so the component's
+ * fetch-on-mount effects behave exactly as they do without a bootstrap.
+ */
+export const entryLayoutBootstrap: TicketScreenBootstrap = {
+  layoutPreference: { layout: 'entry', timelineOrder: 'asc' },
+  checklistItems: null,
+  autoCloseState: null,
+  canViewCommentMetadataDebug: null,
+  teams: null,
+  displaySettings: null,
+  tags: null,
+  streams: null,
+};


### PR DESCRIPTION
## Summary
- Flip the default ticket-detail layout from Entry to Grid (bento) at both default sites: `DEFAULT_LAYOUT_PREFERENCE.layout` in `packages/tickets/src/actions/ticketLayoutPreference.ts` and the client bootstrap fallback in `packages/tickets/src/components/ticket/TicketDetails.tsx`.
- A stored `entry` preference (`user_preferences.ticket_detail_layout`) remains an affirmative choice and continues to be honored — only users/new accounts with no stored row now land on Grid.
- Left untouched: the `timelineOrder` default, and the in-drawer ticket view, which still forces Entry via the `useGridLayout` gate regardless of preference. Client-portal is unaffected — it has its own `TicketDetails` component and container.
- Added `ticketLayoutPreference.defaults.test.ts` to pin the new Grid default, plus a shared `entryLayoutBootstrap` test fixture used to pin `TicketDetailsCreateTask`, `TicketDetails.remoteUpdates`, and `TicketDetails.liveTimerPolicy` to Entry (they render `TicketDetails` without a bootstrap/`isInDrawer`, so they'd otherwise now hit the Grid/bento layout and fail on missing `useQuickAddClient` mocks).

## Test plan
- [x] `ticketLayoutPreference.defaults.test.ts` + the three Entry-pinned specs — 4 files / 19 tests, all pass (independently re-run, not just prior claims).
- [x] Code-diff + DB-state verification against branch base `5d01422eeb`: confirmed the production diff is exactly the two default-flip sites, with `timelineOrder` and the in-drawer forced-Entry gate untouched.
- [x] Dev DB check (26 internal users): only `glinda` (`entry`) and `tinman` (`grid`) have a stored `ticket_detail_layout` row; every other internal user (dorothy, scarecrow, cheshire, madhatter, queenhearts, admin-*/repro-* accounts) has no row and will resolve to the new Grid default.
- [ ] Real-browser UI verification (pre-hydration flash, stored-`entry`-honored, in-drawer-forces-Entry) — **not completed**, for two documented reasons:
  1. alga-dev tooling bug: every browser pane created via `space-new-tab` or `pane-new-tab` reports "belongs to a different host" on every browser command, despite `get-layout` showing it correctly scoped to this host. Reproduced via two separate creation methods plus a delayed retry.
  2. Independent login failure: the recorded dev password for `glinda` byte-exact-matches the server boot banner, but the server logs `[authenticateUser] Invalid password for email glinda@emeraldcity.oz` on every attempt, including a careful curl POST with a valid CSRF token. That attempt was the 5th failed glinda+IP attempt in the current 15-minute window, tripping the app's own login rate limiter (`EMAIL_IP_MAX_FAILURES=5`) for ~15 more minutes. Stopped short of scripting a password reset since that started to resemble a credential-manipulation workaround rather than legitimate smoke testing.
- Evidence directory: `/tmp/alga-smoke-evidence/default-ticket-detail-layout-to-grid-bento-20260819-020151Z`
- Fidelity: stepped down from real-UI verification to code-diff + DB-state + existing-test-suite verification only; no simulator or mock was used — the DB and server checked against were real.