### PR TITLE
Billing email gating: honor client-level billing contact in invoice generation

### DIFF
--- a/packages/billing/src/actions/salesOrderDocumentActions.ts
+++ b/packages/billing/src/actions/salesOrderDocumentActions.ts
@@ -8,6 +8,7 @@ import { StorageService } from '@alga-psa/storage/StorageService';
 import { getServerTranslation } from '@alga-psa/ui/lib/i18n/serverOnly';
 
 import { createPDFGenerationService, publishGeneratedDocumentsToClient } from '../services/pdfGenerationService';
+import { resolveInvoiceBillingRecipient } from '../services/invoiceBillingRecipientService';
 import {
   buildSalesOrderConfirmationEmailContent,
   dedupeRecipients,
@@ -95,9 +96,10 @@ async function renderStoredSalesOrderPdf(
 }
 
 /**
- * Resolve the recipient email(s) for a Sales Order: any explicitly-passed addresses, else the
- * client's billing email. (SOs carry only a client_id — no contact — so the client billing email is
- * the canonical recipient, mirroring how a quote falls back to clients.billing_email.)
+ * Resolve the recipient email(s) for a Sales Order: any explicitly-passed addresses, then the
+ * client's billing recipient. An SO carries only a client_id — no contact of its own — so the
+ * recipient is whoever `resolveInvoiceBillingRecipient` would send that client's invoice to
+ * (billing contact, then clients.billing_email, then a billing or default location email).
  */
 async function resolveSalesOrderRecipients(
   knex: any,
@@ -105,14 +107,11 @@ async function resolveSalesOrderRecipients(
   clientId: string | null | undefined,
   explicit: string[] = [],
 ): Promise<{ recipients: string[]; clientName: string | null }> {
-  const client = clientId
-    ? await knex('clients')
-        .select('billing_email', 'client_name')
-        .where({ tenant, client_id: clientId })
-        .first()
+  const recipient = clientId
+    ? await resolveInvoiceBillingRecipient({ knexOrTrx: knex, tenantId: tenant, clientId })
     : null;
-  const recipients = dedupeRecipients([...explicit, client?.billing_email ?? '']);
-  return { recipients, clientName: client?.client_name ?? null };
+  const recipients = dedupeRecipients([...explicit, recipient?.recipientEmail ?? '']);
+  return { recipients, clientName: recipient?.clientName || null };
 }
 
 /**

--- a/packages/billing/src/components/billing-dashboard/ManualInvoices.tsx
+++ b/packages/billing/src/components/billing-dashboard/ManualInvoices.tsx
@@ -1044,7 +1044,7 @@ const ManualInvoicesContent: React.FC<ManualInvoicesProps> = ({
                 <Alert id="manual-invoice-no-billing-email-warning" variant="warning">
                   <AlertDescription>
                     {t('manualInvoices.warnings.noBillingEmail', {
-                      defaultValue: 'This client has no billing email. Set an email address on the client\'s billing location before generating the invoice.',
+                      defaultValue: 'This client has no billing email. Set a billing contact, a client billing email, or an email on the billing or default location before generating the invoice.',
                     })}
                   </AlertDescription>
                 </Alert>

--- a/packages/billing/src/services/invoiceService.ts
+++ b/packages/billing/src/services/invoiceService.ts
@@ -11,6 +11,7 @@ import { Knex } from 'knex';
 import { Session } from 'next-auth';
 import type { ISO8601String } from '@alga-psa/types';
 import { getClientDefaultTaxRegionCode } from '@alga-psa/shared/billingClients';
+import { resolveInvoiceBillingRecipient } from './invoiceBillingRecipientService';
 import { getCurrentUserAsync, hasPermissionAsync, getSessionAsync, getAnalyticsAsync } from '../lib/authHelpers';
 
 
@@ -254,22 +255,26 @@ export async function getClientDetails(knex: Knex, tenant: string, clientId: str
 }
 
 /**
- * Gets the billing email for a client.
- * Checks billing location first (is_billing_address=true), then falls back to default location.
- * Returns null if no email is found.
+ * Gets the billing email for a client: the address an invoice for this client
+ * would actually be emailed to.
+ *
+ * Delegates to `resolveInvoiceBillingRecipient`, the shared resolver behind email
+ * preview, direct and scheduled delivery, and Stripe customer creation, so that
+ * "can this client be invoiced?" asks exactly the same question as "where does
+ * that invoice get sent?". Precedence is the resolver's: active billing contact,
+ * then clients.billing_email, then an active billing location, then an active
+ * default location.
+ *
+ * Returns null when no candidate carries a valid email.
  */
 export async function getClientBillingEmail(knex: Knex, tenant: string, clientId: string): Promise<string | null> {
-  const location = await tenantScopedTable(knex, tenant, 'client_locations')
-    .where('client_id', clientId)
-    .where(function() {
-      this.where('is_billing_address', true)
-          .orWhere('is_default', true);
-    })
-    .orderByRaw('is_billing_address DESC, is_default DESC')
-    .select('email')
-    .first();
+  const recipient = await resolveInvoiceBillingRecipient({
+    knexOrTrx: knex,
+    tenantId: tenant,
+    clientId,
+  });
 
-  return location?.email || null;
+  return recipient.recipientEmail || null;
 }
 
 export interface ValidationResult {
@@ -292,7 +297,7 @@ export async function validateClientBillingEmail(knex: Knex, tenant: string, cli
       code: 'NO_BILLING_EMAIL',
       params: { clientName },
       error: `Cannot generate invoice: No billing email address for "${clientName}". ` +
-        `Please set an email address on the client's billing location before generating invoices.`
+        `Please set a billing contact, billing email, or a billing/default location email before generating invoices.`
     };
   }
   return { valid: true };

--- a/server/public/locales/de/msp/invoicing.json
+++ b/server/public/locales/de/msp/invoicing.json
@@ -343,7 +343,7 @@
       "refresh": "Beim Aktualisieren der Rechnungsdaten ist ein Fehler aufgetreten.",
       "updateFailed": "Fehler beim Aktualisieren der Rechnung",
       "generateFailed": "Fehler beim Generieren der Rechnung",
-      "NO_BILLING_EMAIL": "Für {{clientName}} ist keine Rechnungs-E-Mail-Adresse hinterlegt. Lege eine E-Mail-Adresse am Rechnungsstandort des Kunden fest und versuche es erneut.",
+      "NO_BILLING_EMAIL": "Für {{clientName}} ist keine Rechnungs-E-Mail-Adresse hinterlegt. Lege einen Rechnungskontakt, eine Rechnungs-E-Mail-Adresse des Kunden oder eine E-Mail-Adresse am Rechnungs- oder Standardstandort fest und versuche es erneut.",
       "CLIENT_NOT_FOUND": "Der ausgewählte Kunde wurde nicht gefunden. Aktualisiere die Seite und versuche es erneut.",
       "SERVICE_NOT_FOUND": "Der Dienst {{serviceId}} wurde nicht gefunden. Aktualisiere die Seite und versuche es erneut.",
       "INVALID_QUANTITY": "Die Menge muss größer als null sein.",
@@ -357,7 +357,7 @@
       "salesOrderNotInvoiceable": "Dieser Kundenauftrag kann nicht mehr abgerechnet werden."
     },
     "warnings": {
-      "noBillingEmail": "Für diesen Kunden ist keine Rechnungs-E-Mail-Adresse hinterlegt. Lege vor dem Generieren der Rechnung eine E-Mail-Adresse am Rechnungsstandort fest."
+      "noBillingEmail": "Für diesen Kunden ist keine Rechnungs-E-Mail-Adresse hinterlegt. Lege vor dem Generieren der Rechnung einen Rechnungskontakt, eine Rechnungs-E-Mail-Adresse des Kunden oder eine E-Mail-Adresse am Rechnungs- oder Standardstandort fest."
     },
     "errorFallback": {
       "title": "Etwas ist schief gelaufen",

--- a/server/public/locales/en/msp/invoicing.json
+++ b/server/public/locales/en/msp/invoicing.json
@@ -343,7 +343,7 @@
       "refresh": "An error occurred while refreshing invoice data.",
       "updateFailed": "Error updating invoice",
       "generateFailed": "Error generating invoice",
-      "NO_BILLING_EMAIL": "{{clientName}} has no billing email. Set an email address on the client's billing location, then try again.",
+      "NO_BILLING_EMAIL": "{{clientName}} has no billing email. Set a billing contact, a client billing email, or an email on the billing or default location, then try again.",
       "CLIENT_NOT_FOUND": "The selected client could not be found. Refresh and try again.",
       "SERVICE_NOT_FOUND": "Service {{serviceId}} could not be found. Refresh and try again.",
       "INVALID_QUANTITY": "Quantity must be greater than zero.",
@@ -357,7 +357,7 @@
       "salesOrderNotInvoiceable": "That sales order is no longer available to invoice."
     },
     "warnings": {
-      "noBillingEmail": "This client has no billing email. Set an email address on the client's billing location before generating the invoice."
+      "noBillingEmail": "This client has no billing email. Set a billing contact, a client billing email, or an email on the billing or default location before generating the invoice."
     },
     "errorFallback": {
       "title": "Something went wrong",

--- a/server/public/locales/es/msp/invoicing.json
+++ b/server/public/locales/es/msp/invoicing.json
@@ -343,7 +343,7 @@
       "refresh": "Se produjo un error al actualizar los datos de la factura.",
       "updateFailed": "Error al actualizar la factura",
       "generateFailed": "Error al generar factura",
-      "NO_BILLING_EMAIL": "{{clientName}} no tiene correo electrónico de facturación. Añada una dirección de correo en la ubicación de facturación del cliente e inténtelo de nuevo.",
+      "NO_BILLING_EMAIL": "{{clientName}} no tiene correo electrónico de facturación. Añada un contacto de facturación, un correo electrónico de facturación del cliente o una dirección de correo en la ubicación de facturación o predeterminada e inténtelo de nuevo.",
       "CLIENT_NOT_FOUND": "No se encontró el cliente seleccionado. Actualice la página e inténtelo de nuevo.",
       "SERVICE_NOT_FOUND": "No se encontró el servicio {{serviceId}}. Actualice la página e inténtelo de nuevo.",
       "INVALID_QUANTITY": "La cantidad debe ser mayor que cero.",
@@ -357,7 +357,7 @@
       "salesOrderNotInvoiceable": "Esa orden de venta ya no está disponible para facturar."
     },
     "warnings": {
-      "noBillingEmail": "Este cliente no tiene correo electrónico de facturación. Añada una dirección de correo en la ubicación de facturación antes de generar la factura."
+      "noBillingEmail": "Este cliente no tiene correo electrónico de facturación. Añada un contacto de facturación, un correo electrónico de facturación del cliente o una dirección de correo en la ubicación de facturación o predeterminada antes de generar la factura."
     },
     "errorFallback": {
       "title": "algo salió mal",

--- a/server/public/locales/fr/msp/invoicing.json
+++ b/server/public/locales/fr/msp/invoicing.json
@@ -343,7 +343,7 @@
       "refresh": "Une erreur s'est produite lors de l'actualisation des données de facture.",
       "updateFailed": "Erreur lors de la mise à jour de la facture",
       "generateFailed": "Erreur lors de la génération de la facture",
-      "NO_BILLING_EMAIL": "{{clientName}} n'a pas d'adresse e-mail de facturation. Ajoutez une adresse e-mail à l'emplacement de facturation du client, puis réessayez.",
+      "NO_BILLING_EMAIL": "{{clientName}} n'a pas d'adresse e-mail de facturation. Ajoutez un contact de facturation, une adresse e-mail de facturation du client ou une adresse e-mail à l'emplacement de facturation ou par défaut, puis réessayez.",
       "CLIENT_NOT_FOUND": "Le client sélectionné est introuvable. Actualisez la page et réessayez.",
       "SERVICE_NOT_FOUND": "Le service {{serviceId}} est introuvable. Actualisez la page et réessayez.",
       "INVALID_QUANTITY": "La quantité doit être supérieure à zéro.",
@@ -357,7 +357,7 @@
       "salesOrderNotInvoiceable": "Cette commande client ne peut plus être facturée."
     },
     "warnings": {
-      "noBillingEmail": "Ce client n'a pas d'adresse e-mail de facturation. Ajoutez une adresse e-mail à son emplacement de facturation avant de générer la facture."
+      "noBillingEmail": "Ce client n'a pas d'adresse e-mail de facturation. Ajoutez un contact de facturation, une adresse e-mail de facturation du client ou une adresse e-mail à son emplacement de facturation ou par défaut avant de générer la facture."
     },
     "errorFallback": {
       "title": "Quelque chose s'est mal passé",

--- a/server/public/locales/it/msp/invoicing.json
+++ b/server/public/locales/it/msp/invoicing.json
@@ -343,7 +343,7 @@
       "refresh": "Si è verificato un errore durante l'aggiornamento dei dati della fattura.",
       "updateFailed": "Errore durante l'aggiornamento della fattura",
       "generateFailed": "Errore nella generazione della fattura",
-      "NO_BILLING_EMAIL": "{{clientName}} non ha un indirizzo e-mail di fatturazione. Imposta un indirizzo e-mail nella sede di fatturazione del cliente e riprova.",
+      "NO_BILLING_EMAIL": "{{clientName}} non ha un indirizzo e-mail di fatturazione. Imposta un contatto per la fatturazione, un indirizzo e-mail di fatturazione del cliente o un indirizzo e-mail nella sede di fatturazione o predefinita e riprova.",
       "CLIENT_NOT_FOUND": "Il cliente selezionato non è stato trovato. Aggiorna la pagina e riprova.",
       "SERVICE_NOT_FOUND": "Il servizio {{serviceId}} non è stato trovato. Aggiorna la pagina e riprova.",
       "INVALID_QUANTITY": "La quantità deve essere maggiore di zero.",
@@ -357,7 +357,7 @@
       "salesOrderNotInvoiceable": "Questo ordine di vendita non è più disponibile per la fatturazione."
     },
     "warnings": {
-      "noBillingEmail": "Questo cliente non ha un indirizzo e-mail di fatturazione. Imposta un indirizzo e-mail nella sede di fatturazione prima di generare la fattura."
+      "noBillingEmail": "Questo cliente non ha un indirizzo e-mail di fatturazione. Imposta un contatto per la fatturazione, un indirizzo e-mail di fatturazione del cliente o un indirizzo e-mail nella sede di fatturazione o predefinita prima di generare la fattura."
     },
     "errorFallback": {
       "title": "Qualcosa è andato storto",

--- a/server/public/locales/nl/msp/invoicing.json
+++ b/server/public/locales/nl/msp/invoicing.json
@@ -343,7 +343,7 @@
       "refresh": "Er is een fout opgetreden bij het vernieuwen van de factuurgegevens.",
       "updateFailed": "Fout bij bijwerken factuur",
       "generateFailed": "Fout bij genereren factuur",
-      "NO_BILLING_EMAIL": "{{clientName}} heeft geen facturatie-e-mailadres. Stel een e-mailadres in op de facturatielocatie van de klant en probeer het opnieuw.",
+      "NO_BILLING_EMAIL": "{{clientName}} heeft geen facturatie-e-mailadres. Stel een contactpersoon voor facturering, een facturatie-e-mailadres van de klant of een e-mailadres op de facturatielocatie of standaardlocatie in en probeer het opnieuw.",
       "CLIENT_NOT_FOUND": "De geselecteerde klant is niet gevonden. Vernieuw de pagina en probeer het opnieuw.",
       "SERVICE_NOT_FOUND": "Service {{serviceId}} is niet gevonden. Vernieuw de pagina en probeer het opnieuw.",
       "INVALID_QUANTITY": "De hoeveelheid moet groter zijn dan nul.",
@@ -357,7 +357,7 @@
       "salesOrderNotInvoiceable": "Deze verkooporder is niet meer beschikbaar voor facturering."
     },
     "warnings": {
-      "noBillingEmail": "Deze klant heeft geen facturatie-e-mailadres. Stel een e-mailadres in op de facturatielocatie voordat u de factuur genereert."
+      "noBillingEmail": "Deze klant heeft geen facturatie-e-mailadres. Stel een contactpersoon voor facturering, een facturatie-e-mailadres van de klant of een e-mailadres op de facturatielocatie of standaardlocatie in voordat u de factuur genereert."
     },
     "errorFallback": {
       "title": "Er is iets misgegaan",

--- a/server/public/locales/pl/msp/invoicing.json
+++ b/server/public/locales/pl/msp/invoicing.json
@@ -361,7 +361,7 @@
       "refresh": "Wystąpił błąd podczas odświeżania danych faktury.",
       "updateFailed": "Błąd podczas aktualizowania faktury",
       "generateFailed": "Błąd podczas generowania faktury",
-      "NO_BILLING_EMAIL": "Klient {{clientName}} nie ma adresu e-mail do rozliczeń. Ustaw adres e-mail w lokalizacji rozliczeniowej klienta i spróbuj ponownie.",
+      "NO_BILLING_EMAIL": "Klient {{clientName}} nie ma adresu e-mail do rozliczeń. Ustaw kontakt ds. rozliczeń, adres e-mail do rozliczeń klienta lub adres e-mail w lokalizacji rozliczeniowej albo domyślnej i spróbuj ponownie.",
       "CLIENT_NOT_FOUND": "Nie znaleziono wybranego klienta. Odśwież stronę i spróbuj ponownie.",
       "SERVICE_NOT_FOUND": "Nie znaleziono usługi {{serviceId}}. Odśwież stronę i spróbuj ponownie.",
       "INVALID_QUANTITY": "Ilość musi być większa od zera.",
@@ -375,7 +375,7 @@
       "salesOrderNotInvoiceable": "Nie można już wystawić faktury dla tego zamówienia sprzedaży."
     },
     "warnings": {
-      "noBillingEmail": "Ten klient nie ma adresu e-mail do rozliczeń. Ustaw adres e-mail w lokalizacji rozliczeniowej przed wygenerowaniem faktury."
+      "noBillingEmail": "Ten klient nie ma adresu e-mail do rozliczeń. Ustaw kontakt ds. rozliczeń, adres e-mail do rozliczeń klienta lub adres e-mail w lokalizacji rozliczeniowej albo domyślnej przed wygenerowaniem faktury."
     },
     "errorFallback": {
       "title": "Coś poszło nie tak",

--- a/server/public/locales/pt/msp/invoicing.json
+++ b/server/public/locales/pt/msp/invoicing.json
@@ -343,7 +343,7 @@
       "refresh": "Ocorreu um erro ao atualizar os dados da fatura.",
       "updateFailed": "Erro ao atualizar fatura",
       "generateFailed": "Erro ao gerar fatura",
-      "NO_BILLING_EMAIL": "{{clientName}} não tem um e-mail de faturação. Defina um endereço de e-mail na localização de faturação do cliente e tente novamente.",
+      "NO_BILLING_EMAIL": "{{clientName}} não tem um e-mail de faturação. Defina um contato de faturação, um e-mail de faturação do cliente ou um endereço de e-mail na localização de faturação ou predefinida e tente novamente.",
       "CLIENT_NOT_FOUND": "O cliente selecionado não foi encontrado. Atualize a página e tente novamente.",
       "SERVICE_NOT_FOUND": "O serviço {{serviceId}} não foi encontrado. Atualize a página e tente novamente.",
       "INVALID_QUANTITY": "A quantidade deve ser maior que zero.",
@@ -357,7 +357,7 @@
       "salesOrderNotInvoiceable": "Esse pedido de venda não está mais disponível para faturamento."
     },
     "warnings": {
-      "noBillingEmail": "Este cliente não tem um e-mail de faturação. Defina um endereço de e-mail na localização de faturação antes de gerar a fatura."
+      "noBillingEmail": "Este cliente não tem um e-mail de faturação. Defina um contato de faturação, um e-mail de faturação do cliente ou um endereço de e-mail na localização de faturação ou predefinida antes de gerar a fatura."
     },
     "errorFallback": {
       "title": "Algo deu errado",

--- a/server/src/test/unit/billing/invoiceService.billingEmailGate.test.ts
+++ b/server/src/test/unit/billing/invoiceService.billingEmailGate.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getClientBillingEmail,
+  validateClientBillingEmail,
+} from '../../../../../packages/billing/src/services/invoiceService';
+
+const TENANT = 'tenant-1';
+const CLIENT_ID = 'client-1';
+
+type Row = Record<string, any>;
+
+function unqualify(column: string) {
+  const [, unqualified] = column.match(/^(?:[^.]+)\.(.+)$/) ?? [];
+  return unqualified ?? column;
+}
+
+/**
+ * Minimal knex stand-in: enough of the builder surface for
+ * resolveInvoiceBillingRecipient (equality where, callback where with orWhereNull,
+ * select, orderBy, first, and awaiting the builder for a row list).
+ */
+function createMockKnex(tables: Record<string, Row[]>) {
+  return ((tableName: string) => {
+    let rows: Row[] = (tables[tableName] ?? []).map((row) => ({ ...row }));
+
+    const builder: any = {
+      where(criteria: any, value?: unknown) {
+        if (typeof criteria === 'function') {
+          const predicates: Array<(row: Row) => boolean> = [];
+          const group: any = {
+            where(column: string, expected: unknown) {
+              predicates.push((row) => row[unqualify(column)] === expected);
+              return group;
+            },
+            orWhere(column: string, expected: unknown) {
+              predicates.push((row) => row[unqualify(column)] === expected);
+              return group;
+            },
+            orWhereNull(column: string) {
+              predicates.push((row) => row[unqualify(column)] === null || row[unqualify(column)] === undefined);
+              return group;
+            },
+          };
+          criteria(group);
+          rows = rows.filter((row) => predicates.some((predicate) => predicate(row)));
+          return builder;
+        }
+
+        if (typeof criteria === 'string') {
+          rows = rows.filter((row) => row[unqualify(criteria)] === value);
+          return builder;
+        }
+
+        rows = rows.filter((row) => Object.entries(criteria).every(
+          ([column, expected]) => row[unqualify(column)] === expected,
+        ));
+        return builder;
+      },
+      andWhere(criteria: any, value?: unknown) {
+        return builder.where(criteria, value);
+      },
+      select() {
+        return builder;
+      },
+      orderBy() {
+        return builder;
+      },
+      async first() {
+        return rows[0] ?? null;
+      },
+      then(onFulfilled: any, onRejected: any) {
+        return Promise.resolve(rows).then(onFulfilled, onRejected);
+      },
+    };
+
+    return builder;
+  }) as any;
+}
+
+function clientRow(overrides: Row = {}): Row {
+  return {
+    tenant: TENANT,
+    client_id: CLIENT_ID,
+    client_name: 'Omni Energy Partners',
+    billing_contact_id: null,
+    billing_email: null,
+    ...overrides,
+  };
+}
+
+describe('manual invoice billing-email gate', () => {
+  it('accepts a client whose only recipient is an active billing contact', async () => {
+    const knex = createMockKnex({
+      clients: [clientRow({ billing_contact_id: 'contact-1' })],
+      contacts: [{
+        tenant: TENANT,
+        contact_name_id: 'contact-1',
+        client_id: CLIENT_ID,
+        full_name: 'Ada Okoro',
+        email: 'ada@omni.test',
+        is_inactive: false,
+      }],
+      client_locations: [],
+    });
+
+    await expect(getClientBillingEmail(knex, TENANT, CLIENT_ID)).resolves.toBe('ada@omni.test');
+    await expect(validateClientBillingEmail(
+      knex,
+      TENANT,
+      CLIENT_ID,
+      'Omni Energy Partners',
+    )).resolves.toEqual({ valid: true });
+  });
+
+  it('accepts a client whose only recipient is clients.billing_email', async () => {
+    const knex = createMockKnex({
+      clients: [clientRow({ billing_email: 'ap@omni.test' })],
+      contacts: [],
+      client_locations: [],
+    });
+
+    await expect(getClientBillingEmail(knex, TENANT, CLIENT_ID)).resolves.toBe('ap@omni.test');
+    await expect(validateClientBillingEmail(
+      knex,
+      TENANT,
+      CLIENT_ID,
+      'Omni Energy Partners',
+    )).resolves.toEqual({ valid: true });
+  });
+
+  it('skips an inactive billing contact and falls through to the billing location', async () => {
+    const knex = createMockKnex({
+      clients: [clientRow({ billing_contact_id: 'contact-1' })],
+      contacts: [{
+        tenant: TENANT,
+        contact_name_id: 'contact-1',
+        client_id: CLIENT_ID,
+        full_name: 'Ada Okoro',
+        email: 'ada@omni.test',
+        is_inactive: true,
+      }],
+      client_locations: [{
+        tenant: TENANT,
+        client_id: CLIENT_ID,
+        location_id: 'loc-1',
+        is_billing_address: true,
+        is_default: false,
+        is_active: true,
+        email: 'billing@omni.test',
+      }],
+    });
+
+    await expect(getClientBillingEmail(knex, TENANT, CLIENT_ID)).resolves.toBe('billing@omni.test');
+  });
+
+  it('ignores an inactive location and blocks with NO_BILLING_EMAIL', async () => {
+    const knex = createMockKnex({
+      clients: [clientRow()],
+      contacts: [],
+      client_locations: [{
+        tenant: TENANT,
+        client_id: CLIENT_ID,
+        location_id: 'loc-1',
+        is_billing_address: true,
+        is_default: true,
+        is_active: false,
+        email: 'stale@omni.test',
+      }],
+    });
+
+    await expect(getClientBillingEmail(knex, TENANT, CLIENT_ID)).resolves.toBeNull();
+
+    const result = await validateClientBillingEmail(knex, TENANT, CLIENT_ID, 'Omni Energy Partners');
+    expect(result).toMatchObject({
+      valid: false,
+      code: 'NO_BILLING_EMAIL',
+      params: { clientName: 'Omni Energy Partners' },
+    });
+    // The REST layer maps this failure to a 409 by matching this exact prefix
+    // (server/src/lib/api/services/InvoiceService.ts). Changing it silently
+    // demotes the response to a 500.
+    expect(result.error).toMatch(/^Cannot generate invoice: No billing email address for "Omni Energy Partners"\. /);
+    expect(result.error).toContain('billing contact');
+  });
+
+  it('does not read another tenant\'s client', async () => {
+    const knex = createMockKnex({
+      clients: [clientRow({ tenant: 'tenant-2', billing_email: 'ap@omni.test' })],
+      contacts: [],
+      client_locations: [],
+    });
+
+    await expect(getClientBillingEmail(knex, TENANT, CLIENT_ID)).resolves.toBeNull();
+  });
+});

--- a/server/src/test/unit/billing/invoiceService.manualPeriodPolicy.test.ts
+++ b/server/src/test/unit/billing/invoiceService.manualPeriodPolicy.test.ts
@@ -65,7 +65,7 @@ function createMockTx(existingInvoiceCharges: Array<Record<string, any>> = []) {
 }
 
 describe('manual invoice service-period policy', () => {
-  it('returns NO_BILLING_EMAIL with the client name when no billing location email exists', async () => {
+  it('returns NO_BILLING_EMAIL with the client name when the client resolves to no billing recipient', async () => {
     const { tx } = createMockTx();
 
     await expect(validateClientBillingEmail(

--- a/server/src/test/unit/billing/invoiceServiceTenantScoped.contract.test.ts
+++ b/server/src/test/unit/billing/invoiceServiceTenantScoped.contract.test.ts
@@ -77,7 +77,10 @@ describe('invoiceService tenant-scoped query contract', () => {
     expect(preManualChargeSection).toContain(
       "db.tenantJoin(clientQuery, 'client_locations as cl', 'c.client_id', 'cl.client_id', {"
     );
-    expect(preManualChargeSection).toContain("tenantScopedTable(knex, tenant, 'client_locations')");
+    // The billing-recipient read is not scoped here: getClientBillingEmail
+    // delegates to resolveInvoiceBillingRecipient, which does its own tenantDb
+    // scoping across clients, contacts, and client_locations.
+    expect(preManualChargeSection).toContain('resolveInvoiceBillingRecipient({');
     expect(preManualChargeSection).toContain("tenantScopedTable(tx, tenant, 'invoice_charges')");
 
     expect(preManualChargeSection).not.toMatch(/\.where\(\{[^}]*['"]?tenant['"]?\s*:/s);

--- a/server/src/test/unit/billing/manualInvoiceActions.errors.test.ts
+++ b/server/src/test/unit/billing/manualInvoiceActions.errors.test.ts
@@ -127,7 +127,8 @@ describe('generateManualInvoice structured errors', () => {
       valid: false,
       code: 'NO_BILLING_EMAIL',
       params: { clientName: 'Omni Energy Partners' },
-      error: 'Cannot generate invoice: No billing email address for "Omni Energy Partners".',
+      error: 'Cannot generate invoice: No billing email address for "Omni Energy Partners". ' +
+        'Please set a billing contact, billing email, or a billing/default location email before generating invoices.',
     });
 
     const result = await generateManualInvoice(request);

--- a/server/src/test/unit/billing/manualInvoiceErrorTranslation.test.ts
+++ b/server/src/test/unit/billing/manualInvoiceErrorTranslation.test.ts
@@ -5,7 +5,7 @@ describe('manual invoice error translation', () => {
   it('renders the specific billing-email message instead of the generic generation error', () => {
     const t = vi.fn((key: string, options?: Record<string, unknown>) => {
       if (key === 'manualInvoices.errors.NO_BILLING_EMAIL') {
-        return `${options?.clientName} has no billing email. Set an email address on the client's billing location, then try again.`;
+        return `${options?.clientName} has no billing email. Set a billing contact, a client billing email, or an email on the billing or default location, then try again.`;
       }
       return 'Error generating invoice';
     });

--- a/server/test-utils/billingTestHelpers.ts
+++ b/server/test-utils/billingTestHelpers.ts
@@ -1009,9 +1009,10 @@ export async function createFixedPlanAssignment(
   };
 }
 
-// Invoice generation refuses clients without a billing email
-// (validateClientBillingEmail), which is read off a billing-or-default
-// client_locations row. Clients created straight through createEntity have none.
+// Invoice generation refuses clients that resolve to no billing recipient
+// (validateClientBillingEmail: billing contact, then clients.billing_email, then a
+// billing-or-default client_locations email). Clients created straight through
+// createEntity satisfy none of those, so this seeds the location email.
 export async function ensureClientBillingEmail(
   context: TestContext,
   clientId?: string

--- a/server/test-utils/testDataFactory.ts
+++ b/server/test-utils/testDataFactory.ts
@@ -84,10 +84,12 @@ export async function createClient(
 
   await tenantDb(db, tenantId).table('clients').insert(client);
 
-  // Invoice generation validates that the client has a billing email on its
-  // billing/default location (invoiceService.getClientBillingEmail), so every
-  // factory client gets one. Tests exercising the missing-email failure path
-  // should create a bare client row directly instead of using this factory.
+  // Invoice generation validates that the client resolves to a billing recipient
+  // — a billing contact, clients.billing_email, or a billing/default location
+  // email (invoiceService.getClientBillingEmail). A location email is the cheapest
+  // of the three to seed, so every factory client gets one. Tests exercising the
+  // missing-email failure path should create a bare client row directly instead of
+  // using this factory.
   await createClientLocation(db, clientId, tenantId, {
     is_billing_address: true,
     is_default: true,


### PR DESCRIPTION
## Summary

Invoice generation used to gate on a single narrow check — an email on the client's *billing location* — even though the actual send path (`resolveInvoiceBillingRecipient`) accepts a wider set of valid recipients: billing contact, then `clients.billing_email`, then an active billing location, then an active default location. Clients whose only billing email lived on a contact or on `clients.billing_email` were hard-blocked from invoicing even though an invoice email would have gone out fine.

This unifies the gate onto the real resolver so "can this client be invoiced?" asks exactly the same question as "where would that invoice actually be emailed?":

- `packages/billing/src/services/invoiceService.ts`: `getClientBillingEmail` now delegates to `resolveInvoiceBillingRecipient` instead of querying `client_locations` directly. `validateClientBillingEmail` keeps its signature/error code but updates the message to describe all four valid sources.
- `packages/billing/src/actions/salesOrderDocumentActions.ts`: `resolveSalesOrderRecipients` now resolves the client's recipient the same way, instead of reading `clients.billing_email` directly (previously the only source SOs checked).
- `packages/billing/src/components/billing-dashboard/ManualInvoices.tsx` and the `invoicing.json` locale files (all packs): updated the pre-emptive banner and toast copy to describe the new set of valid billing-email sources.
- Added `invoiceService.billingEmailGate.test.ts` covering the resolver-backed gate; touched a few adjacent tests/helpers that asserted the old error copy or location-only lookup.

**Real behavior change:** the resolver only considers *active* billing locations. A client whose only billing email sits on an inactive `client_locations` row now gets blocked, where the old location-only gate did not check `is_active`. This is intended (an inactive location shouldn't be a live send target) but is a migration risk for any existing tenant relying on that state — flagged here explicitly.

## Smoke test summary

Full manual pass on rung (a) — real Next.js server (this worktree), real Postgres/Redis (`alga-psa-local-test` stack), real browser — against Oz tenant `dd8cb218`, using 5 purpose-built clients (A: billing contact only, B: `clients.billing_email` only, C: nothing set, D: active billing location, E: inactive billing location).

1. **PASS (the fix)** — Client A (billing contact only): no pre-emptive banner, invoice generated (INV-000055 / $200.00 / draft). Previously hard-blocked.
2. **PASS (the fix)** — Client B (`clients.billing_email` only): generated (INV-000056 / $75.00). Previously hard-blocked.
3. **PASS (gate still gates, new copy)** — Client C (nothing set): banner and refusal both render the new "billing contact, client billing email, or billing/default location" copy. 0 invoices created.
4. **PASS (regression check)** — Client D (active billing location only): still generates (INV-000057 / $75.00); legacy path intact.
5. **PASS, real behavior change** — Client E (email only on an *inactive* billing location): now blocked, confirming the resolver's `is_active` filter is stricter than the old gate.
6. **PASS (recurring preview)** — Emerald City temporarily made billing-contact-only; `Preview Selected` on its Jul 2026 period passed the gate and reached "Nothing to bill" (verified in source that `validateClientBillingEmail` runs before billing calculation, so this genuinely proves the gate passed). Restored afterward.
7. **Negative control** — same client with billing contact cleared: blocked with the exact runtime string `Cannot generate invoice: No billing email address for "Emerald City". ...`, confirming the recurring path is really gated and that the 409-mapping prefix in `InvoiceService.ts` (`server/`) is still byte-identical.
8. **PASS (i18n)** — French locale renders the translated banner copy for Client C.

**Not tested:** the REST 409 mapping end-to-end (blocked by API-key generation being denied in this environment — verified the string match against the live runtime error instead); sales-order document/invoicing recipient resolution (no SMTP wired into this stack); recurring *generation* for a billing-contact-only client (the only Ready period computed "Nothing to bill" before reaching the gate — preview and generation share the same `validateClientBillingEmail` chokepoint, which preview did exercise).

Evidence: `/tmp/alga-smoke-evidence/billing-email-gating-20260819-021500`.

## Test plan

- [x] Manual invoice generation for all four billing-email sources (contact, client email, active location, inactive location)
- [x] Manual invoice gate refusal + banner copy (English and French)
- [x] Recurring invoice preview gate (pass and negative-control block)
- [x] `invoiceService.billingEmailGate.test.ts` unit coverage
- [ ] REST v1 409 mapping (not exercised live — no API key available in this environment)
- [ ] Sales-order recipient resolution end-to-end (no SMTP wired locally)