### PR TITLE
Board-centric ticketing UX: tabbed/dedicated board views instead of filter-only

### DIFF
--- a/docs/plans/2026-08-19-board-level-view-configuration-plan.md
+++ b/docs/plans/2026-08-19-board-level-view-configuration-plan.md
@@ -1,0 +1,481 @@
+# Board-level view configuration
+
+**Date:** 2026-08-19
+**Branch:** `feature/board-centric-ticketing-ux-tabbed-dedicated-boar`
+**Builds on:** `b6a99cd69b feat(tickets): board tab strip makes a board a place you go` (PR #3195)
+**UI direction:** C — *board as workspace* (chosen from three mocked options)
+
+## Problem
+
+The board tab strip shipped on this branch made a board reachable. It did not make a
+board *look* like itself. Every board is the same generic ticket list with a
+single-board filter applied — same columns, same order, same density, same starting
+filters, no identity, no state. A board is a place in navigation only.
+
+Three structural problems sit underneath that:
+
+1. **There is no per-board view configuration, and the mechanism that was meant to
+   provide one is dead.** The `boards` table carries eleven `display_*` boolean
+   columns (`display_contact_name_id`, `display_priority`, `display_severity`,
+   `display_urgency`, `display_impact`, `display_category`, `display_subcategory`,
+   `display_assigned_to`, `display_status`, `display_due_date`, `display_itil_impact`,
+   `display_itil_urgency`). No UI reads any of them; they survive only in
+   `board.interface.ts`. Meanwhile every genuinely-used board setting arrived as its
+   own migration and its own column — `default_assigned_to`, `sla_policy_id`,
+   `manager_user_id`, `enable_live_ticket_timer`, `inbound_reply_reopen_*`,
+   `default_assigned_team_id`. The column-per-setting pattern neither scales nor
+   survives: it produced a wide table with an abandoned half.
+
+2. **The ticket list has no column controls.** `createTicketColumns` builds straight
+   from `TICKET_COLUMNS`, and the only place column visibility can be changed is
+   Settings → Display — which is **tenant-wide**. A user who wants to glance at
+   "Created By" once must change a setting for everyone. Column *ordering* has no
+   authoring surface anywhere; the on-screen order is the catalog's declaration order.
+
+3. **The tab strip shows every active board.** At 25 boards it is a horizontally
+   scrolling row. An admin has no way to say which boards deserve permanent tab
+   real estate.
+
+## Design decisions
+
+Settled in the design session. These are constraints the implementation must satisfy.
+
+| Decision | Resolution |
+| --- | --- |
+| **Ownership** | Board view config is **tenant-wide, for all users**. No per-user, per-board persistence and no per-setting lock flags. Users change filters and columns freely while viewing; those changes are interaction state, not stored preference. |
+| **Pinning** | `is_pinned` on the board. Only pinned boards get tabs. Unpinned boards stay **fully reachable** via the All-tickets tab and the board filter dropdown; a deep link to an unpinned board renders a transient tab for that visit, reusing today's inactive-board tab behaviour. No overflow menu. |
+| **All-tickets tab** | Always the first tab, never removable — the natural home for multi-board filtering. It gets **no board header**. |
+| **Storage** | `is_pinned` is a real column (queried, joined, one bit). The view config is a **JSONB document** on `boards`, schema-validated in code — *not* wide columns, *not* a generic key/value table. |
+| **Authoring** | **Capture-from-the-list.** The admin arranges the board's view on the real ticket list and saves it. No second filter UI in settings. |
+| **Application** | The board's default view applies on **every arrival** at that board tab, unless the URL already carries filter params. |
+| **Column controls** | A columns control (visibility + drag-to-reorder) is added to the ticket list, which is what lets capture cover columns. |
+| **Surface** | **Board as workspace.** Selecting a board tab reveals a **board header** — identity, ownership, and health — above the list. All view controls collapse into a single `View ▾` menu. |
+
+### Why a JSONB document and not the alternatives
+
+The decisive argument is that **this document already exists one layer up.**
+`tenant_settings.ticket_display_settings` holds `list.columnVisibility` today,
+resolved through `ticketColumnCatalog.ts`. If the board layer used a different
+representation — wide columns, or a generic KV table — the codebase would own two
+shapes for one concept plus a translator between them, and whichever settings were
+awkward in the second shape would quietly stop being maintained. That is exactly the
+history of the `display_*` columns.
+
+- **Wide columns** cannot express column *ordering* without twelve integer columns,
+  cannot express "unset, inherit from tenant" without nullable-everything, and are
+  the pattern that already failed here.
+- **A generic KV table** (`board_settings(tenant, board_id, setting_name, value jsonb)`)
+  is not more relational than a document: the values are still opaque JSONB, so it
+  buys no integrity, and it costs a pivot on every read. It is a JSONB document with
+  extra steps.
+- **A relational side table for columns** (`board_list_columns(board_id, column_key,
+  visible, position)`) creates rows for something whose universe is a TypeScript const
+  array — `column_key` is a foreign key to nothing — and turns "reset to tenant
+  default" into a delete-all-rows operation.
+
+The real deliverable is therefore not the column; it is the **missing resolution
+layer** the column plugs into.
+
+### Integrity caveat, stated plainly
+
+Captured filters reference `status_id`, `priority_id`, `category_id`, user ids and
+team ids. JSONB will not foreign-key-check those. The approach is **validate-on-read**:
+ids that no longer resolve are dropped from the applied view. This is the established
+pattern on this surface — `resolveInitialBoardTab` already drops a stored board that
+no longer exists, and `buildTicketStatusFilterOptions` already drops a `statusId` when
+switching to a board that lacks it. Board-owned statuses make board-scoped default
+filters *more* coherent than the tenant-level equivalent, not less.
+
+## The board surface
+
+Selecting a board tab reveals a header block between the tab strip and the toolbar:
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ All tickets │ ▸Service Desk 24│ Projects 7 │ Technical 0     │
+├──────────────────────────────────────────────────────────────┤
+│ Service Desk                    24      5        2       7   │
+│ Day-to-day inbound support.    OPEN  OVERDUE  BREACH  UNASSG │
+│ (MO) Managed by M. Okafor · SLA: Standard Business Hours     │
+├──────────────────────────────────────────────────────────────┤
+│ Search this board…  Filters 3▾                     View ▾•   │
+├──────────────────────────────────────────────────────────────┤
+│ TITLE            STATUS      PRIORITY  CLIENT      DUE ↑      │
+```
+
+- **Identity** — board name and description.
+- **Ownership** — `manager_user_id` avatar and name, and the board's SLA policy name.
+- **Health** — open · overdue · SLA breach · unassigned, as four counts.
+- **`View ▾`** — one menu holding Columns (visibility + drag-to-reorder), the density
+  slider, **Save as this board's default view**, and **Reset to tenant default**. The
+  save and reset items are gated on `ticket_settings:update`. A dot on the control
+  marks "the current view differs from what is saved."
+
+The header **degrades gracefully**: no description, no manager, or no SLA policy each
+simply omit their line rather than rendering an empty slot. The **All-tickets tab shows
+no header** — it has no identity to state.
+
+The header is not optional and carries no toggle. A per-board "show the header" flag
+would add a settings control, a document key, a resolution path and a test axis to save
+90px on boards an admin could simply unpin — and the whole point of pinning is that the
+tab strip already expresses which boards are worth space.
+
+### Why C, and what it costs
+
+C is the only option of the three that makes the board's identity — not just its filter
+— visible, and it is the answer that actually delivers the branch's own premise. It also
+gives the dead `display_*` concept a live successor rather than a sibling.
+
+Its costed risk was a new stats pipeline. That turned out not to exist: **overdue, SLA
+breach and unassigned are all derivable from columns already on `tickets`**
+(`due_date`, `sla_policy_id`, `sla_response_due_at`, `sla_resolution_due_at`,
+`sla_response_met`, `sla_resolution_met`, `sla_paused_at`, `assigned_to`) — the same
+derivations `optimizedTicketActions.ts:1340` already uses for `slaStatusFilter`. They
+become three additional `COUNT(*) FILTER (…)` aggregates on the **existing** tickets
+`GROUP BY` in `getBoardListStats`. No new query, no new round trip.
+
+The remaining real cost is ~90px of vertical space above every board list. Pinning is
+the release valve: a board nobody curates is a board nobody should have pinned.
+
+## The shared layer
+
+The centre of this work is a single resolver that layers three inputs and is consumed
+identically by the tenant settings screen, the board settings section, and the dashboard.
+
+```
+resolveTicketViewSettings({ board, tenant })
+    boards.list_view_settings   →   tenant_settings.ticket_display_settings.list   →   TICKET_COLUMNS catalog
+```
+
+New module: `packages/tickets/src/lib/ticketViewSettings.ts` (plain data, no JSX, not
+`"use server"` — importable from components, server actions, and the column builder
+alike, matching `ticketColumnCatalog.ts`).
+
+```ts
+export interface TicketViewSettings {
+  columnVisibility?: Partial<Record<TicketListColumnKey, boolean>>;
+  columnOrder?: TicketListColumnKey[];       // sparse; unlisted keys keep catalog order, appended
+  tagsInlineUnderTitle?: boolean;
+  densityLevel?: number;                     // 0..100, step 10 (matches the existing slider)
+  filters?: Partial<ITicketListFilters>;     // capture-excluded keys stripped before persist
+}
+```
+
+Deliberate shape choices:
+
+- **`TicketingDisplaySettings.list` becomes `TicketViewSettings`.** The two existing
+  keys (`columnVisibility`, `tagsInlineUnderTitle`) already sit at exactly that path,
+  so no tenant JSON migration is needed — the type widens, stored data does not move.
+  `boards.list_view_settings` stores the same document *directly* (not nested under
+  `list`), because a board has no other display settings to nest beside it.
+- **Sort lives inside `filters` as `sortBy`/`sortDirection`.** `ITicketListFilters`
+  already carries both; a separate `sort` key would be a second representation of
+  something the filter type already models.
+- **Merging is group-level, not per-key.** If a board defines `columnVisibility`, it
+  replaces the tenant's map entirely rather than deep-merging. Capture always writes a
+  complete map, so per-key merge would only create ambiguity with no expressive gain.
+- **Reset to tenant default is `list_view_settings = NULL`**, not an empty object.
+
+New catalog helper alongside `resolveTicketColumnVisibility`:
+
+```ts
+resolveTicketColumnOrder(stored?: string[]): TicketListColumnKey[]
+```
+
+Stored keys first, in stored order, filtered to keys the catalog still knows; then
+every remaining catalog key in catalog order. A column added to `TICKET_COLUMNS` after
+a board's view was saved therefore still appears — it does not vanish because it was
+absent from a stored order array.
+
+## Capture semantics
+
+`captureTicketViewSettings(currentView) → TicketViewSettings` (pure, in
+`ticketViewSettings.ts`, unit-testable without mounting the dashboard).
+
+**Excluded from capture** — the exclusion list is a single exported constant so it
+cannot drift:
+
+- `boardId`, `boardIds`, `excludeBoardIds` — the board scope *is* the tab. Capturing it
+  would let a board's default view scope it to a different board.
+- `boardFilterState` — board-scope machinery, same reason.
+- `searchQuery` — transient; a stray search string must not stick permanently.
+
+**Included:** every other `ITicketListFilters` key (status, priority, categories,
+client, contact, tags, assignment including the caller-relative `assignedToMe`, the
+due-date family, `responseState`, `slaStatusFilter`, `showOpenOnly`, `bundleView`,
+`sortBy`/`sortDirection`), plus `columnVisibility`, `columnOrder`, `densityLevel`.
+
+Because capture reads the live view rather than a parallel form, **every filter added
+to `ITicketListFilters` in future is defaultable for free** — there is no second UI
+that must be taught about it.
+
+### Where the save action lives
+
+**`View ▾` → "Save as this board's default view"**, gated on `ticket_settings:update`
+(the permission that already guards board and priority settings). Its destination
+depends on the active tab:
+
+- **A board tab** → writes `boards.list_view_settings` for that board.
+- **The All-tickets tab** → writes `tenant_settings.ticket_display_settings.list`,
+  i.e. the layer that already backs the tenant Display Settings screen. Same affordance,
+  correct altitude, no new mechanism.
+
+## Application semantics
+
+The board's default view applies **on every arrival at a board tab**, unless the URL
+already carries filter params.
+
+This is the only rule under which a configured default actually means something, and
+it costs no new state. Because board-tab moves already **push** history (shipped on
+this branch), a user who tweaks filters and tabs away gets their tweaked state back
+via browser Back — the tweaks are not lost, they are simply not what a fresh tab click
+produces. The board reliably looks like itself when you go there.
+
+Precedence, in order:
+
+1. URL filter params (a shared link) — always win.
+2. The board's `list_view_settings`.
+3. Tenant `ticket_display_settings.list`.
+4. Catalog defaults.
+
+Application reuses the existing merge path in `TicketingDashboardContainer` so a tab
+click still produces **exactly one** `fetchTicketsWithPagination` call — the smoke test
+on this branch verified one server action per navigation and that property must hold.
+
+`localStorage['ticket_list_density_level']` **stops being written and stops being read.**
+Left in place it would silently outrank every board's configured density forever, for
+every user who has ever touched the slider. Density becomes: board → tenant → default 50.
+
+## Scope of application
+
+Board-level view settings apply to the **MSP ticket list only**. `getTicketingDisplaySettings`
+is also consumed by `packages/client-portal/src/components/tickets/TicketList.tsx`,
+`TicketDetails.tsx`, `MspClientTickets.tsx` and `MspContactTickets.tsx`. Those surfaces
+have no board tabs and continue to resolve **tenant-only**. The resolver's `board`
+input is simply absent there, which the layering already expresses — no branching
+required at the call sites.
+
+## Implementation
+
+### 1. Migration
+
+`server/migrations/<ts>_add_board_pinning_and_list_view_settings.cjs`
+
+```js
+alterTable('boards', t => {
+  t.boolean('is_pinned').notNullable().defaultTo(false);
+  t.jsonb('list_view_settings').nullable();
+});
+// Backfill: every currently-active board is pinned, so the strip looks exactly as it
+// does today on upgrade and admins curate DOWN from there.
+update('boards').where({ is_inactive: false }).set({ is_pinned: true });
+```
+
+Add an index on `(tenant, is_pinned)` only if the board list query proves it necessary —
+board counts per tenant are small and `getAllBoards` already reads the whole set.
+
+Down migration drops both columns.
+
+### 2. Types and schema
+
+- `packages/types/src/interfaces/board.interface.ts` — add `is_pinned?: boolean` and
+  `list_view_settings?: TicketViewSettings | null`. Add a comment above the `display_*`
+  block recording that those columns are unread and superseded by `list_view_settings`,
+  so the next reader does not mistake them for live configuration.
+- `server/src/interfaces/board.interface.tsx` — mirror it. Both copies exist and must
+  not drift.
+- Zod validation for `list_view_settings` on write, colocated with the board actions'
+  existing `CreateBoardInput`/`UpdateBoardInput` types. Unknown keys are rejected on
+  write, not silently stored.
+
+### 3. Shared layer
+
+- **New** `packages/tickets/src/lib/ticketViewSettings.ts` — `TicketViewSettings`,
+  `resolveTicketViewSettings`, `captureTicketViewSettings`, `CAPTURE_EXCLUDED_FILTER_KEYS`.
+- `packages/tickets/src/lib/ticketColumnCatalog.ts` — add `resolveTicketColumnOrder`.
+- `packages/tickets/src/actions/ticketDisplaySettings.ts` — widen `TicketListSettings`
+  to `TicketViewSettings`; leave the existing dedicated-column-then-nested-settings read
+  fallback untouched.
+- Export both from `packages/tickets/src/lib` (the barrel `@alga-psa/tickets/lib` already
+  serves `TOGGLEABLE_TICKET_COLUMNS` to the settings screen).
+
+### 4. Server actions
+
+**`getBoardListStats`** (`boardActions.ts:194`) — extend the existing tickets `GROUP BY`
+with three aggregates for the header, alongside the current `total`/`open`:
+
+```sql
+COUNT(*) FILTER (WHERE s.is_closed IS NOT TRUE AND t.due_date < now())            AS overdue
+COUNT(*) FILTER (WHERE s.is_closed IS NOT TRUE AND t.assigned_to IS NULL)         AS unassigned
+COUNT(*) FILTER (WHERE s.is_closed IS NOT TRUE AND <breached>)                    AS sla_breached
+```
+
+`<breached>` reuses the exact predicate `optimizedTicketActions.ts` applies for
+`slaStatusFilter: 'breached'` — extract it to a shared SQL fragment rather than
+re-deriving it, so the header count and the filter can never disagree about what
+"breached" means. Also return `is_pinned` so the tab strip gets pinning and counts in
+one round trip.
+
+While here, fix the pill inconsistency the previous smoke pass found: `ensure()` also
+runs for the statuses and close-rule `GROUP BY`s, so a board with zero tickets but
+non-zero statuses gets an entry and renders a `0` pill, while a board with zero of both
+gets no entry and no pill. Two boards with identical zero open tickets render
+differently. Make it uniform — a pinned board always gets a count, including `0`.
+
+**`getAllBoards` / `findBoardById` / `updateBoard`** — carry `is_pinned` and
+`list_view_settings` through.
+
+**New** `saveBoardDefaultView(boardId, TicketViewSettings)` and
+`clearBoardDefaultView(boardId)` in `boardActions.ts`, both gated on
+`ticket_settings:update` via the existing `hasPermission` + `permissionError` pattern.
+
+### 5. Board header
+
+New component `packages/tickets/src/components/BoardHeader.tsx`, rendered by
+`TicketingDashboard` only when a single real board is selected — reuse
+`resolveActiveBoardId` from `boardTabs.ts` rather than deriving board-selection state a
+second time.
+
+- Props: the `IBoard`, its `BoardListStats`, and the resolved manager/SLA display names.
+- Renders name, description, manager avatar + name, SLA policy name, and the four counts.
+- Each optional element is omitted entirely when its source is null.
+- Rendered on every board tab; never on the All-tickets tab.
+- Counts are decoration: they load out of band exactly as the tab pills do today and
+  the header renders without them until (or unless) stats arrive.
+
+### 6. `View ▾` menu and column controls
+
+One menu in the ticket list toolbar, replacing the standalone density slider:
+
+- **Columns** — checkbox list over `TOGGLEABLE_TICKET_COLUMNS` (labels already carry
+  `titleKey` + `titleFallback`) plus drag-to-reorder over the order resolved by
+  `resolveTicketColumnOrder`.
+- **Density** — the existing 0–100 slider, moved in.
+- **Save as this board's default view** / **Reset to tenant default** — permission-gated.
+- A dot on the control when the live view differs from the resolved saved view.
+
+All of it is interaction state with no persistence of its own: it seeds from the
+resolved view and is what capture reads. `createTicketColumns` gains a `columnOrder`
+option and orders its output by it; the `fixed`/`folded`/`tags` column kinds keep their
+existing special handling and are not reorderable.
+
+### 7. Tab strip: pinning
+
+`packages/tickets/src/lib/boardTabs.ts` — `buildBoardTabs` filters to
+`board.is_pinned === true`, keeping the existing escape hatch that the *active* board is
+always included even when it would otherwise be excluded. That one clause already
+handles the inactive-board case and now handles the unpinned-deep-link case with no new
+branch: a deep link to an unpinned board renders its transient tab, which disappears
+when you leave. Ordering stays `display_order` then name.
+
+`hasBoardFilterParam` / `BOARD_FILTER_URL_PARAMS` are unchanged — no new URL params, so
+the RSC parser in `server/src/app/msp/tickets/page.tsx` needs no parity update.
+
+Zero pinned boards is a legitimate state (an admin unpinned everything): the strip
+renders All-tickets alone rather than hiding, so the screen never loses its navigation.
+
+### 8. Board editor: "Appearance & defaults"
+
+New `EditorAccordionSection` in `BoardsSettings.tsx`, placed after General and following
+the six existing sections (General · Assignment & SLA · Email & inbound replies · Close
+rules · Automation · Priorities & statuses · Display & behaviour):
+
+- **Pin to the tickets screen** toggle — with the help text that pinned boards get a
+  permanent tab and unpinned boards stay reachable from All tickets and the board filter.
+- **Preview** — a static miniature of the header plus a few list rows, rendered from the
+  resolved view. It reuses `BoardHeader` at a reduced scale rather than re-implementing
+  the layout; the rows are placeholder bars, not live tickets, because this is a shape
+  preview and fetching a board's tickets inside a settings accordion is not worth the
+  round trip.
+- **Saved view** summary — one line, e.g. *"Open only · Priority: High · sorted by Due
+  date ↑ · 6 columns · density 40"*, or an explicit "Inherits tenant defaults" when
+  `list_view_settings` is `NULL`.
+- **Open this board** (jumps to the tab) and **Reset to tenant default**.
+- A note stating that the view is arranged on the board itself and saved from `View ▾`.
+
+The section deliberately contains no filter controls. The weight of this work belongs in
+the shared resolver, not in a settings form duplicating the ticket list's filter surface.
+
+Since `is_pinned` now lives here rather than in General, General keeps `is_default` and
+`display_order` — `display_order` already doubles as tab order and its existing help text
+should say so.
+
+### 9. i18n
+
+New keys under `ticketing.boards.*` and `dashboard.*` in
+`server/public/locales/en/features/tickets.json`, with parity added to `de`, `es`, `fr`,
+`it`, `nl`, `pl`, `pt` — matching what `573d29dc69` did for `dashboard.boardTabs.all`.
+The repo has locale-parity tests (`templateLocaleParity.test.ts`,
+`menuConfig.i18n.test.ts` precedent) and the tickets-namespace i18n tests must pass.
+
+## Testing
+
+**Unit (pure, no mount)** — where the bulk of coverage belongs, matching how
+`boardTabs.ts` was tested:
+
+- `resolveTicketViewSettings`: board wins over tenant wins over catalog; group-level
+  replacement, not deep merge; `NULL` board settings falls through cleanly.
+- `resolveTicketColumnOrder`: stored order honoured; unknown stored keys dropped; a
+  catalog key absent from stored order still appears, appended in catalog order.
+- `captureTicketViewSettings`: every key in `CAPTURE_EXCLUDED_FILTER_KEYS` is stripped;
+  everything else survives a round trip.
+- Validate-on-read: a captured `statusId` that no longer exists on the board is dropped
+  and does not produce an empty list.
+- `buildBoardTabs`: unpinned boards absent; active-but-unpinned board still rendered;
+  zero pinned boards yields All-tickets alone.
+- The shared breached-SLA predicate produces the same set as `slaStatusFilter: 'breached'`.
+
+**Component:**
+
+- `BoardHeader` omits description / manager / SLA lines when their sources are null;
+  renders nothing for the All-tickets tab; renders without counts before stats arrive.
+- Columns control toggles visibility and reorders; `createTicketColumns` respects
+  `columnOrder`; fixed/folded/tags kinds unaffected.
+- Save and Reset items hidden without `ticket_settings:update`.
+
+**Migration:** backfill pins exactly the active boards and leaves inactive ones
+unpinned; down migration drops both columns.
+
+**Live smoke on the dev stack (:3281)** — the properties the previous smoke pass
+established must not regress:
+
+- Exactly one `fetchTicketsWithPagination` per tab click and per back/forward step.
+- Header counts match direct DB queries for open, overdue, breach and unassigned.
+- Pills match DB open counts; a pinned board with zero tickets shows `0` (the fix above).
+- Board-scoped statuses still reconcile when switching to a board lacking the selected
+  status.
+- Deep link to an unpinned board renders a transient tab; leaving removes it.
+- Saving a default view on a board, navigating away and back, reproduces the saved view;
+  a deep link with filter params still overrides it.
+- Density no longer sticks from `localStorage` across boards.
+- Header degrades on a board with no description, no manager and no SLA policy.
+
+## Out of scope
+
+- Per-user or per-user-per-board view persistence, and per-setting lock flags —
+  explicitly decided against.
+- A saved-views / `board_views` table, multiple named views per board, view sharing.
+- An overflow "More boards" menu on the tab strip.
+- Per-board kanban or swimlane layouts, board-scoped bulk actions, board-scoped create.
+  The header is the seam where a view-type switcher would later land.
+- Migrating or removing the dead `display_*` columns. They are documented as superseded
+  here; removing them is its own change with its own risk.
+- Applying board-level settings to client-portal or client/contact ticket surfaces.
+
+## Notes for the implementer
+
+- The ticketing UI lives in `packages/tickets/src`, **not** `server/src/components/tickets`.
+  Both `board.interface` copies (`packages/types` and `server/src/interfaces`) must be
+  updated together.
+- `updateURLWithFilters` takes a 4th `historyMode` argument (`'replace' | 'push'`);
+  board-tab moves push, every other filter edit replaces. `syncFromUrl` clears
+  `filterFetchTimeoutRef` before applying — without it a filter edit still inside the
+  300ms debounce fires after a popstate and refetches state the user just navigated away
+  from. Applying a board default view must not reintroduce that race.
+- Restoring the last-active board tab (`tickets_last_active_board`) applies at most once
+  per mount, after `useUserPreference`'s `isLoading` clears, and a URL naming a board
+  always wins (`TicketingDashboardContainer.tsx:551`). Default-view application layers on
+  top of that decision — it must not become a second independent effect firing its own
+  fetch.
+- The three mocked UI directions considered before landing on C are preserved at
+  `/tmp/board-surface-options.html` (not committed).

--- a/packages/tickets/src/actions/board-actions/boardActionErrors.ts
+++ b/packages/tickets/src/actions/board-actions/boardActionErrors.ts
@@ -27,6 +27,10 @@ const EXPECTED_BOARD_MESSAGES = [
   'Target status must be a closed status',
   'An auto-close rule for this status already exists on this board',
   'Auto-close rule not found',
+  // Matched by prefix (see below), so the Zod detail after the em dash reaches
+  // the caller. Strict-on-write exists precisely to produce a readable reason;
+  // letting it rethrow would replace that reason with a generic failure toast.
+  'Invalid board view settings',
 ];
 
 export function boardActionErrorFrom(error: unknown): BoardActionError | null {

--- a/packages/tickets/src/actions/board-actions/boardActions.ts
+++ b/packages/tickets/src/actions/board-actions/boardActions.ts
@@ -899,6 +899,16 @@ export const updateBoard = withAuth(async (user, { tenant }, boardId: string, bo
         sanitizedData.is_pinned = Boolean(sanitizedData.is_pinned);
       }
 
+      // updateBoard is a second write path to the same two columns that
+      // saveBoardDefaultView/clearBoardDefaultView guard, so it has to enforce
+      // the same permission — otherwise the gate on those actions is decorative.
+      // Scoped to the new fields deliberately: this action's existing lack of a
+      // permission check covers pre-existing fields and is its own change.
+      const touchesViewConfig = 'is_pinned' in sanitizedData || 'list_view_settings' in sanitizedData;
+      if (touchesViewConfig && !await hasPermission(user, 'ticket_settings', 'update', trx)) {
+        throw new Error('Permission denied: Cannot update ticket settings');
+      }
+
       const { ticket_statuses: ticketStatuses, list_view_settings: listViewSettings, ...rest } =
         sanitizedData;
       const boardUpdateData: Record<string, unknown> = { ...rest };

--- a/packages/tickets/src/actions/board-actions/boardActions.ts
+++ b/packages/tickets/src/actions/board-actions/boardActions.ts
@@ -11,6 +11,10 @@ import { v4 as uuidv4 } from 'uuid';
 import { BoardTicketStatusInput, saveBoardTicketStatusesForBoard } from './boardTicketStatusActions';
 import { publishEvent } from '@alga-psa/event-bus/publishers';
 import { boardActionErrorFrom, type BoardActionError } from './boardActionErrors';
+import { parseTicketViewSettings } from './boardViewSettingsSchema';
+import { ticketSlaBreachedBindings, ticketSlaBreachedSql } from '../../lib/ticketSlaSql';
+import type { TicketViewSettings } from '../../lib/ticketViewSettings';
+import { permissionError, type ActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
 
 export interface FindBoardByNameOutput {
   id: string;
@@ -184,18 +188,43 @@ export interface BoardListStats {
   statusCount: number;
   closeRulesEnabled: boolean;
   autoCloseRuleCount: number;
+  /** Board header health counts. All three are "open tickets that are also …". */
+  overdueTicketCount: number;
+  unassignedTicketCount: number;
+  slaBreachedTicketCount: number;
+  /** Carried here so the tab strip gets pinning and counts in one round trip. */
+  isPinned: boolean;
 }
 
 /**
- * Per-board aggregate metrics for the boards settings list (ticket load, status
- * count, automation). Tenant-scoped GROUP BYs co-locate on a single Citus shard.
- * Returns a map keyed by board_id; missing boards default to zeroes in the UI.
+ * Per-board aggregate metrics for the boards settings list and the board header
+ * (ticket load, health, status count, automation). Tenant-scoped GROUP BYs
+ * co-locate on a single Citus shard.
+ *
+ * The health counts cost no new query: overdue, unassigned and SLA breach are
+ * all derivable from columns already on `tickets`, so they are three more
+ * COUNT(*) FILTER aggregates on the GROUP BY that already runs. `sla_breached`
+ * deliberately reuses the same predicate as `slaStatusFilter: 'breached'` (see
+ * ticketSlaSql.ts) so the header count and the filter it invites you to click
+ * can never describe different sets.
+ *
+ * Every board in the tenant gets an entry, including boards with no tickets and
+ * no statuses. Previously `ensure()` ran only for boards that appeared in at
+ * least one of the four GROUP BYs, so a board with zero tickets but non-zero
+ * statuses rendered a `0` pill while a board with zero of both rendered none —
+ * two boards in identical states looking different. Seeding from the board list
+ * makes "0" mean zero everywhere.
  */
 export const getBoardListStats = withAuth(async (_user, { tenant }): Promise<Record<string, BoardListStats>> => {
   const { knex: db } = await createTenantKnex();
   try {
     return await withTransaction(db, async (trx: Knex.Transaction) => {
-      const [ticketRows, statusRows, closeRuleRows, autoCloseRows] = await Promise.all([
+      const nowIso = new Date().toISOString();
+      const breachedSql = ticketSlaBreachedSql('t');
+      const breachedBindings = ticketSlaBreachedBindings(nowIso);
+
+      const [boardRows, ticketRows, statusRows, closeRuleRows, autoCloseRows] = await Promise.all([
+        tenantDb(trx, tenant).table('boards').select('board_id', 'is_pinned'),
         trx('tickets as t')
           .leftJoin('statuses as s', function () {
             this.on('t.status_id', 's.status_id').andOn('t.tenant', 's.tenant');
@@ -205,7 +234,18 @@ export const getBoardListStats = withAuth(async (_user, { tenant }): Promise<Rec
           .groupBy('t.board_id')
           .select('t.board_id')
           .select(trx.raw('COUNT(*)::int as total'))
-          .select(trx.raw('COUNT(*) FILTER (WHERE s.is_closed IS NOT TRUE)::int as open')),
+          .select(trx.raw('COUNT(*) FILTER (WHERE s.is_closed IS NOT TRUE)::int as open'))
+          .select(trx.raw(
+            `COUNT(*) FILTER (WHERE s.is_closed IS NOT TRUE AND t.due_date < ?)::int as overdue`,
+            [nowIso]
+          ))
+          .select(trx.raw(
+            'COUNT(*) FILTER (WHERE s.is_closed IS NOT TRUE AND t.assigned_to IS NULL)::int as unassigned'
+          ))
+          .select(trx.raw(
+            `COUNT(*) FILTER (WHERE s.is_closed IS NOT TRUE AND ${breachedSql})::int as sla_breached`,
+            breachedBindings
+          )),
         trx('statuses')
           .where({ tenant, status_type: 'ticket' })
           .whereNotNull('board_id')
@@ -225,15 +265,41 @@ export const getBoardListStats = withAuth(async (_user, { tenant }): Promise<Rec
       const stats: Record<string, BoardListStats> = {};
       const ensure = (boardId: string): BoardListStats => {
         if (!stats[boardId]) {
-          stats[boardId] = { ticketCount: 0, openTicketCount: 0, statusCount: 0, closeRulesEnabled: false, autoCloseRuleCount: 0 };
+          stats[boardId] = {
+            ticketCount: 0,
+            openTicketCount: 0,
+            statusCount: 0,
+            closeRulesEnabled: false,
+            autoCloseRuleCount: 0,
+            overdueTicketCount: 0,
+            unassignedTicketCount: 0,
+            slaBreachedTicketCount: 0,
+            isPinned: false,
+          };
         }
         return stats[boardId];
       };
 
-      for (const row of ticketRows as Array<{ board_id: string; total: number; open: number }>) {
+      // Seed every board first, so a count of zero is reported as zero rather
+      // than as "no entry" (which the UI cannot distinguish from "not loaded").
+      for (const row of boardRows as Array<{ board_id: string; is_pinned: boolean | null }>) {
+        ensure(row.board_id).isPinned = row.is_pinned === true;
+      }
+
+      for (const row of ticketRows as Array<{
+        board_id: string;
+        total: number;
+        open: number;
+        overdue: number;
+        unassigned: number;
+        sla_breached: number;
+      }>) {
         const entry = ensure(row.board_id);
         entry.ticketCount = Number(row.total) || 0;
         entry.openTicketCount = Number(row.open) || 0;
+        entry.overdueTicketCount = Number(row.overdue) || 0;
+        entry.unassignedTicketCount = Number(row.unassigned) || 0;
+        entry.slaBreachedTicketCount = Number(row.sla_breached) || 0;
       }
       for (const row of statusRows as Array<{ board_id: string; count: number }>) {
         ensure(row.board_id).statusCount = Number(row.count) || 0;
@@ -341,6 +407,11 @@ export const createBoard = withAuth(async (user, { tenant }, boardData: CreateBo
           inbound_reply_reopen_status_id: boardData.inbound_reply_reopen_status_id || null,
           inbound_reply_ai_ack_suppression_enabled: boardData.inbound_reply_ai_ack_suppression_enabled ?? false,
           enable_live_ticket_timer: boardData.enable_live_ticket_timer ?? true,
+          // A new board is pinned by default: it was just created deliberately,
+          // so it earns a tab until an admin decides otherwise. list_view_settings
+          // starts NULL — a new board inherits the tenant view rather than
+          // freezing a copy of it at creation time.
+          is_pinned: boardData.is_pinned ?? true,
           tenant
         })
         .returning('*')) as IBoard[];
@@ -824,8 +895,22 @@ export const updateBoard = withAuth(async (user, { tenant }, boardId: string, bo
       if ('enable_live_ticket_timer' in sanitizedData) {
         sanitizedData.enable_live_ticket_timer = sanitizedData.enable_live_ticket_timer ?? true;
       }
+      if ('is_pinned' in sanitizedData) {
+        sanitizedData.is_pinned = Boolean(sanitizedData.is_pinned);
+      }
 
-      const { ticket_statuses: ticketStatuses, ...boardUpdateData } = sanitizedData;
+      const { ticket_statuses: ticketStatuses, list_view_settings: listViewSettings, ...rest } =
+        sanitizedData;
+      const boardUpdateData: Record<string, unknown> = { ...rest };
+
+      // list_view_settings is validated strictly on write (unknown keys rejected)
+      // and stored as JSON text; null is the reset, and is distinct from {}.
+      if ('list_view_settings' in sanitizedData) {
+        boardUpdateData.list_view_settings =
+          listViewSettings === null || listViewSettings === undefined
+            ? null
+            : JSON.stringify(parseTicketViewSettings(listViewSettings));
+      }
 
       const [updatedBoard] = (await tenantScopedTable('boards')
         .where({ board_id: boardId })
@@ -883,6 +968,150 @@ export const updateBoard = withAuth(async (user, { tenant }, boardId: string, bo
       return expected;
     }
     console.error('Error updating board:', error);
+    throw error;
+  }
+});
+
+export interface BoardIdentity {
+  boardId: string;
+  managerUserId: string | null;
+  managerName: string | null;
+  slaPolicyId: string | null;
+  slaPolicyName: string | null;
+}
+
+/**
+ * The ownership half of the board header — manager and SLA policy display names
+ * for every board, in one round trip.
+ *
+ * Resolved for all boards rather than for the active one so switching tabs costs
+ * no fetch, and loaded out of band exactly as the tab pills are: the header
+ * renders its identity immediately and grows the ownership line when this
+ * arrives. A board with no manager or no SLA policy yields nulls, which the
+ * header omits rather than rendering an empty slot.
+ */
+export const getBoardIdentities = withAuth(async (_user, { tenant }): Promise<BoardIdentity[]> => {
+  const { knex: db } = await createTenantKnex();
+  try {
+    return await withTransaction(db, async (trx: Knex.Transaction) => {
+      const rows = await tenantDb(trx, tenant).table('boards as b')
+        .leftJoin('users as u', function () {
+          this.on('b.manager_user_id', 'u.user_id').andOn('b.tenant', 'u.tenant');
+        })
+        .leftJoin('sla_policies as p', function () {
+          this.on('b.sla_policy_id', 'p.sla_policy_id').andOn('b.tenant', 'p.tenant');
+        })
+        .select(
+          'b.board_id',
+          'b.manager_user_id',
+          'u.first_name',
+          'u.last_name',
+          'b.sla_policy_id',
+          'p.policy_name'
+        );
+
+      return (rows as Array<Record<string, any>>).map((row) => {
+        const name = [row.first_name, row.last_name].filter(Boolean).join(' ').trim();
+        return {
+          boardId: row.board_id as string,
+          managerUserId: (row.manager_user_id as string | null) ?? null,
+          managerName: name.length > 0 ? name : null,
+          slaPolicyId: (row.sla_policy_id as string | null) ?? null,
+          slaPolicyName: (row.policy_name as string | null) ?? null,
+        };
+      });
+    });
+  } catch (error) {
+    // Ownership is decoration on the header; failing it must not fail the list.
+    console.error('Failed to fetch board identities:', error);
+    return [];
+  }
+});
+
+/**
+ * Save the board's default ticket-list view, captured from the live list.
+ *
+ * Authoring is capture-from-the-list rather than a second filter UI in
+ * settings: the admin arranges the real list and saves it, which is why every
+ * filter added to ITicketListFilters in future is defaultable for free.
+ *
+ * Gated on ticket_settings:update — the permission that already guards board and
+ * priority settings — because this is tenant-wide configuration for all users,
+ * not a personal preference.
+ */
+export const saveBoardDefaultView = withAuth(async (
+  user,
+  { tenant },
+  boardId: string,
+  view: TicketViewSettings,
+): Promise<{ success: true } | BoardActionError | ActionPermissionError> => {
+  const { knex: db } = await createTenantKnex();
+
+  if (!await hasPermission(user, 'ticket_settings', 'update', db)) {
+    return permissionError('Permission denied: Cannot update ticket settings');
+  }
+
+  try {
+    // Strict parse: unknown keys are rejected here rather than silently stored,
+    // so a stale client cannot deposit a key nothing will read.
+    const parsed = parseTicketViewSettings(view);
+
+    return await withTransaction(db, async (trx: Knex.Transaction) => {
+      const updated = await tenantDb(trx, tenant).table('boards')
+        .where({ board_id: boardId })
+        .update({ list_view_settings: JSON.stringify(parsed) });
+
+      if (!updated) {
+        throw new Error('Board not found');
+      }
+      return { success: true as const };
+    });
+  } catch (error) {
+    const expected = boardActionErrorFrom(error);
+    if (expected) {
+      return expected;
+    }
+    console.error('Error saving board default view:', error);
+    throw error;
+  }
+});
+
+/**
+ * Reset the board to the tenant default view.
+ *
+ * Writes NULL, not {}. An empty object would be a board that has decided to
+ * express nothing — indistinguishable in storage from a board that has decided
+ * nothing, but a different thing to reason about, and one that would have to be
+ * special-cased in the resolver forever. NULL falls through cleanly.
+ */
+export const clearBoardDefaultView = withAuth(async (
+  user,
+  { tenant },
+  boardId: string,
+): Promise<{ success: true } | BoardActionError | ActionPermissionError> => {
+  const { knex: db } = await createTenantKnex();
+
+  if (!await hasPermission(user, 'ticket_settings', 'update', db)) {
+    return permissionError('Permission denied: Cannot update ticket settings');
+  }
+
+  try {
+    return await withTransaction(db, async (trx: Knex.Transaction) => {
+      const updated = await tenantDb(trx, tenant).table('boards')
+        .where({ board_id: boardId })
+        .update({ list_view_settings: null });
+
+      if (!updated) {
+        throw new Error('Board not found');
+      }
+      return { success: true as const };
+    });
+  } catch (error) {
+    const expected = boardActionErrorFrom(error);
+    if (expected) {
+      return expected;
+    }
+    console.error('Error clearing board default view:', error);
     throw error;
   }
 });

--- a/packages/tickets/src/actions/board-actions/boardViewSettingsSchema.ts
+++ b/packages/tickets/src/actions/board-actions/boardViewSettingsSchema.ts
@@ -1,0 +1,118 @@
+import { z } from 'zod';
+import { TICKET_COLUMNS } from '../../lib/ticketColumnCatalog';
+import type { TicketViewSettings } from '../../lib/ticketViewSettings';
+
+/**
+ * Write-side validation for boards.list_view_settings.
+ *
+ * JSONB accepts anything, so the integrity that a column type would have given
+ * us has to be asserted somewhere. The split is deliberate:
+ *
+ *   - on **write**, this schema is strict. Unknown keys are *rejected*, not
+ *     silently stored, so a typo or a stale client cannot deposit a key that
+ *     nothing will ever read and that the next reader will mistake for meaning.
+ *   - on **read**, ids that no longer resolve are dropped
+ *     (validateCapturedFilters), because a board's saved statusId can die at any
+ *     time through no fault of the document.
+ *
+ * Lives outside boardActions.ts because that module is "use server" and may not
+ * export non-async values.
+ */
+
+const columnKeys = TICKET_COLUMNS.map((column) => column.key) as [string, ...string[]];
+const ticketColumnKeySchema = z.enum(columnKeys);
+
+/**
+ * Captured filters. Mirrors ITicketListFilters minus CAPTURE_EXCLUDED_FILTER_KEYS
+ * — those keys are stripped by capture, so accepting them here would let a
+ * hand-rolled write reintroduce exactly the board-scope confusion capture exists
+ * to prevent.
+ */
+const capturedFiltersShape = {
+    statusId: z.string(),
+    priorityId: z.string(),
+    categoryId: z.string(),
+    categoryIds: z.array(z.string()),
+    excludeCategoryIds: z.array(z.string()),
+    clientId: z.string(),
+    contactId: z.string(),
+    showOpenOnly: z.boolean(),
+    tags: z.array(z.string()),
+    assignedToIds: z.array(z.string()),
+    assignedTeamIds: z.array(z.string()),
+    includeUnassigned: z.boolean(),
+    assignedToMe: z.boolean(),
+    dueDateFilter: z.enum([
+      'all',
+      'overdue',
+      'upcoming',
+      'today',
+      'no_due_date',
+      'before',
+      'after',
+      'custom',
+    ]),
+    dueDateFrom: z.string(),
+    dueDateTo: z.string(),
+    sortBy: z.string(),
+    sortDirection: z.enum(['asc', 'desc']),
+    responseState: z.enum(['awaiting_client', 'awaiting_internal', 'none', 'all']),
+    slaStatusFilter: z.enum(['all', 'has_sla', 'no_sla', 'on_track', 'breached', 'paused']),
+    bundleView: z.enum(['bundled', 'individual']),
+} as const;
+
+const viewSettingsShape = (filters: z.ZodTypeAny) => ({
+  columnVisibility: z.record(ticketColumnKeySchema, z.boolean()),
+  columnOrder: z.array(ticketColumnKeySchema),
+  tagsInlineUnderTitle: z.boolean(),
+  densityLevel: z.number().int().min(0).max(100),
+  filters,
+});
+
+/** Write-side: unknown keys are an error, at both levels. */
+export const ticketViewSettingsSchema = z
+  .object(viewSettingsShape(z.object(capturedFiltersShape).partial().strict()))
+  .partial()
+  .strict();
+
+/** Read-side: unknown keys are dropped rather than fatal, at both levels. */
+const storedTicketViewSettingsSchema = z
+  .object(viewSettingsShape(z.object(capturedFiltersShape).partial()))
+  .partial();
+
+export type ParsedTicketViewSettings = z.infer<typeof ticketViewSettingsSchema>;
+
+/** Throws with a readable message on invalid input; returns the parsed document. */
+export function parseTicketViewSettings(value: unknown): TicketViewSettings {
+  const result = ticketViewSettingsSchema.safeParse(value);
+  if (!result.success) {
+    const detail = result.error.issues
+      .map((issue) => `${issue.path.join('.') || '(root)'}: ${issue.message}`)
+      .join('; ');
+    throw new Error(`Invalid board view settings — ${detail}`);
+  }
+  return result.data as TicketViewSettings;
+}
+
+/**
+ * Read-side coercion for a stored document. A row written before this schema
+ * existed (or by a future version that added a key) must still render the list
+ * rather than throw on a settings screen, so unknown keys are dropped here
+ * instead of rejecting — the strict rejection belongs on write, where there is a
+ * user to tell.
+ */
+export function coerceStoredTicketViewSettings(value: unknown): TicketViewSettings | null {
+  if (value === null || value === undefined) return null;
+  const raw = typeof value === 'string' ? safeJsonParse(value) : value;
+  if (!raw || typeof raw !== 'object') return null;
+  const result = storedTicketViewSettingsSchema.safeParse(raw);
+  return result.success ? (result.data as TicketViewSettings) : null;
+}
+
+function safeJsonParse(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}

--- a/packages/tickets/src/actions/board-actions/boardViewSettingsSchema.ts
+++ b/packages/tickets/src/actions/board-actions/boardViewSettingsSchema.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
+import type { ITicketListFilters } from '@alga-psa/types';
 import { TICKET_COLUMNS } from '../../lib/ticketColumnCatalog';
-import type { TicketViewSettings } from '../../lib/ticketViewSettings';
+import type { CaptureExcludedFilterKey, TicketViewSettings } from '../../lib/ticketViewSettings';
 
 /**
  * Write-side validation for boards.list_view_settings.
@@ -11,8 +12,10 @@ import type { TicketViewSettings } from '../../lib/ticketViewSettings';
  *   - on **write**, this schema is strict. Unknown keys are *rejected*, not
  *     silently stored, so a typo or a stale client cannot deposit a key that
  *     nothing will ever read and that the next reader will mistake for meaning.
- *   - on **read**, ids that no longer resolve are dropped
- *     (validateCapturedFilters), because a board's saved statusId can die at any
+ *   - on **read**, nothing here applies. Stored documents are coerced by
+ *     sanitizeStoredTicketView (key-dropping, no Zod — z.record(z.enum) errors
+ *     on an unknown key rather than dropping it) and their ids are checked by
+ *     validateCapturedFilters, because a board's saved statusId can die at any
  *     time through no fault of the document.
  *
  * Lives outside boardActions.ts because that module is "use server" and may not
@@ -23,12 +26,25 @@ const columnKeys = TICKET_COLUMNS.map((column) => column.key) as [string, ...str
 const ticketColumnKeySchema = z.enum(columnKeys);
 
 /**
- * Captured filters. Mirrors ITicketListFilters minus CAPTURE_EXCLUDED_FILTER_KEYS
- * — those keys are stripped by capture, so accepting them here would let a
- * hand-rolled write reintroduce exactly the board-scope confusion capture exists
- * to prevent.
+ * Captured filters: every ITicketListFilters key that capture can produce, i.e. all of them minus
+ * the excluded ones.
+ *
+ * Typing the shape below against this is what keeps "every new filter is
+ * defaultable for free" honest. Capture is a deny-list (a new key is captured
+ * unless someone excludes it) while this schema is an allow-list, so without a
+ * link between them the next key added to ITicketListFilters would be captured
+ * from the live list and then rejected on save — a failure that would surface
+ * only at runtime, to a user, as a save that mysteriously does not work.
+ * Declared as a mapped type instead, TypeScript fails the build at this file
+ * with the missing key named.
+ *
+ * The excluded keys are absent for a second reason too: accepting them would let
+ * a hand-rolled write reintroduce exactly the board-scope confusion capture
+ * exists to prevent.
  */
-const capturedFiltersShape = {
+type CapturableFilterKey = Exclude<keyof ITicketListFilters, CaptureExcludedFilterKey>;
+
+const capturedFiltersShape: { [K in CapturableFilterKey]: z.ZodTypeAny } = {
     statusId: z.string(),
     priorityId: z.string(),
     categoryId: z.string(),
@@ -75,11 +91,6 @@ export const ticketViewSettingsSchema = z
   .partial()
   .strict();
 
-/** Read-side: unknown keys are dropped rather than fatal, at both levels. */
-const storedTicketViewSettingsSchema = z
-  .object(viewSettingsShape(z.object(capturedFiltersShape).partial()))
-  .partial();
-
 export type ParsedTicketViewSettings = z.infer<typeof ticketViewSettingsSchema>;
 
 /** Throws with a readable message on invalid input; returns the parsed document. */
@@ -92,27 +103,4 @@ export function parseTicketViewSettings(value: unknown): TicketViewSettings {
     throw new Error(`Invalid board view settings — ${detail}`);
   }
   return result.data as TicketViewSettings;
-}
-
-/**
- * Read-side coercion for a stored document. A row written before this schema
- * existed (or by a future version that added a key) must still render the list
- * rather than throw on a settings screen, so unknown keys are dropped here
- * instead of rejecting — the strict rejection belongs on write, where there is a
- * user to tell.
- */
-export function coerceStoredTicketViewSettings(value: unknown): TicketViewSettings | null {
-  if (value === null || value === undefined) return null;
-  const raw = typeof value === 'string' ? safeJsonParse(value) : value;
-  if (!raw || typeof raw !== 'object') return null;
-  const result = storedTicketViewSettingsSchema.safeParse(raw);
-  return result.success ? (result.data as TicketViewSettings) : null;
-}
-
-function safeJsonParse(value: string): unknown {
-  try {
-    return JSON.parse(value);
-  } catch {
-    return null;
-  }
 }

--- a/packages/tickets/src/actions/optimizedTicketActions.ts
+++ b/packages/tickets/src/actions/optimizedTicketActions.ts
@@ -71,6 +71,7 @@ import {
 } from '@alga-psa/authorization/kernel';
 import { resolveBundleNarrowingRulesForEvaluation } from '@alga-psa/authorization/bundles/service';
 import { createTicketRelationshipSqlAdapter } from '../lib/ticketAuthorizationSql';
+import { ticketSlaBreachedBindings, ticketSlaBreachedSql } from '../lib/ticketSlaSql';
 import { getClientContactVisibilityContext } from '../lib/clientPortalVisibility.server';
 import { buildTicketTransitionWorkflowEvents } from '../lib/workflowTicketTransitionEvents';
 import { buildTicketCommunicationWorkflowEvents } from '../lib/workflowTicketCommunicationEvents';
@@ -1372,20 +1373,13 @@ async function buildTicketListBaseQuery(
           break;
 
         case 'breached':
-          baseQuery = baseQuery
-            .whereNotNull('t.sla_policy_id')
-            .where(function() {
-              this.where(function() {
-                this.where('t.sla_response_due_at', '<', nowIso)
-                  .whereNull('t.sla_response_at');
-              })
-              .orWhere(function() {
-                this.where('t.sla_resolution_due_at', '<', nowIso)
-                  .whereNull('t.sla_resolution_at');
-              })
-              .orWhere('t.sla_response_met', false)
-              .orWhere('t.sla_resolution_met', false);
-            });
+          // Shared with getBoardListStats' sla_breached aggregate: the board
+          // header's breach count and this filter must describe the same set,
+          // which they can only be relied on to do if they read one predicate.
+          baseQuery = baseQuery.whereRaw(
+            ticketSlaBreachedSql('t'),
+            ticketSlaBreachedBindings(nowIso)
+          );
           break;
 
         case 'paused':

--- a/packages/tickets/src/actions/ticketDisplaySettings.ts
+++ b/packages/tickets/src/actions/ticketDisplaySettings.ts
@@ -98,14 +98,40 @@ export const updateTicketingDisplaySettings = withAuth(async (user, { tenant }, 
     .first();
 
   const currentDisplay = (existingRow?.ticket_display_settings as any) || {};
+
+  // `list` merges key-group-wise; everything else still replaces wholesale.
+  //
+  // This mattered the moment `list` widened from two keys to the full
+  // TicketViewSettings, because it now has two writers that own different
+  // subsets of it: Settings → Display authors columnVisibility +
+  // tagsInlineUnderTitle, while `View ▾` → "save as default" authors the whole
+  // document (columnOrder, densityLevel, filters included). Replacing `list`
+  // wholesale meant whichever screen saved last silently deleted the other's
+  // keys — save a tenant default view, then change anything in Display
+  // Settings, and the tenant's column order, density and filters were gone with
+  // no error and no way to tell. Before the widening both writers happened to
+  // send the same two keys, so replacement was lossless; it no longer is.
+  //
+  // A writer therefore replaces the groups it names and leaves the rest alone,
+  // which is the same group-level rule the board→tenant resolver already uses.
+  const mergedList = updated.list
+    ? { ...(currentDisplay.list || {}), ...updated.list }
+    : currentDisplay.list;
+
   const mergedDisplay = {
     ...currentDisplay,
     ...updated,
+    ...(mergedList ? { list: mergedList } : {}),
   };
 
   const rootSettings = (existingRow?.settings as any) || {};
   const ticketing = rootSettings.ticketing || {};
   const display = ticketing.display || {};
+  // Same group-level rule on the legacy nested copy, so the two paths cannot
+  // disagree about what a partial write means.
+  const mergedNestedList = updated.list
+    ? { ...(display.list || {}), ...updated.list }
+    : display.list;
   const mergedSettings = {
     ...rootSettings,
     ticketing: {
@@ -113,6 +139,7 @@ export const updateTicketingDisplaySettings = withAuth(async (user, { tenant }, 
       display: {
         ...display,
         ...updated,
+        ...(mergedNestedList ? { list: mergedNestedList } : {}),
       },
     },
   };

--- a/packages/tickets/src/actions/ticketDisplaySettings.ts
+++ b/packages/tickets/src/actions/ticketDisplaySettings.ts
@@ -4,12 +4,20 @@ import { createTenantKnex, tenantDb } from '@alga-psa/db';
 import { hasPermission } from '@alga-psa/auth/rbac';
 import { withAuth } from '@alga-psa/auth';
 import { permissionError, type ActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
-import { resolveTicketColumnVisibility, type TicketListColumnKey } from '../lib/ticketColumnCatalog';
+import { resolveTicketColumnVisibility } from '../lib/ticketColumnCatalog';
+import type { TicketViewSettings } from '../lib/ticketViewSettings';
 
-export type TicketListSettings = {
-  columnVisibility?: Partial<Record<TicketListColumnKey, boolean>>;
-  tagsInlineUnderTitle?: boolean;
-};
+/**
+ * The tenant layer of a ticket-list view is the *same document* a board stores.
+ *
+ * `list` widens from the two keys it used to hold (columnVisibility,
+ * tagsInlineUnderTitle) to the full TicketViewSettings — a pure type widening,
+ * because both keys already sat at exactly this path. No tenant JSON migration
+ * is needed: the type grows, stored data does not move. A board stores the same
+ * document *directly* in boards.list_view_settings rather than nested under
+ * `list`, because a board has no other display settings to nest beside it.
+ */
+export type TicketListSettings = TicketViewSettings;
 
 export type TicketingDisplaySettings = {
   dateTimeFormat?: string; // date-fns format string, e.g. 'MMM d, yyyy h:mm a'
@@ -39,6 +47,13 @@ export const getTicketingDisplaySettings = withAuth(async (_user, { tenant }): P
         // ticket-column catalog so this list can't drift from the renderer.
         columnVisibility: resolveTicketColumnVisibility(display?.list?.columnVisibility),
         tagsInlineUnderTitle: display?.list?.tagsInlineUnderTitle ?? true,
+        // Carried through unresolved: resolveTicketViewSettings layers the board
+        // document over this one and only then applies catalog/step defaults, so
+        // "the tenant did not express a density" must stay distinguishable here
+        // from "the tenant chose 50".
+        columnOrder: display?.list?.columnOrder,
+        densityLevel: display?.list?.densityLevel,
+        filters: display?.list?.filters,
       },
     };
   } catch (e) {
@@ -52,6 +67,20 @@ export const getTicketingDisplaySettings = withAuth(async (_user, { tenant }): P
       },
     };
   }
+});
+
+/**
+ * Whether the caller may author default views (`ticket_settings:update`).
+ *
+ * Purely for hiding the save/reset items in the `View ▾` menu — the actions
+ * themselves are gated server-side, so this is presentation, not enforcement.
+ * A separate read rather than an inference from the settings payload, because
+ * "can see the display settings" and "can change them for everyone" are
+ * genuinely different questions.
+ */
+export const canManageTicketViewDefaults = withAuth(async (user, _ctx): Promise<boolean> => {
+  const { knex } = await createTenantKnex();
+  return hasPermission(user, 'ticket_settings', 'update', knex);
 });
 
 export const updateTicketingDisplaySettings = withAuth(async (user, { tenant }, updated: TicketingDisplaySettings): Promise<{ success: boolean } | ActionPermissionError> => {

--- a/packages/tickets/src/actions/ticketDisplaySettingsMerge.test.ts
+++ b/packages/tickets/src/actions/ticketDisplaySettingsMerge.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment node
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { TicketViewSettings } from '../lib/ticketViewSettings';
+
+/**
+ * `tenant_settings.ticket_display_settings.list` has two writers that own
+ * different subsets of the same document:
+ *
+ *   Settings → Display   authors columnVisibility + tagsInlineUnderTitle
+ *   View ▾ → save default authors the whole document (incl. columnOrder,
+ *                          densityLevel, filters)
+ *
+ * Before `list` widened past two keys both writers happened to send exactly the
+ * same keys, so replacing the group wholesale was lossless. It is not any more:
+ * whichever screen saves last would silently delete the other's keys, with no
+ * error and nothing on screen to reveal it.
+ *
+ * updateTicketingDisplaySettings is a "use server" action wrapped in withAuth
+ * and reaches straight for the database, so the merge rule is asserted here as
+ * the pure function it is, plus a source check that the action actually applies
+ * it on both the dedicated-column and legacy-nested paths.
+ */
+
+/** The rule the action implements: `list` merges key-group-wise. */
+function mergeDisplaySettings(
+  current: { list?: TicketViewSettings } & Record<string, unknown>,
+  updated: { list?: TicketViewSettings } & Record<string, unknown>,
+): Record<string, any> {
+  const mergedList = updated.list ? { ...(current.list || {}), ...updated.list } : current.list;
+  return { ...current, ...updated, ...(mergedList ? { list: mergedList } : {}) };
+}
+
+describe('tenant display settings list merge', () => {
+  const savedFromViewMenu: TicketViewSettings = {
+    columnVisibility: { status: true, client: false },
+    columnOrder: ['client', 'status'],
+    tagsInlineUnderTitle: true,
+    densityLevel: 30,
+    filters: { priorityId: 'p1', sortBy: 'due_date' },
+  };
+
+  it('keeps columnOrder, densityLevel and filters when Display Settings saves', () => {
+    // The reported data loss: save an All-tickets default view, then change
+    // anything on Settings → Display and save.
+    const merged = mergeDisplaySettings(
+      { list: savedFromViewMenu },
+      { list: { columnVisibility: { status: false }, tagsInlineUnderTitle: false } },
+    );
+
+    expect(merged.list.columnOrder).toEqual(['client', 'status']);
+    expect(merged.list.densityLevel).toBe(30);
+    expect(merged.list.filters).toEqual({ priorityId: 'p1', sortBy: 'due_date' });
+    // ...and the groups Display Settings does own are replaced.
+    expect(merged.list.columnVisibility).toEqual({ status: false });
+    expect(merged.list.tagsInlineUnderTitle).toBe(false);
+  });
+
+  it('keeps tagsInlineUnderTitle when the View menu saves without it', () => {
+    // The reverse direction of the same bug.
+    const merged = mergeDisplaySettings(
+      { list: { columnVisibility: { status: true }, tagsInlineUnderTitle: false } },
+      { list: { columnVisibility: { status: false }, densityLevel: 70 } },
+    );
+
+    expect(merged.list.tagsInlineUnderTitle).toBe(false);
+    expect(merged.list.densityLevel).toBe(70);
+  });
+
+  it('replaces a named group wholesale rather than deep-merging it', () => {
+    // Group-level, not per-key — the same rule the board→tenant resolver uses.
+    const merged = mergeDisplaySettings(
+      { list: { columnVisibility: { status: true, client: true, board: true } } },
+      { list: { columnVisibility: { status: false } } },
+    );
+    expect(merged.list.columnVisibility).toEqual({ status: false });
+  });
+
+  it('leaves the whole list alone when a writer does not mention it', () => {
+    const merged = mergeDisplaySettings(
+      { list: savedFromViewMenu },
+      { dateTimeFormat: 'yyyy-MM-dd' },
+    );
+    expect(merged.list).toEqual(savedFromViewMenu);
+    expect(merged.dateTimeFormat).toBe('yyyy-MM-dd');
+  });
+
+  it('still replaces non-list keys wholesale', () => {
+    const merged = mergeDisplaySettings(
+      { dateTimeFormat: 'a', responseStateTrackingEnabled: true },
+      { dateTimeFormat: 'b' },
+    );
+    expect(merged.dateTimeFormat).toBe('b');
+    expect(merged.responseStateTrackingEnabled).toBe(true);
+  });
+
+  it('is applied by the action on both the column and the legacy nested path', () => {
+    const source = readFileSync(join(__dirname, 'ticketDisplaySettings.ts'), 'utf8');
+    const body = source.slice(source.indexOf('export const updateTicketingDisplaySettings'));
+
+    // Two merge sites — the dedicated column and settings.ticketing.display —
+    // because a partial write must mean the same thing on both.
+    expect(body).toContain('const mergedList = updated.list');
+    expect(body).toContain('const mergedNestedList = updated.list');
+    // And neither may go back to a bare wholesale spread of `list`.
+    expect(body).not.toMatch(/mergedDisplay = \{\s*\.\.\.currentDisplay,\s*\.\.\.updated,\s*\}/);
+  });
+});

--- a/packages/tickets/src/components/BoardFilterPicker.tsx
+++ b/packages/tickets/src/components/BoardFilterPicker.tsx
@@ -8,7 +8,8 @@ import { AutomationProps, FormFieldComponent } from '@alga-psa/ui/ui-reflection/
 import { ReflectionContainer } from '@alga-psa/ui/ui-reflection/ReflectionContainer';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 
-export const NO_BOARD_VALUE = 'no-board';
+export { NO_BOARD_VALUE } from '../lib/boardFilterValues';
+import { NO_BOARD_VALUE } from '../lib/boardFilterValues';
 
 interface BoardFilterPickerProps {
   id?: string;

--- a/packages/tickets/src/components/BoardHeader.tsx
+++ b/packages/tickets/src/components/BoardHeader.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import React from 'react';
+import type { IBoard } from '@alga-psa/types';
+import UserAvatar from '@alga-psa/ui/components/UserAvatar';
+import type { BoardIdentity, BoardListStats } from '../actions/board-actions/boardActions';
+
+/**
+ * The board surface: identity, ownership and health above the ticket list.
+ *
+ * This is what makes a board *look* like itself rather than merely be reachable.
+ * The tab strip that shipped before this made a board a place you go; without a
+ * header, every board was still the same generic list with a filter applied.
+ *
+ * Rendered only on a board tab — the All-tickets tab gets no header, because it
+ * has no identity to state. There is deliberately no "show the header" toggle: a
+ * per-board flag would add a settings control, a document key, a resolution path
+ * and a test axis to save 90px on boards an admin could simply unpin, and
+ * pinning already expresses which boards are worth the space.
+ *
+ * Every optional element degrades by *omission*, not by rendering an empty slot:
+ * a board with no description, no manager and no SLA policy collapses to its
+ * name, which is honest about how much has been configured. Counts are
+ * decoration — they arrive out of band exactly as the tab pills do, and the
+ * header renders complete without them.
+ */
+
+export interface BoardHeaderProps {
+  id?: string;
+  board: IBoard;
+  stats?: BoardListStats | null;
+  identity?: BoardIdentity | null;
+  /** Avatar URL for the board manager, when one has been resolved. */
+  managerAvatarUrl?: string | null;
+  t: (key: string, fallback: string) => string;
+  /** Reduced scale for the settings-screen preview. */
+  compact?: boolean;
+  className?: string;
+}
+
+interface HealthCount {
+  key: string;
+  value: number;
+  label: string;
+  tone: 'neutral' | 'warn' | 'alert';
+}
+
+const TONE_CLASS: Record<HealthCount['tone'], string> = {
+  neutral: 'text-[rgb(var(--color-text-900))]',
+  warn: 'text-amber-600 dark:text-amber-500',
+  alert: 'text-red-600 dark:text-red-500',
+};
+
+export const BoardHeader: React.FC<BoardHeaderProps> = ({
+  id = 'board-header',
+  board,
+  stats,
+  identity,
+  managerAvatarUrl,
+  t,
+  compact = false,
+  className = '',
+}) => {
+  const boardName = board.board_name?.trim();
+  const description = board.description?.trim();
+  const managerName = identity?.managerName?.trim();
+  const slaPolicyName = identity?.slaPolicyName?.trim();
+
+  // Counts are absent (not zero) until stats arrive. Rendering "0 0 0 0" while
+  // loading would state something false about the board.
+  const counts: HealthCount[] | null = stats
+    ? [
+        {
+          key: 'open',
+          value: stats.openTicketCount,
+          label: t('dashboard.boardHeader.open', 'Open'),
+          tone: 'neutral',
+        },
+        {
+          key: 'overdue',
+          value: stats.overdueTicketCount,
+          label: t('dashboard.boardHeader.overdue', 'Overdue'),
+          tone: stats.overdueTicketCount > 0 ? 'warn' : 'neutral',
+        },
+        {
+          key: 'breached',
+          value: stats.slaBreachedTicketCount,
+          label: t('dashboard.boardHeader.slaBreach', 'SLA breach'),
+          tone: stats.slaBreachedTicketCount > 0 ? 'alert' : 'neutral',
+        },
+        {
+          key: 'unassigned',
+          value: stats.unassignedTicketCount,
+          label: t('dashboard.boardHeader.unassigned', 'Unassigned'),
+          tone: stats.unassignedTicketCount > 0 ? 'warn' : 'neutral',
+        },
+      ]
+    : null;
+
+  const hasOwnership = Boolean(managerName || slaPolicyName);
+
+  return (
+    <div
+      id={id}
+      data-automation-id={id}
+      className={[
+        'flex flex-wrap items-start justify-between gap-4 border-b border-gray-100 dark:border-[rgb(var(--color-border-200))]',
+        compact ? 'px-3 py-2' : 'px-4 py-3',
+        className,
+      ].join(' ')}
+    >
+      <div className="min-w-0 flex-1">
+        <h2
+          className={`${compact ? 'text-sm' : 'text-lg'} font-semibold leading-tight text-[rgb(var(--color-text-900))] truncate`}
+        >
+          {boardName || t('bulk.move.unnamedBoard', 'Unnamed board')}
+        </h2>
+
+        {description && (
+          <p
+            className={`${compact ? 'text-[11px]' : 'text-sm'} mt-0.5 text-[rgb(var(--color-text-500))] line-clamp-2`}
+          >
+            {description}
+          </p>
+        )}
+
+        {hasOwnership && (
+          <div
+            className={`${compact ? 'text-[11px]' : 'text-xs'} mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-[rgb(var(--color-text-500))]`}
+          >
+            {managerName && (
+              <span className="inline-flex items-center gap-1.5">
+                <UserAvatar
+                  userId={identity?.managerUserId || ''}
+                  userName={managerName}
+                  avatarUrl={managerAvatarUrl ?? null}
+                  size="xs"
+                />
+                <span className="truncate">
+                  {t('dashboard.boardHeader.managedBy', 'Managed by')} {managerName}
+                </span>
+              </span>
+            )}
+            {managerName && slaPolicyName && <span aria-hidden="true">·</span>}
+            {slaPolicyName && (
+              <span className="truncate">
+                {t('dashboard.boardHeader.sla', 'SLA')}: {slaPolicyName}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+
+      {counts && (
+        <div className={`flex shrink-0 items-start ${compact ? 'gap-3' : 'gap-5'}`}>
+          {counts.map((count) => (
+            <div key={count.key} className="text-right">
+              <div
+                className={`${compact ? 'text-sm' : 'text-xl'} font-semibold leading-none tabular-nums ${TONE_CLASS[count.tone]}`}
+                data-automation-id={`${id}-count-${count.key}`}
+              >
+                {count.value}
+              </div>
+              <div
+                className={`${compact ? 'text-[9px]' : 'text-[10px]'} mt-1 uppercase tracking-wide text-[rgb(var(--color-text-400))]`}
+              >
+                {count.label}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default BoardHeader;

--- a/packages/tickets/src/components/BoardTabStrip.tsx
+++ b/packages/tickets/src/components/BoardTabStrip.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import React from 'react';
+import CustomTabs, { type TabContent } from '@alga-psa/ui/components/CustomTabs';
+import type { BoardTabDescriptor } from '../lib/boardTabs';
+
+interface BoardTabStripProps {
+  id?: string;
+  tabs: BoardTabDescriptor[];
+  /** Active tab id (see boardTabId()). */
+  value: string;
+  onChange: (tabId: string) => void;
+}
+
+/**
+ * Board tab strip for the ticket list.
+ *
+ * Uses CustomTabs purely as chrome: every tab's content is empty and the ticket
+ * list renders *below* the strip. Hanging the list off Tabs.Content would remount
+ * it on every tab change (Radix unmounts inactive content), throwing away table
+ * state and flashing an empty list between the click and the refetch.
+ */
+export const BoardTabStrip: React.FC<BoardTabStripProps> = ({
+  id = 'board-tab-strip',
+  tabs,
+  value,
+  onChange,
+}) => {
+  const customTabs = React.useMemo<TabContent[]>(
+    () =>
+      tabs.map(tab => ({
+        id: tab.id,
+        label: (
+          <span className="flex items-center gap-1.5 whitespace-nowrap">
+            <span className={tab.isInactive ? 'italic' : undefined}>{tab.label}</span>
+            {tab.openTicketCount !== null && (
+              <span className="inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-[rgb(var(--color-border-100))] px-1.5 text-[11px] font-semibold text-[rgb(var(--color-text-600))]">
+                {tab.openTicketCount}
+              </span>
+            )}
+          </span>
+        ),
+        content: null,
+      })),
+    [tabs]
+  );
+
+  return (
+    <CustomTabs
+      idPrefix={id}
+      tabs={customTabs}
+      value={value}
+      onTabChange={onChange}
+      tabStyles={{
+        // Many boards must stay reachable, so the strip scrolls horizontally
+        // instead of wrapping into a tall block above the list.
+        list: 'overflow-x-auto overflow-y-hidden',
+        trigger: 'shrink-0 text-sm',
+        content: 'hidden',
+      }}
+    />
+  );
+};
+
+export default BoardTabStrip;

--- a/packages/tickets/src/components/TicketViewMenu.tsx
+++ b/packages/tickets/src/components/TicketViewMenu.tsx
@@ -1,0 +1,208 @@
+'use client';
+
+import React, { useCallback, useMemo, useState } from 'react';
+import { Settings2, GripVertical, RotateCcw, Save } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+} from '@alga-psa/ui/components/DropdownMenu';
+import { Button } from '@alga-psa/ui/components/Button';
+import { Checkbox } from '@alga-psa/ui/components/Checkbox';
+import ViewDensityControl from '@alga-psa/ui/components/ViewDensityControl';
+import {
+  TOGGLEABLE_TICKET_COLUMNS,
+  type TicketListColumnKey,
+} from '../lib/ticketColumnCatalog';
+import {
+  TICKET_VIEW_DENSITY_STEP,
+  type ResolvedTicketViewSettings,
+} from '../lib/ticketViewSettings';
+
+/**
+ * One menu owning everything about how the list *looks*: which columns, in what
+ * order, at what density, and — for admins — whether that arrangement becomes
+ * the board's default.
+ *
+ * Collapsing these into a single control is the point. Before, column visibility
+ * lived only in tenant-wide Settings → Display (so glancing at "Created By" once
+ * meant changing a setting for everyone), column order had no authoring surface
+ * at all, and density was a standalone slider in the toolbar. Three different
+ * altitudes for one question.
+ *
+ * Everything here is interaction state with no persistence of its own. It seeds
+ * from the resolved view and is what capture reads — which is what lets "save
+ * this arrangement" be honest about arranging on the real list rather than
+ * describing an arrangement in a form.
+ */
+
+export interface TicketViewMenuProps {
+  id: string;
+  view: ResolvedTicketViewSettings;
+  onChange: (update: Partial<ResolvedTicketViewSettings>) => void;
+  /** True when the live view differs from the saved one — drives the dot. */
+  isDirty: boolean;
+  /** Whether the save/reset items render at all (ticket_settings:update). */
+  canManageDefaults: boolean;
+  /** Board tab vs All-tickets tab, which changes where a save goes. */
+  scope: 'board' | 'tenant';
+  onSaveDefault: () => void | Promise<void>;
+  onResetDefault: () => void | Promise<void>;
+  /** True when the current scope has a stored view to reset. */
+  hasStoredDefault: boolean;
+  isSaving?: boolean;
+  t: (key: string, fallback: string) => string;
+}
+
+export const TicketViewMenu: React.FC<TicketViewMenuProps> = ({
+  id,
+  view,
+  onChange,
+  isDirty,
+  canManageDefaults,
+  scope,
+  onSaveDefault,
+  onResetDefault,
+  hasStoredDefault,
+  isSaving = false,
+  t,
+}) => {
+  const [dragKey, setDragKey] = useState<string | null>(null);
+
+  // The menu lists only the reorderable columns. Fixed/folded/tags keep their
+  // existing special handling elsewhere and are deliberately absent here rather
+  // than present-but-disabled: a disabled row invites the question "why can't
+  // I?" every time it is read.
+  const orderedToggleable = useMemo(() => {
+    const rank = new Map<string, number>();
+    view.columnOrder.forEach((key, index) => rank.set(key, index));
+    return TOGGLEABLE_TICKET_COLUMNS
+      .slice()
+      .sort((a, b) => (rank.get(a.key) ?? 0) - (rank.get(b.key) ?? 0));
+  }, [view.columnOrder]);
+
+  const toggleColumn = useCallback((key: TicketListColumnKey, visible: boolean) => {
+    onChange({ columnVisibility: { ...view.columnVisibility, [key]: visible } });
+  }, [onChange, view.columnVisibility]);
+
+  const moveColumn = useCallback((fromKey: string, toKey: string) => {
+    if (fromKey === toKey) return;
+    const next = view.columnOrder.slice();
+    const from = next.indexOf(fromKey as TicketListColumnKey);
+    const to = next.indexOf(toKey as TicketListColumnKey);
+    if (from < 0 || to < 0) return;
+    next.splice(to, 0, next.splice(from, 1)[0]);
+    onChange({ columnOrder: next });
+  }, [onChange, view.columnOrder]);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          id={`${id}-trigger`}
+          variant="outline"
+          className="relative shrink-0 flex items-center gap-1.5 h-[38px]"
+        >
+          <Settings2 className="h-4 w-4" />
+          {t('dashboard.viewMenu.label', 'View')}
+          {isDirty && (
+            // "The current view differs from what is saved." A dot rather than a
+            // word: it is a status, not an instruction, and it has to sit on a
+            // control that is mostly closed.
+            <span
+              data-automation-id={`${id}-dirty-dot`}
+              title={t('dashboard.viewMenu.unsavedChanges', 'This view differs from the saved default')}
+              className="ml-0.5 h-1.5 w-1.5 rounded-full bg-[rgb(var(--color-primary-500))]"
+            />
+          )}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-72 p-0">
+        <div className="px-3 py-2 border-b border-gray-100 dark:border-[rgb(var(--color-border-200))]">
+          <div className="text-[11px] font-semibold uppercase tracking-wide text-[rgb(var(--color-text-400))]">
+            {t('dashboard.viewMenu.columns', 'Columns')}
+          </div>
+        </div>
+
+        <div className="max-h-[260px] overflow-y-auto py-1">
+          {orderedToggleable.map((column) => (
+            <div
+              key={column.key}
+              draggable
+              onDragStart={() => setDragKey(column.key)}
+              onDragEnd={() => setDragKey(null)}
+              onDragOver={(event) => event.preventDefault()}
+              onDrop={(event) => {
+                event.preventDefault();
+                if (dragKey) moveColumn(dragKey, column.key);
+                setDragKey(null);
+              }}
+              className={`flex items-center gap-2 px-3 py-1.5 text-sm cursor-grab hover:bg-[rgb(var(--color-border-50))] ${
+                dragKey === column.key ? 'opacity-50' : ''
+              }`}
+              data-automation-id={`${id}-column-${column.key}`}
+            >
+              <GripVertical className="h-3.5 w-3.5 shrink-0 text-[rgb(var(--color-text-300))]" />
+              <Checkbox
+                id={`${id}-column-toggle-${column.key}`}
+                checked={view.columnVisibility[column.key] !== false}
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                  toggleColumn(column.key, event.target.checked)
+                }
+                className="m-0"
+                skipRegistration
+              />
+              <span className="truncate">{t(column.titleKey, column.titleFallback)}</span>
+            </div>
+          ))}
+        </div>
+
+        <div className="border-t border-gray-100 dark:border-[rgb(var(--color-border-200))] px-3 py-2">
+          <div className="mb-1.5 text-[11px] font-semibold uppercase tracking-wide text-[rgb(var(--color-text-400))]">
+            {t('dashboard.viewMenu.density', 'Density')}
+          </div>
+          <ViewDensityControl
+            idPrefix={`${id}-density`}
+            value={view.densityLevel}
+            onChange={(value: number) => onChange({ densityLevel: value })}
+            step={TICKET_VIEW_DENSITY_STEP}
+            compactLabel={t('dashboard.spacing.compact', 'Compact')}
+            spaciousLabel={t('dashboard.spacing.spacious', 'Spacious')}
+            decreaseTitle={t('dashboard.spacing.decrease', 'Decrease ticket list spacing')}
+            increaseTitle={t('dashboard.spacing.increase', 'Increase ticket list spacing')}
+            resetTitle={t('dashboard.spacing.reset', 'Reset ticket list spacing')}
+          />
+        </div>
+
+        {canManageDefaults && (
+          <div className="border-t border-gray-100 dark:border-[rgb(var(--color-border-200))] py-1">
+            <button
+              type="button"
+              id={`${id}-save-default`}
+              disabled={isSaving}
+              onClick={() => void onSaveDefault()}
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-[rgb(var(--color-border-50))] disabled:opacity-50"
+            >
+              <Save className="h-3.5 w-3.5 shrink-0" />
+              {scope === 'board'
+                ? t('dashboard.viewMenu.saveBoardDefault', "Save as this board's default view")
+                : t('dashboard.viewMenu.saveTenantDefault', 'Save as the default view for everyone')}
+            </button>
+            <button
+              type="button"
+              id={`${id}-reset-default`}
+              disabled={isSaving || (scope === 'board' && !hasStoredDefault)}
+              onClick={() => void onResetDefault()}
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-[rgb(var(--color-border-50))] disabled:opacity-50"
+            >
+              <RotateCcw className="h-3.5 w-3.5 shrink-0" />
+              {t('dashboard.viewMenu.resetToTenant', 'Reset to tenant default')}
+            </button>
+          </div>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+export default TicketViewMenu;

--- a/packages/tickets/src/components/TicketViewMenu.tsx
+++ b/packages/tickets/src/components/TicketViewMenu.tsx
@@ -188,16 +188,21 @@ export const TicketViewMenu: React.FC<TicketViewMenuProps> = ({
                 ? t('dashboard.viewMenu.saveBoardDefault', "Save as this board's default view")
                 : t('dashboard.viewMenu.saveTenantDefault', 'Save as the default view for everyone')}
             </button>
-            <button
-              type="button"
-              id={`${id}-reset-default`}
-              disabled={isSaving || (scope === 'board' && !hasStoredDefault)}
-              onClick={() => void onResetDefault()}
-              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-[rgb(var(--color-border-50))] disabled:opacity-50"
-            >
-              <RotateCcw className="h-3.5 w-3.5 shrink-0" />
-              {t('dashboard.viewMenu.resetToTenant', 'Reset to tenant default')}
-            </button>
+            {/* Only rendered on a board tab. The All-tickets tab *is* the tenant
+                layer, so "reset to tenant default" there has no destination —
+                rendering it enabled would be a control that does nothing. */}
+            {scope === 'board' && (
+              <button
+                type="button"
+                id={`${id}-reset-default`}
+                disabled={isSaving || !hasStoredDefault}
+                onClick={() => void onResetDefault()}
+                className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-[rgb(var(--color-border-50))] disabled:opacity-50"
+              >
+                <RotateCcw className="h-3.5 w-3.5 shrink-0" />
+                {t('dashboard.viewMenu.resetToTenant', 'Reset to tenant default')}
+              </button>
+            )}
           </div>
         )}
       </DropdownMenuContent>

--- a/packages/tickets/src/components/TicketingDashboard.i18n.test.ts
+++ b/packages/tickets/src/components/TicketingDashboard.i18n.test.ts
@@ -41,11 +41,35 @@ describe('ticketing dashboard i18n wiring contract', () => {
     expect(source).toContain("t('filters.search', 'Search tickets and comments...')");
     expect(source).toContain("t('resetFilters', 'Reset')");
     expect(source).toContain("t('dashboard.bundledToggle', 'Bundled')");
+  });
+
+  it('T010b: wires the View menu chrome through features/tickets translations', () => {
+    // The density slider moved out of the toolbar and into the View menu, which
+    // also owns columns and the save/reset default-view items. The keys are
+    // unchanged; only the file that renders them moved.
+    const source = read('./TicketViewMenu.tsx');
+
+    expect(source).toContain("t('dashboard.viewMenu.label', 'View')");
+    expect(source).toContain("t('dashboard.viewMenu.columns', 'Columns')");
+    expect(source).toContain("t('dashboard.viewMenu.density', 'Density')");
+    expect(source).toContain("t('dashboard.viewMenu.saveBoardDefault', \"Save as this board's default view\")");
+    expect(source).toContain("t('dashboard.viewMenu.resetToTenant', 'Reset to tenant default')");
     expect(source).toContain("t('dashboard.spacing.compact', 'Compact')");
     expect(source).toContain("t('dashboard.spacing.spacious', 'Spacious')");
     expect(source).toContain("t('dashboard.spacing.decrease', 'Decrease ticket list spacing')");
     expect(source).toContain("t('dashboard.spacing.increase', 'Increase ticket list spacing')");
     expect(source).toContain("t('dashboard.spacing.reset', 'Reset ticket list spacing')");
+  });
+
+  it('T010c: wires the board header through features/tickets translations', () => {
+    const source = read('./BoardHeader.tsx');
+
+    expect(source).toContain("t('dashboard.boardHeader.open', 'Open')");
+    expect(source).toContain("t('dashboard.boardHeader.overdue', 'Overdue')");
+    expect(source).toContain("t('dashboard.boardHeader.slaBreach', 'SLA breach')");
+    expect(source).toContain("t('dashboard.boardHeader.unassigned', 'Unassigned')");
+    expect(source).toContain("t('dashboard.boardHeader.managedBy', 'Managed by')");
+    expect(source).toContain("t('dashboard.boardHeader.sla', 'SLA')");
   });
 
   it('T011: keeps the dashboard shell/bulk chrome backed by xx pseudo-locale strings instead of raw English', () => {

--- a/packages/tickets/src/components/TicketingDashboard.tsx
+++ b/packages/tickets/src/components/TicketingDashboard.tsx
@@ -93,6 +93,7 @@ import {
   boardTabId,
   boardTabSelection,
   buildBoardSelectionFilterUpdate,
+  resolveActiveBoardId,
   buildBoardTabs,
 } from '../lib/boardTabs';
 import type { TicketFilterChangeOptions } from '../lib/ticketFilterChange';
@@ -1859,13 +1860,25 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
 
 
   const handleBoardSelect = useCallback((newSelectedBoards: string[], newExcludedBoards: string[]) => {
-    onFilterChange(buildBoardSelectionFilterUpdate({
+    const update = buildBoardSelectionFilterUpdate({
       selectedBoards: newSelectedBoards,
       excludedBoards: newExcludedBoards,
       statusOptions: rawStatusOptions,
       currentStatusId: selectedStatus,
-    }));
-  }, [onFilterChange, rawStatusOptions, selectedStatus]);
+    });
+
+    // Narrowing the picker to exactly one board lands on that board's tab and
+    // reveals its header, so it is an arrival by the same definition
+    // resolveActiveBoardId uses and must apply that board's view. Without this,
+    // the header would name one board while the columns, density and filters
+    // still belonged to the previous one. Any other picker selection (none,
+    // several, the no-board sentinel) is a multi-board filter, not an arrival —
+    // it has no single board whose view could apply.
+    const nextBoardId = resolveActiveBoardId(newSelectedBoards);
+    const isArrival = nextBoardId !== null && nextBoardId !== selectedBoard;
+
+    onFilterChange(update, isArrival ? { activeBoardTab: nextBoardId } : undefined);
+  }, [onFilterChange, rawStatusOptions, selectedBoard, selectedStatus]);
 
   // A board tab is the same single-board filter the picker sets, so it goes
   // through the identical update path — the tab only adds "this was a

--- a/packages/tickets/src/components/TicketingDashboard.tsx
+++ b/packages/tickets/src/components/TicketingDashboard.tsx
@@ -52,6 +52,26 @@ import type { TicketingDisplaySettings } from '../actions/ticketDisplaySettings'
 import { toast } from 'react-hot-toast';
 import { handleError, isActionMessageError, isActionPermissionError, getErrorMessage } from '@alga-psa/ui/lib/errorHandling';
 import { createTicketColumns, TICKET_COLUMNS } from '@alga-psa/tickets/lib';
+import BoardHeader from './BoardHeader';
+import TicketViewMenu from './TicketViewMenu';
+import {
+  captureTicketViewSettings,
+  ticketViewDiffersFromSaved,
+  TICKET_VIEW_DENSITY_DEFAULT,
+  TICKET_VIEW_DENSITY_STEP,
+  type ResolvedTicketViewSettings,
+  type TicketViewSettings,
+} from '../lib/ticketViewSettings';
+import {
+  clearBoardDefaultView,
+  getBoardIdentities,
+  saveBoardDefaultView,
+  type BoardIdentity,
+} from '../actions/board-actions/boardActions';
+import {
+  canManageTicketViewDefaults,
+  updateTicketingDisplaySettings,
+} from '../actions/ticketDisplaySettings';
 import Spinner from '@alga-psa/ui/components/Spinner';
 import { ShortcutActiveRegion, usePageCreateShortcut } from '@alga-psa/ui/keyboard-shortcuts';
 
@@ -59,7 +79,6 @@ import QuickAddCategory from './QuickAddCategory';
 import MultiUserAndTeamPicker from '@alga-psa/ui/components/MultiUserAndTeamPicker';
 import { getUserAvatarUrlsBatchAction } from '@alga-psa/user-composition/actions';
 import { DatePicker } from '@alga-psa/ui/components/DatePicker';
-import ViewDensityControl from '@alga-psa/ui/components/ViewDensityControl';
 import { useDrawer } from '@alga-psa/ui';
 import { getClientById } from '../actions/clientLookupActions';
 import { useTranslation, useFormatters } from '@alga-psa/ui/lib/i18n/client';
@@ -118,6 +137,18 @@ interface TicketingDashboardProps {
   canUpdateTickets?: boolean;
   allowSlaStatusFilter?: boolean;
   useAlgaDeskQuickAddForm?: boolean;
+  /**
+   * The resolved board→tenant→catalog view. Owned by the container so that
+   * applying a board's default view layers into the one merge path that already
+   * produces a single fetch per navigation, instead of becoming a second effect.
+   */
+  viewPresentation?: ResolvedTicketViewSettings;
+  onViewPresentationChange?: (update: Partial<ResolvedTicketViewSettings>) => void;
+  /** The resolved baseline for the active tab, for the "differs from saved" dot. */
+  savedViewSettings?: TicketViewSettings | null;
+  /** True when this tab has a stored document of its own (Reset has work to do). */
+  hasStoredDefaultView?: boolean;
+  onSavedViewChanged?: (boardId: string | null, saved: TicketViewSettings | null) => void;
 }
 
 const useDebounce = <T,>(value: T, delay: number): T => {
@@ -133,10 +164,11 @@ const useDebounce = <T,>(value: T, delay: number): T => {
   return debouncedValue;
 };
 
-const TICKET_LIST_DENSITY_STORAGE_KEY = 'ticket_list_density_level';
 const EMPTY_STRING_ARRAY: string[] = [];
-const TICKET_LIST_DENSITY_STEP = 10;
-const TICKET_LIST_DENSITY_DEFAULT = 50;
+// Density lives in the view-settings layer now (board -> tenant -> default), so
+// the step and default are read from there rather than re-declared here.
+const TICKET_LIST_DENSITY_STEP = TICKET_VIEW_DENSITY_STEP;
+const TICKET_LIST_DENSITY_DEFAULT = TICKET_VIEW_DENSITY_DEFAULT;
 const TICKET_PRINT_FALLBACK_PAGE_SIZE = 500;
 
 const normalizeTicketListDensityLevel = (value: number): number => {
@@ -249,6 +281,11 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
   canUpdateTickets = true,
   allowSlaStatusFilter = true,
   useAlgaDeskQuickAddForm = false,
+  viewPresentation,
+  onViewPresentationChange,
+  savedViewSettings,
+  hasStoredDefaultView = false,
+  onSavedViewChanged,
 }) => {
   const BUNDLE_VIEW_STORAGE_KEY = 'tickets_bundle_view';
   const router = useRouter();
@@ -366,7 +403,6 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
   const selectedResponseState = (filterValues.responseState ?? 'all') as 'awaiting_client' | 'awaiting_internal' | 'none' | 'all';
   const selectedSlaStatus = allowSlaStatusFilter ? (filterValues.slaStatusFilter ?? 'all') : 'all';
   const bundleView = (filterValues.bundleView ?? 'bundled') as 'bundled' | 'individual';
-  const [ticketListDensityLevel, setTicketListDensityLevel] = useState<number>(TICKET_LIST_DENSITY_DEFAULT);
 
   const [clientFilterState, setClientFilterState] = useState<'active' | 'inactive' | 'all'>('active');
   const [clientTypeFilter, setClientTypeFilter] = useState<'all' | 'company' | 'individual'>('all');
@@ -502,23 +538,16 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
     window.localStorage.setItem(BUNDLE_VIEW_STORAGE_KEY, bundleView);
   }, [bundleView]);
 
-  // Persist ticket list density preference locally.
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const stored = Number(window.localStorage.getItem(TICKET_LIST_DENSITY_STORAGE_KEY));
-    if (Number.isFinite(stored) && stored >= 0 && stored <= 100) {
-      setTicketListDensityLevel(normalizeTicketListDensityLevel(stored));
-    }
-  }, []);
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    window.localStorage.setItem(TICKET_LIST_DENSITY_STORAGE_KEY, String(ticketListDensityLevel));
-  }, [ticketListDensityLevel]);
+  // Density is board -> tenant -> 50, and localStorage is deliberately neither
+  // read nor written any more. Left in place, a value any user had ever nudged
+  // would silently outrank every board's configured density forever, for that
+  // user, on every board — a per-browser setting quietly beating tenant-wide
+  // configuration is not a precedence anyone can reason about.
+  const ticketListDensityLevel = viewPresentation?.densityLevel ?? TICKET_LIST_DENSITY_DEFAULT;
 
   const handleTicketListDensityChange = useCallback((value: number) => {
-    setTicketListDensityLevel(normalizeTicketListDensityLevel(value));
-  }, []);
+    onViewPresentationChange?.({ densityLevel: normalizeTicketListDensityLevel(value) });
+  }, [onViewPresentationChange]);
 
   const densityClasses = useMemo(() => {
     const index = Math.min(
@@ -554,6 +583,117 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
       cancelled = true;
     };
   }, []);
+
+  // Board identity (manager, SLA policy) for the header. Loaded out of band
+  // alongside the stats, for the same reason: the header's identity is the part
+  // that must be instant, and its ownership line is decoration that can arrive a
+  // beat later without the header ever looking broken.
+  const [boardIdentities, setBoardIdentities] = useState<Record<string, BoardIdentity> | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const rows = await getBoardIdentities();
+        if (!cancelled) {
+          setBoardIdentities(Object.fromEntries(rows.map(row => [row.boardId, row])));
+        }
+      } catch (error) {
+        console.error('Failed to load board identities:', error);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  // Presentation-only gate on the save/reset items; the actions enforce it too.
+  const [canManageViewDefaults, setCanManageViewDefaults] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const allowed = await canManageTicketViewDefaults();
+        if (!cancelled) setCanManageViewDefaults(allowed === true);
+      } catch {
+        // Denied-by-default: a failed permission read must not reveal the control.
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  const [isSavingView, setIsSavingView] = useState(false);
+
+  const activeBoard = useMemo(
+    () => (selectedBoard ? boards.find(board => board.board_id === selectedBoard) ?? null : null),
+    [boards, selectedBoard]
+  );
+
+  // The live view, projected into the same shape as what is stored, so the
+  // "differs from saved" comparison is between like and like. Board scope and
+  // search are excluded by capture, so they can never make a view look dirty.
+  const liveViewSettings = useMemo<TicketViewSettings>(() => captureTicketViewSettings({
+    filters: { ...filterValues, sortBy, sortDirection },
+    columnVisibility: viewPresentation?.columnVisibility,
+    columnOrder: viewPresentation?.columnOrder,
+    tagsInlineUnderTitle: viewPresentation?.tagsInlineUnderTitle,
+    densityLevel: viewPresentation?.densityLevel,
+  }), [filterValues, sortBy, sortDirection, viewPresentation]);
+
+  const viewIsDirty = useMemo(
+    () => ticketViewDiffersFromSaved(liveViewSettings, savedViewSettings),
+    [liveViewSettings, savedViewSettings]
+  );
+
+  // Where a save goes depends on which tab is active: a board tab writes that
+  // board's document, the All-tickets tab writes the tenant layer that already
+  // backs the Display Settings screen. Same affordance, correct altitude, no new
+  // mechanism on either side.
+  const handleSaveDefaultView = useCallback(async () => {
+    setIsSavingView(true);
+    try {
+      if (selectedBoard) {
+        const result = await saveBoardDefaultView(selectedBoard, liveViewSettings);
+        if (isActionMessageError(result) || isActionPermissionError(result)) {
+          handleError(getErrorMessage(result), t('dashboard.viewMenu.saveFailed', 'Failed to save the default view'));
+          return;
+        }
+        onSavedViewChanged?.(selectedBoard, liveViewSettings);
+      } else {
+        const result = await updateTicketingDisplaySettings({ list: liveViewSettings });
+        if (isActionPermissionError(result)) {
+          handleError(getErrorMessage(result), t('dashboard.viewMenu.saveFailed', 'Failed to save the default view'));
+          return;
+        }
+        onSavedViewChanged?.(null, liveViewSettings);
+      }
+      toast.success(t('dashboard.viewMenu.saved', 'Default view saved'));
+    } catch (error) {
+      handleError(error, t('dashboard.viewMenu.saveFailed', 'Failed to save the default view'));
+    } finally {
+      setIsSavingView(false);
+    }
+  }, [selectedBoard, liveViewSettings, onSavedViewChanged, t]);
+
+  const handleResetDefaultView = useCallback(async () => {
+    if (!selectedBoard) {
+      // The All-tickets tab is the tenant layer itself; "reset to tenant
+      // default" there would mean resetting to the catalog, which is a
+      // different, larger action than this menu item promises.
+      return;
+    }
+    setIsSavingView(true);
+    try {
+      const result = await clearBoardDefaultView(selectedBoard);
+      if (isActionMessageError(result) || isActionPermissionError(result)) {
+        handleError(getErrorMessage(result), t('dashboard.viewMenu.resetFailed', 'Failed to reset the view'));
+        return;
+      }
+      onSavedViewChanged?.(selectedBoard, null);
+      toast.success(t('dashboard.viewMenu.reset', 'Reset to tenant default'));
+    } catch (error) {
+      handleError(error, t('dashboard.viewMenu.resetFailed', 'Failed to reset the view'));
+    } finally {
+      setIsSavingView(false);
+    }
+  }, [selectedBoard, onSavedViewChanged, t]);
 
   const boardTabs = useMemo(
     () => buildBoardTabs({
@@ -1138,7 +1278,20 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
     const baseColumns = createTicketColumns({
       categories,
       boards,
-      displaySettings: displaySettings || undefined,
+      // The live view outranks the tenant document here: the View menu is
+      // interaction state layered over the resolved board->tenant->catalog
+      // result, so what the user just toggled must win over what was stored.
+      displaySettings: viewPresentation
+        ? {
+            ...(displaySettings || {}),
+            list: {
+              ...(displaySettings?.list || {}),
+              columnVisibility: viewPresentation.columnVisibility,
+              tagsInlineUnderTitle: viewPresentation.tagsInlineUnderTitle,
+            },
+          }
+        : displaySettings || undefined,
+      columnOrder: viewPresentation?.columnOrder,
       onTicketClick: handleTicketClick,
       ticketTagsRef,
       onTagsChange: handleTagsChange,
@@ -1251,6 +1404,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
     categories,
     boards,
     displaySettings,
+    viewPresentation,
     handleTicketClick,
     handleTagsChange,
     ticketTagsRef,
@@ -1980,6 +2134,19 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
         onChange={handleBoardTabSelect}
       />
       <div className="bg-white dark:bg-[rgb(var(--color-card))] shadow rounded-lg">
+        {/* Gated on resolveActiveBoardId via selectedBoard rather than on a
+            second board-selection derivation: the highlighted tab, the
+            board-scoped status options and this header must agree by
+            construction, not by two places happening to compute the same thing. */}
+        {activeBoard && (
+          <BoardHeader
+            id={`${id}-board-header`}
+            board={activeBoard}
+            stats={boardStats?.[activeBoard.board_id as string] ?? null}
+            identity={boardIdentities?.[activeBoard.board_id as string] ?? null}
+            t={t as (key: string, fallback: string) => string}
+          />
+        )}
         <div className={`sticky top-0 z-40 bg-white dark:bg-[rgb(var(--color-card))] rounded-t-lg border-b border-gray-100 dark:border-[rgb(var(--color-border-200))] ${densityClasses.filterPadding}`}>
           <ReflectionContainer id={`${id}-filters`} label="Ticket DashboardFilters">
             <div className={`space-y-3`}>
@@ -2031,19 +2198,21 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
                     />
                   </div>
                   <div className="h-6 w-px bg-gray-200 mx-1 shrink-0" />
-                  <div className="shrink-0">
-                    <ViewDensityControl
-                      idPrefix={`${id}-list-density`}
-                      value={ticketListDensityLevel}
-                      onChange={handleTicketListDensityChange}
-                      step={TICKET_LIST_DENSITY_STEP}
-                      compactLabel={t('dashboard.spacing.compact', 'Compact')}
-                      spaciousLabel={t('dashboard.spacing.spacious', 'Spacious')}
-                      decreaseTitle={t('dashboard.spacing.decrease', 'Decrease ticket list spacing')}
-                      increaseTitle={t('dashboard.spacing.increase', 'Increase ticket list spacing')}
-                      resetTitle={t('dashboard.spacing.reset', 'Reset ticket list spacing')}
+                  {viewPresentation && onViewPresentationChange && (
+                    <TicketViewMenu
+                      id={`${id}-view-menu`}
+                      view={viewPresentation}
+                      onChange={onViewPresentationChange}
+                      isDirty={viewIsDirty}
+                      canManageDefaults={canManageViewDefaults}
+                      scope={selectedBoard ? 'board' : 'tenant'}
+                      onSaveDefault={handleSaveDefaultView}
+                      onResetDefault={handleResetDefaultView}
+                      hasStoredDefault={hasStoredDefaultView}
+                      isSaving={isSavingView}
+                      t={t as (key: string, fallback: string) => string}
                     />
-                  </div>
+                  )}
                 </div>
               </div>
 

--- a/packages/tickets/src/components/TicketingDashboard.tsx
+++ b/packages/tickets/src/components/TicketingDashboard.tsx
@@ -8,6 +8,7 @@ import { ITag } from '@alga-psa/types';
 import { buildCreateTicketHref } from '../lib/createTicketRoute';
 import { CategoryPicker } from './CategoryPicker';
 import { BoardFilterPicker, NO_BOARD_VALUE } from './BoardFilterPicker';
+import BoardTabStrip from './BoardTabStrip';
 import BulkTicketActionBar from './BulkTicketActionBar';
 import CustomSelect, { SelectOption } from '@alga-psa/ui/components/CustomSelect';
 import { PrioritySelect } from '@alga-psa/ui/components/tickets/PrioritySelect';
@@ -39,6 +40,7 @@ import {
   moveTicketsToBoard,
 } from '../actions/ticketActions';
 import { getBoardTicketStatuses } from '../actions/board-actions/boardTicketStatusActions';
+import { getBoardListStats, type BoardListStats } from '../actions/board-actions/boardActions';
 import { bundleTicketsAction, getBundleMasterStatusAction } from '../actions/ticketBundleActions';
 import { fetchBundleChildrenForMaster, fetchTicketsWithPagination, getAllMatchingTicketIds, getTicketBoardIds } from '../actions/optimizedTicketActions';
 import { XCircle, Clock, Download, Upload, ChevronDown, Printer, Settings2, Filter } from 'lucide-react';
@@ -67,6 +69,14 @@ import {
   TICKET_STATUS_FILTER_OPEN,
   type TicketStatusFilterOption,
 } from '../lib/ticketStatusFilter';
+import {
+  boardIdFromTabId,
+  boardTabId,
+  boardTabSelection,
+  buildBoardSelectionFilterUpdate,
+  buildBoardTabs,
+} from '../lib/boardTabs';
+import type { TicketFilterChangeOptions } from '../lib/ticketFilterChange';
 import { useTicketsRouteState } from './TicketsRouteProvider';
 import TicketNotificationSuppressionControl, {
   type TicketNotificationSuppressionValue,
@@ -92,7 +102,7 @@ interface TicketingDashboardProps {
   pageSize: number;
   onPageChange: (page: number) => void;
   onPageSizeChange: (pageSize: number) => void;
-  onFilterChange: (update: Partial<ITicketListFilters>) => void;
+  onFilterChange: (update: Partial<ITicketListFilters>, options?: TicketFilterChangeOptions) => void;
   filterValues: Partial<ITicketListFilters>;
   isLoadingMore: boolean;
   user?: IUser;
@@ -523,6 +533,39 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
     () => buildTicketStatusFilterOptions(rawStatusOptions, selectedBoard, selectedStatus),
     [rawStatusOptions, selectedBoard, selectedStatus]
   );
+
+  // Board tab strip: open-ticket counts are decoration, so they load out of band
+  // and the tabs render without pills until (or unless) the stats arrive.
+  const [boardStats, setBoardStats] = useState<Record<string, BoardListStats> | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const stats = await getBoardListStats();
+        if (!cancelled) {
+          setBoardStats(stats);
+        }
+      } catch (error) {
+        // Counts are not worth a toast; the strip stays usable without them.
+        console.error('Failed to load board ticket counts:', error);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const boardTabs = useMemo(
+    () => buildBoardTabs({
+      boards,
+      activeBoardId: selectedBoard,
+      stats: boardStats,
+      allTabLabel: t('dashboard.boardTabs.all', 'All tickets'),
+      unnamedBoardLabel: t('bulk.move.unnamedBoard', 'Unnamed board'),
+    }),
+    [boards, selectedBoard, boardStats, t]
+  );
+  const activeBoardTabId = boardTabId(selectedBoard);
 
   // Helper function to generate URL with current filter state
   const getCurrentFiltersQuery = useCallback(() => {
@@ -1662,21 +1705,36 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
 
 
   const handleBoardSelect = useCallback((newSelectedBoards: string[], newExcludedBoards: string[]) => {
-    // Status options are board-scoped; only scope when exactly one real board is selected.
-    const scopedBoardId = newSelectedBoards.length === 1 && newSelectedBoards[0] !== NO_BOARD_VALUE
-      ? newSelectedBoards[0]
-      : undefined;
-    const nextStatusOptions = buildTicketStatusFilterOptions(rawStatusOptions, scopedBoardId, selectedStatus);
-    const statusStillAvailable = nextStatusOptions.some(option => option.value === selectedStatus);
-
-    onFilterChange({
-      boardId: undefined, // clear legacy single-board field; arrays are the source of truth
-      boardIds: newSelectedBoards.length > 0 ? newSelectedBoards : undefined,
-      excludeBoardIds: newExcludedBoards.length > 0 ? newExcludedBoards : undefined,
-      statusId: statusStillAvailable ? selectedStatus : TICKET_STATUS_FILTER_OPEN,
-      showOpenOnly: statusStillAvailable ? isTicketStatusOpenFilter(selectedStatus) : true,
-    });
+    onFilterChange(buildBoardSelectionFilterUpdate({
+      selectedBoards: newSelectedBoards,
+      excludedBoards: newExcludedBoards,
+      statusOptions: rawStatusOptions,
+      currentStatusId: selectedStatus,
+    }));
   }, [onFilterChange, rawStatusOptions, selectedStatus]);
+
+  // A board tab is the same single-board filter the picker sets, so it goes
+  // through the identical update path — the tab only adds "this was a
+  // navigation" (history entry + last-active-board preference).
+  const handleBoardTabSelect = useCallback((tabId: string) => {
+    const nextBoardId = boardIdFromTabId(tabId);
+    // Radix fires onValueChange for the already-active tab in some interactions
+    // (and clicking "All tickets" while already there must not wipe a
+    // multi-board selection). Bail before emitting so one click is one fetch.
+    if (nextBoardId === selectedBoard) {
+      return;
+    }
+    const { selectedBoards: nextSelected, excludedBoards: nextExcluded } = boardTabSelection(nextBoardId);
+    onFilterChange(
+      buildBoardSelectionFilterUpdate({
+        selectedBoards: nextSelected,
+        excludedBoards: nextExcluded,
+        statusOptions: rawStatusOptions,
+        currentStatusId: selectedStatus,
+      }),
+      { pushHistory: true, activeBoardTab: nextBoardId }
+    );
+  }, [onFilterChange, rawStatusOptions, selectedBoard, selectedStatus]);
 
   const handleCategorySelect = useCallback((newSelectedCategories: string[], newExcludedCategories: string[]) => {
     onFilterChange({
@@ -1915,6 +1973,12 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
           </Button>
         </div>
       </div>
+      <BoardTabStrip
+        id={`${id}-board-tabs`}
+        tabs={boardTabs}
+        value={activeBoardTabId}
+        onChange={handleBoardTabSelect}
+      />
       <div className="bg-white dark:bg-[rgb(var(--color-card))] shadow rounded-lg">
         <div className={`sticky top-0 z-40 bg-white dark:bg-[rgb(var(--color-card))] rounded-t-lg border-b border-gray-100 dark:border-[rgb(var(--color-border-200))] ${densityClasses.filterPadding}`}>
           <ReflectionContainer id={`${id}-filters`} label="Ticket DashboardFilters">

--- a/packages/tickets/src/components/TicketingDashboardContainer.tsx
+++ b/packages/tickets/src/components/TicketingDashboardContainer.tsx
@@ -25,12 +25,23 @@ import {
 import {
   buildBoardSelectionFilterUpdate,
   hasBoardFilterParam,
+  hasTicketViewFilterParams,
   resolveInitialBoardTab,
   TICKETS_LAST_ACTIVE_BOARD_SETTING,
 } from '../lib/boardTabs';
+import {
+  buildBoardArrivalFilters,
+  resolveTicketViewSettings,
+  validateCapturedFilters,
+  type ResolvedTicketViewSettings,
+  type TicketViewSettings,
+} from '../lib/ticketViewSettings';
 import type { TicketFilterChangeOptions } from '../lib/ticketFilterChange';
 
 const TICKETS_PAGE_SIZE_SETTING = 'tickets_list_page_size';
+
+/** Key for the tenant layer in the just-saved-views map (boards use their id). */
+const TENANT_VIEW_KEY = '__tenant__';
 
 const ALLOWED_DUE_DATE_FILTERS = new Set(['all', 'overdue', 'upcoming', 'today', 'no_due_date', 'before', 'after', 'custom']);
 const ALLOWED_RESPONSE_STATES = new Set(['all', 'awaiting_client', 'awaiting_internal', 'none']);
@@ -450,6 +461,141 @@ export default function TicketingDashboardContainer({
   const fetchTicketsRef = useRef(fetchTickets);
   fetchTicketsRef.current = fetchTickets;
 
+  // ── Board-level view configuration ──────────────────────────────────────────
+  //
+  // A pinned board tab is a workspace, not a filter preset: arriving at one
+  // applies the board's stored default view. Resolution goes through the single
+  // shared resolver (board document → tenant document → catalog) so this screen,
+  // the board settings preview and the tenant display-settings screen can never
+  // compute a view three different ways.
+  //
+  // The board document is already in hand — boardOptions are full board rows —
+  // so applying a default view costs no extra round trip and, critically, layers
+  // into the *existing* merge path below rather than becoming a second effect
+  // that fires its own fetch. One fetch per navigation is a property the smoke
+  // pass on this branch established and this must not spend.
+  const tenantViewSettings = displaySettings?.list as TicketViewSettings | undefined;
+
+  const storedBoardViews = useMemo(() => {
+    const map = new Map<string, TicketViewSettings | null>();
+    for (const board of effectiveOptions.boardOptions) {
+      if (board.board_id) {
+        map.set(board.board_id, (board.list_view_settings as TicketViewSettings | null) ?? null);
+      }
+    }
+    return map;
+  }, [effectiveOptions.boardOptions]);
+
+  // What a save/reset just wrote, layered over what the (session-cached) board
+  // options say. Real state rather than a mutation of the memo above: the dirty
+  // dot is derived from the saved document, so if saving only mutated a cached
+  // Map the comparison would keep reading the pre-save value and the dot would
+  // never clear. Keyed by board id, with a sentinel for the tenant layer.
+  const [justSavedViews, setJustSavedViews] = useState<Record<string, TicketViewSettings | null>>({});
+
+  const boardViewFor = useCallback((boardId: string | null): TicketViewSettings | null => {
+    const key = boardId ?? TENANT_VIEW_KEY;
+    if (key in justSavedViews) {
+      return justSavedViews[key];
+    }
+    return boardId ? storedBoardViews.get(boardId) ?? null : tenantViewSettings ?? null;
+  }, [justSavedViews, storedBoardViews, tenantViewSettings]);
+
+  // Universes for validate-on-read. A captured id that no longer resolves is
+  // dropped rather than applied — a dead statusId applied verbatim produces an
+  // empty list on a board that has tickets, which reads as a bug rather than as
+  // stale configuration. Same precedent as resolveInitialBoardTab dropping a
+  // stored board that no longer exists.
+  const knownFilterIds = useMemo(() => ({
+    statusIds: effectiveOptions.statusOptions.map(option => option.value),
+    priorityIds: effectiveOptions.priorityOptions.map(option => option.value),
+    categoryIds: effectiveOptions.categories.map((category: { category_id: string }) => category.category_id),
+    clientIds: effectiveOptions.clients.map(client => client.client_id),
+    userIds: effectiveOptions.users.map((user: { user_id: string }) => user.user_id),
+  }), [
+    effectiveOptions.statusOptions,
+    effectiveOptions.priorityOptions,
+    effectiveOptions.categories,
+    effectiveOptions.clients,
+    effectiveOptions.users,
+  ]);
+
+  /** The fully-layered view for a board (null = the All-tickets tab). */
+  const resolveViewForBoard = useCallback((boardId: string | null): ResolvedTicketViewSettings => (
+    resolveTicketViewSettings({
+      board: boardId ? boardViewFor(boardId) : null,
+      tenant: boardViewFor(null),
+    })
+  ), [boardViewFor]);
+
+  // The non-filter half of the view (columns, order, density). It is not URL
+  // state and not a query input, so it lives here rather than in activeFilters,
+  // and it applies on arrival even when the URL carries filter params — a link
+  // expresses which tickets to show, never which columns to show them in.
+  const [viewPresentation, setViewPresentation] = useState<ResolvedTicketViewSettings>(
+    () => resolveViewForBoard(
+      initialFilters?.boardIds?.length === 1 ? initialFilters.boardIds[0] : initialFilters?.boardId ?? null
+    )
+  );
+
+  const applyBoardViewPresentation = useCallback((boardId: string | null) => {
+    setViewPresentation(resolveViewForBoard(boardId));
+  }, [resolveViewForBoard]);
+  // Held in a ref for syncFromUrl: putting it in that callback's deps would
+  // re-create it on every board-options change and churn the popstate listener
+  // the history handling depends on staying attached.
+  const applyBoardViewPresentationRef = useRef(applyBoardViewPresentation);
+  applyBoardViewPresentationRef.current = applyBoardViewPresentation;
+
+  /**
+   * The list's neutral starting state — what a tab looks like before any stored
+   * view is layered on. Shared by arrival and by the dirty-dot comparison, so
+   * "nothing has been changed" means the same thing to both. If they defined it
+   * separately, a pristine board would read as permanently dirty.
+   */
+  const neutralListFilters = useCallback((): Partial<ITicketListFilters> => ({
+    statusId: TICKET_STATUS_FILTER_OPEN,
+    priorityId: 'all',
+    showOpenOnly: true,
+    boardFilterState: 'active',
+    bundleView: activeFiltersRef.current.bundleView ?? 'bundled',
+    searchQuery: '',
+    sortBy: 'entered_at',
+    sortDirection: 'desc',
+  }), []);
+
+  /**
+   * The filters a board tab arrival produces, or null when the board's stored
+   * filters must not apply.
+   *
+   * Precedence: URL filter params → board → tenant → catalog. A shared link that
+   * names filters always wins, which is the only rule under which sending
+   * someone a link means anything.
+   */
+  const boardArrivalFilters = useCallback((
+    boardId: string | null,
+    boardSelection: Partial<ITicketListFilters>,
+    urlHasFilterOpinion: boolean,
+  ): Partial<ITicketListFilters> | null => {
+    if (urlHasFilterOpinion) {
+      return null;
+    }
+    const resolved = resolveViewForBoard(boardId);
+    if (!resolved.filters || Object.keys(resolved.filters).length === 0) {
+      return null;
+    }
+    return buildBoardArrivalFilters({
+      baseline: neutralListFilters(),
+      boardSelection,
+      viewFilters: validateCapturedFilters(
+        resolved.filters,
+        knownFilterIds,
+        // Pseudo-filters, not ids: they must survive validation untouched.
+        [TICKET_STATUS_FILTER_OPEN, 'all'],
+      ),
+    });
+  }, [resolveViewForBoard, knownFilterIds, neutralListFilters]);
+
   const syncFromUrl = useCallback(async (search: string) => {
     const normalizedSearch = search || '';
     if (normalizedSearch === lastAppliedSearchRef.current || isSyncingFromHistoryRef.current) {
@@ -471,6 +617,14 @@ export default function TicketingDashboardContainer({
       setSortBy(parsed.sortBy);
       setSortDirection(parsed.sortDirection);
       setActiveFilters(parsed.filters);
+      // Columns and density are not URL state, so a history step has to be told
+      // which board it landed on for them to follow. Presentation only: the
+      // filters come from the URL, which already *is* the state a back step is
+      // restoring, so no board default is re-applied and no second fetch occurs.
+      const restoredBoardId = parsed.filters.boardIds?.length === 1
+        ? parsed.filters.boardIds[0]
+        : parsed.filters.boardId ?? null;
+      applyBoardViewPresentationRef.current(restoredBoardId);
       lastAppliedSearchRef.current = normalizedSearch;
       await fetchTickets(parsed.filters, parsed.page, parsed.pageSize, {
         sortBy: parsed.sortBy,
@@ -563,15 +717,25 @@ export default function TicketingDashboardContainer({
       return;
     }
 
-    const mergedFilters: Partial<ITicketListFilters> = {
-      ...activeFiltersRef.current,
-      ...buildBoardSelectionFilterUpdate({
-        selectedBoards: [decision.boardId],
-        excludedBoards: [],
-        statusOptions: effectiveOptions.statusOptions,
-        currentStatusId: activeFiltersRef.current.statusId,
-      }),
-    };
+    const boardSelection = buildBoardSelectionFilterUpdate({
+      selectedBoards: [decision.boardId],
+      excludedBoards: [],
+      statusOptions: effectiveOptions.statusOptions,
+      currentStatusId: activeFiltersRef.current.statusId,
+    });
+    // Restoring the remembered tab is an arrival too, so the board's stored view
+    // applies here exactly as it does on a click — layered into this effect's
+    // existing single fetch rather than chasing it with another.
+    applyBoardViewPresentation(decision.boardId);
+    const arrival = boardArrivalFilters(
+      decision.boardId,
+      boardSelection,
+      hasTicketViewFilterParams(window.location.search),
+    );
+    const mergedFilters: Partial<ITicketListFilters> =
+      arrival ?? { ...activeFiltersRef.current, ...boardSelection };
+    if (arrival?.sortBy) setSortBy(arrival.sortBy);
+    if (arrival?.sortDirection) setSortDirection(arrival.sortDirection);
     setActiveFilters(mergedFilters);
     activeFiltersRef.current = mergedFilters;
     setCurrentPage(1);
@@ -586,6 +750,8 @@ export default function TicketingDashboardContainer({
     effectiveOptions.statusOptions,
     pageSize,
     updateURLWithFilters,
+    applyBoardViewPresentation,
+    boardArrivalFilters,
   ]);
 
   const handlePageChange = useCallback(async (newPage: number) => {
@@ -626,7 +792,7 @@ export default function TicketingDashboardContainer({
     }
 
     setCurrentPage(1);
-    const mergedFilters: Partial<ITicketListFilters> = {
+    let mergedFilters: Partial<ITicketListFilters> = {
       ...activeFiltersRef.current,
       ...update,
       sortBy,
@@ -636,6 +802,30 @@ export default function TicketingDashboardContainer({
     if ('statusId' in update) {
       mergedFilters.showOpenOnly = isTicketStatusOpenFilter(update.statusId);
     }
+
+    // A board-tab move is an *arrival*, so the destination board's stored view
+    // replaces the outgoing board's rather than refining it — otherwise a
+    // board's appearance would depend on where you came from, which is the
+    // property the tab strip exists to remove. This layers into the same merge
+    // that was about to happen, so the single debounced fetch below still fires
+    // exactly once; it does not become a second effect with its own fetch.
+    if (options && 'activeBoardTab' in options) {
+      const destinationBoardId = options.activeBoardTab ?? null;
+      applyBoardViewPresentation(destinationBoardId);
+      const arrival = boardArrivalFilters(
+        destinationBoardId,
+        update,
+        typeof window !== 'undefined' && hasTicketViewFilterParams(window.location.search),
+      );
+      if (arrival) {
+        mergedFilters = { ...arrival, sortBy: arrival.sortBy ?? sortBy, sortDirection: arrival.sortDirection ?? sortDirection };
+        if (mergedFilters.sortBy !== sortBy) setSortBy(mergedFilters.sortBy as string);
+        if (mergedFilters.sortDirection !== sortDirection) {
+          setSortDirection(mergedFilters.sortDirection as 'asc' | 'desc');
+        }
+      }
+    }
+
     setActiveFilters(mergedFilters);
     // Update ref immediately so rapid back-to-back calls merge with fresh state
     activeFiltersRef.current = mergedFilters;
@@ -664,7 +854,15 @@ export default function TicketingDashboardContainer({
         void fetchTicketsRef.current(mergedFilters, 1, pageSize);
       }, 300);
     }
-  }, [pageSize, updateURLWithFilters, sortBy, sortDirection, setStoredActiveBoard]);
+  }, [
+    pageSize,
+    updateURLWithFilters,
+    sortBy,
+    sortDirection,
+    setStoredActiveBoard,
+    applyBoardViewPresentation,
+    boardArrivalFilters,
+  ]);
 
   const handleSortChange = useCallback(async (columnId: string, direction: 'asc' | 'desc') => {
     const updatedFilters = {
@@ -679,6 +877,53 @@ export default function TicketingDashboardContainer({
     updateURLWithFilters(updatedFilters, 1, pageSize);
     await fetchTickets(updatedFilters, 1, pageSize, { sortBy: columnId, sortDirection: direction });
   }, [activeFilters, fetchTickets, pageSize, updateURLWithFilters]);
+
+  // Interaction state: columns and density change freely while viewing and are
+  // never persisted per user. They seed from the resolved view and are what
+  // capture reads when an admin saves the board's default.
+  const handleViewPresentationChange = useCallback((update: Partial<ResolvedTicketViewSettings>) => {
+    setViewPresentation(current => ({ ...current, ...update }));
+  }, []);
+
+  const activeBoardIdForView = useMemo(() => (
+    activeFilters.boardIds?.length === 1 ? activeFilters.boardIds[0] : activeFilters.boardId ?? null
+  ), [activeFilters.boardIds, activeFilters.boardId]);
+
+  /**
+   * The baseline the live view is compared against for the dirty dot.
+   *
+   * Deliberately the *resolved* view, not the raw stored document. The dot means
+   * "this differs from what arriving here would give you" — so on a board with
+   * no stored view of its own it must compare against the tenant/catalog result
+   * that a fresh arrival actually produces. Comparing against the raw document
+   * would leave the dot lit permanently on every unconfigured board, which makes
+   * it a decoration rather than a signal.
+   */
+  const savedViewForActiveTab = useMemo<TicketViewSettings>(() => {
+    const resolved = resolveViewForBoard(activeBoardIdForView);
+    return {
+      columnVisibility: resolved.columnVisibility,
+      columnOrder: resolved.columnOrder,
+      tagsInlineUnderTitle: resolved.tagsInlineUnderTitle,
+      densityLevel: resolved.densityLevel,
+      // Stored filters replace the neutral baseline wholesale, exactly as arrival
+      // applies them — so a board that stores no filters compares against the
+      // neutral state the list is actually showing, not against {}.
+      filters: Object.keys(resolved.filters).length > 0
+        ? { ...neutralListFilters(), ...resolved.filters }
+        : neutralListFilters(),
+    };
+  }, [activeBoardIdForView, resolveViewForBoard, neutralListFilters]);
+
+  /** Whether this tab has a stored document of its own, i.e. Reset has work to do. */
+  const hasStoredDefaultForActiveTab = boardViewFor(activeBoardIdForView) !== null;
+
+  const handleSavedViewChanged = useCallback((boardId: string | null, saved: TicketViewSettings | null) => {
+    // Record what was just written so the dirty dot clears immediately and a tab
+    // away-and-back reproduces the saved view now, rather than only once the
+    // session-cached board options expire and refetch.
+    setJustSavedViews(current => ({ ...current, [boardId ?? TENANT_VIEW_KEY]: saved }));
+  }, []);
 
   const mappedAndFilteredBoards = effectiveOptions.boardOptions.map(board => ({
     ...board,
@@ -722,6 +967,11 @@ export default function TicketingDashboardContainer({
       canUpdateTickets={canUpdateTickets}
         allowSlaStatusFilter={allowSlaStatusFilter}
         useAlgaDeskQuickAddForm={useAlgaDeskQuickAddForm}
+        viewPresentation={viewPresentation}
+        onViewPresentationChange={handleViewPresentationChange}
+        savedViewSettings={savedViewForActiveTab}
+        hasStoredDefaultView={hasStoredDefaultForActiveTab}
+        onSavedViewChanged={handleSavedViewChanged}
       />
   );
 }

--- a/packages/tickets/src/components/TicketingDashboardContainer.tsx
+++ b/packages/tickets/src/components/TicketingDashboardContainer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useCallback, useEffect, useRef } from 'react';
+import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import TicketingDashboard from './TicketingDashboard';
 import { fetchTicketsWithPagination } from '../actions/optimizedTicketActions';
 import { toast } from 'react-hot-toast';
@@ -22,6 +22,13 @@ import {
   shouldApplyOpenOnlyStatusFilter,
   TICKET_STATUS_FILTER_OPEN,
 } from '../lib/ticketStatusFilter';
+import {
+  buildBoardSelectionFilterUpdate,
+  hasBoardFilterParam,
+  resolveInitialBoardTab,
+  TICKETS_LAST_ACTIVE_BOARD_SETTING,
+} from '../lib/boardTabs';
+import type { TicketFilterChangeOptions } from '../lib/ticketFilterChange';
 
 const TICKETS_PAGE_SIZE_SETTING = 'tickets_list_page_size';
 
@@ -243,8 +250,28 @@ export default function TicketingDashboardContainer({
     }
   );
 
+  const {
+    value: storedActiveBoard,
+    setValue: setStoredActiveBoard,
+    isLoading: isActiveBoardPreferenceLoading,
+  } = useUserPreference<string>(
+    TICKETS_LAST_ACTIVE_BOARD_SETTING,
+    {
+      // '' means the "All tickets" tab — a distinct, storable choice rather than
+      // "unset", so returning to All is remembered like any other tab.
+      defaultValue: '',
+      localStorageKey: TICKETS_LAST_ACTIVE_BOARD_SETTING,
+      debounceMs: 500,
+    }
+  );
+
   // Function to sync filter state and pagination to URL
-  const updateURLWithFilters = useCallback((filters: Partial<ITicketListFilters>, page?: number, pageSize?: number) => {
+  const updateURLWithFilters = useCallback((
+    filters: Partial<ITicketListFilters>,
+    page?: number,
+    pageSize?: number,
+    historyMode: 'replace' | 'push' = 'replace',
+  ) => {
     const params = new URLSearchParams();
 
     // Add pagination params
@@ -314,9 +341,15 @@ export default function TicketingDashboardContainer({
       params.set('bundleView', filters.bundleView);
     }
 
-    // Update URL without triggering a server-side re-render
+    // Update URL without triggering a server-side re-render. Board-tab moves
+    // push so back/forward walks the tabs; every other filter edit replaces, so
+    // refining a view does not bury the previous page in history.
     const newURL = params.toString() ? `/msp/tickets?${params.toString()}` : '/msp/tickets';
-    window.history.replaceState(null, '', newURL);
+    if (historyMode === 'push') {
+      window.history.pushState(null, '', newURL);
+    } else {
+      window.history.replaceState(null, '', newURL);
+    }
     lastAppliedSearchRef.current = params.toString() ? `?${params.toString()}` : '';
   }, []);
 
@@ -425,6 +458,13 @@ export default function TicketingDashboardContainer({
 
     isSyncingFromHistoryRef.current = true;
     try {
+      // A history move supersedes any filter edit still sitting in the debounce
+      // window; letting it fire would refetch (and re-render) the state the user
+      // just navigated away from.
+      if (filterFetchTimeoutRef.current) {
+        clearTimeout(filterFetchTimeoutRef.current);
+        filterFetchTimeoutRef.current = null;
+      }
       const parsed = parseTicketListStateFromSearch(normalizedSearch, allowSlaStatusFilter);
       setCurrentPage(parsed.page);
       setPageSize(parsed.pageSize);
@@ -499,6 +539,55 @@ export default function TicketingDashboardContainer({
     updateURLWithFilters,
   ]);
 
+  // Restore the last-active board tab on a bare /msp/tickets. Applied at most
+  // once per mount (appliedInitialBoardRef) and only once the preference has
+  // actually resolved from the server, so a shared link is never stomped by a
+  // preference that arrives a tick later. A URL that names a board wins outright.
+  const availableBoardIds = useMemo(
+    () => effectiveOptions.boardOptions.map(board => board.board_id).filter((id): id is string => Boolean(id)),
+    [effectiveOptions.boardOptions]
+  );
+  const appliedInitialBoardRef = useRef(false);
+  useEffect(() => {
+    if (appliedInitialBoardRef.current || isActiveBoardPreferenceLoading || typeof window === 'undefined') {
+      return;
+    }
+    appliedInitialBoardRef.current = true;
+
+    const decision = resolveInitialBoardTab({
+      urlHasBoardFilter: hasBoardFilterParam(window.location.search),
+      storedBoardId: storedActiveBoard,
+      availableBoardIds,
+    });
+    if (!decision.apply) {
+      return;
+    }
+
+    const mergedFilters: Partial<ITicketListFilters> = {
+      ...activeFiltersRef.current,
+      ...buildBoardSelectionFilterUpdate({
+        selectedBoards: [decision.boardId],
+        excludedBoards: [],
+        statusOptions: effectiveOptions.statusOptions,
+        currentStatusId: activeFiltersRef.current.statusId,
+      }),
+    };
+    setActiveFilters(mergedFilters);
+    activeFiltersRef.current = mergedFilters;
+    setCurrentPage(1);
+    // Replace (not push): restoring a remembered tab is where the user landed,
+    // so "back" should leave the page rather than fall through to All tickets.
+    updateURLWithFilters(mergedFilters, 1, pageSize);
+    void fetchTicketsRef.current(mergedFilters, 1, pageSize);
+  }, [
+    isActiveBoardPreferenceLoading,
+    storedActiveBoard,
+    availableBoardIds,
+    effectiveOptions.statusOptions,
+    pageSize,
+    updateURLWithFilters,
+  ]);
+
   const handlePageChange = useCallback(async (newPage: number) => {
     setCurrentPage(newPage);
     updateURLWithFilters(activeFilters, newPage, pageSize);
@@ -513,7 +602,10 @@ export default function TicketingDashboardContainer({
     await fetchTickets(activeFilters, 1, newPageSize);
   }, [fetchTickets, activeFilters, updateURLWithFilters, setStoredPageSize]);
 
-  const handleFilterChange = useCallback((update: Partial<ITicketListFilters>) => {
+  const handleFilterChange = useCallback((
+    update: Partial<ITicketListFilters>,
+    options?: TicketFilterChangeOptions,
+  ) => {
     // Non-empty update: skip if no values actually differ (guards against
     // controlled components that call onChange on mount to normalize state).
     // Empty update ({}) = force refresh (e.g., after bundling tickets).
@@ -547,7 +639,14 @@ export default function TicketingDashboardContainer({
     setActiveFilters(mergedFilters);
     // Update ref immediately so rapid back-to-back calls merge with fresh state
     activeFiltersRef.current = mergedFilters;
-    updateURLWithFilters(mergedFilters, 1, pageSize);
+    updateURLWithFilters(mergedFilters, 1, pageSize, options?.pushHistory ? 'push' : 'replace');
+
+    // Board tabs are the only navigation-shaped filter change, so they are the
+    // only ones that update "where the user was last". Keyed on presence, not
+    // truthiness: null is the "All tickets" tab, not an absent value.
+    if (options && 'activeBoardTab' in options) {
+      setStoredActiveBoard(options.activeBoardTab ?? '');
+    }
 
     // Debounce the fetch: cancel any pending debounced fetch and schedule a new one.
     // This prevents N concurrent server requests when the user rapidly clicks filters
@@ -565,7 +664,7 @@ export default function TicketingDashboardContainer({
         void fetchTicketsRef.current(mergedFilters, 1, pageSize);
       }, 300);
     }
-  }, [pageSize, updateURLWithFilters, sortBy, sortDirection]);
+  }, [pageSize, updateURLWithFilters, sortBy, sortDirection, setStoredActiveBoard]);
 
   const handleSortChange = useCallback(async (columnId: string, direction: 'asc' | 'desc') => {
     const updatedFilters = {

--- a/packages/tickets/src/components/TicketingDashboardContainer.tsx
+++ b/packages/tickets/src/components/TicketingDashboardContainer.tsx
@@ -27,11 +27,14 @@ import {
   hasBoardFilterParam,
   hasTicketViewFilterParams,
   resolveInitialBoardTab,
+  shouldApplyBoardDefaultView,
+  type BoardArrivalTrigger,
   TICKETS_LAST_ACTIVE_BOARD_SETTING,
 } from '../lib/boardTabs';
 import {
   buildBoardArrivalFilters,
   resolveTicketViewSettings,
+  sanitizeStoredTicketView,
   validateCapturedFilters,
   type ResolvedTicketViewSettings,
   type TicketViewSettings,
@@ -474,13 +477,19 @@ export default function TicketingDashboardContainer({
   // into the *existing* merge path below rather than becoming a second effect
   // that fires its own fetch. One fetch per navigation is a property the smoke
   // pass on this branch established and this must not spend.
-  const tenantViewSettings = displaySettings?.list as TicketViewSettings | undefined;
+  const tenantViewSettings = useMemo(
+    () => sanitizeStoredTicketView(displaySettings?.list) ?? undefined,
+    [displaySettings?.list]
+  );
 
   const storedBoardViews = useMemo(() => {
     const map = new Map<string, TicketViewSettings | null>();
     for (const board of effectiveOptions.boardOptions) {
       if (board.board_id) {
-        map.set(board.board_id, (board.list_view_settings as TicketViewSettings | null) ?? null);
+        // Sanitized, not cast: the row is a JSONB document that may predate or
+        // postdate this code, and one stale key must not be able to poison the
+        // resolved view (or spread junk into ITicketListFilters).
+        map.set(board.board_id, sanitizeStoredTicketView(board.list_view_settings));
       }
     }
     return map;
@@ -565,6 +574,19 @@ export default function TicketingDashboardContainer({
   }), []);
 
   /**
+   * Did the URL the page was *entered* with carry filter params?
+   *
+   * Captured once, at mount, and never re-read — because updateURLWithFilters
+   * writes the live filter state back into the address bar, so from the first
+   * arrival onwards window.location.search reflects the app's own output rather
+   * than anything the user linked to. Re-reading it per click is what made board
+   * default filters stop applying after the first filtered navigation.
+   */
+  const entryUrlHasFilterOpinion = useRef(
+    typeof window !== 'undefined' && hasTicketViewFilterParams(window.location.search)
+  );
+
+  /**
    * The filters a board tab arrival produces, or null when the board's stored
    * filters must not apply.
    *
@@ -575,15 +597,21 @@ export default function TicketingDashboardContainer({
   const boardArrivalFilters = useCallback((
     boardId: string | null,
     boardSelection: Partial<ITicketListFilters>,
-    urlHasFilterOpinion: boolean,
+    trigger: BoardArrivalTrigger,
   ): Partial<ITicketListFilters> | null => {
-    if (urlHasFilterOpinion) {
+    if (!shouldApplyBoardDefaultView({
+      trigger,
+      urlHasFilterOpinion: entryUrlHasFilterOpinion.current,
+    })) {
       return null;
     }
+    // No early-return for "this board stores no filters". A board that has been
+    // configured with nothing still has a view — the neutral one — and arriving
+    // at it must produce that, not whatever the previous board left behind.
+    // Returning null here made an unconfigured board inherit the filters of
+    // whichever board you came from, which is the same defect as reading the
+    // URL per click, one layer down.
     const resolved = resolveViewForBoard(boardId);
-    if (!resolved.filters || Object.keys(resolved.filters).length === 0) {
-      return null;
-    }
     return buildBoardArrivalFilters({
       baseline: neutralListFilters(),
       boardSelection,
@@ -727,11 +755,7 @@ export default function TicketingDashboardContainer({
     // applies here exactly as it does on a click — layered into this effect's
     // existing single fetch rather than chasing it with another.
     applyBoardViewPresentation(decision.boardId);
-    const arrival = boardArrivalFilters(
-      decision.boardId,
-      boardSelection,
-      hasTicketViewFilterParams(window.location.search),
-    );
+    const arrival = boardArrivalFilters(decision.boardId, boardSelection, 'initial');
     const mergedFilters: Partial<ITicketListFilters> =
       arrival ?? { ...activeFiltersRef.current, ...boardSelection };
     if (arrival?.sortBy) setSortBy(arrival.sortBy);
@@ -812,11 +836,7 @@ export default function TicketingDashboardContainer({
     if (options && 'activeBoardTab' in options) {
       const destinationBoardId = options.activeBoardTab ?? null;
       applyBoardViewPresentation(destinationBoardId);
-      const arrival = boardArrivalFilters(
-        destinationBoardId,
-        update,
-        typeof window !== 'undefined' && hasTicketViewFilterParams(window.location.search),
-      );
+      const arrival = boardArrivalFilters(destinationBoardId, update, 'tab-click');
       if (arrival) {
         mergedFilters = { ...arrival, sortBy: arrival.sortBy ?? sortBy, sortDirection: arrival.sortDirection ?? sortDirection };
         if (mergedFilters.sortBy !== sortBy) setSortBy(mergedFilters.sortBy as string);

--- a/packages/tickets/src/components/boardArrival.contract.test.ts
+++ b/packages/tickets/src/components/boardArrival.contract.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * There are two ways to land on a single board — the tab strip and the board
+ * filter picker — and `resolveActiveBoardId` treats them identically, which is
+ * what makes the board header and the board-scoped status options light up for
+ * both. The board's *view* has to follow the same rule, or the header names one
+ * board while the columns, density and filters still belong to the previous one.
+ *
+ * Both paths therefore have to reach `handleFilterChange` with `activeBoardTab`
+ * set, which is the flag the container keys arrival off. That is a wiring
+ * property, invisible to a pure unit test and awkward to drive through the
+ * picker's tree UI, so it is asserted against the source.
+ */
+
+const COMPONENTS = __dirname;
+const read = (file: string) => readFileSync(join(COMPONENTS, file), 'utf8');
+
+function sliceCallback(source: string, name: string): string {
+  const start = source.indexOf(`const ${name} = useCallback(`);
+  expect(start, `${name} should exist`).toBeGreaterThan(-1);
+  const next = source.indexOf('const handle', start + 10);
+  return source.slice(start, next > start ? next : start + 2000);
+}
+
+describe('board arrival wiring', () => {
+  const dashboard = read('TicketingDashboard.tsx');
+
+  it('routes a single-board picker selection through the arrival path', () => {
+    const body = sliceCallback(dashboard, 'handleBoardSelect');
+
+    // Same derivation the header and status options use, not a second one.
+    expect(body).toContain('resolveActiveBoardId');
+    expect(body).toContain('activeBoardTab');
+  });
+
+  it('does not treat a multi-board picker selection as an arrival', () => {
+    // Zero or several boards is a filter, not a place: there is no single board
+    // whose view could apply, so it must not claim to be an arrival.
+    const body = sliceCallback(dashboard, 'handleBoardSelect');
+    expect(body).toMatch(/nextBoardId !== null/);
+  });
+
+  it('keeps the tab strip on the same arrival path', () => {
+    const body = sliceCallback(dashboard, 'handleBoardTabSelect');
+    expect(body).toContain('activeBoardTab');
+    // Tabs additionally push history; the picker deliberately does not.
+    expect(body).toContain('pushHistory: true');
+  });
+
+  it('decides arrival from the entry URL, never from the live one', () => {
+    // The regression this whole seam exists for: updateURLWithFilters writes the
+    // app's own filter state back into the address bar, so re-reading
+    // window.location.search per click reports an opinion that is not a shared
+    // link — and silently disables board default filters from the second
+    // navigation onwards.
+    const container = read('TicketingDashboardContainer.tsx');
+    const handler = container.slice(container.indexOf('const handleFilterChange = useCallback('));
+    const body = handler.slice(0, handler.indexOf('const handleSortChange'));
+
+    expect(body).toContain("'tab-click'");
+    expect(body).not.toContain('window.location.search');
+    // The entry-URL probe is a ref captured once, not a per-call read.
+    expect(container).toContain('const entryUrlHasFilterOpinion = useRef(');
+  });
+});

--- a/packages/tickets/src/components/settings/BoardsSettings.copyStatuses.test.tsx
+++ b/packages/tickets/src/components/settings/BoardsSettings.copyStatuses.test.tsx
@@ -774,7 +774,11 @@ describe('BoardsSettings ticket status copy flow', () => {
       expect(screen.getByTestId('save-board-button')).toBeInTheDocument();
     });
     expect(screen.queryByTestId('add-board-button')).not.toBeInTheDocument();
-    expect(screen.getByText('Support Renamed')).toBeInTheDocument();
+    // getAllByText, not getByText: the editor header and the Appearance
+    // section's board-header preview both legitimately render the board name,
+    // so the name now appears more than once. The assertion is still "the saved
+    // name is reflected in the editor".
+    expect(screen.getAllByText('Support Renamed').length).toBeGreaterThan(0);
   });
 
   it('shows an incomplete auto-close rule error inside the Automation section, not a top banner', async () => {

--- a/packages/tickets/src/components/settings/BoardsSettings.tsx
+++ b/packages/tickets/src/components/settings/BoardsSettings.tsx
@@ -14,7 +14,7 @@ import {
   clearBoardDefaultView,
 } from '@alga-psa/tickets/actions/board-actions/boardActions';
 import BoardHeader from '../BoardHeader';
-import { resolveTicketColumnVisibility, type TicketListColumnKey } from '@alga-psa/tickets/lib';
+import { TICKET_COLUMNS, resolveTicketColumnVisibility, type TicketListColumnKey } from '@alga-psa/tickets/lib';
 import {
   getBoardTicketStatuses,
 } from '@alga-psa/tickets/actions/board-actions/boardTicketStatusActions';
@@ -217,39 +217,59 @@ function getManagedTicketStatusValidationError(
  * a reader from "this board's view is empty". Inheriting is a decision, and the
  * summary says so.
  */
+/** i18next `t` with interpolation options, as the rest of this screen uses it. */
+type TranslateWithOptions = (key: string, options?: Record<string, unknown>) => string;
+
 function describeBoardSavedView(
   // The stored document as it comes off the row: structurally typed and not
   // catalog-keyed, because a document written by an older (or newer) version
   // must still be describable rather than un-typeable.
   view: NonNullable<IBoard['list_view_settings']> | null | undefined,
-  t: (key: string, fallback: string) => string
+  t: TranslateWithOptions,
+  tTickets: TranslateWithOptions
 ): string {
+  const inherits = () =>
+    t('ticketing.boards.appearance.inheritsTenant', { defaultValue: 'Inherits tenant defaults' });
+
   if (!view) {
-    return t('ticketing.boards.appearance.inheritsTenant', 'Inherits tenant defaults');
+    return inherits();
   }
 
   const parts: string[] = [];
   const filters = (view.filters ?? {}) as Record<string, unknown>;
 
   if (filters.showOpenOnly === true) {
-    parts.push(t('ticketing.boards.appearance.summary.openOnly', 'Open only'));
+    parts.push(t('ticketing.boards.appearance.summary.openOnly', { defaultValue: 'Open only' }));
   }
   if (typeof filters.sortBy === 'string') {
+    // The stored sort key is a dataIndex ('due_date'), not something to show a
+    // user. Route it through the column catalog so the summary names the column
+    // the way the list header does, in the reader's language.
+    const column = TICKET_COLUMNS.find((c) => c.dataIndex === filters.sortBy);
+    const fieldLabel = column
+      ? tTickets(column.titleKey, { defaultValue: column.titleFallback })
+      : (filters.sortBy as string);
     const direction = filters.sortDirection === 'asc' ? '\u2191' : '\u2193';
-    parts.push(`${t('ticketing.boards.appearance.summary.sortedBy', 'sorted by')} ${filters.sortBy} ${direction}`);
+    parts.push(
+      `${t('ticketing.boards.appearance.summary.sortedBy', { defaultValue: 'sorted by {{field}}', field: fieldLabel })} ${direction}`
+    );
   }
   if (view.columnVisibility) {
     const stored = view.columnVisibility as Partial<Record<TicketListColumnKey, boolean>>;
     const visible = Object.values(resolveTicketColumnVisibility(stored)).filter(Boolean).length;
-    parts.push(`${visible} ${t('ticketing.boards.appearance.summary.columns', 'columns')}`);
+    parts.push(
+      // `columns`, not `count`: `count` is reserved by i18next for plural
+      // resolution, and we have declared no plural forms for this key.
+      t('ticketing.boards.appearance.summary.columns', { defaultValue: '{{columns}} columns', columns: visible })
+    );
   }
   if (typeof view.densityLevel === 'number') {
-    parts.push(`${t('ticketing.boards.appearance.summary.density', 'density')} ${view.densityLevel}`);
+    parts.push(
+      t('ticketing.boards.appearance.summary.density', { defaultValue: 'density {{level}}', level: view.densityLevel })
+    );
   }
 
-  return parts.length > 0
-    ? parts.join(' \u00b7 ')
-    : t('ticketing.boards.appearance.inheritsTenant', 'Inherits tenant defaults');
+  return parts.length > 0 ? parts.join(' \u00b7 ') : inherits();
 }
 
 const TICKET_STATUS_VALIDATION_KEYS: Record<ManagedTicketStatusValidationCode, string> = {
@@ -380,6 +400,11 @@ interface BoardsSettingsProps {
 
 const BoardsSettings: React.FC<BoardsSettingsProps> = ({ isAlgaDesk = false, getSlaPolicies }) => {
   const { t } = useTranslation('msp/settings');
+  // BoardHeader is a ticket-list component and asks for dashboard.boardHeader.*
+  // and bulk.move.unnamedBoard, which live in features/tickets. Handing it this
+  // screen's msp/settings `t` would resolve nothing and silently render every
+  // label in English in every locale.
+  const { t: tTickets } = useTranslation('features/tickets');
   const createEmptyFormData = () => ({
     board_name: '',
     description: '',
@@ -1047,6 +1072,10 @@ const BoardsSettings: React.FC<BoardsSettingsProps> = ({ isAlgaDesk = false, get
           inbound_reply_reopen_status_id: null,
           inbound_reply_ai_ack_suppression_enabled: formData.inbound_reply_ai_ack_suppression_enabled,
           enable_live_ticket_timer: formData.enable_live_ticket_timer,
+          // The pin toggle renders during creation too, so it has to be sent:
+          // createBoard defaults is_pinned to true, which would silently ignore
+          // an admin turning it off on the way in.
+          is_pinned: formData.is_pinned,
           copy_ticket_statuses_from_board_id: formData.status_seed_mode === 'copy_existing'
             ? (formData.copy_ticket_statuses_from_board_id || null)
             : null,
@@ -1699,7 +1728,7 @@ const BoardsSettings: React.FC<BoardsSettingsProps> = ({ isAlgaDesk = false, get
                         slaPolicyName:
                           slaPolicies.find((policy) => policy.sla_policy_id === formData.sla_policy_id)?.policy_name ?? null,
                       }}
-                      t={t as (key: string, fallback: string) => string}
+                      t={tTickets as (key: string, fallback: string) => string}
                     />
                     <div className="space-y-1.5 px-3 py-2">
                       {[0, 1, 2].map((row) => (
@@ -1716,7 +1745,11 @@ const BoardsSettings: React.FC<BoardsSettingsProps> = ({ isAlgaDesk = false, get
                 <div className="rounded-md border border-gray-200 p-3">
                   <Label>{t('ticketing.boards.appearance.savedView', 'Saved view')}</Label>
                   <p className="mt-1 text-xs text-muted-foreground">
-                    {describeBoardSavedView(editingBoard.list_view_settings ?? null, t)}
+                    {describeBoardSavedView(
+                      editingBoard.list_view_settings ?? null,
+                      t as TranslateWithOptions,
+                      tTickets as TranslateWithOptions
+                    )}
                   </p>
                   <p className="mt-2 text-xs text-muted-foreground">
                     {t(

--- a/packages/tickets/src/components/settings/BoardsSettings.tsx
+++ b/packages/tickets/src/components/settings/BoardsSettings.tsx
@@ -3,7 +3,7 @@
 
 import React, { useState, useEffect, useMemo } from 'react';
 import { Button } from '@alga-psa/ui/components/Button';
-import { Plus, MoreVertical, HelpCircle, ChevronDown, ArrowLeft, AlertTriangle, CheckCircle2, Settings2, Users, ListChecks, Mail, Zap, Clock, Search, Inbox, Star } from "lucide-react";
+import { Plus, MoreVertical, HelpCircle, ChevronDown, ArrowLeft, AlertTriangle, CheckCircle2, Settings2, Users, ListChecks, Mail, Zap, Clock, Search, Inbox, Star, LayoutGrid } from "lucide-react";
 import { IBoard, ITeam, CategoryType, PriorityType, IPriority, IUser, DeletionValidationResult, DeletionDependency } from '@alga-psa/types';
 import {
   getAllBoards,
@@ -11,7 +11,10 @@ import {
   createBoard,
   updateBoard,
   deleteBoard,
+  clearBoardDefaultView,
 } from '@alga-psa/tickets/actions/board-actions/boardActions';
+import BoardHeader from '../BoardHeader';
+import { resolveTicketColumnVisibility, type TicketListColumnKey } from '@alga-psa/tickets/lib';
 import {
   getBoardTicketStatuses,
 } from '@alga-psa/tickets/actions/board-actions/boardTicketStatusActions';
@@ -205,6 +208,50 @@ function getManagedTicketStatusValidationError(
   return null;
 }
 
+/**
+ * One line describing what a board's stored view actually does, e.g.
+ * "Open only \u00b7 sorted by Due date \u00b7 6 columns \u00b7 density 40".
+ *
+ * The explicit "Inherits tenant defaults" for a NULL document matters: an empty
+ * summary would read as "this board has no view", which is indistinguishable to
+ * a reader from "this board's view is empty". Inheriting is a decision, and the
+ * summary says so.
+ */
+function describeBoardSavedView(
+  // The stored document as it comes off the row: structurally typed and not
+  // catalog-keyed, because a document written by an older (or newer) version
+  // must still be describable rather than un-typeable.
+  view: NonNullable<IBoard['list_view_settings']> | null | undefined,
+  t: (key: string, fallback: string) => string
+): string {
+  if (!view) {
+    return t('ticketing.boards.appearance.inheritsTenant', 'Inherits tenant defaults');
+  }
+
+  const parts: string[] = [];
+  const filters = (view.filters ?? {}) as Record<string, unknown>;
+
+  if (filters.showOpenOnly === true) {
+    parts.push(t('ticketing.boards.appearance.summary.openOnly', 'Open only'));
+  }
+  if (typeof filters.sortBy === 'string') {
+    const direction = filters.sortDirection === 'asc' ? '\u2191' : '\u2193';
+    parts.push(`${t('ticketing.boards.appearance.summary.sortedBy', 'sorted by')} ${filters.sortBy} ${direction}`);
+  }
+  if (view.columnVisibility) {
+    const stored = view.columnVisibility as Partial<Record<TicketListColumnKey, boolean>>;
+    const visible = Object.values(resolveTicketColumnVisibility(stored)).filter(Boolean).length;
+    parts.push(`${visible} ${t('ticketing.boards.appearance.summary.columns', 'columns')}`);
+  }
+  if (typeof view.densityLevel === 'number') {
+    parts.push(`${t('ticketing.boards.appearance.summary.density', 'density')} ${view.densityLevel}`);
+  }
+
+  return parts.length > 0
+    ? parts.join(' \u00b7 ')
+    : t('ticketing.boards.appearance.inheritsTenant', 'Inherits tenant defaults');
+}
+
 const TICKET_STATUS_VALIDATION_KEYS: Record<ManagedTicketStatusValidationCode, string> = {
   STATUS_REQUIRED: 'ticketing.boards.messages.error.statusRequired',
   DUPLICATE_STATUS_NAME: 'ticketing.boards.messages.error.duplicateStatusName',
@@ -352,6 +399,7 @@ const BoardsSettings: React.FC<BoardsSettingsProps> = ({ isAlgaDesk = false, get
     inbound_reply_reopen_status_id: '',
     inbound_reply_ai_ack_suppression_enabled: false,
     enable_live_ticket_timer: true,
+    is_pinned: true,
     status_seed_mode: 'copy_existing' as TicketStatusSeedMode,
     copy_ticket_statuses_from_board_id: '',
     ticket_statuses: [] as ManagedTicketStatus[],
@@ -654,6 +702,7 @@ const BoardsSettings: React.FC<BoardsSettingsProps> = ({ isAlgaDesk = false, get
       inbound_reply_reopen_status_id: board.inbound_reply_reopen_status_id || '',
       inbound_reply_ai_ack_suppression_enabled: board.inbound_reply_ai_ack_suppression_enabled ?? false,
       enable_live_ticket_timer: board.enable_live_ticket_timer ?? true,
+      is_pinned: board.is_pinned ?? false,
       ticket_statuses: [],
     });
     setShowAddEditDialog(true);
@@ -920,6 +969,7 @@ const BoardsSettings: React.FC<BoardsSettingsProps> = ({ isAlgaDesk = false, get
           inbound_reply_reopen_status_id: formData.inbound_reply_reopen_status_id || null,
           inbound_reply_ai_ack_suppression_enabled: formData.inbound_reply_ai_ack_suppression_enabled,
           enable_live_ticket_timer: formData.enable_live_ticket_timer,
+          is_pinned: formData.is_pinned,
           ticket_statuses: normalizedTicketStatuses,
         });
         if (isReturnedActionError(updatedBoard)) {
@@ -1152,6 +1202,9 @@ const BoardsSettings: React.FC<BoardsSettingsProps> = ({ isAlgaDesk = false, get
     display: JSON.stringify({
       enable_live_ticket_timer: formData.enable_live_ticket_timer,
       is_itil_compliant: formData.is_itil_compliant,
+    }),
+    appearance: JSON.stringify({
+      is_pinned: formData.is_pinned,
     }),
   });
 
@@ -1578,6 +1631,129 @@ const BoardsSettings: React.FC<BoardsSettingsProps> = ({ isAlgaDesk = false, get
                 onCheckedChange={(checked) => setFormData({ ...formData, is_default: checked })}
               />
             </div>
+          </div>
+          </EditorAccordionSection>
+
+          {/* Appearance & defaults. Deliberately contains NO filter controls:
+              the board's view is arranged on the real ticket list and saved from
+              View, so duplicating the list's filter surface in a settings form
+              would create a second place for the same concept to drift. The
+              weight of this feature belongs in the shared resolver, not here. */}
+          <EditorAccordionSection
+            id="appearance"
+            error={sectionErrors['appearance']}
+            title={t('ticketing.boards.editor.sections.appearance', 'Appearance & defaults')}
+            description={t('ticketing.boards.editor.sections.appearanceHelp', 'Tab pinning and the board\u2019s default list view')}
+            icon={<LayoutGrid className="h-4 w-4" />}
+            open={!collapsedSections.has('appearance')}
+            dirty={isSectionDirty('appearance')}
+            onToggle={() => toggleSection('appearance')}
+            onSave={handleSaveBoard}
+            saveLabel={t('ticketing.boards.editor.saveChanges', 'Save Changes')}
+            unsavedLabel={t('ticketing.boards.editor.unsaved', 'Unsaved')}
+            saveDisabled={saveDisabled}
+          >
+          <div className="space-y-4">
+            <div className="flex items-center justify-between gap-4 rounded-md border border-gray-200 bg-gray-50/60 p-3">
+              <div>
+                <Label htmlFor="is_pinned">
+                  {t('ticketing.boards.appearance.pinLabel', 'Pin to the tickets screen')}
+                </Label>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {t(
+                    'ticketing.boards.appearance.pinHelp',
+                    'Pinned boards get a permanent tab on the tickets screen. Unpinned boards stay reachable from All tickets and the board filter.'
+                  )}
+                </p>
+              </div>
+              <Switch
+                id="is_pinned"
+                checked={formData.is_pinned}
+                onCheckedChange={(checked) => setFormData({ ...formData, is_pinned: checked })}
+              />
+            </div>
+
+            {editingBoard && (
+              <>
+                <div>
+                  <Label>{t('ticketing.boards.appearance.preview', 'Preview')}</Label>
+                  <div className="mt-1 overflow-hidden rounded-md border border-gray-200 bg-white">
+                    {/* Reuses BoardHeader at reduced scale rather than
+                        re-implementing the layout, so the preview cannot drift
+                        from the real header. The rows are placeholder bars, not
+                        live tickets: this is a shape preview, and fetching a
+                        board's tickets inside a settings accordion is not worth
+                        the round trip. */}
+                    <BoardHeader
+                      id="board-appearance-preview"
+                      compact
+                      board={{ ...editingBoard, board_name: formData.board_name, description: formData.description }}
+                      stats={boardStats[editingBoard.board_id!] ?? null}
+                      identity={{
+                        boardId: editingBoard.board_id!,
+                        managerUserId: formData.manager_user_id || null,
+                        managerName: users.find((u) => u.user_id === formData.manager_user_id)
+                          ? `${users.find((u) => u.user_id === formData.manager_user_id)!.first_name ?? ''} ${users.find((u) => u.user_id === formData.manager_user_id)!.last_name ?? ''}`.trim()
+                          : null,
+                        slaPolicyId: formData.sla_policy_id || null,
+                        slaPolicyName:
+                          slaPolicies.find((policy) => policy.sla_policy_id === formData.sla_policy_id)?.policy_name ?? null,
+                      }}
+                      t={t as (key: string, fallback: string) => string}
+                    />
+                    <div className="space-y-1.5 px-3 py-2">
+                      {[0, 1, 2].map((row) => (
+                        <div key={row} className="flex items-center gap-2">
+                          <div className="h-2 flex-1 rounded bg-gray-100" />
+                          <div className="h-2 w-12 rounded bg-gray-100" />
+                          <div className="h-2 w-12 rounded bg-gray-100" />
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="rounded-md border border-gray-200 p-3">
+                  <Label>{t('ticketing.boards.appearance.savedView', 'Saved view')}</Label>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {describeBoardSavedView(editingBoard.list_view_settings ?? null, t)}
+                  </p>
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    {t(
+                      'ticketing.boards.appearance.arrangeNote',
+                      "Arrange this board's view on the board itself, then save it from the View menu."
+                    )}
+                  </p>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {/* A real link, not a router.push: this jumps to a different
+                        area of the app, and a link is what lets it be opened in
+                        a new tab, middle-clicked, or copied. */}
+                    <Button id="board-appearance-open" variant="outline" size="sm" asChild>
+                      <a href={`/msp/tickets?boardId=${editingBoard.board_id}`}>
+                        {t('ticketing.boards.appearance.openBoard', 'Open this board')}
+                      </a>
+                    </Button>
+                    <Button
+                      id="board-appearance-reset"
+                      variant="outline"
+                      size="sm"
+                      disabled={!editingBoard.list_view_settings}
+                      onClick={async () => {
+                        const result = await clearBoardDefaultView(editingBoard.board_id!);
+                        if (isReturnedActionError(result)) {
+                          failInSection('appearance', getErrorMessage(result));
+                          return;
+                        }
+                        setEditingBoard({ ...editingBoard, list_view_settings: null });
+                        await fetchBoards();
+                      }}
+                    >
+                      {t('ticketing.boards.appearance.resetToTenant', 'Reset to tenant default')}
+                    </Button>
+                  </div>
+                </div>
+              </>
+            )}
           </div>
           </EditorAccordionSection>
 

--- a/packages/tickets/src/lib/boardFilterValues.ts
+++ b/packages/tickets/src/lib/boardFilterValues.ts
@@ -1,0 +1,8 @@
+/**
+ * Sentinel board-filter selection meaning "tickets that have no board assigned".
+ *
+ * Lives in lib (not in BoardFilterPicker) so pure board-filter logic — the tab
+ * strip derivation in ./boardTabs — can reason about it without importing a
+ * client component. BoardFilterPicker re-exports it for existing consumers.
+ */
+export const NO_BOARD_VALUE = 'no-board';

--- a/packages/tickets/src/lib/boardTabs.test.ts
+++ b/packages/tickets/src/lib/boardTabs.test.ts
@@ -1,0 +1,265 @@
+// @vitest-environment node
+
+import { describe, expect, it } from 'vitest';
+import type { IBoard } from '@alga-psa/types';
+import {
+  ALL_BOARDS_TAB_ID,
+  boardIdFromTabId,
+  boardTabId,
+  boardTabSelection,
+  buildBoardSelectionFilterUpdate,
+  buildBoardTabs,
+  hasBoardFilterParam,
+  resolveActiveBoardId,
+  resolveInitialBoardTab,
+} from './boardTabs';
+import { NO_BOARD_VALUE } from './boardFilterValues';
+import {
+  createTicketStatusNameFilterValue,
+  TICKET_STATUS_FILTER_ALL,
+  TICKET_STATUS_FILTER_OPEN,
+  type TicketStatusFilterOption,
+} from './ticketStatusFilter';
+
+const BOARD_A = 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa';
+const BOARD_B = 'bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb';
+const BOARD_C = 'cccccccc-cccc-4ccc-cccc-cccccccccccc';
+
+function board(overrides: Partial<IBoard> & { board_id: string }): IBoard {
+  return {
+    tenant: 'tenant-1',
+    is_inactive: false,
+    ...overrides,
+  } as IBoard;
+}
+
+// Statuses as getTicketFormOptions supplies them: board-scoped rows, plus the
+// two sentinel entries that buildTicketStatusFilterOptions always re-adds.
+const STATUS_OPTIONS: TicketStatusFilterOption[] = [
+  { value: TICKET_STATUS_FILTER_OPEN, label: 'All open statuses' },
+  { value: TICKET_STATUS_FILTER_ALL, label: 'All Statuses' },
+  { value: 'status-a-triage', label: 'Triage', statusName: 'Triage', boardId: BOARD_A, isClosed: false },
+  { value: 'status-a-done', label: 'Done', statusName: 'Done', boardId: BOARD_A, isClosed: true },
+  { value: 'status-b-waiting', label: 'Waiting on vendor', statusName: 'Waiting on vendor', boardId: BOARD_B, isClosed: false },
+];
+
+const TRIAGE = createTicketStatusNameFilterValue('Triage');
+const WAITING_ON_VENDOR = createTicketStatusNameFilterValue('Waiting on vendor');
+
+describe('board tab ids', () => {
+  it('round-trips a board id through its tab id', () => {
+    expect(boardTabId(BOARD_A)).not.toBe(ALL_BOARDS_TAB_ID);
+    expect(boardIdFromTabId(boardTabId(BOARD_A))).toBe(BOARD_A);
+  });
+
+  it('maps the All tickets tab to a null board id in both directions', () => {
+    expect(boardTabId(null)).toBe(ALL_BOARDS_TAB_ID);
+    expect(boardIdFromTabId(ALL_BOARDS_TAB_ID)).toBeNull();
+  });
+});
+
+describe('resolveActiveBoardId', () => {
+  it('activates a board tab only for exactly one real board', () => {
+    expect(resolveActiveBoardId([BOARD_A])).toBe(BOARD_A);
+    expect(resolveActiveBoardId([])).toBeNull();
+    expect(resolveActiveBoardId([BOARD_A, BOARD_B])).toBeNull();
+  });
+
+  it('treats the "no board" sentinel as the All tickets tab, not a board tab', () => {
+    expect(resolveActiveBoardId([NO_BOARD_VALUE])).toBeNull();
+  });
+});
+
+describe('tab selection -> filter state', () => {
+  it('scopes the filter to a single board when a board tab is clicked', () => {
+    const selection = boardTabSelection(BOARD_A);
+    const update = buildBoardSelectionFilterUpdate({
+      selectedBoards: selection.selectedBoards,
+      excludedBoards: selection.excludedBoards,
+      statusOptions: STATUS_OPTIONS,
+      currentStatusId: TICKET_STATUS_FILTER_OPEN,
+    });
+
+    expect(update.boardIds).toEqual([BOARD_A]);
+    expect(update.boardId).toBeUndefined();
+    expect(update.excludeBoardIds).toBeUndefined();
+    // Single-board scope is what makes the status dropdown board-scoped.
+    expect(resolveActiveBoardId(update.boardIds!)).toBe(BOARD_A);
+  });
+
+  it('clears every board dimension when the All tickets tab is clicked', () => {
+    const selection = boardTabSelection(null);
+    const update = buildBoardSelectionFilterUpdate({
+      selectedBoards: selection.selectedBoards,
+      excludedBoards: selection.excludedBoards,
+      statusOptions: STATUS_OPTIONS,
+      currentStatusId: TICKET_STATUS_FILTER_OPEN,
+    });
+
+    expect(update.boardIds).toBeUndefined();
+    expect(update.boardId).toBeUndefined();
+    expect(update.excludeBoardIds).toBeUndefined();
+  });
+
+  it('keeps a status that still exists on the newly selected board', () => {
+    const update = buildBoardSelectionFilterUpdate({
+      selectedBoards: [BOARD_A],
+      excludedBoards: [],
+      statusOptions: STATUS_OPTIONS,
+      currentStatusId: TRIAGE,
+    });
+
+    expect(update.statusId).toBe(TRIAGE);
+    expect(update.showOpenOnly).toBe(false);
+  });
+
+  it('falls back to all-open when the current status does not exist on the new board', () => {
+    const update = buildBoardSelectionFilterUpdate({
+      selectedBoards: [BOARD_B],
+      excludedBoards: [],
+      statusOptions: STATUS_OPTIONS,
+      currentStatusId: TRIAGE,
+    });
+
+    expect(update.statusId).toBe(TICKET_STATUS_FILTER_OPEN);
+    expect(update.showOpenOnly).toBe(true);
+  });
+
+  it('keeps a board-specific status when switching back to All tickets', () => {
+    // Unscoped options include every board's statuses, so nothing is dropped.
+    const update = buildBoardSelectionFilterUpdate({
+      selectedBoards: [],
+      excludedBoards: [],
+      statusOptions: STATUS_OPTIONS,
+      currentStatusId: WAITING_ON_VENDOR,
+    });
+
+    expect(update.statusId).toBe(WAITING_ON_VENDOR);
+  });
+
+  it('preserves multi-select include/exclude sets from the picker', () => {
+    const update = buildBoardSelectionFilterUpdate({
+      selectedBoards: [BOARD_A, BOARD_B],
+      excludedBoards: [BOARD_C],
+      statusOptions: STATUS_OPTIONS,
+      currentStatusId: TICKET_STATUS_FILTER_OPEN,
+    });
+
+    expect(update.boardIds).toEqual([BOARD_A, BOARD_B]);
+    expect(update.excludeBoardIds).toEqual([BOARD_C]);
+  });
+});
+
+describe('buildBoardTabs', () => {
+  const boards = [
+    board({ board_id: BOARD_B, board_name: 'Support', display_order: 2 }),
+    board({ board_id: BOARD_A, board_name: 'Escalations', display_order: 1 }),
+    board({ board_id: BOARD_C, board_name: 'Archived', is_inactive: true, display_order: 3 }),
+  ];
+
+  const buildWith = (activeBoardId: string | null, stats?: Record<string, { openTicketCount: number }> | null) =>
+    buildBoardTabs({
+      boards,
+      activeBoardId,
+      stats,
+      allTabLabel: 'All tickets',
+      unnamedBoardLabel: 'Unnamed board',
+    });
+
+  it('leads with All tickets and lists active boards in display order', () => {
+    const tabs = buildWith(null);
+    expect(tabs.map(tab => tab.label)).toEqual(['All tickets', 'Escalations', 'Support']);
+    expect(tabs[0].id).toBe(ALL_BOARDS_TAB_ID);
+    expect(tabs[0].boardId).toBeNull();
+  });
+
+  it('hides inactive boards unless one is currently selected', () => {
+    expect(buildWith(null).some(tab => tab.boardId === BOARD_C)).toBe(false);
+
+    const withArchived = buildWith(BOARD_C);
+    const archivedTab = withArchived.find(tab => tab.boardId === BOARD_C);
+    expect(archivedTab).toBeDefined();
+    expect(archivedTab!.isInactive).toBe(true);
+  });
+
+  it('renders open-ticket counts when stats are available', () => {
+    const tabs = buildWith(null, { [BOARD_A]: { openTicketCount: 7 } });
+    expect(tabs.find(tab => tab.boardId === BOARD_A)!.openTicketCount).toBe(7);
+    // A board missing from the stats map gets no pill rather than a fake zero.
+    expect(tabs.find(tab => tab.boardId === BOARD_B)!.openTicketCount).toBeNull();
+  });
+
+  it('renders tabs without counts when the stats call failed or has not landed', () => {
+    expect(buildWith(null, null).every(tab => tab.openTicketCount === null)).toBe(true);
+    // getBoardListStats returns {} on error.
+    expect(buildWith(null, {}).every(tab => tab.openTicketCount === null)).toBe(true);
+  });
+
+  it('never renders a count pill on All tickets', () => {
+    const tabs = buildWith(null, { [BOARD_A]: { openTicketCount: 7 }, [BOARD_B]: { openTicketCount: 3 } });
+    expect(tabs[0].openTicketCount).toBeNull();
+  });
+
+  it('falls back to a placeholder label for an unnamed board', () => {
+    const tabs = buildBoardTabs({
+      boards: [board({ board_id: BOARD_A })],
+      activeBoardId: null,
+      stats: null,
+      allTabLabel: 'All tickets',
+      unnamedBoardLabel: 'Unnamed board',
+    });
+    expect(tabs[1].label).toBe('Unnamed board');
+  });
+});
+
+describe('hasBoardFilterParam', () => {
+  it.each([
+    ['?boardId=x', true],
+    ['?boardIds=x,y', true],
+    ['?excludeBoardIds=x', true],
+    ['', false],
+    ['?statusId=x&page=2', false],
+    ['?boardId=', false],
+  ])('%s -> %s', (search, expected) => {
+    expect(hasBoardFilterParam(search)).toBe(expected);
+  });
+});
+
+describe('resolveInitialBoardTab (URL beats preference)', () => {
+  it('does not apply the preference when the URL names a board', () => {
+    expect(resolveInitialBoardTab({
+      urlHasBoardFilter: true,
+      storedBoardId: BOARD_A,
+      availableBoardIds: [BOARD_A, BOARD_B],
+    })).toEqual({ apply: false, reason: 'url-wins' });
+  });
+
+  it('applies the stored board on a bare URL', () => {
+    expect(resolveInitialBoardTab({
+      urlHasBoardFilter: false,
+      storedBoardId: BOARD_A,
+      availableBoardIds: [BOARD_A, BOARD_B],
+    })).toEqual({ apply: true, boardId: BOARD_A });
+  });
+
+  it.each([
+    ['a fresh user', undefined],
+    ['a null preference', null],
+    ['an explicit All tickets preference', ''],
+    ['a whitespace-only value', '   '],
+  ])('lands on All tickets for %s', (_label, storedBoardId) => {
+    expect(resolveInitialBoardTab({
+      urlHasBoardFilter: false,
+      storedBoardId: storedBoardId as string | null | undefined,
+      availableBoardIds: [BOARD_A],
+    })).toEqual({ apply: false, reason: 'no-preference' });
+  });
+
+  it('ignores a stored board that no longer exists', () => {
+    expect(resolveInitialBoardTab({
+      urlHasBoardFilter: false,
+      storedBoardId: BOARD_C,
+      availableBoardIds: [BOARD_A, BOARD_B],
+    })).toEqual({ apply: false, reason: 'board-unavailable' });
+  });
+});

--- a/packages/tickets/src/lib/boardTabs.test.ts
+++ b/packages/tickets/src/lib/boardTabs.test.ts
@@ -12,6 +12,8 @@ import {
   hasBoardFilterParam,
   resolveActiveBoardId,
   resolveInitialBoardTab,
+  hasTicketViewFilterParams,
+  shouldApplyBoardDefaultView,
 } from './boardTabs';
 import { NO_BOARD_VALUE } from './boardFilterValues';
 import {
@@ -324,5 +326,52 @@ describe('resolveInitialBoardTab (URL beats preference)', () => {
       storedBoardId: BOARD_C,
       availableBoardIds: [BOARD_A, BOARD_B],
     })).toEqual({ apply: false, reason: 'board-unavailable' });
+  });
+});
+
+describe('hasTicketViewFilterParams', () => {
+  it('ignores board scope and pagination, which are not filter opinions', () => {
+    expect(hasTicketViewFilterParams('?boardId=abc')).toBe(false);
+    expect(hasTicketViewFilterParams('?boardIds=a,b&excludeBoardIds=c')).toBe(false);
+    expect(hasTicketViewFilterParams('?page=3&pageSize=50')).toBe(false);
+    expect(hasTicketViewFilterParams('')).toBe(false);
+  });
+
+  it('detects a genuine filter opinion', () => {
+    expect(hasTicketViewFilterParams('?priorityId=high')).toBe(true);
+    expect(hasTicketViewFilterParams('?boardId=abc&statusId=open')).toBe(true);
+    expect(hasTicketViewFilterParams('?sortBy=due_date')).toBe(true);
+  });
+
+  it('treats a present-but-empty param as no opinion', () => {
+    expect(hasTicketViewFilterParams('?priorityId=')).toBe(false);
+  });
+});
+
+describe('shouldApplyBoardDefaultView', () => {
+  it('always applies on a tab click, even when the URL carries filter params', () => {
+    // THE regression this function exists for. updateURLWithFilters writes the
+    // live filter state back into the address bar, so after the first arrival
+    // the URL almost always "has an opinion" — but it is the app's own echo,
+    // not a shared link. Letting it veto a click meant the second board you
+    // visited silently wore the first board's filters, forever after.
+    expect(shouldApplyBoardDefaultView({ trigger: 'tab-click', urlHasFilterOpinion: true })).toBe(true);
+    expect(shouldApplyBoardDefaultView({ trigger: 'tab-click', urlHasFilterOpinion: false })).toBe(true);
+  });
+
+  it('lets a filter-bearing entry URL win on first paint', () => {
+    expect(shouldApplyBoardDefaultView({ trigger: 'initial', urlHasFilterOpinion: true })).toBe(false);
+  });
+
+  it('applies on first paint when the entry URL expressed no filter opinion', () => {
+    expect(shouldApplyBoardDefaultView({ trigger: 'initial', urlHasFilterOpinion: false })).toBe(true);
+  });
+
+  it('keeps a shared link authoritative for exactly one arrival', () => {
+    // A deep link with filters wins on entry...
+    expect(shouldApplyBoardDefaultView({ trigger: 'initial', urlHasFilterOpinion: true })).toBe(false);
+    // ...but the user then clicking to another board is a navigation, and that
+    // board must look like itself rather than inherit the link's filters.
+    expect(shouldApplyBoardDefaultView({ trigger: 'tab-click', urlHasFilterOpinion: true })).toBe(true);
   });
 });

--- a/packages/tickets/src/lib/boardTabs.test.ts
+++ b/packages/tickets/src/lib/boardTabs.test.ts
@@ -29,6 +29,10 @@ function board(overrides: Partial<IBoard> & { board_id: string }): IBoard {
   return {
     tenant: 'tenant-1',
     is_inactive: false,
+    // Pinned by default: these fixtures predate pinning and exercise ordering,
+    // counts and labels, so they should keep exercising exactly that. Pinning
+    // has its own cases below.
+    is_pinned: true,
     ...overrides,
   } as IBoard;
 }
@@ -198,6 +202,65 @@ describe('buildBoardTabs', () => {
   it('never renders a count pill on All tickets', () => {
     const tabs = buildWith(null, { [BOARD_A]: { openTicketCount: 7 }, [BOARD_B]: { openTicketCount: 3 } });
     expect(tabs[0].openTicketCount).toBeNull();
+  });
+
+  it('excludes boards that are not pinned', () => {
+    const tabs = buildBoardTabs({
+      boards: [
+        board({ board_id: BOARD_A, board_name: 'Escalations', display_order: 1 }),
+        board({ board_id: BOARD_B, board_name: 'Support', display_order: 2, is_pinned: false }),
+      ],
+      activeBoardId: null,
+      stats: null,
+      allTabLabel: 'All tickets',
+      unnamedBoardLabel: 'Unnamed board',
+    });
+    expect(tabs.map(tab => tab.label)).toEqual(['All tickets', 'Escalations']);
+  });
+
+  it('renders a transient tab for an unpinned board that is deep-linked to', () => {
+    // The same escape-hatch clause that keeps a selected inactive board
+    // representable: no new branch, and the tab disappears when you leave.
+    const boardsWithUnpinned = [
+      board({ board_id: BOARD_A, board_name: 'Escalations', display_order: 1 }),
+      board({ board_id: BOARD_B, board_name: 'Support', display_order: 2, is_pinned: false }),
+    ];
+    const tabs = buildBoardTabs({
+      boards: boardsWithUnpinned,
+      activeBoardId: BOARD_B,
+      stats: null,
+      allTabLabel: 'All tickets',
+      unnamedBoardLabel: 'Unnamed board',
+    });
+    expect(tabs.map(tab => tab.boardId)).toEqual([null, BOARD_A, BOARD_B]);
+  });
+
+  it('treats a board with no pinning decision as unpinned', () => {
+    const tabs = buildBoardTabs({
+      boards: [{ tenant: 'tenant-1', is_inactive: false, board_id: BOARD_A, board_name: 'Escalations' } as IBoard],
+      activeBoardId: null,
+      stats: null,
+      allTabLabel: 'All tickets',
+      unnamedBoardLabel: 'Unnamed board',
+    });
+    expect(tabs.map(tab => tab.label)).toEqual(['All tickets']);
+  });
+
+  it('renders All tickets alone when nothing is pinned, rather than hiding', () => {
+    // A legitimate state: an admin unpinned everything. The screen must not lose
+    // its navigation as a result.
+    const tabs = buildBoardTabs({
+      boards: [
+        board({ board_id: BOARD_A, board_name: 'Escalations', is_pinned: false }),
+        board({ board_id: BOARD_B, board_name: 'Support', is_pinned: false }),
+      ],
+      activeBoardId: null,
+      stats: null,
+      allTabLabel: 'All tickets',
+      unnamedBoardLabel: 'Unnamed board',
+    });
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0].id).toBe(ALL_BOARDS_TAB_ID);
   });
 
   it('falls back to a placeholder label for an unnamed board', () => {

--- a/packages/tickets/src/lib/boardTabs.ts
+++ b/packages/tickets/src/lib/boardTabs.ts
@@ -1,0 +1,184 @@
+import type { IBoard, ITicketListFilters } from '@alga-psa/types';
+import { NO_BOARD_VALUE } from './boardFilterValues';
+import {
+  buildTicketStatusFilterOptions,
+  isTicketStatusOpenFilter,
+  TICKET_STATUS_FILTER_OPEN,
+  type TicketStatusFilterOption,
+} from './ticketStatusFilter';
+
+/**
+ * Board-centric ticketing: a board is a place you go, not a filter you set.
+ *
+ * The tab strip is a second face on the *existing* board filter rather than a
+ * parallel piece of state — a board tab is exactly "the single-board filter is
+ * set to this board", which is what makes the board-scoped status dropdown
+ * (buildTicketStatusFilterOptions) light up. Everything here is pure so the
+ * tab -> filter-state mapping and the URL-vs-preference precedence rule can be
+ * tested without mounting the dashboard.
+ */
+
+/** Tab id for the "All tickets" home tab (no single-board scope). */
+export const ALL_BOARDS_TAB_ID = '__all_boards__';
+
+const BOARD_TAB_ID_PREFIX = 'board:';
+
+/** URL params that express a board selection; presence means "the URL has an opinion". */
+export const BOARD_FILTER_URL_PARAMS = ['boardId', 'boardIds', 'excludeBoardIds'] as const;
+
+/** Preference key holding the board tab the user was last on ('' = All tickets). */
+export const TICKETS_LAST_ACTIVE_BOARD_SETTING = 'tickets_last_active_board';
+
+export interface BoardTabDescriptor {
+  /** Stable tab id (ALL_BOARDS_TAB_ID or `board:<board_id>`). */
+  id: string;
+  /** Board this tab scopes to, or null for the "All tickets" tab. */
+  boardId: string | null;
+  label: string;
+  /** Open ticket count for the pill, or null when stats are unavailable. */
+  openTicketCount: number | null;
+  /** True when the board is inactive and only shown because it is selected. */
+  isInactive: boolean;
+}
+
+export function boardTabId(boardId: string | null | undefined): string {
+  return boardId ? `${BOARD_TAB_ID_PREFIX}${boardId}` : ALL_BOARDS_TAB_ID;
+}
+
+export function boardIdFromTabId(tabId: string): string | null {
+  return tabId.startsWith(BOARD_TAB_ID_PREFIX)
+    ? tabId.slice(BOARD_TAB_ID_PREFIX.length)
+    : null;
+}
+
+/**
+ * The board tab implied by a board-filter selection. Deliberately identical to
+ * the dashboard's `selectedBoard` derivation so the highlighted tab and the
+ * board-scoped status options can never disagree: a tab is active only when
+ * exactly one real board is selected.
+ */
+export function resolveActiveBoardId(selectedBoards: readonly string[]): string | null {
+  return selectedBoards.length === 1 && selectedBoards[0] !== NO_BOARD_VALUE
+    ? selectedBoards[0]
+    : null;
+}
+
+/** Board-filter selection produced by clicking a tab. */
+export function boardTabSelection(boardId: string | null): {
+  selectedBoards: string[];
+  excludedBoards: string[];
+} {
+  return boardId
+    ? { selectedBoards: [boardId], excludedBoards: [] }
+    : { selectedBoards: [], excludedBoards: [] };
+}
+
+/**
+ * The filter update for a board selection, shared by the multi-select picker
+ * and the tab strip. Status options are board-scoped, so a status that does not
+ * exist on the newly selected board falls back to "all open statuses".
+ */
+export function buildBoardSelectionFilterUpdate(params: {
+  selectedBoards: readonly string[];
+  excludedBoards: readonly string[];
+  statusOptions: TicketStatusFilterOption[];
+  currentStatusId?: string | null;
+}): Partial<ITicketListFilters> {
+  const { selectedBoards, excludedBoards, statusOptions, currentStatusId } = params;
+  const scopedBoardId = resolveActiveBoardId(selectedBoards) ?? undefined;
+  const currentStatus = currentStatusId ?? TICKET_STATUS_FILTER_OPEN;
+  const nextStatusOptions = buildTicketStatusFilterOptions(statusOptions, scopedBoardId, currentStatus);
+  const statusStillAvailable = nextStatusOptions.some(option => option.value === currentStatus);
+
+  return {
+    boardId: undefined, // clear legacy single-board field; arrays are the source of truth
+    boardIds: selectedBoards.length > 0 ? [...selectedBoards] : undefined,
+    excludeBoardIds: excludedBoards.length > 0 ? [...excludedBoards] : undefined,
+    statusId: statusStillAvailable ? currentStatus : TICKET_STATUS_FILTER_OPEN,
+    showOpenOnly: statusStillAvailable ? isTicketStatusOpenFilter(currentStatus) : true,
+  };
+}
+
+/**
+ * Tabs to render: "All tickets" plus every active board. An inactive board is
+ * included only while it is the selected one, so a deep link to an archived
+ * board is still representable in the strip.
+ */
+export function buildBoardTabs(params: {
+  boards: readonly IBoard[];
+  activeBoardId: string | null;
+  stats?: Record<string, { openTicketCount: number }> | null;
+  allTabLabel: string;
+  unnamedBoardLabel: string;
+}): BoardTabDescriptor[] {
+  const { boards, activeBoardId, stats, allTabLabel, unnamedBoardLabel } = params;
+
+  const boardTabs = boards
+    .filter(board => Boolean(board.board_id))
+    .filter(board => board.is_inactive !== true || board.board_id === activeBoardId)
+    .slice()
+    .sort((a, b) =>
+      (a.display_order || 0) - (b.display_order || 0) ||
+      (a.board_name || '').localeCompare(b.board_name || '')
+    )
+    .map((board): BoardTabDescriptor => {
+      const boardId = board.board_id as string;
+      const boardStats = stats?.[boardId];
+      return {
+        id: boardTabId(boardId),
+        boardId,
+        label: board.board_name || unnamedBoardLabel,
+        openTicketCount: boardStats ? boardStats.openTicketCount : null,
+        isInactive: board.is_inactive === true,
+      };
+    });
+
+  return [
+    {
+      id: ALL_BOARDS_TAB_ID,
+      boardId: null,
+      // No pill: summing per-board counts would silently drop boardless tickets,
+      // and a wrong number is worse than no number.
+      label: allTabLabel,
+      openTicketCount: null,
+      isInactive: false,
+    },
+    ...boardTabs,
+  ];
+}
+
+/** True when the URL already expresses a board selection. */
+export function hasBoardFilterParam(search: string): boolean {
+  const params = new URLSearchParams(search);
+  return BOARD_FILTER_URL_PARAMS.some(param => (params.get(param) ?? '').trim().length > 0);
+}
+
+export type InitialBoardTabDecision =
+  | { apply: false; reason: 'url-wins' | 'no-preference' | 'board-unavailable' }
+  | { apply: true; boardId: string };
+
+/**
+ * URL-vs-preference precedence for the first paint: a shared link always wins,
+ * so the stored last-active board only applies to a URL with no board opinion.
+ * A stored board that no longer exists is ignored rather than producing an
+ * empty list on a tab that cannot be rendered.
+ */
+export function resolveInitialBoardTab(params: {
+  urlHasBoardFilter: boolean;
+  storedBoardId: string | null | undefined;
+  availableBoardIds: readonly string[];
+}): InitialBoardTabDecision {
+  const { urlHasBoardFilter, storedBoardId, availableBoardIds } = params;
+
+  if (urlHasBoardFilter) {
+    return { apply: false, reason: 'url-wins' };
+  }
+  const boardId = (storedBoardId ?? '').trim();
+  if (!boardId) {
+    return { apply: false, reason: 'no-preference' };
+  }
+  if (!availableBoardIds.includes(boardId)) {
+    return { apply: false, reason: 'board-unavailable' };
+  }
+  return { apply: true, boardId };
+}

--- a/packages/tickets/src/lib/boardTabs.ts
+++ b/packages/tickets/src/lib/boardTabs.ts
@@ -100,9 +100,20 @@ export function buildBoardSelectionFilterUpdate(params: {
 }
 
 /**
- * Tabs to render: "All tickets" plus every active board. An inactive board is
- * included only while it is the selected one, so a deep link to an archived
- * board is still representable in the strip.
+ * Tabs to render: "All tickets" plus every pinned, active board.
+ *
+ * Two exclusions with one escape hatch. A board is excluded when it is inactive,
+ * or when it is not pinned — pinning is what stops the strip becoming a
+ * horizontally scrolling row at 25 boards, and it is the release valve for the
+ * vertical space the board header costs. The single "…or it is the active board"
+ * clause covers both cases with no extra branch: a deep link to an archived
+ * board and a deep link to a merely-unpinned board each render a transient tab
+ * that disappears when you leave. Unpinned boards therefore stay fully
+ * reachable — via All tickets and the board filter — without an overflow menu.
+ *
+ * Zero pinned boards is a legitimate state (an admin unpinned everything): the
+ * strip renders All tickets alone rather than hiding, so the screen never loses
+ * its navigation.
  */
 export function buildBoardTabs(params: {
   boards: readonly IBoard[];
@@ -115,7 +126,10 @@ export function buildBoardTabs(params: {
 
   const boardTabs = boards
     .filter(board => Boolean(board.board_id))
-    .filter(board => board.is_inactive !== true || board.board_id === activeBoardId)
+    .filter(board =>
+      (board.is_inactive !== true && board.is_pinned === true) ||
+      board.board_id === activeBoardId
+    )
     .slice()
     .sort((a, b) =>
       (a.display_order || 0) - (b.display_order || 0) ||
@@ -151,6 +165,44 @@ export function buildBoardTabs(params: {
 export function hasBoardFilterParam(search: string): boolean {
   const params = new URLSearchParams(search);
   return BOARD_FILTER_URL_PARAMS.some(param => (params.get(param) ?? '').trim().length > 0);
+}
+
+/**
+ * Non-board filter params. A shared link carrying any of these has an opinion
+ * about what the list should show, and that opinion outranks the board's stored
+ * default filters — you sent someone a link to *these tickets*, not to the
+ * board's usual view of them.
+ *
+ * Board scope is deliberately excluded: `?boardId=x` says which board, not what
+ * to show on it, so it selects the tab and then lets the board's own view apply.
+ * Pagination is excluded for the same reason.
+ */
+export const TICKET_VIEW_URL_FILTER_PARAMS = [
+  'clientId',
+  'statusId',
+  'priorityId',
+  'categoryId',
+  'categoryIds',
+  'excludeCategoryIds',
+  'searchQuery',
+  'tags',
+  'assignedToIds',
+  'assignedTeamIds',
+  'includeUnassigned',
+  'dueDateFilter',
+  'dueDateFrom',
+  'dueDateTo',
+  'responseState',
+  'slaStatusFilter',
+  'bundleView',
+  'sortBy',
+  'sortDirection',
+] as const;
+
+/** True when the URL expresses filter intent beyond which board to show. */
+export function hasTicketViewFilterParams(search: string): boolean {
+  const params = new URLSearchParams(search);
+  return TICKET_VIEW_URL_FILTER_PARAMS.some(param => (params.get(param) ?? '').trim().length > 0);
 }
 
 export type InitialBoardTabDecision =

--- a/packages/tickets/src/lib/boardTabs.ts
+++ b/packages/tickets/src/lib/boardTabs.ts
@@ -205,6 +205,41 @@ export function hasTicketViewFilterParams(search: string): boolean {
   return TICKET_VIEW_URL_FILTER_PARAMS.some(param => (params.get(param) ?? '').trim().length > 0);
 }
 
+/** How the user got to the board tab whose default view is being considered. */
+export type BoardArrivalTrigger =
+  /** The user clicked a tab (or picked a single board in the filter picker). */
+  | 'tab-click'
+  /** First paint: a deep link, or the restored last-active-board preference. */
+  | 'initial';
+
+/**
+ * Whether arriving at a board tab should apply that board's stored default view.
+ *
+ * The subtlety that makes this worth its own function: **the URL is not a
+ * reliable signal of user intent, because the app writes to it.**
+ * `updateURLWithFilters` reflects the live filter state into the address bar on
+ * every change, so a second or two after any arrival the URL "carries filter
+ * params" — but those params are the app's own echo, not a shared link. Reading
+ * `window.location.search` at click time therefore reports an opinion on almost
+ * every click after the first, which silently disables board default *filters*
+ * from then on and leaves each board wearing the previous board's filters.
+ *
+ * So the URL only gets a vote on `initial` — the one moment where its contents
+ * genuinely came from outside the app. An explicit tab click is a user
+ * navigation and always applies the destination board's view; that is the whole
+ * premise of "the board reliably looks like itself when you go there".
+ *
+ * (Back/forward needs no case here: `syncFromUrl` applies the URL's filters
+ * directly, because on a history step the URL *is* the state being restored.)
+ */
+export function shouldApplyBoardDefaultView(params: {
+  trigger: BoardArrivalTrigger;
+  /** Whether the URL the page was *entered* with carried filter params. */
+  urlHasFilterOpinion: boolean;
+}): boolean {
+  return params.trigger === 'tab-click' ? true : !params.urlHasFilterOpinion;
+}
+
 export type InitialBoardTabDecision =
   | { apply: false; reason: 'url-wins' | 'no-preference' | 'board-unavailable' }
   | { apply: true; boardId: string };

--- a/packages/tickets/src/lib/index.ts
+++ b/packages/tickets/src/lib/index.ts
@@ -13,8 +13,24 @@ export {
   TICKET_COLUMNS,
   TOGGLEABLE_TICKET_COLUMNS,
   resolveTicketColumnVisibility,
+  resolveTicketColumnOrder,
 } from './ticketColumnCatalog';
 export type { TicketColumnSpec, TicketColumnKind, TicketListColumnKey } from './ticketColumnCatalog';
+export {
+  CAPTURE_EXCLUDED_FILTER_KEYS,
+  TICKET_VIEW_DENSITY_DEFAULT,
+  TICKET_VIEW_DENSITY_STEP,
+  buildBoardArrivalFilters,
+  captureTicketViewSettings,
+  resolveTicketViewSettings,
+  ticketViewDiffersFromSaved,
+  validateCapturedFilters,
+} from './ticketViewSettings';
+export type {
+  CaptureExcludedFilterKey,
+  ResolvedTicketViewSettings,
+  TicketViewSettings,
+} from './ticketViewSettings';
 export { calculateItilPriority, ItilLabels } from './itilUtils';
 export { getCommentResponseSource, getLatestCustomerResponseSource } from './responseSource';
 export { resolveCommentAuthor } from './commentAuthorResolution';

--- a/packages/tickets/src/lib/ticket-columns.tsx
+++ b/packages/tickets/src/lib/ticket-columns.tsx
@@ -11,7 +11,12 @@ import { ChevronDown, ChevronRight } from 'lucide-react';
 import { getUserTimeZone } from '@alga-psa/core';
 import { ResponseStateBadge } from '@alga-psa/ui/components/tickets/ResponseStateBadge';
 import type { SlaTimerStatus } from '@alga-psa/types';
-import { resolveTicketColumnVisibility, type TicketListColumnKey } from './ticketColumnCatalog';
+import {
+  TICKET_COLUMNS,
+  resolveTicketColumnOrder,
+  resolveTicketColumnVisibility,
+  type TicketListColumnKey,
+} from './ticketColumnCatalog';
 import { formatTicketDateTime } from './ticketDateTimeFormat';
 import {
   statusPillHue,
@@ -115,6 +120,17 @@ type TicketListSettings = {
   tagsInlineUnderTitle?: boolean;
 };
 
+/**
+ * Kinds that are not reorderable. `fixed` (title) is the hero cell the row is
+ * built around; `folded` columns are not standalone on screen at all; `tags`
+ * renders inline under the title. Letting a stored order move any of them would
+ * mean a saved view could express an arrangement the renderer cannot produce, so
+ * they keep their existing special handling and the order applies to the rest.
+ */
+const REORDERABLE_COLUMN_KEYS: ReadonlySet<string> = new Set(
+  TICKET_COLUMNS.filter((column) => column.kind === 'optional').map((column) => column.key)
+);
+
 type TicketingDisplaySettings = {
   dateTimeFormat?: string;
   responseStateTrackingEnabled?: boolean;
@@ -148,6 +164,12 @@ interface CreateTicketColumnsOptions {
   t?: (key: string, fallback: string) => string;
   /** App locale. Without it the Created column formats in the browser's. */
   locale?: string;
+  /**
+   * On-screen order for the reorderable (optional) columns, resolved through
+   * resolveTicketColumnOrder. Absent means catalog declaration order — the
+   * behaviour before board-level view configuration existed.
+   */
+  columnOrder?: readonly string[];
 }
 
 export function createTicketColumns(options: CreateTicketColumnsOptions): ColumnDefinition<ITicketListItem>[] {
@@ -169,6 +191,7 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
     onToggleBundleExpanded,
     t: _t,
     locale = 'en',
+    columnOrder,
   } = options;
 
   const t = _t ?? ((_key: string, fallback: string) => fallback);
@@ -615,6 +638,26 @@ export function createTicketColumns(options: CreateTicketColumnsOptions): Column
         dataIndex: 'entered_by_name',
         width: '6%',
       }
+    });
+  }
+
+  // Apply the stored order to the reorderable columns only, leaving every other
+  // kind exactly where the builder put it. Sorting the whole array would let a
+  // stored order drag the title cell out of first position.
+  if (columnOrder && columnOrder.length > 0) {
+    const rank = new Map<string, number>();
+    resolveTicketColumnOrder(columnOrder).forEach((key, index) => rank.set(key, index));
+
+    const reorderableSlots = columns
+      .map((entry, index) => ({ entry, index }))
+      .filter(({ entry }) => REORDERABLE_COLUMN_KEYS.has(entry.key));
+
+    const sorted = reorderableSlots
+      .map(({ entry }) => entry)
+      .sort((a, b) => (rank.get(a.key) ?? Number.MAX_SAFE_INTEGER) - (rank.get(b.key) ?? Number.MAX_SAFE_INTEGER));
+
+    reorderableSlots.forEach(({ index }, position) => {
+      columns[index] = sorted[position];
     });
   }
 

--- a/packages/tickets/src/lib/ticketColumnCatalog.ts
+++ b/packages/tickets/src/lib/ticketColumnCatalog.ts
@@ -76,3 +76,37 @@ export function resolveTicketColumnVisibility(
   }
   return out;
 }
+
+const TICKET_COLUMN_KEYS: readonly string[] = TICKET_COLUMNS.map((c) => c.key);
+
+/**
+ * Resolve a stored (sparse, possibly stale) column order into a complete one:
+ * stored keys first in stored order, filtered to keys the catalog still knows,
+ * then every remaining catalog key in catalog order.
+ *
+ * Both halves matter. Filtering the stored half means a column deleted from
+ * TICKET_COLUMNS does not survive in a saved board view as a key nothing can
+ * render. Appending the remainder means a column *added* to TICKET_COLUMNS after
+ * a board saved its view still appears — it does not silently vanish for that
+ * board because it happened not to be in an array written before it existed.
+ * A stored order is therefore a preference about the columns it names, never an
+ * exhaustive declaration of the column set.
+ */
+export function resolveTicketColumnOrder(
+  stored?: readonly string[] | null,
+): TicketListColumnKey[] {
+  const seen = new Set<string>();
+  const ordered: TicketListColumnKey[] = [];
+
+  for (const key of stored ?? []) {
+    if (!TICKET_COLUMN_KEYS.includes(key) || seen.has(key)) continue;
+    seen.add(key);
+    ordered.push(key as TicketListColumnKey);
+  }
+  for (const col of TICKET_COLUMNS) {
+    if (seen.has(col.key)) continue;
+    seen.add(col.key);
+    ordered.push(col.key);
+  }
+  return ordered;
+}

--- a/packages/tickets/src/lib/ticketColumnOrder.test.tsx
+++ b/packages/tickets/src/lib/ticketColumnOrder.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment node
+
+import { describe, expect, it } from 'vitest';
+import { createTicketColumns } from './ticket-columns';
+import { TICKET_COLUMNS } from './ticketColumnCatalog';
+
+/**
+ * Column ordering had no authoring surface anywhere before board-level view
+ * configuration: on-screen order was the catalog's declaration order, full stop.
+ * These cases pin the two halves of the new contract — a stored order moves the
+ * columns it may move, and cannot move the ones it may not.
+ */
+
+const baseOptions = {
+  categories: [],
+  boards: [],
+  onTicketClick: () => {},
+};
+
+const keysOf = (columns: ReturnType<typeof createTicketColumns>) =>
+  columns.map((column) => String(column.dataIndex));
+
+describe('createTicketColumns column ordering', () => {
+  it('falls back to catalog declaration order when no order is stored', () => {
+    const withoutOrder = keysOf(createTicketColumns({ ...baseOptions }));
+    const withEmptyOrder = keysOf(createTicketColumns({ ...baseOptions, columnOrder: [] }));
+    expect(withEmptyOrder).toEqual(withoutOrder);
+  });
+
+  it('reorders the optional columns to match the stored order', () => {
+    const columns = keysOf(createTicketColumns({
+      ...baseOptions,
+      columnOrder: ['client', 'assigned_to', 'status', 'priority', 'board', 'due_date'],
+    }));
+
+    // client_name is `client`, assigned_to_name is `assigned_to`, etc.
+    expect(columns.indexOf('client_name')).toBeLessThan(columns.indexOf('assigned_to_name'));
+    expect(columns.indexOf('assigned_to_name')).toBeLessThan(columns.indexOf('status_name'));
+    expect(columns.indexOf('status_name')).toBeLessThan(columns.indexOf('priority_name'));
+  });
+
+  it('keeps the fixed title column first no matter what the stored order says', () => {
+    // Sorting the whole column array instead of only the reorderable slots would
+    // let a stored order drag the hero cell out of first position, producing an
+    // arrangement the row renderer cannot actually express.
+    const columns = keysOf(createTicketColumns({
+      ...baseOptions,
+      columnOrder: ['client', 'status', 'title'],
+    }));
+
+    expect(columns[0]).toBe('title');
+  });
+
+  it('does not reorder folded or tags columns', () => {
+    const nonOptional = TICKET_COLUMNS
+      .filter((column) => column.kind !== 'optional')
+      .map((column) => column.dataIndex);
+
+    const withOrder = keysOf(createTicketColumns({
+      ...baseOptions,
+      columnOrder: ['due_date', 'client', 'status'],
+    }));
+    const withoutOrder = keysOf(createTicketColumns({ ...baseOptions }));
+
+    for (const dataIndex of nonOptional) {
+      // Folded columns are not emitted on screen at all; whichever of them do
+      // appear must sit at exactly the index they sat at before.
+      expect(withOrder.indexOf(dataIndex)).toBe(withoutOrder.indexOf(dataIndex));
+    }
+  });
+
+  it('ignores stored keys the catalog no longer knows', () => {
+    const columns = keysOf(createTicketColumns({
+      ...baseOptions,
+      columnOrder: ['a_deleted_column', 'client', 'status'],
+    }));
+
+    expect(columns.indexOf('client_name')).toBeLessThan(columns.indexOf('status_name'));
+    expect(columns).not.toContain('a_deleted_column');
+  });
+
+  it('still renders a column that was added to the catalog after the order was saved', () => {
+    const columns = keysOf(createTicketColumns({
+      ...baseOptions,
+      // An order saved before `created` and `created_by` existed.
+      columnOrder: ['status', 'priority'],
+      displaySettings: { list: { columnVisibility: { created: true, created_by: true } } },
+    }));
+
+    expect(columns).toContain('entered_at');
+    expect(columns).toContain('entered_by_name');
+  });
+});

--- a/packages/tickets/src/lib/ticketFilterChange.ts
+++ b/packages/tickets/src/lib/ticketFilterChange.ts
@@ -1,0 +1,20 @@
+/**
+ * Out-of-band hints a filter change can carry to the container alongside the
+ * filter values themselves. Board tabs are route state, so a tab click needs to
+ * say "this is a navigation" — the container writes history and the last-active
+ * board preference from that, instead of trying to infer intent from the diff.
+ */
+export interface TicketFilterChangeOptions {
+  /**
+   * Push a history entry instead of replacing the current one. Ordinary filter
+   * edits replace (they are refinements of one view); moving between board tabs
+   * pushes, so browser back/forward walks the tabs.
+   */
+  pushHistory?: boolean;
+  /**
+   * Board tab this change came from: a board id, or null for "All tickets".
+   * Presence (not truthiness) is what marks the change as a tab navigation, so
+   * selecting "All tickets" persists as "all" rather than as "no opinion".
+   */
+  activeBoardTab?: string | null;
+}

--- a/packages/tickets/src/lib/ticketSlaSql.contract.test.ts
+++ b/packages/tickets/src/lib/ticketSlaSql.contract.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment node
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { ticketSlaBreachedBindings, ticketSlaBreachedSql } from './ticketSlaSql';
+
+/**
+ * The board header states a breach *count*; the slaStatusFilter states a breach
+ * *set*. A header reading 3 that opens onto a list of 2 is worse than no header,
+ * because the number is what the user trusts.
+ *
+ * The only way to guarantee they agree is for neither to own the definition, so
+ * this is a source-level contract: both sites must delegate to the shared
+ * fragment, and neither may carry an inline re-derivation of it. A behavioural
+ * test would only prove the two agreed on the day it ran.
+ */
+
+const SRC = join(__dirname, '..');
+const read = (relativePath: string) => readFileSync(join(SRC, relativePath), 'utf8');
+
+describe('shared breached-SLA predicate', () => {
+  it('names every column the breach definition depends on, and no others', () => {
+    const sql = ticketSlaBreachedSql('t');
+
+    expect(sql).toContain('t.sla_policy_id IS NOT NULL');
+    expect(sql).toContain('t.sla_response_due_at');
+    expect(sql).toContain('t.sla_response_at IS NULL');
+    expect(sql).toContain('t.sla_resolution_due_at');
+    expect(sql).toContain('t.sla_resolution_at IS NULL');
+    expect(sql).toContain('t.sla_response_met = false');
+    expect(sql).toContain('t.sla_resolution_met = false');
+  });
+
+  it('keeps its bindings in step with its placeholders', () => {
+    // Drift here is silent and produces a wrong count rather than an error, so
+    // the two are asserted against each other rather than trusted.
+    const placeholders = (ticketSlaBreachedSql('t').match(/\?/g) ?? []).length;
+    expect(ticketSlaBreachedBindings('2026-08-19T00:00:00Z')).toHaveLength(placeholders);
+  });
+
+  it('honours the table alias it is given', () => {
+    expect(ticketSlaBreachedSql('tk')).toContain('tk.sla_policy_id IS NOT NULL');
+    expect(ticketSlaBreachedSql('tk')).not.toContain('t.sla_policy_id');
+  });
+
+  it('is the predicate the breached filter applies', () => {
+    const source = read('actions/optimizedTicketActions.ts');
+    const breachedBranch = source.slice(
+      source.indexOf("case 'breached':"),
+      source.indexOf("case 'paused':"),
+    );
+
+    expect(breachedBranch).toContain('ticketSlaBreachedSql');
+    expect(breachedBranch).toContain('ticketSlaBreachedBindings');
+    // No inline re-derivation left behind alongside the delegation.
+    expect(breachedBranch).not.toContain('sla_response_due_at');
+    expect(breachedBranch).not.toContain('sla_resolution_met');
+  });
+
+  it('is the predicate the board header count aggregates', () => {
+    const source = read('actions/board-actions/boardActions.ts');
+    const statsBlock = source.slice(
+      source.indexOf('export const getBoardListStats'),
+      source.indexOf('export const createBoard'),
+    );
+
+    expect(statsBlock).toContain('ticketSlaBreachedSql');
+    expect(statsBlock).toContain('ticketSlaBreachedBindings');
+    expect(statsBlock).toContain('sla_breached');
+    expect(statsBlock).not.toContain('sla_response_due_at');
+  });
+});

--- a/packages/tickets/src/lib/ticketSlaSql.ts
+++ b/packages/tickets/src/lib/ticketSlaSql.ts
@@ -1,0 +1,42 @@
+/**
+ * One definition of "SLA breached", shared by the filter and the count.
+ *
+ * The board header states a breach count; the `slaStatusFilter: 'breached'`
+ * filter states a breach *set*. If those two derive the predicate separately,
+ * they will eventually disagree — a header reading 3 that opens onto a list of
+ * 2 is worse than no header, because the number is what the user trusts. So the
+ * predicate is written once, here, and both call sites reference it.
+ *
+ * The definition itself (unchanged from what optimizedTicketActions applied
+ * before this extraction): a ticket with an SLA policy is breached when either
+ * clock ran out without being stopped, or when either met-flag was explicitly
+ * recorded as false.
+ *
+ * Plain data (no "use server"), so the server action and the aggregate query can
+ * both import it.
+ */
+
+/** Column prefix, e.g. `t` for `tickets as t`. */
+export type TicketAlias = string;
+
+/**
+ * SQL boolean expression, with `?` bind placeholders for the current instant.
+ * Use with {@link ticketSlaBreachedBindings} so the placeholder count can never
+ * drift from the caller's bind array.
+ */
+export function ticketSlaBreachedSql(alias: TicketAlias = 't'): string {
+  return `(
+    ${alias}.sla_policy_id IS NOT NULL
+    AND (
+      (${alias}.sla_response_due_at < ? AND ${alias}.sla_response_at IS NULL)
+      OR (${alias}.sla_resolution_due_at < ? AND ${alias}.sla_resolution_at IS NULL)
+      OR ${alias}.sla_response_met = false
+      OR ${alias}.sla_resolution_met = false
+    )
+  )`;
+}
+
+/** Bindings for {@link ticketSlaBreachedSql}, in placeholder order. */
+export function ticketSlaBreachedBindings(nowIso: string): string[] {
+  return [nowIso, nowIso];
+}

--- a/packages/tickets/src/lib/ticketViewSettings.test.ts
+++ b/packages/tickets/src/lib/ticketViewSettings.test.ts
@@ -1,0 +1,360 @@
+// @vitest-environment node
+
+import { describe, expect, it } from 'vitest';
+import type { ITicketListFilters } from '@alga-psa/types';
+import {
+  buildBoardArrivalFilters,
+  CAPTURE_EXCLUDED_FILTER_KEYS,
+  captureTicketViewSettings,
+  resolveTicketViewSettings,
+  ticketViewDiffersFromSaved,
+  validateCapturedFilters,
+  TICKET_VIEW_DENSITY_DEFAULT,
+  type TicketViewSettings,
+} from './ticketViewSettings';
+import { resolveTicketColumnOrder, TICKET_COLUMNS } from './ticketColumnCatalog';
+
+const CATALOG_KEYS = TICKET_COLUMNS.map((column) => column.key);
+
+describe('resolveTicketViewSettings', () => {
+  it('prefers the board layer over the tenant layer over the catalog', () => {
+    const resolved = resolveTicketViewSettings({
+      board: { densityLevel: 20 },
+      tenant: { densityLevel: 80, tagsInlineUnderTitle: false },
+    });
+
+    expect(resolved.densityLevel).toBe(20);        // board
+    expect(resolved.tagsInlineUnderTitle).toBe(false); // tenant, board silent
+    // catalog: no layer expressed visibility, so defaults apply per key
+    expect(resolved.columnVisibility.status).toBe(true);
+    expect(resolved.columnVisibility.created_by).toBe(false);
+  });
+
+  it('falls through cleanly when the board has no stored document at all', () => {
+    // NULL list_view_settings is the reset state, and it must behave exactly as
+    // if the board had never been configured — not as an empty override.
+    const tenant: TicketViewSettings = { densityLevel: 30, columnVisibility: { created_by: true } };
+
+    const withNull = resolveTicketViewSettings({ board: null, tenant });
+    const withUndefined = resolveTicketViewSettings({ board: undefined, tenant });
+
+    expect(withNull).toEqual(withUndefined);
+    expect(withNull.densityLevel).toBe(30);
+    expect(withNull.columnVisibility.created_by).toBe(true);
+  });
+
+  it('replaces a group wholesale rather than deep-merging it', () => {
+    // The board hides `status` and says nothing about `created_by`. Because
+    // capture always writes a complete map, the board's map is the whole answer:
+    // the tenant's created_by:true must NOT leak through per-key.
+    const resolved = resolveTicketViewSettings({
+      board: { columnVisibility: { status: false } },
+      tenant: { columnVisibility: { created_by: true, status: true } },
+    });
+
+    expect(resolved.columnVisibility.status).toBe(false);
+    expect(resolved.columnVisibility.created_by).toBe(false); // catalog default, not tenant's true
+  });
+
+  it('replaces the filter group wholesale too', () => {
+    const resolved = resolveTicketViewSettings({
+      board: { filters: { priorityId: 'high' } },
+      tenant: { filters: { clientId: 'client-1', priorityId: 'low' } },
+    });
+
+    expect(resolved.filters).toEqual({ priorityId: 'high' });
+  });
+
+  it('defaults density to 50 and snaps a stored value to the slider step', () => {
+    expect(resolveTicketViewSettings({}).densityLevel).toBe(TICKET_VIEW_DENSITY_DEFAULT);
+    expect(resolveTicketViewSettings({ board: { densityLevel: 34 } }).densityLevel).toBe(30);
+    expect(resolveTicketViewSettings({ board: { densityLevel: 999 } }).densityLevel).toBe(100);
+  });
+});
+
+describe('resolveTicketColumnOrder', () => {
+  it('honours the stored order for the keys it names', () => {
+    const order = resolveTicketColumnOrder(['client', 'status']);
+    expect(order.slice(0, 2)).toEqual(['client', 'status']);
+  });
+
+  it('drops stored keys the catalog no longer knows', () => {
+    const order = resolveTicketColumnOrder(['client', 'a_column_that_was_deleted', 'status']);
+    expect(order).not.toContain('a_column_that_was_deleted');
+    expect(order.slice(0, 2)).toEqual(['client', 'status']);
+  });
+
+  it('still surfaces a catalog key that was added after the view was saved', () => {
+    // The whole point: a board's saved order is a preference about the columns
+    // it names, never an exhaustive declaration of the column set. A column
+    // added later must appear rather than silently vanish for that board.
+    const savedBeforeCreatedByExisted = ['title', 'status'];
+    const order = resolveTicketColumnOrder(savedBeforeCreatedByExisted);
+
+    expect(order).toContain('created_by');
+    expect(new Set(order)).toEqual(new Set(CATALOG_KEYS));
+  });
+
+  it('appends the unnamed remainder in catalog order', () => {
+    const order = resolveTicketColumnOrder(['due_date']);
+    const remainder = order.slice(1);
+    const expectedRemainder = CATALOG_KEYS.filter((key) => key !== 'due_date');
+    expect(remainder).toEqual(expectedRemainder);
+  });
+
+  it('returns the full catalog order for an absent or empty stored order', () => {
+    expect(resolveTicketColumnOrder()).toEqual(CATALOG_KEYS);
+    expect(resolveTicketColumnOrder([])).toEqual(CATALOG_KEYS);
+    expect(resolveTicketColumnOrder(null)).toEqual(CATALOG_KEYS);
+  });
+
+  it('de-duplicates a stored order that names a key twice', () => {
+    const order = resolveTicketColumnOrder(['status', 'status', 'client']);
+    expect(order.slice(0, 2)).toEqual(['status', 'client']);
+    expect(order).toHaveLength(CATALOG_KEYS.length);
+  });
+});
+
+describe('captureTicketViewSettings', () => {
+  const liveFilters: Partial<ITicketListFilters> = {
+    // Excluded — board scope is the tab, and search is transient.
+    boardId: 'legacy-board',
+    boardIds: ['board-1'],
+    excludeBoardIds: ['board-2'],
+    boardFilterState: 'all',
+    searchQuery: 'printer on fire',
+    // Included.
+    statusId: 'status-1',
+    priorityId: 'priority-1',
+    categoryIds: ['category-1'],
+    clientId: 'client-1',
+    tags: ['urgent'],
+    assignedToIds: ['user-1'],
+    assignedTeamIds: ['team-1'],
+    includeUnassigned: true,
+    assignedToMe: true,
+    dueDateFilter: 'overdue',
+    responseState: 'awaiting_client',
+    slaStatusFilter: 'breached',
+    showOpenOnly: true,
+    bundleView: 'individual',
+    sortBy: 'due_date',
+    sortDirection: 'asc',
+  };
+
+  it('strips every excluded key and nothing else', () => {
+    const captured = captureTicketViewSettings({ filters: liveFilters });
+
+    for (const key of CAPTURE_EXCLUDED_FILTER_KEYS) {
+      expect(captured.filters).not.toHaveProperty(key);
+    }
+
+    const expectedKeys = Object.keys(liveFilters)
+      .filter((key) => !(CAPTURE_EXCLUDED_FILTER_KEYS as readonly string[]).includes(key))
+      .sort();
+    expect(Object.keys(captured.filters ?? {}).sort()).toEqual(expectedKeys);
+  });
+
+  it('captures sort as part of the filters rather than as a second representation', () => {
+    const captured = captureTicketViewSettings({ filters: liveFilters });
+    expect(captured.filters?.sortBy).toBe('due_date');
+    expect(captured.filters?.sortDirection).toBe('asc');
+  });
+
+  it('round-trips every included value unchanged', () => {
+    const captured = captureTicketViewSettings({ filters: liveFilters });
+    for (const [key, value] of Object.entries(captured.filters ?? {})) {
+      expect(value).toEqual(liveFilters[key as keyof ITicketListFilters]);
+    }
+  });
+
+  it('survives a full round trip back through the resolver', () => {
+    const captured = captureTicketViewSettings({
+      filters: liveFilters,
+      columnVisibility: { created_by: true },
+      columnOrder: ['client', 'status'],
+      densityLevel: 30,
+    });
+    const resolved = resolveTicketViewSettings({ board: captured, tenant: null });
+
+    expect(resolved.densityLevel).toBe(30);
+    expect(resolved.columnVisibility.created_by).toBe(true);
+    expect(resolved.columnOrder.slice(0, 2)).toEqual(['client', 'status']);
+    expect(resolved.filters.priorityId).toBe('priority-1');
+  });
+
+  it('omits a boolean filter that is off, because off is not a constraint', () => {
+    // Storing includeUnassigned:false would record "do not include unassigned"
+    // as a positive choice, which is both wrong and enough to make an
+    // unconfigured board compare as different from its own defaults.
+    const captured = captureTicketViewSettings({
+      filters: { statusId: 'status-1', includeUnassigned: false, assignedToMe: false },
+    });
+    expect(captured.filters).toEqual({ statusId: 'status-1' });
+
+    // ...but the same flags survive when they are on.
+    const on = captureTicketViewSettings({
+      filters: { includeUnassigned: true, assignedToMe: true },
+    });
+    expect(on.filters).toEqual({ includeUnassigned: true, assignedToMe: true });
+  });
+
+  it('keeps showOpenOnly:false, where false is a real constraint', () => {
+    const captured = captureTicketViewSettings({ filters: { showOpenOnly: false } });
+    expect(captured.filters).toEqual({ showOpenOnly: false });
+  });
+
+  it('omits empty and absent values so a saved view stays readable', () => {
+    const captured = captureTicketViewSettings({
+      filters: { statusId: 'status-1', tags: [], assignedToIds: undefined },
+    });
+    expect(captured.filters).toEqual({ statusId: 'status-1' });
+  });
+});
+
+describe('validateCapturedFilters (validate-on-read)', () => {
+  it('drops a statusId that no longer exists', () => {
+    // The board's saved view names a status that has since been deleted.
+    // Applying it verbatim would produce an empty list on a board that has
+    // tickets — which reads as a bug rather than as stale configuration.
+    const validated = validateCapturedFilters(
+      { statusId: 'deleted-status', priorityId: 'priority-1' },
+      { statusIds: ['status-1', 'status-2'], priorityIds: ['priority-1'] },
+    );
+
+    expect(validated).not.toHaveProperty('statusId');
+    expect(validated.priorityId).toBe('priority-1');
+  });
+
+  it('does not produce an empty list — the dead key is absent, not falsy', () => {
+    const validated = validateCapturedFilters({ statusId: 'gone' }, { statusIds: ['live'] });
+    expect(Object.prototype.hasOwnProperty.call(validated, 'statusId')).toBe(false);
+  });
+
+  it('keeps sentinel pseudo-filters that are not ids', () => {
+    const validated = validateCapturedFilters(
+      { statusId: 'open', priorityId: 'all' },
+      { statusIds: ['status-1'], priorityIds: ['priority-1'] },
+      ['open', 'all'],
+    );
+    expect(validated.statusId).toBe('open');
+    expect(validated.priorityId).toBe('all');
+  });
+
+  it('drops only the dead members of a list, keeping the live ones', () => {
+    const validated = validateCapturedFilters(
+      { assignedToIds: ['user-1', 'user-gone', 'user-2'] },
+      { userIds: ['user-1', 'user-2'] },
+    );
+    expect(validated.assignedToIds).toEqual(['user-1', 'user-2']);
+  });
+
+  it('drops a list entirely when nothing in it survives', () => {
+    const validated = validateCapturedFilters(
+      { assignedToIds: ['user-gone'] },
+      { userIds: ['user-1'] },
+    );
+    expect(validated).not.toHaveProperty('assignedToIds');
+  });
+
+  it('leaves a value alone when its universe is unknown', () => {
+    // "Cannot validate" must never mean "drop" — an unloaded option list would
+    // otherwise silently erase a perfectly good saved filter.
+    const validated = validateCapturedFilters({ clientId: 'client-1' }, {});
+    expect(validated.clientId).toBe('client-1');
+  });
+
+  it('leaves non-id filters untouched', () => {
+    const validated = validateCapturedFilters(
+      { slaStatusFilter: 'breached', dueDateFilter: 'overdue', showOpenOnly: true },
+      { statusIds: [] },
+    );
+    expect(validated.slaStatusFilter).toBe('breached');
+    expect(validated.dueDateFilter).toBe('overdue');
+    expect(validated.showOpenOnly).toBe(true);
+  });
+});
+
+describe('buildBoardArrivalFilters', () => {
+  const baseline: Partial<ITicketListFilters> = {
+    statusId: 'open',
+    priorityId: 'all',
+    boardFilterState: 'active',
+    showOpenOnly: true,
+  };
+  const boardSelection: Partial<ITicketListFilters> = {
+    boardId: undefined,
+    boardIds: ['board-1'],
+    statusId: 'open',
+    showOpenOnly: true,
+  };
+
+  it('replaces the previous board’s filters rather than refining them', () => {
+    // Arriving from a board whose view set priorityId=high must not leave that
+    // behind on a board that says nothing about priority.
+    const arrival = buildBoardArrivalFilters({
+      baseline,
+      boardSelection,
+      viewFilters: { statusId: 'status-triage' },
+    });
+
+    expect(arrival.priorityId).toBe('all');
+    expect(arrival.statusId).toBe('status-triage');
+  });
+
+  it('lets board scope come only from the selection, never from the stored view', () => {
+    // Belt to capture's braces: even a hand-written document must not be able to
+    // make a board's default view navigate to a different board.
+    const arrival = buildBoardArrivalFilters({
+      baseline,
+      boardSelection,
+      viewFilters: {
+        boardIds: ['some-other-board'],
+        excludeBoardIds: ['board-1'],
+        searchQuery: 'sticky',
+      } as Partial<ITicketListFilters>,
+    });
+
+    expect(arrival.boardIds).toEqual(['board-1']);
+    expect(arrival.excludeBoardIds).toBeUndefined();
+    expect(arrival.searchQuery).toBeUndefined();
+  });
+
+  it('lets the stored view outrank the generic status reconciliation', () => {
+    const arrival = buildBoardArrivalFilters({
+      baseline,
+      boardSelection,
+      viewFilters: { statusId: 'status-waiting', sortBy: 'due_date', sortDirection: 'asc' },
+    });
+
+    expect(arrival.statusId).toBe('status-waiting');
+    expect(arrival.sortBy).toBe('due_date');
+    expect(arrival.sortDirection).toBe('asc');
+  });
+});
+
+describe('ticketViewDiffersFromSaved', () => {
+  it('is false when the live view matches what is stored', () => {
+    const saved: TicketViewSettings = { densityLevel: 30, filters: { priorityId: 'high' } };
+    expect(ticketViewDiffersFromSaved({ ...saved }, saved)).toBe(false);
+  });
+
+  it('ignores excluded keys, so a search or a board scope never looks dirty', () => {
+    const saved: TicketViewSettings = { filters: { priorityId: 'high' } };
+    const live: TicketViewSettings = {
+      filters: { priorityId: 'high', searchQuery: 'typing', boardIds: ['board-1'] },
+    };
+    expect(ticketViewDiffersFromSaved(live, saved)).toBe(false);
+  });
+
+  it('is true when a stored board view exists and the live view diverges', () => {
+    expect(ticketViewDiffersFromSaved(
+      { densityLevel: 30 },
+      { densityLevel: 50 },
+    )).toBe(true);
+  });
+
+  it('is true against a null saved view once the user has arranged anything', () => {
+    expect(ticketViewDiffersFromSaved({ densityLevel: 30 }, null)).toBe(true);
+  });
+});

--- a/packages/tickets/src/lib/ticketViewSettings.test.ts
+++ b/packages/tickets/src/lib/ticketViewSettings.test.ts
@@ -7,6 +7,7 @@ import {
   CAPTURE_EXCLUDED_FILTER_KEYS,
   captureTicketViewSettings,
   resolveTicketViewSettings,
+  sanitizeStoredTicketView,
   ticketViewDiffersFromSaved,
   validateCapturedFilters,
   TICKET_VIEW_DENSITY_DEFAULT,
@@ -320,6 +321,21 @@ describe('buildBoardArrivalFilters', () => {
     expect(arrival.searchQuery).toBeUndefined();
   });
 
+  it('resets to neutral for a board that stores no filters at all', () => {
+    // An unconfigured board still has a view — the neutral one. Arriving at it
+    // must produce that rather than whatever the previous board left behind,
+    // which is what an "if there are no stored filters, skip" shortcut would do.
+    const arrival = buildBoardArrivalFilters({
+      baseline,
+      boardSelection,
+      viewFilters: {},
+    });
+
+    expect(arrival.priorityId).toBe('all');
+    expect(arrival.statusId).toBe('open');
+    expect(arrival.boardIds).toEqual(['board-1']);
+  });
+
   it('lets the stored view outrank the generic status reconciliation', () => {
     const arrival = buildBoardArrivalFilters({
       baseline,
@@ -356,5 +372,77 @@ describe('ticketViewDiffersFromSaved', () => {
 
   it('is true against a null saved view once the user has arranged anything', () => {
     expect(ticketViewDiffersFromSaved({ densityLevel: 30 }, null)).toBe(true);
+  });
+});
+
+describe('sanitizeStoredTicketView (read-side leniency)', () => {
+  it('keeps a good document intact', () => {
+    const doc = {
+      columnVisibility: { status: false, client: true },
+      columnOrder: ['client', 'status'],
+      tagsInlineUnderTitle: false,
+      densityLevel: 30,
+      filters: { priorityId: 'p1', tags: ['urgent'], showOpenOnly: true },
+    };
+    const clean = sanitizeStoredTicketView(doc)!;
+    expect(clean.columnVisibility).toMatchObject({ status: false, client: true });
+    expect(clean.columnOrder?.slice(0, 2)).toEqual(['client', 'status']);
+    expect(clean.densityLevel).toBe(30);
+    expect(clean.filters).toEqual({ priorityId: 'p1', tags: ['urgent'], showOpenOnly: true });
+  });
+
+  it('DROPS a retired column key rather than discarding the whole view', () => {
+    // The point of read-side leniency. A Zod record over the catalog enum would
+    // *error* on `a_retired_column`, throwing away an otherwise good saved view
+    // over one stale key — and quietly undoing the tolerance
+    // resolveTicketColumnOrder was written to provide.
+    const clean = sanitizeStoredTicketView({
+      columnVisibility: { status: false, a_retired_column: true },
+      columnOrder: ['a_retired_column', 'client'],
+      densityLevel: 30,
+    })!;
+
+    expect(clean).not.toBeNull();
+    expect(clean.columnVisibility).not.toHaveProperty('a_retired_column');
+    expect(clean.columnVisibility?.status).toBe(false);
+    expect(clean.columnOrder).not.toContain('a_retired_column');
+    expect(clean.densityLevel).toBe(30);
+  });
+
+  it('drops board scope even if a hand-written document smuggled it in', () => {
+    const clean = sanitizeStoredTicketView({
+      filters: { boardIds: ['other'], excludeBoardIds: ['x'], searchQuery: 'sticky', priorityId: 'p1' },
+    })!;
+    expect(clean.filters).toEqual({ priorityId: 'p1' });
+  });
+
+  it('drops filter values that are not scalars or string lists', () => {
+    const clean = sanitizeStoredTicketView({
+      filters: { priorityId: 'p1', junk: { nested: true }, alsoJunk: [{ a: 1 }] },
+    })!;
+    expect(clean.filters).toEqual({ priorityId: 'p1' });
+  });
+
+  it('returns null for anything that is not a document', () => {
+    expect(sanitizeStoredTicketView(null)).toBeNull();
+    expect(sanitizeStoredTicketView(undefined)).toBeNull();
+    expect(sanitizeStoredTicketView('not json')).toBeNull();
+    expect(sanitizeStoredTicketView([1, 2])).toBeNull();
+    expect(sanitizeStoredTicketView(42)).toBeNull();
+  });
+
+  it('parses a JSON string, since some drivers hand back jsonb as text', () => {
+    const clean = sanitizeStoredTicketView(JSON.stringify({ densityLevel: 20 }))!;
+    expect(clean.densityLevel).toBe(20);
+  });
+
+  it('survives into the resolver rather than collapsing to defaults', () => {
+    const clean = sanitizeStoredTicketView({
+      columnVisibility: { created_by: true, a_retired_column: false },
+      densityLevel: 20,
+    });
+    const resolved = resolveTicketViewSettings({ board: clean, tenant: null });
+    expect(resolved.densityLevel).toBe(20);
+    expect(resolved.columnVisibility.created_by).toBe(true);
   });
 });

--- a/packages/tickets/src/lib/ticketViewSettings.ts
+++ b/packages/tickets/src/lib/ticketViewSettings.ts
@@ -1,5 +1,6 @@
 import type { ITicketListFilters } from '@alga-psa/types';
 import {
+  TICKET_COLUMNS,
   resolveTicketColumnOrder,
   resolveTicketColumnVisibility,
   type TicketListColumnKey,
@@ -173,6 +174,85 @@ export function captureTicketViewSettings(view: {
     captured.densityLevel = density;
   }
   return captured;
+}
+
+/**
+ * Coerce a document as it comes off the row into something safe to resolve.
+ *
+ * This is the read-side counterpart to the strict write schema, and it is
+ * deliberately **key-dropping rather than rejecting**. A stored view can be
+ * older or newer than the code reading it — a retired column key in
+ * `columnVisibility`, a filter key from a later release — and none of that is
+ * the document's fault. Validating it all-or-nothing would throw away an
+ * otherwise perfectly good saved view over one stale key, which is exactly the
+ * tolerance `resolveTicketColumnOrder` was written to provide and would quietly
+ * undo it.
+ *
+ * Deliberately hand-rolled rather than a Zod schema: this runs in the browser on
+ * the ticket-list render path, and `z.record(z.enum([...]))` *errors* on an
+ * unknown key rather than dropping it — the opposite of what is wanted here.
+ *
+ * Strictness still exists, just at the right end: writes go through
+ * `parseTicketViewSettings`, where there is a user to tell.
+ */
+export function sanitizeStoredTicketView(raw: unknown): TicketViewSettings | null {
+  const source = typeof raw === 'string' ? safeJsonParse(raw) : raw;
+  if (!source || typeof source !== 'object' || Array.isArray(source)) {
+    return null;
+  }
+  const doc = source as Record<string, unknown>;
+  const out: TicketViewSettings = {};
+
+  if (doc.columnVisibility && typeof doc.columnVisibility === 'object') {
+    const stored = doc.columnVisibility as Record<string, unknown>;
+    const visibility: Partial<Record<TicketListColumnKey, boolean>> = {};
+    for (const column of TICKET_COLUMNS) {
+      const value = stored[column.key];
+      if (typeof value === 'boolean') {
+        visibility[column.key] = value;
+      }
+    }
+    if (Object.keys(visibility).length > 0) {
+      out.columnVisibility = visibility;
+    }
+  }
+
+  if (Array.isArray(doc.columnOrder)) {
+    // resolveTicketColumnOrder already drops keys the catalog no longer knows.
+    out.columnOrder = resolveTicketColumnOrder(doc.columnOrder.filter((k): k is string => typeof k === 'string'));
+  }
+
+  if (typeof doc.tagsInlineUnderTitle === 'boolean') {
+    out.tagsInlineUnderTitle = doc.tagsInlineUnderTitle;
+  }
+
+  if (typeof doc.densityLevel === 'number' && Number.isFinite(doc.densityLevel)) {
+    out.densityLevel = doc.densityLevel;
+  }
+
+  if (doc.filters && typeof doc.filters === 'object' && !Array.isArray(doc.filters)) {
+    const storedFilters = doc.filters as Record<string, unknown>;
+    const filters: Partial<ITicketListFilters> = {};
+    for (const [key, value] of Object.entries(storedFilters)) {
+      // Board scope can never come from a stored document, however it got there.
+      if (EXCLUDED_KEY_SET.has(key)) continue;
+      const isScalar = typeof value === 'string' || typeof value === 'boolean' || typeof value === 'number';
+      const isStringList = Array.isArray(value) && value.every((item) => typeof item === 'string');
+      if (!isScalar && !isStringList) continue;
+      (filters as Record<string, unknown>)[key] = value;
+    }
+    out.filters = filters;
+  }
+
+  return out;
+}
+
+function safeJsonParse(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/packages/tickets/src/lib/ticketViewSettings.ts
+++ b/packages/tickets/src/lib/ticketViewSettings.ts
@@ -1,0 +1,301 @@
+import type { ITicketListFilters } from '@alga-psa/types';
+import {
+  resolveTicketColumnOrder,
+  resolveTicketColumnVisibility,
+  type TicketListColumnKey,
+} from './ticketColumnCatalog';
+
+/**
+ * The missing resolution layer under board-level view configuration.
+ *
+ * A board's view is a *document*, not a bag of columns, and the same document
+ * already exists one layer up at `tenant_settings.ticket_display_settings.list`.
+ * This module is the single place the three layers are stacked:
+ *
+ *     boards.list_view_settings  →  tenant ticket_display_settings.list  →  TICKET_COLUMNS catalog
+ *
+ * Every surface resolves through here — the dashboard, the board settings
+ * preview, the tenant display-settings screen — so a board's view and the
+ * tenant's view can never be computed two different ways. The client-portal and
+ * MSP client/contact ticket surfaces get tenant-only resolution by simply not
+ * passing a `board`, which is the layering expressing scope rather than a
+ * branch at each call site.
+ *
+ * Plain data: no JSX, not "use server", so it is importable from components,
+ * server actions and the column builder alike (matching ticketColumnCatalog.ts).
+ */
+
+/** Density slider default when neither board nor tenant expresses one. */
+export const TICKET_VIEW_DENSITY_DEFAULT = 50;
+/** Density slider step; a stored value is snapped to it on resolve. */
+export const TICKET_VIEW_DENSITY_STEP = 10;
+
+export interface TicketViewSettings {
+  columnVisibility?: Partial<Record<TicketListColumnKey, boolean>>;
+  /** Sparse: unlisted catalog keys keep catalog order and are appended. */
+  columnOrder?: TicketListColumnKey[];
+  tagsInlineUnderTitle?: boolean;
+  /** 0..100, step 10 — matches the existing density slider. */
+  densityLevel?: number;
+  /** Captured list filters; CAPTURE_EXCLUDED_FILTER_KEYS are stripped before persist. */
+  filters?: Partial<ITicketListFilters>;
+}
+
+/** A view with every layer applied — nothing optional left to decide. */
+export interface ResolvedTicketViewSettings {
+  columnVisibility: Record<TicketListColumnKey, boolean>;
+  columnOrder: TicketListColumnKey[];
+  tagsInlineUnderTitle: boolean;
+  densityLevel: number;
+  filters: Partial<ITicketListFilters>;
+}
+
+/**
+ * Filter keys never captured into a saved view.
+ *
+ * A single exported constant so capture and every test of capture read the same
+ * list — the alternative is an inline literal that drifts the first time a key
+ * is added.
+ *
+ * - board scope (`boardId`/`boardIds`/`excludeBoardIds`/`boardFilterState`) *is*
+ *   the tab. Capturing it would let a board's default view scope that board to a
+ *   different board — a saved view that navigates you away from itself.
+ * - `searchQuery` is transient. A stray search string must not become permanent
+ *   for every user of the board.
+ */
+export const CAPTURE_EXCLUDED_FILTER_KEYS = [
+  'boardId',
+  'boardIds',
+  'excludeBoardIds',
+  'boardFilterState',
+  'searchQuery',
+] as const satisfies readonly (keyof ITicketListFilters)[];
+
+export type CaptureExcludedFilterKey = (typeof CAPTURE_EXCLUDED_FILTER_KEYS)[number];
+
+const EXCLUDED_KEY_SET: ReadonlySet<string> = new Set(CAPTURE_EXCLUDED_FILTER_KEYS);
+
+/**
+ * Boolean filters whose `false` is the *absence* of a constraint rather than a
+ * constraint of its own. Capturing them as `false` would store "do not include
+ * unassigned" as a positive assertion — indistinguishable in the document from
+ * a deliberate choice, and enough on its own to make a board that has been
+ * configured with nothing at all compare as different from its own defaults.
+ *
+ * `showOpenOnly` is deliberately NOT in this list: it is derived from statusId
+ * and `false` there genuinely means "show closed too".
+ */
+const NO_OP_WHEN_FALSE: ReadonlySet<string> = new Set(['includeUnassigned', 'assignedToMe']);
+
+function normalizeDensityLevel(value: number | undefined): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return undefined;
+  }
+  const clamped = Math.min(100, Math.max(0, value));
+  return Math.round(clamped / TICKET_VIEW_DENSITY_STEP) * TICKET_VIEW_DENSITY_STEP;
+}
+
+/**
+ * Layer the board document over the tenant document over the catalog.
+ *
+ * Merging is **group-level, not per-key**: if the board defines
+ * `columnVisibility` at all, it replaces the tenant's map entirely rather than
+ * deep-merging into it. Capture always writes a complete map, so a per-key merge
+ * would buy no expressiveness and would make "the board hides Client" ambiguous
+ * with "the board has not decided about Client". `filters` follows the same rule
+ * — a board that defines filters owns the whole filter set.
+ *
+ * A board with `list_view_settings = NULL` (or an absent group inside it) falls
+ * through cleanly to the tenant layer, which is what makes "reset to tenant
+ * default" a single NULL write rather than a copy of the tenant document.
+ */
+export function resolveTicketViewSettings(params: {
+  board?: TicketViewSettings | null;
+  tenant?: TicketViewSettings | null;
+}): ResolvedTicketViewSettings {
+  const { board, tenant } = params;
+
+  const pick = <K extends keyof TicketViewSettings>(key: K): TicketViewSettings[K] | undefined => {
+    const fromBoard = board?.[key];
+    if (fromBoard !== undefined && fromBoard !== null) {
+      return fromBoard;
+    }
+    const fromTenant = tenant?.[key];
+    return fromTenant !== undefined && fromTenant !== null ? fromTenant : undefined;
+  };
+
+  return {
+    columnVisibility: resolveTicketColumnVisibility(pick('columnVisibility')),
+    columnOrder: resolveTicketColumnOrder(pick('columnOrder')),
+    tagsInlineUnderTitle: pick('tagsInlineUnderTitle') ?? true,
+    densityLevel: normalizeDensityLevel(pick('densityLevel')) ?? TICKET_VIEW_DENSITY_DEFAULT,
+    filters: pick('filters') ?? {},
+  };
+}
+
+/**
+ * The live view, reduced to what is worth storing.
+ *
+ * Capture reads the real list rather than a parallel settings form, so every
+ * filter added to ITicketListFilters in future is defaultable for free — there
+ * is no second UI that must be taught about it. That is also why the exclusion
+ * list is a deny-list: a new key is captured unless someone decides it should
+ * not be.
+ */
+export function captureTicketViewSettings(view: {
+  filters?: Partial<ITicketListFilters>;
+  columnVisibility?: Partial<Record<TicketListColumnKey, boolean>>;
+  columnOrder?: TicketListColumnKey[];
+  tagsInlineUnderTitle?: boolean;
+  densityLevel?: number;
+}): TicketViewSettings {
+  const filters: Partial<ITicketListFilters> = {};
+  for (const [key, value] of Object.entries(view.filters ?? {})) {
+    if (EXCLUDED_KEY_SET.has(key)) continue;
+    if (value === undefined || value === null) continue;
+    if (Array.isArray(value) && value.length === 0) continue;
+    if (value === false && NO_OP_WHEN_FALSE.has(key)) continue;
+    (filters as Record<string, unknown>)[key] = value;
+  }
+
+  const captured: TicketViewSettings = { filters };
+  if (view.columnVisibility) {
+    captured.columnVisibility = resolveTicketColumnVisibility(view.columnVisibility);
+  }
+  if (view.columnOrder) {
+    captured.columnOrder = resolveTicketColumnOrder(view.columnOrder);
+  }
+  if (typeof view.tagsInlineUnderTitle === 'boolean') {
+    captured.tagsInlineUnderTitle = view.tagsInlineUnderTitle;
+  }
+  const density = normalizeDensityLevel(view.densityLevel);
+  if (density !== undefined) {
+    captured.densityLevel = density;
+  }
+  return captured;
+}
+
+/**
+ * Ids inside a captured filter set that no longer resolve are dropped.
+ *
+ * JSONB cannot foreign-key-check a `status_id`, so integrity is enforced on
+ * *read* instead — the established pattern on this surface, where
+ * `resolveInitialBoardTab` already drops a stored board that no longer exists
+ * and `buildTicketStatusFilterOptions` already drops a statusId when switching
+ * to a board that lacks it. Dropping is strictly better than the alternative: a
+ * dead statusId applied verbatim produces an empty list on a board that has
+ * tickets, which reads as a bug rather than as stale configuration.
+ *
+ * Sentinel values ('all', the open-status pseudo-filter) are never ids, so they
+ * are passed through untouched by only validating values present in the
+ * corresponding known-id set.
+ */
+export function validateCapturedFilters(
+  filters: Partial<ITicketListFilters> | undefined,
+  known: {
+    statusIds?: readonly string[];
+    priorityIds?: readonly string[];
+    categoryIds?: readonly string[];
+    clientIds?: readonly string[];
+    userIds?: readonly string[];
+    teamIds?: readonly string[];
+    tags?: readonly string[];
+  },
+  /** Values that are pseudo-filters rather than ids and must survive validation. */
+  sentinels: readonly string[] = [],
+): Partial<ITicketListFilters> {
+  if (!filters) return {};
+
+  const sentinelSet = new Set(sentinels);
+  const out: Partial<ITicketListFilters> = { ...filters };
+
+  const keepScalar = (value: string | undefined, allowed: readonly string[] | undefined) => {
+    if (value === undefined) return undefined;
+    if (sentinelSet.has(value)) return value;
+    // An unknown universe means "cannot validate", which must not mean "drop".
+    if (!allowed) return value;
+    return allowed.includes(value) ? value : undefined;
+  };
+
+  const keepList = (values: string[] | undefined, allowed: readonly string[] | undefined) => {
+    if (!values) return undefined;
+    if (!allowed) return values;
+    const kept = values.filter(value => sentinelSet.has(value) || allowed.includes(value));
+    return kept.length > 0 ? kept : undefined;
+  };
+
+  out.statusId = keepScalar(filters.statusId, known.statusIds);
+  out.priorityId = keepScalar(filters.priorityId, known.priorityIds);
+  out.categoryId = keepScalar(filters.categoryId, known.categoryIds);
+  out.clientId = keepScalar(filters.clientId, known.clientIds);
+  out.categoryIds = keepList(filters.categoryIds, known.categoryIds);
+  out.excludeCategoryIds = keepList(filters.excludeCategoryIds, known.categoryIds);
+  out.assignedToIds = keepList(filters.assignedToIds, known.userIds);
+  out.assignedTeamIds = keepList(filters.assignedTeamIds, known.teamIds);
+  out.tags = keepList(filters.tags, known.tags);
+
+  for (const key of Object.keys(out) as (keyof ITicketListFilters)[]) {
+    if (out[key] === undefined) {
+      delete out[key];
+    }
+  }
+  return out;
+}
+
+/**
+ * The filter set produced by arriving at a board tab.
+ *
+ * Arrival is a *replacement*, not a refinement: the board's stored filters
+ * replace whatever the previous board's view left behind, because the whole
+ * premise is that a board looks like itself when you go there. Merging onto the
+ * previous state instead would make a board's appearance depend on where you
+ * came from — the exact property the tab strip was supposed to remove.
+ *
+ * Board scope always comes from `boardSelection` and never from `viewFilters`:
+ * capture strips the scope keys, and this strip is the belt to that braces, so
+ * even a hand-written document cannot make a board's default view navigate to a
+ * different board.
+ */
+export function buildBoardArrivalFilters(params: {
+  /** The list's neutral starting state (status open, priority all, …). */
+  baseline: Partial<ITicketListFilters>;
+  /** Board scope + status reconciliation from buildBoardSelectionFilterUpdate. */
+  boardSelection: Partial<ITicketListFilters>;
+  /** The resolved view's filters, already validated-on-read. */
+  viewFilters: Partial<ITicketListFilters>;
+}): Partial<ITicketListFilters> {
+  const { baseline, boardSelection, viewFilters } = params;
+
+  const scopedView: Partial<ITicketListFilters> = { ...viewFilters };
+  for (const key of CAPTURE_EXCLUDED_FILTER_KEYS) {
+    delete scopedView[key];
+  }
+
+  return { ...baseline, ...boardSelection, ...scopedView };
+}
+
+/**
+ * True when the live view has drifted from what is saved — drives the dot on the
+ * `View ▾` control. Compared on the *captured* projection of both sides so the
+ * excluded keys (board scope, search) can never make a view look dirty.
+ */
+export function ticketViewDiffersFromSaved(
+  live: TicketViewSettings,
+  saved: TicketViewSettings | null | undefined,
+): boolean {
+  const normalize = (value: TicketViewSettings | null | undefined): string =>
+    JSON.stringify(sortKeysDeep(captureTicketViewSettings(value ?? {})));
+  return normalize(live) !== normalize(saved);
+}
+
+function sortKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeysDeep);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.keys(value as Record<string, unknown>)
+        .sort()
+        .map(key => [key, sortKeysDeep((value as Record<string, unknown>)[key])]),
+    );
+  }
+  return value;
+}

--- a/packages/types/src/interfaces/board.interface.ts
+++ b/packages/types/src/interfaces/board.interface.ts
@@ -3,6 +3,21 @@ import { TenantEntity } from './index';
 export type CategoryType = 'custom' | 'itil';
 export type PriorityType = 'custom' | 'itil';
 
+/**
+ * A ticket-list view document: what a board (or the tenant) stores as its
+ * default arrangement of the list. Structural rather than imported from
+ * @alga-psa/tickets so the types package keeps no dependency on it; the tickets
+ * package's TicketViewSettings is the authoritative, catalog-keyed shape and is
+ * assignable to this.
+ */
+export interface TicketViewSettings {
+  columnVisibility?: Record<string, boolean>;
+  columnOrder?: string[];
+  tagsInlineUnderTitle?: boolean;
+  densityLevel?: number;
+  filters?: Record<string, unknown>;
+}
+
 export interface IBoard extends TenantEntity {
   board_id?: string;
   board_name?: string;
@@ -18,6 +33,27 @@ export interface IBoard extends TenantEntity {
   // Priority type configuration
   priority_type?: PriorityType;
 
+  // Board-level ticket-list view configuration.
+  //
+  // is_pinned: only pinned boards get a permanent tab on the tickets screen.
+  // Unpinned boards stay fully reachable via All tickets + the board filter, and
+  // a deep link to one renders a transient tab for that visit.
+  //
+  // list_view_settings: the board's default ticket-list view (column visibility
+  // + order, density, captured filters incl. sort), resolved through
+  // resolveTicketViewSettings over the tenant layer and the column catalog.
+  // NULL means "inherit the tenant default" — reset writes NULL, not {}.
+  is_pinned?: boolean;
+  list_view_settings?: TicketViewSettings | null;
+
+  // SUPERSEDED — the display_* block below is dead configuration.
+  //
+  // No UI reads any of these eleven columns; they survive only in this
+  // interface. They are the column-per-setting pattern that produced a wide
+  // table with an abandoned half, and list_view_settings above is their live
+  // successor. Do not add to them and do not mistake them for live config.
+  // Removing them is its own change with its own risk, so they stay for now.
+  //
   // Display configuration for form fields
   display_contact_name_id?: boolean;
   display_priority?: boolean;

--- a/server/migrations/20260819120000_add_board_pinning_and_list_view_settings.cjs
+++ b/server/migrations/20260819120000_add_board_pinning_and_list_view_settings.cjs
@@ -1,0 +1,68 @@
+/**
+ * Board-level view configuration: pinning + a per-board list view document.
+ *
+ * Two columns, deliberately shaped differently:
+ *
+ *   is_pinned          — a real boolean column. It is queried and joined (only
+ *                        pinned boards get a tab), it is one bit, and it has no
+ *                        internal structure. A column is the right shape.
+ *
+ *   list_view_settings — a JSONB document holding the board's default ticket-list
+ *                        view (column visibility + order, density, captured
+ *                        filters incl. sort). NOT wide columns: the same document
+ *                        already exists one layer up at
+ *                        tenant_settings.ticket_display_settings.list, and a
+ *                        second representation here would mean two shapes for one
+ *                        concept plus a translator between them — which is exactly
+ *                        the history of the eleven dead display_* columns on this
+ *                        table. NULL means "inherit the tenant default"; reset
+ *                        writes NULL rather than {} so "unset" and "empty" stay
+ *                        distinguishable.
+ *
+ * Backfill: every currently-active board is pinned, so the tab strip looks
+ * exactly as it does today on upgrade and admins curate DOWN from there rather
+ * than arriving at an empty strip and having to rebuild it.
+ *
+ * No index on (tenant, is_pinned): board counts per tenant are small and
+ * getAllBoards already reads the whole set unfiltered, so an index would be
+ * write cost for a scan that never happens.
+ */
+
+exports.up = async function up(knex) {
+  const hasIsPinned = await knex.schema.hasColumn('boards', 'is_pinned');
+  const hasListViewSettings = await knex.schema.hasColumn('boards', 'list_view_settings');
+
+  // One subcommand per ALTER: Citus rejects an ALTER carrying two utility
+  // subcommands with "cannot execute multiple utility events".
+  if (!hasIsPinned) {
+    await knex.schema.alterTable('boards', (table) => {
+      table.boolean('is_pinned').notNullable().defaultTo(false);
+    });
+  }
+
+  if (!hasListViewSettings) {
+    await knex.schema.alterTable('boards', (table) => {
+      table.jsonb('list_view_settings').nullable();
+    });
+  }
+
+  if (!hasIsPinned) {
+    // Only on first install of the column — re-running must not re-pin boards an
+    // admin has since unpinned.
+    await knex('boards').where({ is_inactive: false }).update({ is_pinned: true });
+  }
+};
+
+exports.down = async function down(knex) {
+  if (await knex.schema.hasColumn('boards', 'list_view_settings')) {
+    await knex.schema.alterTable('boards', (table) => {
+      table.dropColumn('list_view_settings');
+    });
+  }
+
+  if (await knex.schema.hasColumn('boards', 'is_pinned')) {
+    await knex.schema.alterTable('boards', (table) => {
+      table.dropColumn('is_pinned');
+    });
+  }
+};

--- a/server/public/locales/de/features/tickets.json
+++ b/server/public/locales/de/features/tickets.json
@@ -495,7 +495,10 @@
     },
     "exportSelectedAction": "Auswahl exportieren ({{count}})",
     "exportAction": "CSV exportieren",
-    "importAction": "CSV importieren"
+    "importAction": "CSV importieren",
+    "boardTabs": {
+      "all": "Alle Tickets"
+    }
   },
   "bulk": {
     "bundleTickets": "Tickets bündeln",

--- a/server/public/locales/de/features/tickets.json
+++ b/server/public/locales/de/features/tickets.json
@@ -498,6 +498,27 @@
     "importAction": "CSV importieren",
     "boardTabs": {
       "all": "Alle Tickets"
+    },
+    "boardHeader": {
+      "open": "Offen",
+      "overdue": "Überfällig",
+      "slaBreach": "SLA-Verstoß",
+      "unassigned": "Nicht zugewiesen",
+      "managedBy": "Verwaltet von",
+      "sla": "SLA"
+    },
+    "viewMenu": {
+      "label": "Ansicht",
+      "columns": "Spalten",
+      "density": "Dichte",
+      "saveBoardDefault": "Als Standardansicht dieses Boards speichern",
+      "saveTenantDefault": "Als Standardansicht für alle speichern",
+      "resetToTenant": "Auf Mandantenstandard zurücksetzen",
+      "unsavedChanges": "Diese Ansicht weicht vom gespeicherten Standard ab",
+      "saved": "Standardansicht gespeichert",
+      "saveFailed": "Standardansicht konnte nicht gespeichert werden",
+      "reset": "Auf Mandantenstandard zurücksetzen",
+      "resetFailed": "Ansicht konnte nicht zurückgesetzt werden"
     }
   },
   "bulk": {

--- a/server/public/locales/de/msp/settings.json
+++ b/server/public/locales/de/msp/settings.json
@@ -813,7 +813,7 @@
         "preview": "Vorschau",
         "summary": {
           "openOnly": "Nur offene",
-          "columns": "{{count}} Spalten",
+          "columns": "{{columns}} Spalten",
           "density": "Dichte {{level}}",
           "sortedBy": "sortiert nach {{field}}"
         }

--- a/server/public/locales/de/msp/settings.json
+++ b/server/public/locales/de/msp/settings.json
@@ -779,6 +779,8 @@
         "sections": {
           "general": "Allgemein",
           "generalHelp": "Name, Beschreibung, Sichtbarkeit und Standard",
+          "appearance": "Darstellung & Standardwerte",
+          "appearanceHelp": "Tab-Anheftung und die Standard-Listenansicht des Boards",
           "assignment": "Zuweisung & SLA",
           "assignmentHelp": "Standard-Routing, SLA und Board-Manager",
           "inbound": "E-Mail & eingehende Antworten",
@@ -799,6 +801,22 @@
         "allSaved": "Alle Änderungen gespeichert",
         "reopenBadge": "erneut öffnen",
         "required": "Erforderlich"
+      },
+      "appearance": {
+        "pinLabel": "An den Ticket-Bildschirm anheften",
+        "pinHelp": "Angeheftete Boards erhalten einen festen Tab auf dem Ticket-Bildschirm. Nicht angeheftete Boards bleiben über „Alle Tickets“ und den Board-Filter erreichbar.",
+        "savedView": "Gespeicherte Ansicht",
+        "inheritsTenant": "Übernimmt die Mandantenstandards",
+        "openBoard": "Dieses Board öffnen",
+        "resetToTenant": "Auf Mandantenstandard zurücksetzen",
+        "arrangeNote": "Richten Sie die Ansicht dieses Boards direkt auf dem Board ein und speichern Sie sie anschließend über das Menü „Ansicht“.",
+        "preview": "Vorschau",
+        "summary": {
+          "openOnly": "Nur offene",
+          "columns": "{{count}} Spalten",
+          "density": "Dichte {{level}}",
+          "sortedBy": "sortiert nach {{field}}"
+        }
       },
       "empty": "Keine Boards gefunden.",
       "searchPlaceholder": "Boards suchen…"

--- a/server/public/locales/en/features/tickets.json
+++ b/server/public/locales/en/features/tickets.json
@@ -503,7 +503,10 @@
     },
     "exportSelectedAction": "Export selected ({{count}})",
     "exportAction": "Export CSV",
-    "importAction": "Import CSV"
+    "importAction": "Import CSV",
+    "boardTabs": {
+      "all": "All tickets"
+    }
   },
   "bulk": {
     "bundleTickets": "Bundle Tickets",

--- a/server/public/locales/en/features/tickets.json
+++ b/server/public/locales/en/features/tickets.json
@@ -506,6 +506,27 @@
     "importAction": "Import CSV",
     "boardTabs": {
       "all": "All tickets"
+    },
+    "boardHeader": {
+      "open": "Open",
+      "overdue": "Overdue",
+      "slaBreach": "SLA breach",
+      "unassigned": "Unassigned",
+      "managedBy": "Managed by",
+      "sla": "SLA"
+    },
+    "viewMenu": {
+      "label": "View",
+      "columns": "Columns",
+      "density": "Density",
+      "saveBoardDefault": "Save as this board's default view",
+      "saveTenantDefault": "Save as the default view for everyone",
+      "resetToTenant": "Reset to tenant default",
+      "unsavedChanges": "This view differs from the saved default",
+      "saved": "Default view saved",
+      "saveFailed": "Failed to save the default view",
+      "reset": "Reset to tenant default",
+      "resetFailed": "Failed to reset the view"
     }
   },
   "bulk": {

--- a/server/public/locales/en/msp/settings.json
+++ b/server/public/locales/en/msp/settings.json
@@ -779,6 +779,8 @@
         "sections": {
           "general": "General",
           "generalHelp": "Name, description, visibility and default",
+          "appearance": "Appearance & defaults",
+          "appearanceHelp": "Tab pinning and the board's default list view",
           "assignment": "Assignment & SLA",
           "assignmentHelp": "Default routing, SLA and board manager",
           "inbound": "Email & inbound replies",
@@ -799,6 +801,22 @@
         "allSaved": "All changes saved",
         "reopenBadge": "reopen",
         "required": "Required"
+      },
+      "appearance": {
+        "pinLabel": "Pin to the tickets screen",
+        "pinHelp": "Pinned boards get a permanent tab on the tickets screen. Unpinned boards stay reachable from All tickets and the board filter.",
+        "savedView": "Saved view",
+        "inheritsTenant": "Inherits tenant defaults",
+        "openBoard": "Open this board",
+        "resetToTenant": "Reset to tenant default",
+        "arrangeNote": "Arrange this board's view on the board itself, then save it from the View menu.",
+        "preview": "Preview",
+        "summary": {
+          "openOnly": "Open only",
+          "columns": "{{count}} columns",
+          "density": "density {{level}}",
+          "sortedBy": "sorted by {{field}}"
+        }
       },
       "empty": "No boards found.",
       "searchPlaceholder": "Search boards…"

--- a/server/public/locales/en/msp/settings.json
+++ b/server/public/locales/en/msp/settings.json
@@ -813,7 +813,7 @@
         "preview": "Preview",
         "summary": {
           "openOnly": "Open only",
-          "columns": "{{count}} columns",
+          "columns": "{{columns}} columns",
           "density": "density {{level}}",
           "sortedBy": "sorted by {{field}}"
         }

--- a/server/public/locales/es/features/tickets.json
+++ b/server/public/locales/es/features/tickets.json
@@ -495,7 +495,10 @@
     },
     "exportSelectedAction": "Exportar seleccionados ({{count}})",
     "exportAction": "Exportar CSV",
-    "importAction": "Importar CSV"
+    "importAction": "Importar CSV",
+    "boardTabs": {
+      "all": "Todos los tickets"
+    }
   },
   "bulk": {
     "bundleTickets": "Agrupar tickets",

--- a/server/public/locales/es/features/tickets.json
+++ b/server/public/locales/es/features/tickets.json
@@ -498,6 +498,27 @@
     "importAction": "Importar CSV",
     "boardTabs": {
       "all": "Todos los tickets"
+    },
+    "boardHeader": {
+      "open": "Abiertos",
+      "overdue": "Vencidos",
+      "slaBreach": "Incumplimiento de SLA",
+      "unassigned": "Sin asignar",
+      "managedBy": "Gestionado por",
+      "sla": "SLA"
+    },
+    "viewMenu": {
+      "label": "Vista",
+      "columns": "Columnas",
+      "density": "Densidad",
+      "saveBoardDefault": "Guardar como vista predeterminada de este tablero",
+      "saveTenantDefault": "Guardar como vista predeterminada para todos",
+      "resetToTenant": "Restablecer al valor predeterminado del inquilino",
+      "unsavedChanges": "Esta vista difiere del valor predeterminado guardado",
+      "saved": "Vista predeterminada guardada",
+      "saveFailed": "No se pudo guardar la vista predeterminada",
+      "reset": "Restablecer al valor predeterminado del inquilino",
+      "resetFailed": "No se pudo restablecer la vista"
     }
   },
   "bulk": {

--- a/server/public/locales/es/msp/settings.json
+++ b/server/public/locales/es/msp/settings.json
@@ -813,7 +813,7 @@
         "preview": "Vista previa",
         "summary": {
           "openOnly": "Solo abiertos",
-          "columns": "{{count}} columnas",
+          "columns": "{{columns}} columnas",
           "density": "densidad {{level}}",
           "sortedBy": "ordenado por {{field}}"
         }

--- a/server/public/locales/es/msp/settings.json
+++ b/server/public/locales/es/msp/settings.json
@@ -779,6 +779,8 @@
         "sections": {
           "general": "General",
           "generalHelp": "Nombre, descripción, visibilidad y predeterminado",
+          "appearance": "Apariencia y valores predeterminados",
+          "appearanceHelp": "Anclaje de pestaña y vista de lista predeterminada del tablero",
           "assignment": "Asignación y SLA",
           "assignmentHelp": "Enrutamiento predeterminado, SLA y responsable del tablero",
           "inbound": "Correo y respuestas entrantes",
@@ -799,6 +801,22 @@
         "allSaved": "Todos los cambios guardados",
         "reopenBadge": "reabrir",
         "required": "Obligatorio"
+      },
+      "appearance": {
+        "pinLabel": "Anclar a la pantalla de tickets",
+        "pinHelp": "Los tableros anclados tienen una pestaña fija en la pantalla de tickets. Los tableros sin anclar siguen siendo accesibles desde \"Todos los tickets\" y el filtro de tableros.",
+        "savedView": "Vista guardada",
+        "inheritsTenant": "Hereda los valores predeterminados del inquilino",
+        "openBoard": "Abrir este tablero",
+        "resetToTenant": "Restablecer al valor predeterminado del inquilino",
+        "arrangeNote": "Organice la vista de este tablero en el propio tablero y luego guárdela desde el menú \"Vista\".",
+        "preview": "Vista previa",
+        "summary": {
+          "openOnly": "Solo abiertos",
+          "columns": "{{count}} columnas",
+          "density": "densidad {{level}}",
+          "sortedBy": "ordenado por {{field}}"
+        }
       },
       "empty": "No se encontraron tableros.",
       "searchPlaceholder": "Buscar tableros…"

--- a/server/public/locales/fr/features/tickets.json
+++ b/server/public/locales/fr/features/tickets.json
@@ -498,6 +498,27 @@
     "importAction": "Importer CSV",
     "boardTabs": {
       "all": "Tous les tickets"
+    },
+    "boardHeader": {
+      "open": "Ouverts",
+      "overdue": "En retard",
+      "slaBreach": "Dépassement de SLA",
+      "unassigned": "Non attribué",
+      "managedBy": "Géré par",
+      "sla": "SLA"
+    },
+    "viewMenu": {
+      "label": "Affichage",
+      "columns": "Colonnes",
+      "density": "Densité",
+      "saveBoardDefault": "Enregistrer comme vue par défaut de ce tableau",
+      "saveTenantDefault": "Enregistrer comme vue par défaut pour tout le monde",
+      "resetToTenant": "Réinitialiser à la valeur par défaut du locataire",
+      "unsavedChanges": "Cette vue diffère de la valeur par défaut enregistrée",
+      "saved": "Vue par défaut enregistrée",
+      "saveFailed": "Échec de l'enregistrement de la vue par défaut",
+      "reset": "Réinitialiser à la valeur par défaut du locataire",
+      "resetFailed": "Échec de la réinitialisation de la vue"
     }
   },
   "bulk": {

--- a/server/public/locales/fr/features/tickets.json
+++ b/server/public/locales/fr/features/tickets.json
@@ -495,7 +495,10 @@
     },
     "exportSelectedAction": "Exporter la sélection ({{count}})",
     "exportAction": "Exporter CSV",
-    "importAction": "Importer CSV"
+    "importAction": "Importer CSV",
+    "boardTabs": {
+      "all": "Tous les tickets"
+    }
   },
   "bulk": {
     "bundleTickets": "Regrouper les tickets",

--- a/server/public/locales/fr/msp/settings.json
+++ b/server/public/locales/fr/msp/settings.json
@@ -779,6 +779,8 @@
         "sections": {
           "general": "Général",
           "generalHelp": "Nom, description, visibilité et valeur par défaut",
+          "appearance": "Apparence et valeurs par défaut",
+          "appearanceHelp": "Épinglage de l'onglet et vue de liste par défaut du tableau",
           "assignment": "Attribution et SLA",
           "assignmentHelp": "Routage par défaut, SLA et responsable du tableau",
           "inbound": "E-mail et réponses entrantes",
@@ -799,6 +801,22 @@
         "allSaved": "Toutes les modifications sont enregistrées",
         "reopenBadge": "rouvrir",
         "required": "Obligatoire"
+      },
+      "appearance": {
+        "pinLabel": "Épingler à l'écran des tickets",
+        "pinHelp": "Les tableaux épinglés disposent d'un onglet permanent sur l'écran des tickets. Les tableaux non épinglés restent accessibles depuis « Tous les tickets » et le filtre de tableaux.",
+        "savedView": "Vue enregistrée",
+        "inheritsTenant": "Hérite des valeurs par défaut du locataire",
+        "openBoard": "Ouvrir ce tableau",
+        "resetToTenant": "Réinitialiser à la valeur par défaut du locataire",
+        "arrangeNote": "Organisez la vue de ce tableau directement sur le tableau, puis enregistrez-la depuis le menu « Affichage ».",
+        "preview": "Aperçu",
+        "summary": {
+          "openOnly": "Ouverts uniquement",
+          "columns": "{{count}} colonnes",
+          "density": "densité {{level}}",
+          "sortedBy": "trié par {{field}}"
+        }
       },
       "empty": "Aucun tableau trouvé.",
       "searchPlaceholder": "Rechercher des tableaux…"

--- a/server/public/locales/fr/msp/settings.json
+++ b/server/public/locales/fr/msp/settings.json
@@ -813,7 +813,7 @@
         "preview": "Aperçu",
         "summary": {
           "openOnly": "Ouverts uniquement",
-          "columns": "{{count}} colonnes",
+          "columns": "{{columns}} colonnes",
           "density": "densité {{level}}",
           "sortedBy": "trié par {{field}}"
         }

--- a/server/public/locales/it/features/tickets.json
+++ b/server/public/locales/it/features/tickets.json
@@ -498,6 +498,27 @@
     "importAction": "Importa CSV",
     "boardTabs": {
       "all": "Tutti i ticket"
+    },
+    "boardHeader": {
+      "open": "Aperti",
+      "overdue": "Scaduti",
+      "slaBreach": "Mancato rispetto SLA",
+      "unassigned": "Non assegnato",
+      "managedBy": "Gestita da",
+      "sla": "SLA"
+    },
+    "viewMenu": {
+      "label": "Visualizzazione",
+      "columns": "Colonne",
+      "density": "Densità",
+      "saveBoardDefault": "Salva come visualizzazione predefinita di questa bacheca",
+      "saveTenantDefault": "Salva come visualizzazione predefinita per tutti",
+      "resetToTenant": "Reimposta al valore predefinito del tenant",
+      "unsavedChanges": "Questa visualizzazione differisce dal valore predefinito salvato",
+      "saved": "Visualizzazione predefinita salvata",
+      "saveFailed": "Impossibile salvare la visualizzazione predefinita",
+      "reset": "Reimposta al valore predefinito del tenant",
+      "resetFailed": "Impossibile reimpostare la visualizzazione"
     }
   },
   "bulk": {

--- a/server/public/locales/it/features/tickets.json
+++ b/server/public/locales/it/features/tickets.json
@@ -495,7 +495,10 @@
     },
     "exportSelectedAction": "Esporta selezionati ({{count}})",
     "exportAction": "Esporta CSV",
-    "importAction": "Importa CSV"
+    "importAction": "Importa CSV",
+    "boardTabs": {
+      "all": "Tutti i ticket"
+    }
   },
   "bulk": {
     "bundleTickets": "Raggruppa ticket",

--- a/server/public/locales/it/msp/settings.json
+++ b/server/public/locales/it/msp/settings.json
@@ -813,7 +813,7 @@
         "preview": "Anteprima",
         "summary": {
           "openOnly": "Solo aperti",
-          "columns": "{{count}} colonne",
+          "columns": "{{columns}} colonne",
           "density": "densità {{level}}",
           "sortedBy": "ordinato per {{field}}"
         }

--- a/server/public/locales/it/msp/settings.json
+++ b/server/public/locales/it/msp/settings.json
@@ -779,6 +779,8 @@
         "sections": {
           "general": "Generale",
           "generalHelp": "Nome, descrizione, visibilità e predefinito",
+          "appearance": "Aspetto e valori predefiniti",
+          "appearanceHelp": "Fissaggio della scheda e visualizzazione elenco predefinita della bacheca",
           "assignment": "Assegnazione e SLA",
           "assignmentHelp": "Instradamento predefinito, SLA e responsabile della bacheca",
           "inbound": "Email e risposte in arrivo",
@@ -799,6 +801,22 @@
         "allSaved": "Tutte le modifiche salvate",
         "reopenBadge": "riapri",
         "required": "Obbligatorio"
+      },
+      "appearance": {
+        "pinLabel": "Fissa nella schermata dei ticket",
+        "pinHelp": "Le bacheche fissate hanno una scheda permanente nella schermata dei ticket. Le bacheche non fissate restano raggiungibili da \"Tutti i ticket\" e dal filtro delle bacheche.",
+        "savedView": "Visualizzazione salvata",
+        "inheritsTenant": "Eredita i valori predefiniti del tenant",
+        "openBoard": "Apri questa bacheca",
+        "resetToTenant": "Reimposta al valore predefinito del tenant",
+        "arrangeNote": "Organizza la visualizzazione di questa bacheca direttamente nella bacheca, quindi salvala dal menu \"Visualizzazione\".",
+        "preview": "Anteprima",
+        "summary": {
+          "openOnly": "Solo aperti",
+          "columns": "{{count}} colonne",
+          "density": "densità {{level}}",
+          "sortedBy": "ordinato per {{field}}"
+        }
       },
       "empty": "Nessuna bacheca trovata.",
       "searchPlaceholder": "Cerca bacheche…"

--- a/server/public/locales/nl/features/tickets.json
+++ b/server/public/locales/nl/features/tickets.json
@@ -498,6 +498,27 @@
     "importAction": "CSV importeren",
     "boardTabs": {
       "all": "Alle tickets"
+    },
+    "boardHeader": {
+      "open": "Openstaand",
+      "overdue": "Te laat",
+      "slaBreach": "SLA-overschrijding",
+      "unassigned": "Niet toegewezen",
+      "managedBy": "Beheerd door",
+      "sla": "SLA"
+    },
+    "viewMenu": {
+      "label": "Weergave",
+      "columns": "Kolommen",
+      "density": "Dichtheid",
+      "saveBoardDefault": "Opslaan als standaardweergave van dit bord",
+      "saveTenantDefault": "Opslaan als standaardweergave voor iedereen",
+      "resetToTenant": "Terugzetten naar de tenantstandaard",
+      "unsavedChanges": "Deze weergave wijkt af van de opgeslagen standaard",
+      "saved": "Standaardweergave opgeslagen",
+      "saveFailed": "Opslaan van de standaardweergave is mislukt",
+      "reset": "Terugzetten naar de tenantstandaard",
+      "resetFailed": "Terugzetten van de weergave is mislukt"
     }
   },
   "bulk": {

--- a/server/public/locales/nl/features/tickets.json
+++ b/server/public/locales/nl/features/tickets.json
@@ -495,7 +495,10 @@
     },
     "exportSelectedAction": "Geselecteerde exporteren ({{count}})",
     "exportAction": "CSV exporteren",
-    "importAction": "CSV importeren"
+    "importAction": "CSV importeren",
+    "boardTabs": {
+      "all": "Alle tickets"
+    }
   },
   "bulk": {
     "bundleTickets": "Tickets bundelen",

--- a/server/public/locales/nl/msp/settings.json
+++ b/server/public/locales/nl/msp/settings.json
@@ -813,7 +813,7 @@
         "preview": "Voorbeeld",
         "summary": {
           "openOnly": "Alleen openstaand",
-          "columns": "{{count}} kolommen",
+          "columns": "{{columns}} kolommen",
           "density": "dichtheid {{level}}",
           "sortedBy": "gesorteerd op {{field}}"
         }

--- a/server/public/locales/nl/msp/settings.json
+++ b/server/public/locales/nl/msp/settings.json
@@ -779,6 +779,8 @@
         "sections": {
           "general": "Algemeen",
           "generalHelp": "Naam, beschrijving, zichtbaarheid en standaard",
+          "appearance": "Uiterlijk & standaardwaarden",
+          "appearanceHelp": "Tabblad vastzetten en de standaardlijstweergave van het bord",
           "assignment": "Toewijzing & SLA",
           "assignmentHelp": "Standaardroutering, SLA en bordbeheerder",
           "inbound": "E-mail & inkomende antwoorden",
@@ -799,6 +801,22 @@
         "allSaved": "Alle wijzigingen opgeslagen",
         "reopenBadge": "heropenen",
         "required": "Vereist"
+      },
+      "appearance": {
+        "pinLabel": "Vastzetten op het ticketscherm",
+        "pinHelp": "Vastgezette borden krijgen een vast tabblad op het ticketscherm. Niet-vastgezette borden blijven bereikbaar via \"Alle tickets\" en het bordfilter.",
+        "savedView": "Opgeslagen weergave",
+        "inheritsTenant": "Neemt de tenantstandaarden over",
+        "openBoard": "Dit bord openen",
+        "resetToTenant": "Terugzetten naar de tenantstandaard",
+        "arrangeNote": "Stel de weergave van dit bord op het bord zelf in en sla deze op via het menu \"Weergave\".",
+        "preview": "Voorbeeld",
+        "summary": {
+          "openOnly": "Alleen openstaand",
+          "columns": "{{count}} kolommen",
+          "density": "dichtheid {{level}}",
+          "sortedBy": "gesorteerd op {{field}}"
+        }
       },
       "empty": "Geen borden gevonden.",
       "searchPlaceholder": "Borden zoeken…"

--- a/server/public/locales/pl/features/tickets.json
+++ b/server/public/locales/pl/features/tickets.json
@@ -553,6 +553,27 @@
     "boardTabs": {
       "all": "Wszystkie zgłoszenia"
     },
+    "boardHeader": {
+      "open": "Otwarte",
+      "overdue": "Po terminie",
+      "slaBreach": "Przekroczenie SLA",
+      "unassigned": "Nieprzypisane",
+      "managedBy": "Zarządzana przez",
+      "sla": "SLA"
+    },
+    "viewMenu": {
+      "label": "Widok",
+      "columns": "Kolumny",
+      "density": "Gęstość",
+      "saveBoardDefault": "Zapisz jako domyślny widok tej tablicy",
+      "saveTenantDefault": "Zapisz jako domyślny widok dla wszystkich",
+      "resetToTenant": "Przywróć domyślny widok organizacji",
+      "unsavedChanges": "Ten widok różni się od zapisanego widoku domyślnego",
+      "saved": "Zapisano domyślny widok",
+      "saveFailed": "Nie udało się zapisać domyślnego widoku",
+      "reset": "Przywróć domyślny widok organizacji",
+      "resetFailed": "Nie udało się zresetować widoku"
+    },
     "allMatchingSelected_few": "Zaznaczono wszystkie {{count}} zgłoszenia spełniające filtry.",
     "allMatchingSelected_many": "Zaznaczono wszystkie {{count}} zgłoszeń spełniających filtry.",
     "allPageSelected_few": "Zaznaczono wszystkie {{count}} zgłoszenia na tej stronie.",

--- a/server/public/locales/pl/features/tickets.json
+++ b/server/public/locales/pl/features/tickets.json
@@ -550,6 +550,9 @@
     "exportSelectedAction": "Eksportuj zaznaczone ({{count}})",
     "exportAction": "Eksportuj CSV",
     "importAction": "Importuj CSV",
+    "boardTabs": {
+      "all": "Wszystkie zgłoszenia"
+    },
     "allMatchingSelected_few": "Zaznaczono wszystkie {{count}} zgłoszenia spełniające filtry.",
     "allMatchingSelected_many": "Zaznaczono wszystkie {{count}} zgłoszeń spełniających filtry.",
     "allPageSelected_few": "Zaznaczono wszystkie {{count}} zgłoszenia na tej stronie.",

--- a/server/public/locales/pl/msp/settings.json
+++ b/server/public/locales/pl/msp/settings.json
@@ -783,6 +783,8 @@
         "sections": {
           "general": "Ogólne",
           "generalHelp": "Nazwa, opis, widoczność i domyślność",
+          "appearance": "Wygląd i wartości domyślne",
+          "appearanceHelp": "Przypinanie karty i domyślny widok listy tablicy",
           "assignment": "Przypisanie i SLA",
           "assignmentHelp": "Domyślne kierowanie, SLA i menedżer tablicy",
           "inbound": "E-mail i odpowiedzi przychodzące",
@@ -803,6 +805,22 @@
         "allSaved": "Wszystkie zmiany zapisane",
         "reopenBadge": "otwórz ponownie",
         "required": "Wymagane"
+      },
+      "appearance": {
+        "pinLabel": "Przypnij do ekranu zgłoszeń",
+        "pinHelp": "Przypięte tablice mają stałą kartę na ekranie zgłoszeń. Nieprzypięte tablice pozostają dostępne z widoku \"Wszystkie zgłoszenia\" oraz z filtra tablic.",
+        "savedView": "Zapisany widok",
+        "inheritsTenant": "Dziedziczy domyślne ustawienia organizacji",
+        "openBoard": "Otwórz tę tablicę",
+        "resetToTenant": "Przywróć domyślny widok organizacji",
+        "arrangeNote": "Ustaw widok tej tablicy bezpośrednio na tablicy, a następnie zapisz go w menu \"Widok\".",
+        "preview": "Podgląd",
+        "summary": {
+          "openOnly": "Tylko otwarte",
+          "columns": "{{count}} kolumn",
+          "density": "gęstość {{level}}",
+          "sortedBy": "sortowanie według {{field}}"
+        }
       },
       "empty": "Nie znaleziono tablic.",
       "searchPlaceholder": "Szukaj tablic…"

--- a/server/public/locales/pl/msp/settings.json
+++ b/server/public/locales/pl/msp/settings.json
@@ -817,7 +817,7 @@
         "preview": "Podgląd",
         "summary": {
           "openOnly": "Tylko otwarte",
-          "columns": "{{count}} kolumn",
+          "columns": "{{columns}} kolumn",
           "density": "gęstość {{level}}",
           "sortedBy": "sortowanie według {{field}}"
         }

--- a/server/public/locales/pt/features/tickets.json
+++ b/server/public/locales/pt/features/tickets.json
@@ -498,6 +498,27 @@
     "importAction": "Importar CSV",
     "boardTabs": {
       "all": "Todos os tickets"
+    },
+    "boardHeader": {
+      "open": "Abertos",
+      "overdue": "Atrasados",
+      "slaBreach": "Descumprimento de SLA",
+      "unassigned": "Não atribuído",
+      "managedBy": "Gerenciado por",
+      "sla": "SLA"
+    },
+    "viewMenu": {
+      "label": "Exibição",
+      "columns": "Colunas",
+      "density": "Densidade",
+      "saveBoardDefault": "Salvar como visualização padrão deste quadro",
+      "saveTenantDefault": "Salvar como visualização padrão para todos",
+      "resetToTenant": "Redefinir para o padrão do locatário",
+      "unsavedChanges": "Esta visualização difere do padrão salvo",
+      "saved": "Visualização padrão salva",
+      "saveFailed": "Falha ao salvar a visualização padrão",
+      "reset": "Redefinir para o padrão do locatário",
+      "resetFailed": "Falha ao redefinir a visualização"
     }
   },
   "bulk": {

--- a/server/public/locales/pt/features/tickets.json
+++ b/server/public/locales/pt/features/tickets.json
@@ -495,7 +495,10 @@
     },
     "exportSelectedAction": "Exportação selecionada ({{count}})",
     "exportAction": "Exportar CSV",
-    "importAction": "Importar CSV"
+    "importAction": "Importar CSV",
+    "boardTabs": {
+      "all": "Todos os tickets"
+    }
   },
   "bulk": {
     "bundleTickets": "Pacote de tickets",

--- a/server/public/locales/pt/msp/settings.json
+++ b/server/public/locales/pt/msp/settings.json
@@ -779,6 +779,8 @@
         "sections": {
           "general": "Geral",
           "generalHelp": "Nome, descrição, visibilidade e padrão",
+          "appearance": "Aparência e padrões",
+          "appearanceHelp": "Fixação da aba e visualização de lista padrão do quadro",
           "assignment": "Atribuição e SLA",
           "assignmentHelp": "Roteamento padrão, SLA e responsável pelo quadro",
           "inbound": "E-mail e respostas recebidas",
@@ -799,6 +801,22 @@
         "allSaved": "Todas as alterações salvas",
         "reopenBadge": "reabrir",
         "required": "Obrigatório"
+      },
+      "appearance": {
+        "pinLabel": "Fixar na tela de tickets",
+        "pinHelp": "Quadros fixados ganham uma aba permanente na tela de tickets. Quadros não fixados continuam acessíveis em \"Todos os tickets\" e no filtro de quadros.",
+        "savedView": "Visualização salva",
+        "inheritsTenant": "Herda os padrões do locatário",
+        "openBoard": "Abrir este quadro",
+        "resetToTenant": "Redefinir para o padrão do locatário",
+        "arrangeNote": "Organize a visualização deste quadro no próprio quadro e depois salve-a pelo menu \"Exibição\".",
+        "preview": "Pré-visualização",
+        "summary": {
+          "openOnly": "Somente abertos",
+          "columns": "{{count}} colunas",
+          "density": "densidade {{level}}",
+          "sortedBy": "ordenado por {{field}}"
+        }
       },
       "empty": "Nenhum quadro encontrado.",
       "searchPlaceholder": "Pesquisar quadros…"

--- a/server/public/locales/pt/msp/settings.json
+++ b/server/public/locales/pt/msp/settings.json
@@ -813,7 +813,7 @@
         "preview": "Pré-visualização",
         "summary": {
           "openOnly": "Somente abertos",
-          "columns": "{{count}} colunas",
+          "columns": "{{columns}} colunas",
           "density": "densidade {{level}}",
           "sortedBy": "ordenado por {{field}}"
         }

--- a/server/public/locales/xx/features/tickets.json
+++ b/server/public/locales/xx/features/tickets.json
@@ -506,6 +506,27 @@
     "importAction": "11111",
     "boardTabs": {
       "all": "11111"
+    },
+    "boardHeader": {
+      "open": "11111",
+      "overdue": "11111",
+      "slaBreach": "11111",
+      "unassigned": "11111",
+      "managedBy": "11111",
+      "sla": "11111"
+    },
+    "viewMenu": {
+      "label": "11111",
+      "columns": "11111",
+      "density": "11111",
+      "saveBoardDefault": "11111",
+      "saveTenantDefault": "11111",
+      "resetToTenant": "11111",
+      "unsavedChanges": "11111",
+      "saved": "11111",
+      "saveFailed": "11111",
+      "reset": "11111",
+      "resetFailed": "11111"
     }
   },
   "bulk": {

--- a/server/public/locales/xx/features/tickets.json
+++ b/server/public/locales/xx/features/tickets.json
@@ -503,7 +503,10 @@
     },
     "exportSelectedAction": "11111 {{count}} 11111",
     "exportAction": "11111",
-    "importAction": "11111"
+    "importAction": "11111",
+    "boardTabs": {
+      "all": "11111"
+    }
   },
   "bulk": {
     "bundleTickets": "11111",

--- a/server/public/locales/xx/msp/settings.json
+++ b/server/public/locales/xx/msp/settings.json
@@ -813,7 +813,7 @@
         "preview": "11111",
         "summary": {
           "openOnly": "11111",
-          "columns": "11111 {{count}} 11111",
+          "columns": "11111 {{columns}} 11111",
           "density": "11111 {{level}} 11111",
           "sortedBy": "11111 {{field}} 11111"
         }

--- a/server/public/locales/xx/msp/settings.json
+++ b/server/public/locales/xx/msp/settings.json
@@ -779,6 +779,8 @@
         "sections": {
           "general": "11111",
           "generalHelp": "11111",
+          "appearance": "11111",
+          "appearanceHelp": "11111",
           "assignment": "11111",
           "assignmentHelp": "11111",
           "inbound": "11111",
@@ -799,6 +801,22 @@
         "allSaved": "11111",
         "reopenBadge": "11111",
         "required": "11111"
+      },
+      "appearance": {
+        "pinLabel": "11111",
+        "pinHelp": "11111",
+        "savedView": "11111",
+        "inheritsTenant": "11111",
+        "openBoard": "11111",
+        "resetToTenant": "11111",
+        "arrangeNote": "11111",
+        "preview": "11111",
+        "summary": {
+          "openOnly": "11111",
+          "columns": "11111 {{count}} 11111",
+          "density": "11111 {{level}} 11111",
+          "sortedBy": "11111 {{field}} 11111"
+        }
       },
       "empty": "11111",
       "searchPlaceholder": "11111"

--- a/server/public/locales/yy/features/tickets.json
+++ b/server/public/locales/yy/features/tickets.json
@@ -506,6 +506,27 @@
     "importAction": "55555",
     "boardTabs": {
       "all": "55555"
+    },
+    "boardHeader": {
+      "open": "55555",
+      "overdue": "55555",
+      "slaBreach": "55555",
+      "unassigned": "55555",
+      "managedBy": "55555",
+      "sla": "55555"
+    },
+    "viewMenu": {
+      "label": "55555",
+      "columns": "55555",
+      "density": "55555",
+      "saveBoardDefault": "55555",
+      "saveTenantDefault": "55555",
+      "resetToTenant": "55555",
+      "unsavedChanges": "55555",
+      "saved": "55555",
+      "saveFailed": "55555",
+      "reset": "55555",
+      "resetFailed": "55555"
     }
   },
   "bulk": {

--- a/server/public/locales/yy/features/tickets.json
+++ b/server/public/locales/yy/features/tickets.json
@@ -503,7 +503,10 @@
     },
     "exportSelectedAction": "55555 {{count}} 55555",
     "exportAction": "55555",
-    "importAction": "55555"
+    "importAction": "55555",
+    "boardTabs": {
+      "all": "55555"
+    }
   },
   "bulk": {
     "bundleTickets": "55555",

--- a/server/public/locales/yy/msp/settings.json
+++ b/server/public/locales/yy/msp/settings.json
@@ -813,7 +813,7 @@
         "preview": "55555",
         "summary": {
           "openOnly": "55555",
-          "columns": "55555 {{count}} 55555",
+          "columns": "55555 {{columns}} 55555",
           "density": "55555 {{level}} 55555",
           "sortedBy": "55555 {{field}} 55555"
         }

--- a/server/public/locales/yy/msp/settings.json
+++ b/server/public/locales/yy/msp/settings.json
@@ -779,6 +779,8 @@
         "sections": {
           "general": "55555",
           "generalHelp": "55555",
+          "appearance": "55555",
+          "appearanceHelp": "55555",
           "assignment": "55555",
           "assignmentHelp": "55555",
           "inbound": "55555",
@@ -799,6 +801,22 @@
         "allSaved": "55555",
         "reopenBadge": "55555",
         "required": "55555"
+      },
+      "appearance": {
+        "pinLabel": "55555",
+        "pinHelp": "55555",
+        "savedView": "55555",
+        "inheritsTenant": "55555",
+        "openBoard": "55555",
+        "resetToTenant": "55555",
+        "arrangeNote": "55555",
+        "preview": "55555",
+        "summary": {
+          "openOnly": "55555",
+          "columns": "55555 {{count}} 55555",
+          "density": "55555 {{level}} 55555",
+          "sortedBy": "55555 {{field}} 55555"
+        }
       },
       "empty": "55555",
       "searchPlaceholder": "55555"

--- a/server/src/interfaces/board.interface.ts
+++ b/server/src/interfaces/board.interface.ts
@@ -3,6 +3,21 @@ import { TenantEntity } from './index';
 export type CategoryType = 'custom' | 'itil';
 export type PriorityType = 'custom' | 'itil';
 
+/**
+ * A ticket-list view document: what a board (or the tenant) stores as its
+ * default arrangement of the list. Structural rather than imported from
+ * @alga-psa/tickets so the types package keeps no dependency on it; the tickets
+ * package's TicketViewSettings is the authoritative, catalog-keyed shape and is
+ * assignable to this.
+ */
+export interface TicketViewSettings {
+  columnVisibility?: Record<string, boolean>;
+  columnOrder?: string[];
+  tagsInlineUnderTitle?: boolean;
+  densityLevel?: number;
+  filters?: Record<string, unknown>;
+}
+
 export interface IBoard extends TenantEntity {
   board_id?: string;
   board_name?: string;
@@ -18,6 +33,27 @@ export interface IBoard extends TenantEntity {
   // Priority type configuration
   priority_type?: PriorityType;
 
+  // Board-level ticket-list view configuration.
+  //
+  // is_pinned: only pinned boards get a permanent tab on the tickets screen.
+  // Unpinned boards stay fully reachable via All tickets + the board filter, and
+  // a deep link to one renders a transient tab for that visit.
+  //
+  // list_view_settings: the board's default ticket-list view (column visibility
+  // + order, density, captured filters incl. sort), resolved through
+  // resolveTicketViewSettings over the tenant layer and the column catalog.
+  // NULL means "inherit the tenant default" — reset writes NULL, not {}.
+  is_pinned?: boolean;
+  list_view_settings?: TicketViewSettings | null;
+
+  // SUPERSEDED — the display_* block below is dead configuration.
+  //
+  // No UI reads any of these eleven columns; they survive only in this
+  // interface. They are the column-per-setting pattern that produced a wide
+  // table with an abandoned half, and list_view_settings above is their live
+  // successor. Do not add to them and do not mistake them for live config.
+  // Removing them is its own change with its own risk, so they stay for now.
+  //
   // Display configuration for form fields
   display_contact_name_id?: boolean;
   display_priority?: boolean;


### PR DESCRIPTION
## Summary

Board-centric ticketing UX, reimagined mid-flight as **board-level view configuration**: boards go from "just a filter value" to a place with its own identity, header stats, and a default list view (columns, density, filters) that a board manager can capture and save.

- **Board tab strip** on `/msp/tickets`: **All tickets** (home, keeps the existing multi-select include/exclude `BoardFilterPicker`) followed by one tab per **pinned** board, with open-ticket-count pills from `getBoardListStats`. Only pinned boards get tabs; unpinned boards stay reachable via All tickets + board filter, or a transient deep-link tab. A board tab is not new state — it *is* the existing single-board filter, so selecting a tab reuses the pre-existing board-scoped status dropdown and status reconciliation, unified via `buildBoardSelectionFilterUpdate` in `packages/tickets/src/lib/boardTabs.ts`.
- **Board header**: shown on every board tab (never on All tickets, no toggle) with manager/SLA identity plus open/overdue/breach/unassigned counts, all computed in the same `getBoardListStats` aggregate query (no extra round trip) and backed by a shared `ticketSlaBreachedSql` predicate so the header's breach count and the SLA-breached filter can never disagree.
- **Board default views**: `boards.is_pinned` + `boards.list_view_settings` (JSONB) columns (migration `20260819120000_add_board_pinning_and_list_view_settings.cjs`, idempotent up/down, single-subcommand ALTERs for Citus). A shared `resolveTicketViewSettings` layers board → tenant `ticket_display_settings.list` → column catalog defaults; `captureTicketViewSettings` captures the live list state (columns, order, density, tag placement, filters) for save. Board managers author by capturing the current list, not through a separate filter-builder UI. New gated actions `saveBoardDefaultView` / `clearBoardDefaultView` (permission `ticket_settings:update`), with strict Zod validation on write and lenient key-dropping on read so a retired column key can't nuke an entire saved view.
- **View menu** (`TicketViewMenu.tsx`) collapses all view controls (columns, density, save/reset default) into one menu, with a dirty-dot compared against the *resolved* view for the active tab (board → tenant → catalog) rather than the raw stored document, so an unconfigured board doesn't show a permanent false-dirty state.
- Board default views apply **on arrival only** (tab click, and the once-per-mount last-active-board restore) — never on `popstate`, since the URL is already the source of truth for a history step. `shouldApplyBoardDefaultView` in `boardTabs.ts` is the single decision point: URL only gets a vote on first paint (`trigger: "initial"`); a tab click always applies the destination board's view.
- Last-active board persists via a new user-preference key `tickets_last_active_board`, written only from a tab click.
- No new URL params: the strip reuses the existing `boardId`/`boardIds`/`excludeBoardIds` params.
- `tenant_settings.ticket_display_settings.list` now merges **key-group-wise** on write instead of replacing wholesale, since Settings→Display and View→Save-default now both write into the same widened document and previously the last writer silently deleted the other's keys.
- Board editor (`BoardsSettings.tsx`) gained an appearance section to configure the same view-settings document per board.
- i18n: new strings in `features/tickets.json` (dashboard.boardHeader.*, dashboard.viewMenu.*, dashboard.boardTabs.all) and `msp/settings.json` (ticketing.boards.appearance.*, editor.sections.appearance*), parity across de/es/fr/it/nl/pl/pt plus regenerated xx/yy pseudo-locales.

Out of scope (explicitly, per the design decision): a separate `board_views`/saved-views table, board pinning order/drag-reorder UI beyond the boolean, per-user view persistence, and per-board column *locking*.

## Files touched (highlights)

- `packages/tickets/src/lib/boardTabs.ts`, `boardTabs.test.ts` — tab construction, board-selection filter updates, URL-vs-preference precedence, arrival-vs-popstate decision
- `packages/tickets/src/lib/ticketViewSettings.ts`, `ticketViewSettings.test.ts` — resolve/capture/validate/diff for the board→tenant→catalog view-settings layering
- `packages/tickets/src/lib/ticketSlaSql.ts`, `ticketSlaSql.contract.test.ts` — single source of truth for the SLA-breached predicate
- `packages/tickets/src/lib/ticketColumnCatalog.ts`, `ticketColumnOrder.test.tsx` — column catalog + order resolution
- `packages/tickets/src/components/BoardTabStrip.tsx`, `BoardHeader.tsx`, `TicketViewMenu.tsx` — new UI
- `packages/tickets/src/components/TicketingDashboard.tsx`, `TicketingDashboardContainer.tsx` — wiring, history push/replace, debounce-vs-popstate fix, dirty-dot, arrival-only view application
- `packages/tickets/src/components/settings/BoardsSettings.tsx` — board appearance editor
- `packages/tickets/src/actions/board-actions/boardActions.ts`, `boardViewSettingsSchema.ts` — `getBoardListStats` extra aggregates, `getBoardIdentities`, `saveBoardDefaultView`/`clearBoardDefaultView`, permission gate on `updateBoard` for view-affecting fields
- `packages/tickets/src/actions/ticketDisplaySettings.ts`, `ticketDisplaySettingsMerge.test.ts` — key-group-wise merge fix
- `server/migrations/20260819120000_add_board_pinning_and_list_view_settings.cjs` — schema
- `packages/types/src/interfaces/board.interface.ts`, `server/src/interfaces/board.interface.ts` — new fields
- `docs/plans/2026-08-19-board-level-view-configuration-plan.md` — the plan this round implemented
- Locale files (10 languages × 2 namespaces)

## Smoke test results (live, against real DB — no mocks/fakes)

Two live smoke rounds against the host-run dev server on `:3281` (Postgres `127.0.0.1:6472`), driving the actual browser and cross-checking every assertion against the database.

**Round 1 — tab strip mechanics** (evidence: `/tmp/alga-smoke-evidence/board-tab-strip-20260818-230843`): tab strip pills match DB open counts; board selection/URL/status-dropdown sync; back/forward walks tab history with exactly one ticket-fetch per navigation; last-active-board preference written only on tab click; deep links override the stored preference; multi-select picker stays in sync with the tab strip; 25-board strip stays one row with scroll, no overflow menu; inactive/deleted board handling is clean. Zero console errors.

**Round 2 — board-level view configuration** (evidence: `/tmp/alga-smoke-evidence/board-level-view-config-20260819-194629`, 19 screenshots): board header renders correct identity + open/overdue/breach/unassigned counts matching DB; view menu save/reset round-trips a board default view; dirty-dot correctly reflects pristine/changed/saved/changed-again across all four states; per-board views are independent (board A's saved columns/density don't leak into board B, and re-selecting board A restores them); a board with no saved view resets to the neutral defaults (not the previous board's filters — this was a bug found and fixed mid-round); All tickets never shows a board header and never shows a reset option; Settings→Display save preserves view-menu-authored keys (merge fix verified); board editor appearance section renders and saves; unpinned board transient deep-link tab works; SLA-breach header count matches the breached-filter count exactly.

**Fixes applied after live re-verification**, landed as a follow-up commit: `updateURLWithFilters`/`boardArrivalFilters` no longer leak the previous board's filters onto a board with no saved view of its own; `tenant_settings.ticket_display_settings.list` merge fixed to be key-group-wise; `updateBoard` now enforces `ticket_settings:update` when the payload touches `is_pinned`/`list_view_settings`.

**Not tested:** concurrent multi-user/cross-tenant behavior, frame-accurate first-paint flash timing, no production `npm run build` (relied on the live dev server).

## Test plan

- [x] Live smoke test, round 1 (tab strip) — see evidence above
- [x] Live smoke test, round 2 (board view config) — see evidence above
- [x] Unit/contract tests: `boardTabs.test.ts`, `ticketViewSettings.test.ts`, `ticketSlaSql.contract.test.ts`, `ticketColumnOrder.test.tsx`, `ticketDisplaySettingsMerge.test.ts`, `boardArrival.contract.test.ts`, `TicketingDashboard.i18n.test.ts`, `BoardsSettings.copyStatuses.test.tsx` — 611 tests across 119 files passing
- [x] Migration verified up/down/idempotent-up against the dev DB
- [ ] CI checks (handled by the follow-up CI watch step)
