### PR TITLE
chore(flags): rename release-v1.5-feature to release-v1-5-feature

### DIFF
--- a/docs/plans/2026-08-11-client-portal-prepaid-balance-plan.md
+++ b/docs/plans/2026-08-11-client-portal-prepaid-balance-plan.md
@@ -32,13 +32,13 @@ already has:
 
 The portal dashboard (`ClientDashboard.tsx`) has no billing/prepaid presence.
 
-The feature flag `release-v1.5-feature` appears nowhere in the repo yet; this card
+The feature flag `release-v1-5-feature` appears nowhere in the repo yet; this card
 introduces the first portal-side flag check.
 
 ## Feature flag gating (standing release requirement)
 
-Every UI change below is gated behind `release-v1.5-feature` via
-`useFeatureFlag('release-v1.5-feature', { defaultValue: false })`
+Every UI change below is gated behind `release-v1-5-feature` via
+`useFeatureFlag('release-v1-5-feature', { defaultValue: false })`
 (`packages/ui/src/hooks/useFeatureFlag.tsx`; PostHog provider is mounted in the root
 layout so portal routes are covered). Flag off ⇒ the rendered UI is exactly today's:
 no history affordance, unchanged bucket meter, no dashboard widget. While the flag

--- a/docs/plans/2026-08-11-client-portal-root-404-plan.md
+++ b/docs/plans/2026-08-11-client-portal-root-404-plan.md
@@ -45,7 +45,7 @@ The current code confirms the split:
 - Do not commit, attach, or inspect the credential-bearing customer HAR beyond the already-redacted card description.
 - Do not address the separately reported password-reset email/log issue.
 - Do not redesign the client portal, duplicate the dashboard component, broaden accepted return URLs, or change session/OTT security behavior.
-- No `release-v1.5-feature` gate is needed because this is route correction with no new or changed UI.
+- No `release-v1-5-feature` gate is needed because this is route correction with no new or changed UI.
 
 ## Risks and handling
 

--- a/docs/plans/2026-08-11-deferred-revenue-reporting-plan.md
+++ b/docs/plans/2026-08-11-deferred-revenue-reporting-plan.md
@@ -25,7 +25,7 @@ liability. Accountants currently have nothing to tie out at close.
   (remaining amount, expiration, source — flagging prepayment-sourced credits that
   never reach QBO) and individual bucket lines (remaining minutes, period, value).
 - CSV download of the rollforward plus a printable view.
-- All new UI gated behind the `release-v1.5-feature` feature flag; flag off
+- All new UI gated behind the `release-v1-5-feature` feature flag; flag off
   preserves existing UI and behavior exactly.
 
 ## Non-goals
@@ -152,12 +152,12 @@ source).
 ## UI
 
 - **Page:** `server/src/app/msp/reports/deferred-revenue/page.tsx` — server
-  component that checks `featureFlags.isEnabled('release-v1.5-feature', …)` and the
+  component that checks `featureFlags.isEnabled('release-v1-5-feature', …)` and the
   user's permission; flag off → `notFound()`. Renders a client component from
   `packages/reporting/src/components/deferred-revenue/`.
 - **Hub card:** add a `billing`-category entry to the `REPORTS` catalog in
   `packages/msp-composition/src/reports/Reports.tsx` (`kind: 'link'`, href to the
-  new page), rendered only when the `release-v1.5-feature` flag is on
+  new page), rendered only when the `release-v1-5-feature` flag is on
   (`useFeatureFlag`, `defaultValue: false`).
 - **Report component:** month picker (default: previous month — the close month);
   summary stat row (total liability per currency, split credits vs hours, delta vs

--- a/docs/plans/2026-08-11-entity-passwords-plan.md
+++ b/docs/plans/2026-08-11-entity-passwords-plan.md
@@ -20,7 +20,7 @@ Feature posture:
   `assertTierAccess(TIER_FEATURES.CREDENTIALS)` (new tier feature, minimum tier
   `pro`). CE builds get render-nothing stubs via the `@enterprise` alias, the
   same pattern as `HuduClientPasswordsTab`.
-- **All new/changed UI is gated behind the `release-v1.5-feature` flag.** Flag
+- **All new/changed UI is gated behind the `release-v1-5-feature` flag.** Flag
   off ⇒ no nav item, no tabs change, and the existing Hudu-only client
   Passwords tab keeps its current behavior exactly.
 - **No client-portal exposure** in v1.
@@ -375,7 +375,7 @@ CE stubs for the action barrel and components via the `@enterprise` alias so CE
 bundles compile without EE code (existing `packages/ee/.../_stub.ts` /
 CE-stub-component pattern).
 
-### UI (all behind `release-v1.5-feature`)
+### UI (all behind `release-v1-5-feature`)
 
 New package area `packages/ee/src/components/credentials/` (CE stubs) with EE
 implementations in `ee/server/src/components/credentials/`:
@@ -414,7 +414,7 @@ i18n CI checks.
 |---|---|---|
 | Edition | `@enterprise` alias; CE stubs render null | Feature absent in CE |
 | Tier | `assertTierAccess(TIER_FEATURES.CREDENTIALS)` server-side; `getCredentialsContext` for UI | Actions throw tier error; UI hidden |
-| Release flag | `useFeatureFlag('release-v1.5-feature')` | Existing UI/behavior preserved (incl. Hudu-only client tab) |
+| Release flag | `useFeatureFlag('release-v1-5-feature')` | Existing UI/behavior preserved (incl. Hudu-only client tab) |
 
 New tier feature: add `CREDENTIALS` to `TIER_FEATURES` /
 `FEATURE_MINIMUM_TIER` (`pro`) in `packages/types` tier constants.
@@ -464,7 +464,7 @@ New tier feature: add `CREDENTIALS` to `TIER_FEATURES` /
   key with arbitrary extension secrets.
 - **Hosted values wiring:** add `ALGA_VAULT_CREDENTIALS_TRANSIT_KEY` to
   `hosted.values.yaml` (the value is only referenced by name; the key's
-  material lives in Vault). Before enabling the `release-v1.5-feature` flag in
+  material lives in Vault). Before enabling the `release-v1-5-feature` flag in
   hosted, create the transit key with key-derivation allowed:
 
   ```sh
@@ -499,7 +499,7 @@ New tier feature: add `CREDENTIALS` to `TIER_FEATURES` /
 1. Apply the migrations (tables + permission seed).
 2. Create the transit key in Vault (above) and add the env name to
    `hosted.values.yaml`.
-3. Enable the `release-v1.5-feature` flag in PostHog.
+3. Enable the `release-v1-5-feature` flag in PostHog.
 4. The nav item / client tab / asset section appear automatically (EE + Pro
    tier + flag).
 

--- a/docs/plans/2026-08-11-invoice-payment-links-plan.md
+++ b/docs/plans/2026-08-11-invoice-payment-links-plan.md
@@ -26,7 +26,7 @@ These gaps leave a finalized, unpaid invoice harder to pay depending on how it w
 
 - Replacing Stripe, introducing a second production payment provider, or refactoring `PaymentService` onto `PaymentProviderRegistry`.
 - Changing invoice finalization, payment accounting, refunds, credit application, reconciliation, or the existing webhook ledger design.
-- Redesigning the MSP send dialog or payment settings. The only new product UI is the portal payment-error state, behind `release-v1.5-feature`.
+- Redesigning the MSP send dialog or payment settings. The only new product UI is the portal payment-error state, behind `release-v1-5-feature`.
 - Retrofitting the inactive `server/src/utils/email/emailService.tsx` copy or the stub `InvoiceService.sendInvoiceEmail` in `server/src/lib/api/services/InvoiceService.ts`.
 - Solving concurrent first-writer races when two requests create a link at exactly the same time. Sequential active-link reuse remains required and covered.
 - Adding production deployment, operational controls, dashboards, metrics, alerts, or logging beyond preserving the existing server error cause.
@@ -71,7 +71,7 @@ These gaps leave a finalized, unpaid invoice harder to pay depending on how it w
 - `PayInvoicePage` in `server/src/app/client-portal/billing/invoices/[invoiceId]/pay/page.tsx` wraps both work and Next.js `redirect()` calls in one `try/catch`. Because `redirect()` throws, intended redirects can also be caught and rewritten as `payment_error`.
 - Link-creation failures redirect to `/client-portal/billing?tab=invoices&message=...`, but `BillingOverview` in `packages/client-portal/src/components/billing/BillingOverview.tsx` reads only `tab`; neither it nor `InvoicesTab` renders `message`. This is the silent failure.
 - On success, `PaymentRedirect` in `packages/client-portal/src/components/billing/PaymentRedirect.tsx` assigns `window.location.href` and can open the hosted Checkout URL. `verifyClientPortalPayment` validates the returned session ID against the tenant-scoped invoice payment-link record before asking the provider for status.
-- `useFeatureFlag` in `packages/ui/src/hooks/useFeatureFlag.tsx` supports the existing `NEXT_PUBLIC_FORCE_FEATURE_FLAGS` test override. No portal payment component currently uses `release-v1.5-feature`.
+- `useFeatureFlag` in `packages/ui/src/hooks/useFeatureFlag.tsx` supports the existing `NEXT_PUBLIC_FORCE_FEATURE_FLAGS` test override. No portal payment component currently uses `release-v1-5-feature`.
 
 ### Emulator and tests
 
@@ -137,7 +137,7 @@ Change `PaymentActionResult` in `clientPaymentActions.ts` to return a typed, non
 
 Refactor `PayInvoicePage` so `redirect()` is not inside a broad catch. Successful link creation still renders `PaymentRedirect`; already-paid invoices can redirect to Billing outside the work catch; link configuration/creation failures render a new `PaymentUnavailable` component.
 
-`PaymentUnavailable` belongs in `packages/client-portal/src/components/billing`, is exported by that package, and calls `useFeatureFlag('release-v1.5-feature')`:
+`PaymentUnavailable` belongs in `packages/client-portal/src/components/billing`, is exported by that package, and calls `useFeatureFlag('release-v1-5-feature')`:
 
 - while the flag resolves, show the existing loading treatment;
 - when enabled, show a localized heading, safe reason-specific explanation, **Try again** action for retryable creation failures, and **Back to billing** link retaining the invoices tab/invoice ID;
@@ -188,7 +188,7 @@ The notifier signs each event with the configured `whsec_*` secret using Stripeâ
 1. Add the Stripe package to the workspace/lockfile, `packages/emulators/suite` dependencies and `SUITE_EMULATORS`, CLI port mapping, `compose.yml`, `build-image.sh`, `Dockerfile` copy/build stages and `EXPOSE`, suite tests, and the emulator README/port table.
 2. Standard local/test values are `STRIPE_SECRET_KEY=sk_test_algasim`, `STRIPE_PAYMENT_WEBHOOK_SECRET=whsec_algasim`, `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_algasim`, and `STRIPE_API_BASE_URL=http://127.0.0.1:4050`. They are fixtures, not usable credentials.
 3. Integration tests start an `EmulatorHost` in-process on an ephemeral API port, configure the base URL before importing/constructing `StripePaymentProvider`, and reset emulator state between cases.
-4. The portal Playwright setup starts the Stripe emulator on 4050 (control may use an ephemeral port), passes the four Stripe variables into the Next.js `webServer.env`, and sets `NEXT_PUBLIC_FORCE_FEATURE_FLAGS=release-v1.5-feature:true` for the changed error UI.
+4. The portal Playwright setup starts the Stripe emulator on 4050 (control may use an ephemeral port), passes the four Stripe variables into the Next.js `webServer.env`, and sets `NEXT_PUBLIC_FORCE_FEATURE_FLAGS=release-v1-5-feature:true` for the changed error UI.
 5. Configure the emulator notifier target to the test appâ€™s existing `/api/webhooks/stripe/payments` route and use the same signing secret in both processes. The browser success test must therefore traverse the simulated hosted page, the real webhook handler, `PaymentService.processWebhookEvent`, the existing payment/event ledgers, and the success page.
 6. Keep the broad mocked-SDK integration suite for fast provider edge coverage. The emulator-backed cases are the smaller behavioral layer that proves wire compatibility and user flow.
 
@@ -198,7 +198,7 @@ The notifier signs each event with the configured `whsec_*` secret using Stripeâ
 2. **Align eligibility and URLs.** Add the shared invoice-email link-context helper, tenant vanity-domain-aware portal URL builder, finalized/payable checks, and corrected Checkout cancel URL. Make direct and scheduled send use the helper and log retained link errors while continuing with the portal fallback.
 3. **Extend email rendering.** Add payment/portal variables to the direct context, localized migration template, registry seed, hardcoded fallbacks, scheduled `EmailService`, and compatibility renderer for tenant-authored templates. Add the forward system-template migration.
 4. **Make payment failures typed.** Preserve EE initialization/provider/creation causes in `paymentActions.ts`; return stable safe codes from `clientPaymentActions.ts`; retain all current portal tenant, ownership, invoice, and session-ID checks.
-5. **Add the flagged portal failure state.** Refactor `PayInvoicePage` redirect control flow, implement/export/localize `PaymentUnavailable`, and gate the new UI with `release-v1.5-feature`. Keep successful `PaymentRedirect` behavior unchanged.
+5. **Add the flagged portal failure state.** Refactor `PayInvoicePage` redirect control flow, implement/export/localize `PaymentUnavailable`, and gate the new UI with `release-v1-5-feature`. Keep successful `PaymentRedirect` behavior unchanged.
 6. **Implement the emulator.** Add the pure core, Stripe wire endpoints, hosted Checkout, signed notifier, standard controls/state, tests/smoke script, and suite/container/documentation registration. Add only the opt-in API-base override to the production Stripe adapter.
 7. **Add DB-backed behavior tests.** Cover direct delivery, shared recipient precedence, link fallback/reuse, portal link creation, hosted success/webhook settlement, creation failure UI/retry, and tenant/access boundaries. Update the journey README to remove the direct-email behavioral gap.
 8. **Run focused validation, then broader affected suites.** Run formatter/type checks for changed packages, template/locale validation, migration tests, emulator tests/smoke, payment integration tests, invoice-email journey, job unit tests, and the focused Playwright spec before the normal affected CI lanes.
@@ -213,7 +213,7 @@ The notifier signs each event with the configured `whsec_*` secret using Stripeâ
 | Invoice paid meanwhile | No payment CTA; portal CTA may remain | Redirect to Billing/invoice state | Stable `already_paid` result |
 | Draft, cancelled, credit note, or no positive balance | No payment CTA; portal link only where viewing is valid | Server rejects payment before provider call | Stable non-retryable code |
 | Cross-client/cross-tenant invoice or mismatched returned session | No externally generated link | No disclosure; existing access-denied/not-found behavior | Scoped diagnostic only on server |
-| `release-v1.5-feature` disabled | Email behavior unchanged because it is not UI | Preserve current Billing redirect instead of rendering new failure UI | Cause still preserved server-side |
+| `release-v1-5-feature` disabled | Email behavior unchanged because it is not UI | Preserve current Billing redirect instead of rendering new failure UI | Cause still preserved server-side |
 
 ## Security, tenancy, and idempotency
 
@@ -231,7 +231,7 @@ The notifier signs each event with the configured `whsec_*` secret using Stripeâ
 1. Land the resolver, email behavior, payment cause preservation, emulator, and tests together so direct/scheduled parity is protected from the first release.
 2. Apply the forward template migration through the normal application migration path; it updates system invoice-email templates without rewriting tenant custom templates.
 3. Deploy with `STRIPE_API_BASE_URL` unset. Existing Stripe configuration and webhook paths remain unchanged.
-4. Release backend/email behavior normally. Keep the new portal failure component disabled until `release-v1.5-feature` is enabled for the intended cohort; successful Checkout redirection remains the existing behavior.
+4. Release backend/email behavior normally. Keep the new portal failure component disabled until `release-v1-5-feature` is enabled for the intended cohort; successful Checkout redirection remains the existing behavior.
 5. After the flag is enabled, failures show the new retry/back state. Rollback consists of disabling the flag for UI and reverting application code/template migration through the normal release process; no new business-data table is introduced.
 
 ## Risks and open questions
@@ -271,11 +271,11 @@ The starred cases are the smallest high-value set that must be DB-backed and exe
 - [ ] If payments are disabled, unconfigured, or fail to create a link, invoice delivery still succeeds with a working portal fallback when a public portal base is available.
 - [ ] System HTML/text templates in every supported locale render the new CTAs; existing tenant custom templates receive missing CTAs without being overwritten or duplicating URLs.
 - [ ] Portal **Pay Now** opens Stripe Checkout for an eligible owned invoice, and successful hosted payment completes through the signed webhook/status path.
-- [ ] Checkout creation failures show a localized retry/back state when `release-v1.5-feature` is enabled; the legacy redirect remains when it is disabled.
+- [ ] Checkout creation failures show a localized retry/back state when `release-v1-5-feature` is enabled; the legacy redirect remains when it is disabled.
 - [ ] The browser receives only stable safe error codes/messages, while server logging/tests retain the original provider or initialization exception through `cause`.
 - [ ] Billing contact, `clients.billing_email`, billing location, and default location precedence is identical for email preview, email delivery, scheduled delivery, and Stripe customer creation.
 - [ ] All invoice/payment/session lookups remain tenant-scoped and client ownership is checked before any external provider request.
 - [ ] Repeated direct sends reuse the active payment link; duplicate webhook delivery applies one payment.
 - [ ] `@alga-psa/emulator-stripe` runs in the existing emulator suite, supports the required Stripe wire surface and hosted success/failure/cancel interface, and is selected only through explicit test configuration.
 - [ ] DB-backed journey and Playwright coverage protects direct email happy/fallback behavior and portal creation-success, payment-success, and creation-failure flows.
-- [ ] No new production operations or observability surface is introduced, and all changed portal UI is behind `release-v1.5-feature`.
+- [ ] No new production operations or observability surface is introduced, and all changed portal UI is behind `release-v1-5-feature`.

--- a/docs/plans/2026-08-11-notification-priorities-plan.md
+++ b/docs/plans/2026-08-11-notification-priorities-plan.md
@@ -41,7 +41,7 @@ Mobile push carries the priority as **payload metadata only**: the Expo push
 accordingly. Which templates push, and how loudly the OS delivers them, does
 not change in this card.
 
-All user-visible changes are gated behind the `release-v1.5-feature` feature
+All user-visible changes are gated behind the `release-v1-5-feature` feature
 flag. With the flag off, the badge, panel, settings screen, and activities
 list look and behave exactly as today. Schema changes, priority stamping, and
 push metadata are flag-independent because they are invisible to users.
@@ -106,7 +106,7 @@ push metadata are flag-independent because they are invisible to users.
 | High-tier visual language | Muted "attention red" (desaturated, no tinted row background) for rails, pills, section header, and badge — attention-worthy, not emergency |
 | Mobile push | Priority included as payload metadata; no delivery gating, no OS-priority mapping |
 | Email notifications | Out of scope (separate `notification_*` system untouched) |
-| Feature flag | `release-v1.5-feature` gates every user-visible change |
+| Feature flag | `release-v1-5-feature` gates every user-visible change |
 
 ### Rejected alternatives
 
@@ -210,7 +210,7 @@ the tenant-settings migration style and avoid enum-alteration friction later.
   `data` payload. The `TICKET_PUSH_TEMPLATES` allowlist and Expo delivery
   options are unchanged.
 
-## UI changes (all gated on `release-v1.5-feature`)
+## UI changes (all gated on `release-v1-5-feature`)
 
 Use the client-side feature-flag hook per
 `server/src/lib/feature-flags/README.md`; with the flag off every component
@@ -294,7 +294,7 @@ renders exactly the current markup.
   preference, and "View All" no longer persists the view mode when the
   flag is on (still does when off).
 - Full click-through happens in the card's later Smoke Test step (dev
-  server on port 3729; `NEXT_PUBLIC_FORCE_FEATURE_FLAGS=release-v1.5-feature:true`
+  server on port 3729; `NEXT_PUBLIC_FORCE_FEATURE_FLAGS=release-v1-5-feature:true`
   to force the flag on).
 
 ## Out of scope

--- a/docs/plans/2026-08-13-ad-hoc-prepaid-hour-blocks-plan.md
+++ b/docs/plans/2026-08-13-ad-hoc-prepaid-hour-blocks-plan.md
@@ -40,7 +40,7 @@ most-requested prepaid shape for clients without recurring contracts.
    (reason required), void before any burn. Auto-expiration job + expiring-soon
    notification. OUT: client-to-client transfer, first-class refunds (expire + credit
    note covers it).
-6. **UI (all behind `release-v1.5-feature`):** MSP client detail gets an Hour Blocks
+6. **UI (all behind `release-v1-5-feature`):** MSP client detail gets an Hour Blocks
    section (credits-page UX); no tenant-wide roll-up in v1; time-entry dialog
    untouched; client portal extends `PrepaidHoursCard` and the billing overview.
 
@@ -74,7 +74,7 @@ most-requested prepaid shape for clients without recurring contracts.
   non-recurring invoice-linked record is `project_billing_schedule_entries`.
 - **Flag plumbing exists**: `useFeatureFlag` (`packages/ui/src/hooks/useFeatureFlag.tsx`)
   client-side, `isFeatureFlagEnabled` (`packages/core/src/lib/features.ts`)
-  server-side; `release-v1.5-feature` call sites already exist in the client portal
+  server-side; `release-v1-5-feature` call sites already exist in the client portal
   (`PrepaidHoursCard.tsx:30`, `BucketUsageChart.tsx:24`, `CreditsSummaryCard.tsx:78`).
 
 ## Data model (new tables, all tenant-scoped with RLS, composite PK with `tenant`)
@@ -258,7 +258,7 @@ New `packages/billing/src/components/hour-blocks/`:
 - Mounted in the client detail billing area
   (`packages/clients/src/components/clients/` — alongside
   `BillingConfiguration.tsx` / `ClientContractLineDashboard.tsx`), gated with
-  `useFeatureFlag('release-v1.5-feature', { defaultValue: false })`; flag off or
+  `useFeatureFlag('release-v1-5-feature', { defaultValue: false })`; flag off or
   loading ⇒ render nothing, page byte-identical to today.
 - All strings in `server/public/locales/<locale>/…` for **all** locales (CI-enforced).
 

--- a/docs/plans/2026-08-14-weighted-bucket-burn-rates-plan.md
+++ b/docs/plans/2026-08-14-weighted-bucket-burn-rates-plan.md
@@ -2,7 +2,7 @@
 
 **Card:** 29.8.23 (release v1.5) · **Branch:** `feature/weighted-burn-rates-for-bucket-hours`
 **Status:** approved design, ready for implementation
-**Feature flag:** all new/changed UI behind `release-v1.5-feature`; flag off ⇒ existing UI and behavior preserved.
+**Feature flag:** all new/changed UI behind `release-v1-5-feature`; flag off ⇒ existing UI and behavior preserved.
 
 ## Goal
 
@@ -191,7 +191,7 @@ and the `bucket_usage.bucket_id` column; the frozen legacy tables still describe
   from `bucket_config.service_id` to the scope-resolution rule (membership or line catch-all);
   tie-break "prefer the line with a bucket for this service" is unchanged in spirit.
 
-## 5. UI (all changes behind `release-v1.5-feature`; use `alga-feature-flags` patterns)
+## 5. UI (all changes behind `release-v1-5-feature`; use `alga-feature-flags` patterns)
 
 **Flag off:** every existing component (`BucketOverlayFields.tsx`, `ServiceBucketConfigForm.tsx`,
 `BucketServiceConfigPanel.tsx`, wizard steps, `ContractLineDialog`) renders exactly as today,

--- a/docs/plans/2026-08-15-credit-drawdown-review-guide.md
+++ b/docs/plans/2026-08-15-credit-drawdown-review-guide.md
@@ -67,7 +67,7 @@ facts to verify:
   `export type CreditActionError = ...` alias; the `resolveCreditDrawdownPolicy`
   re-export at line 463 is a value re-export).
 
-### Four UI surfaces (all gated behind `release-v1.5-feature`)
+### Four UI surfaces (all gated behind `release-v1-5-feature`)
 1. `CreditDrawdownSettings.tsx` (new) — tenant defaults on the Billing Settings
    page, mounted from `BillingSettings.tsx`.
 2. `ClientCreditDrawdownSettings.tsx` (new) — per-client overrides, mounted from

--- a/docs/plans/2026-08-15-low-balance-alerts-plan.md
+++ b/docs/plans/2026-08-15-low-balance-alerts-plan.md
@@ -12,7 +12,7 @@
 
 ## Outcome
 
-Add a fully `release-v1.5-feature`-gated, per-client policy that warns the assigned account manager and optionally the client billing recipient before prepaid credit or a current bucket is exhausted. The existing daily 09:00 UTC maintenance paths initiate the scan: CE schedules a tenant job and EE reuses the global maintenance schedule plus its per-tenant fanout. The server evaluates canonical ledgers, persists one logical alert per dedupe subject, and routes preference-aware internal/email deliveries through durable leased rows and the existing event-email retry/idempotency path.
+Add a fully `release-v1-5-feature`-gated, per-client policy that warns the assigned account manager and optionally the client billing recipient before prepaid credit or a current bucket is exhausted. The existing daily 09:00 UTC maintenance paths initiate the scan: CE schedules a tenant job and EE reuses the global maintenance schedule plus its per-tenant fanout. The server evaluates canonical ledgers, persists one logical alert per dedupe subject, and routes preference-aware internal/email deliveries through durable leased rows and the existing event-email retry/idempotency path.
 
 The implementation must preserve two intentionally different boundaries:
 
@@ -29,7 +29,7 @@ No product code is part of this design commit. `features.json` and `tests.json` 
 - The card is in Billing > General, after Credit Expiration Settings and before External Credit Settings.
 - Account-manager routing is required whenever an active assigned manager can be resolved. Client email is a separate, default-off opt-in to the canonical invoice billing recipient.
 - Saving only persists policy; it never evaluates or sends immediately. The card says the next check is the daily 09:00 UTC scan.
-- The component, read action, update action, and subscriber independently gate on `release-v1.5-feature` with a false default. Loading, missing, disabled, or throwing flag infrastructure is inert.
+- The component, read action, update action, and subscriber independently gate on `release-v1-5-feature` with a false default. Loading, missing, disabled, or throwing flag infrastructure is inert.
 
 ### Credit subjects
 
@@ -112,7 +112,7 @@ Do not proceed to orchestration until a migrated database proves the check const
 
 17. `server/src/lib/eventBus/subscribers/prepaidBalanceAlertEvaluator.ts` — query configured clients and canonical credit/bucket subjects; lock each `client_billing_settings` row in a short transaction; resolve/rearm policy episodes; insert/upsert stable alert rows; refresh diagnostic observations without duplicating logical alerts.
 18. `server/src/lib/eventBus/subscribers/prepaidBalanceAlertDelivery.ts` — resolve manager/client recipients, normalize/dedupe roles, plan unique delivery rows, claim with `FOR UPDATE SKIP LOCKED`, reclaim stale leases, enforce five attempts, transact internal delivery, and send email outside the transaction through the existing event-email path.
-19. `server/src/lib/eventBus/subscribers/prepaidBalanceAlertSubscriber.ts` — fail closed on `release-v1.5-feature`, invoke evaluator then delivery drain, isolate per-client/recipient failures, and emit one tenant summary plus structured warnings.
+19. `server/src/lib/eventBus/subscribers/prepaidBalanceAlertSubscriber.ts` — fail closed on `release-v1-5-feature`, invoke evaluator then delivery drain, isolate per-client/recipient failures, and emit one tenant summary plus structured warnings.
 20. `server/src/lib/eventBus/subscribers/index.ts` — register the `PREPAID_BALANCE_ALERT_SCAN_REQUESTED` subscriber.
 21. `server/src/lib/notifications/prepaidBalanceAlertTemplates.ts` — provide localized credit/bucket email and internal template definitions/variables with manager `/msp/clients/{clientId}?tab=billing` and client `/client-portal/billing` links; internal variants are `warning` and default `high`.
 22. `server/src/lib/notifications/prepaidBalanceAlertTemplates.test.ts` — verify every billing-email locale and both event variants/recipient link shapes are registered.
@@ -136,7 +136,7 @@ The subscriber is the only layer allowed to evaluate PostHog, query ledgers, res
    - `server/public/locales/xx/msp/clients.json`
    - `server/public/locales/yy/msp/clients.json`
 
-The component itself must call `useFeatureFlag('release-v1.5-feature', { defaultValue: false })` and return `null` for both loading and disabled states. Do not gate only at the parent or expose settings via an ungated server action.
+The component itself must call `useFeatureFlag('release-v1-5-feature', { defaultValue: false })` and return `null` for both loading and disabled states. Do not gate only at the parent or expose settings via an ungated server action.
 
 ### 6. DB-backed behavior, retry, and schedule tests
 
@@ -149,7 +149,7 @@ Use repository-native integration/bootstrap utilities when implementing these fi
 
 ## Feature-flag and rollout contract
 
-1. Deploy schema, registries, scheduler wiring, subscriber, actions, UI, and tests together while `release-v1.5-feature` remains off.
+1. Deploy schema, registries, scheduler wiring, subscriber, actions, UI, and tests together while `release-v1-5-feature` remains off.
 2. Confirm a configured-low migrated fixture produces zero alert/delivery/notification writes with the flag disabled or checker unavailable.
 3. Enable internal/test tenants and configure explicit policies. Observe two daily runs: the first opens/sends; the second deduplicates.
 4. Exercise recovery/re-drop for credit and a period rollover for buckets before gradual flag expansion.

--- a/ee/docs/plans/2026-08-15-low-balance-alerts/PRD.md
+++ b/ee/docs/plans/2026-08-15-low-balance-alerts/PRD.md
@@ -9,7 +9,7 @@
 
 Warn the client account manager, and optionally the client, before prepaid value is exhausted. Each client may configure a currency-specific prepaid-credit floor and/or one bucket-consumption percentage. A daily 09:00 UTC scan evaluates canonical credit and bucket ledgers, creates one durable alert per threshold episode, and routes notifications through the existing notification framework.
 
-The feature is wholly gated by `release-v1.5-feature`. While the flag is loading or disabled, the new client setting card is absent, settings actions reject access, and the scheduled scan performs no alert-state or delivery writes. Nullable/false migration defaults also make deployment inert before enablement.
+The feature is wholly gated by `release-v1-5-feature`. While the flag is loading or disabled, the new client setting card is absent, settings actions reject access, and the scheduled scan performs no alert-state or delivery writes. Nullable/false migration defaults also make deployment inert before enablement.
 
 ## Problem
 
@@ -25,7 +25,7 @@ Without a threshold warning, the first obvious signal may be an overage charge o
 - Use canonical credit and bucket ledgers without summing unrelated currencies or bucket periods.
 - Send at most one alert per credit below-threshold episode and one alert per bucket period/configured threshold.
 - Make alert creation concurrency-safe and retry notification delivery without creating a second logical alert.
-- Preserve existing UI and runtime behavior while `release-v1.5-feature` is off.
+- Preserve existing UI and runtime behavior while `release-v1-5-feature` is off.
 - Reuse notification subtype, template, localization, preference, and internal-priority infrastructure.
 - Leave a queryable audit of alert decisions and delivery outcomes.
 
@@ -47,7 +47,7 @@ Without a threshold warning, the first obvious signal may be an overage charge o
 ### Billing administrator configures a client
 
 1. The administrator opens the client's Billing tab and General section.
-2. When `release-v1.5-feature` is enabled, a Prepaid balance alerts card appears after Credit Expiration Settings and before External Credit Settings.
+2. When `release-v1-5-feature` is enabled, a Prepaid balance alerts card appears after Credit Expiration Settings and before External Credit Settings.
 3. The administrator enables a credit alert and supplies a positive minor-unit threshold plus ISO currency, enables a bucket alert and supplies an integer percentage from 1 to 100, or configures both.
 4. The administrator may opt in to also email the client billing recipient. The account manager route is automatic.
 5. One Save action validates and persists only the new alert fields. Saving does not send immediately; the next scheduled scan evaluates the policy.
@@ -55,7 +55,7 @@ Without a threshold warning, the first obvious signal may be an overage charge o
 ### Daily scan identifies low prepaid credit
 
 1. At 09:00 UTC, the CE or EE scheduler submits a tenant-scoped low-balance scan request.
-2. A server subscriber fails closed unless `release-v1.5-feature` is enabled for the tenant.
+2. A server subscriber fails closed unless `release-v1-5-feature` is enabled for the tenant.
 3. For each configured client/currency with credit history, the subscriber sums non-expired `credit_tracking.remaining_amount` in that currency.
 4. A value strictly below the configured floor opens a credit alert episode. Equality is recovery, not an alert.
 5. Repeated scans below the same policy deduplicate. Recovery to the threshold or above resolves the episode and rearms a later drop.
@@ -77,7 +77,7 @@ Without a threshold warning, the first obvious signal may be an overage charge o
 ## UX / UI Notes
 
 - Add `ClientPrepaidBalanceAlertSettings.tsx` to `packages/clients/src/components/clients/`, rendered by `BillingConfiguration.tsx` in the existing General billing section.
-- The component must call `useFeatureFlag('release-v1.5-feature', { defaultValue: false })` and return `null` both while loading and when disabled. Do not leave a skeleton, spacer, heading, or altered tab markup in flag-off state.
+- The component must call `useFeatureFlag('release-v1-5-feature', { defaultValue: false })` and return `null` both while loading and when disabled. Do not leave a skeleton, spacer, heading, or altered tab markup in flag-off state.
 - Credit controls: enable switch, threshold money input, and ISO currency selector initialized from `clients.default_currency_code` when no policy exists. Persist money in minor units; never persist a localized decimal string.
 - Bucket controls: enable switch and whole-number percentage input constrained to 1–100 inclusive.
 - Client routing control: “Also email the client billing recipient,” default off and disabled when neither alert type is enabled.
@@ -89,7 +89,7 @@ Without a threshold warning, the first obvious signal may be an overage charge o
 
 ### Feature gating
 
-- The client component, read action, update action, and scan subscriber must independently gate on `release-v1.5-feature` with a false default.
+- The client component, read action, update action, and scan subscriber must independently gate on `release-v1-5-feature` with a false default.
 - A disabled or unavailable flag checker must cause no alert evaluation, no alert/delivery rows, and no notification side effects.
 - Schema defaults are `NULL` thresholds and `false` client opt-in; the migration itself must not enable a client.
 - Existing expiring-credit scheduling, settings, templates, and subscribers must not be modified as a shortcut for this feature.
@@ -210,7 +210,7 @@ Without a threshold warning, the first obvious signal may be an overage charge o
 
 ## Rollout / Migration
 
-1. Ship schema, definitions, scheduler wiring, server subscriber, actions, UI, and tests together while `release-v1.5-feature` remains off.
+1. Ship schema, definitions, scheduler wiring, server subscriber, actions, UI, and tests together while `release-v1-5-feature` remains off.
 2. Verify migration distribution metadata and that a disabled tenant produces no alert/delivery writes at the 09:00 UTC run.
 3. Enable the existing flag for internal/test tenants, configure explicit client policies, and observe at least two daily runs to verify first-send and deduplication behavior.
 4. Expand the flag gradually. There is no backfill: the first enabled daily scan establishes current alert episodes from canonical ledgers.
@@ -232,7 +232,7 @@ Without a threshold warning, the first obvious signal may be an overage charge o
 
 ## Dependencies and Constraints
 
-- Depends on the existing `release-v1.5-feature` bridge in `packages/core/src/lib/features.ts` and UI hook in `packages/ui/src/hooks/useFeatureFlag.tsx`.
+- Depends on the existing `release-v1-5-feature` bridge in `packages/core/src/lib/features.ts` and UI hook in `packages/ui/src/hooks/useFeatureFlag.tsx`.
 - Depends on canonical credit math in `packages/billing/src/lib/creditBalance.ts`.
 - Depends on canonical bucket ownership and period state in `shared/billingClients/bucketUsageService.ts` and `packages/billing/src/lib/billing/compute/computeBucketCharges.ts`.
 - Depends on canonical invoice billing recipient resolution in `packages/billing/src/services/invoiceBillingRecipientService.ts`.
@@ -248,7 +248,7 @@ Without a threshold warning, the first obvious signal may be an overage charge o
 - (2026-08-15) Treat credit equality as recovered and bucket equality as reached.
 - (2026-08-15) Notify the active account manager by internal notification and email; optionally email exactly one canonical client billing recipient.
 - (2026-08-15) Persist alerts and deliveries so deduplication, retries, and operational history survive process restarts.
-- (2026-08-15) Keep notification evaluation fail-closed behind `release-v1.5-feature` in addition to UI/action gating.
+- (2026-08-15) Keep notification evaluation fail-closed behind `release-v1-5-feature` in addition to UI/action gating.
 
 ## Open Questions
 
@@ -256,7 +256,7 @@ None. Engineering choices are resolved for draft implementation.
 
 ## Acceptance Criteria (Definition of Done)
 
-1. With `release-v1.5-feature` disabled or unavailable, the client UI is byte-for-byte structurally unchanged at the insertion point, settings actions cannot expose/mutate the policy, and a scheduled scan creates no alerts, deliveries, or notifications.
+1. With `release-v1-5-feature` disabled or unavailable, the client UI is byte-for-byte structurally unchanged at the insertion point, settings actions cannot expose/mutate the policy, and a scheduled scan creates no alerts, deliveries, or notifications.
 2. An authorized user can independently enable/disable a positive currency-specific credit floor, a 1–100 bucket percentage, and optional client email for one tenant-scoped client.
 3. The migrated schema enforces paired credit amount/currency, valid ranges, composite tenant keys, unique dedupe/delivery keys, and Citus distribution metadata.
 4. A client with relevant credit history opens one alert when non-expired remaining credit in the configured currency is below the floor, does not open at equality, and rearms only after recovery to equality or above.

--- a/ee/docs/plans/2026-08-15-low-balance-alerts/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-08-15-low-balance-alerts/SCRATCHPAD.md
@@ -12,7 +12,7 @@
 - (2026-08-15) Account-manager routing is mandatory when an active manager can be resolved; client billing-recipient email is separately opt-in and defaults off.
 - (2026-08-15) A credit alert is one below-threshold episode, rearmed only after recovery to equality or above. A bucket alert is one `bucket_usage` period/configured-percent pair.
 - (2026-08-15) Persist logical alerts separately from delivery attempts. Internal delivery is transactionally idempotent; email uses a stable leased delivery row and bounded retries with documented at-least-once semantics.
-- (2026-08-15) `release-v1.5-feature` gates the whole feature independently at UI, settings action, and scan-subscriber boundaries; unavailable flag infrastructure fails closed.
+- (2026-08-15) `release-v1-5-feature` gates the whole feature independently at UI, settings action, and scan-subscriber boundaries; unavailable flag infrastructure fails closed.
 
 ## Discoveries / Constraints
 

--- a/ee/docs/plans/2026-08-15-low-balance-alerts/features.json
+++ b/ee/docs/plans/2026-08-15-low-balance-alerts/features.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "F001",
-    "description": "The prepaid balance alert settings card is absent, without residual layout, while release-v1.5-feature is loading, unavailable, or disabled.",
+    "description": "The prepaid balance alert settings card is absent, without residual layout, while release-v1-5-feature is loading, unavailable, or disabled.",
     "implemented": true,
     "prdRefs": [
       "Requirements > Feature gating",
@@ -10,7 +10,7 @@
   },
   {
     "id": "F002",
-    "description": "The dedicated settings read and update actions independently fail closed behind release-v1.5-feature and retain billing_settings.read and billing_settings.update permissions.",
+    "description": "The dedicated settings read and update actions independently fail closed behind release-v1-5-feature and retain billing_settings.read and billing_settings.update permissions.",
     "implemented": true,
     "prdRefs": [
       "Requirements > Feature gating",
@@ -20,7 +20,7 @@
   },
   {
     "id": "F003",
-    "description": "The scan subscriber performs no evaluation, alert, delivery, or notification write when release-v1.5-feature is disabled or its checker is unavailable.",
+    "description": "The scan subscriber performs no evaluation, alert, delivery, or notification write when release-v1-5-feature is disabled or its checker is unavailable.",
     "implemented": true,
     "prdRefs": [
       "Requirements > Feature gating",
@@ -319,7 +319,7 @@
   },
   {
     "id": "F038",
-    "description": "Disabling release-v1.5-feature after rollout makes scheduling effects inert without deleting nullable policy settings, alert history, or delivery audit rows.",
+    "description": "Disabling release-v1-5-feature after rollout makes scheduling effects inert without deleting nullable policy settings, alert history, or delivery audit rows.",
     "implemented": true,
     "prdRefs": [
       "Rollout / Migration",

--- a/ee/docs/plans/2026-08-15-low-balance-alerts/tests.json
+++ b/ee/docs/plans/2026-08-15-low-balance-alerts/tests.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "T001",
-    "description": "Component: while release-v1.5-feature is loading, unavailable, or false, BillingConfiguration has no prepaid-alert card, spacer, heading, or changed surrounding order; when true, the card is between credit-expiration and external-credit settings.",
+    "description": "Component: while release-v1-5-feature is loading, unavailable, or false, BillingConfiguration has no prepaid-alert card, spacer, heading, or changed surrounding order; when true, the card is between credit-expiration and external-credit settings.",
     "implemented": true,
     "featureIds": [
       "F001",
@@ -188,7 +188,7 @@
   },
   {
     "id": "T021",
-    "description": "DB-backed feature-flag guard: with release-v1.5-feature false, throwing, or unregistered, a scan against configured low credit and bucket data creates zero alerts, deliveries, internal notifications, and email-provider calls.",
+    "description": "DB-backed feature-flag guard: with release-v1-5-feature false, throwing, or unregistered, a scan against configured low credit and bucket data creates zero alerts, deliveries, internal notifications, and email-provider calls.",
     "implemented": true,
     "featureIds": [
       "F003",

--- a/ee/server/src/__tests__/unit/credentials/credentialsCeStubs.contract.test.ts
+++ b/ee/server/src/__tests__/unit/credentials/credentialsCeStubs.contract.test.ts
@@ -115,7 +115,7 @@ describe('credentials vault — flag-off legacy Hudu tab preservation', () => {
     // Shared wrapper: flag-gated. Flag off => the legacy placeholder card
     // renders in both EE and CE builds; flag on => the vault section loads via
     // @enterprise (EE renders the card, CE renders nothing).
-    expect(wrapper).toContain("useFeatureFlag('release-v1.5-feature'");
+    expect(wrapper).toContain("useFeatureFlag('release-v1-5-feature'");
     expect(wrapper).toContain('if (!flagEnabled) {');
     expect(wrapper).toContain("t('documentsPasswordsTab.passwords.title'");
     expect(wrapper).toContain("t('documentsPasswordsTab.passwords.comingSoon'");
@@ -135,7 +135,7 @@ describe('credentials vault — flag-off legacy Hudu tab preservation', () => {
     // null, never an empty title-only card) and derives the asset ids.
     expect(eeSection).toContain('EntityCredentialsSection');
     expect(eeSection).toContain('entityType="asset"');
-    expect(eeGenericSection).toContain("useFeatureFlag('release-v1.5-feature'");
+    expect(eeGenericSection).toContain("useFeatureFlag('release-v1-5-feature'");
     expect(eeGenericSection).toContain('if (!flagEnabled) {');
     expect(eeGenericSection).toContain('return null;');
     expect(eeGenericSection).toContain('id={cardId}');
@@ -145,7 +145,7 @@ describe('credentials vault — flag-off legacy Hudu tab preservation', () => {
   it('the client gate requires the release flag, EE, and the tier probe (useCredentialsVaultTab)', () => {
     const hook = readRepoFile('packages/clients/src/components/clients/useCredentialsVaultTab.ts');
     expect(hook).toContain("isEnterprise");
-    expect(hook).toContain("useFeatureFlag('release-v1.5-feature'");
+    expect(hook).toContain("useFeatureFlag('release-v1-5-feature'");
     expect(hook).toContain("getCredentialsContext");
     expect(hook).toContain('visible: enabled && flagEnabled && tierOk');
   });
@@ -154,7 +154,7 @@ describe('credentials vault — flag-off legacy Hudu tab preservation', () => {
     const screen = readRepoFile(
       'ee/server/src/components/credentials/CredentialsScreen.tsx'
     );
-    expect(screen).toContain("useFeatureFlag('release-v1.5-feature'");
+    expect(screen).toContain("useFeatureFlag('release-v1-5-feature'");
     expect(screen).toContain('if (!flagEnabled) {');
     expect(screen).toContain('return null;');
   });
@@ -163,7 +163,7 @@ describe('credentials vault — flag-off legacy Hudu tab preservation', () => {
     const sidebar = readRepoFile('server/src/components/layout/SidebarWithFeatureFlags.tsx');
     const menuConfig = readRepoFile('server/src/config/menuConfig.ts');
 
-    expect(sidebar).toContain("useFeatureFlag('release-v1.5-feature'");
+    expect(sidebar).toContain("useFeatureFlag('release-v1-5-feature'");
     expect(sidebar).toContain("item.name !== 'Passwords' || credentialsVaultEnabled");
     // The nav item itself is tier+edition gated (hidden on CE and below pro).
     expect(menuConfig).toContain("name: 'Passwords'");

--- a/ee/server/src/__tests__/unit/huduClientPasswordsTabGate.test.tsx
+++ b/ee/server/src/__tests__/unit/huduClientPasswordsTabGate.test.tsx
@@ -4,7 +4,7 @@
  * (client-passwords-tab group).
  *
  * Since the credentials vault, the client Passwords surface is gated by
- * `useCredentialsVaultTab` (EE + release-v1.5-feature + credentials tier);
+ * `useCredentialsVaultTab` (EE + release-v1-5-feature + credentials tier);
  * when that vault gate is ON the unified Passwords tab REPLACES only the
  * legacy Hudu-only Passwords tab. The general "Hudu" client tab (F070) stays
  * registered whenever EE + Hudu connected + this client mapped — the flag

--- a/ee/server/src/components/credentials/ClientCredentialsTab.tsx
+++ b/ee/server/src/components/credentials/ClientCredentialsTab.tsx
@@ -5,7 +5,7 @@
  *
  * The shared CredentialsScreen scoped to the client: native + Hudu rows merged
  * (Hudu rows keep their reveal-proxy behavior inside the unified list). The
- * screen re-checks the `release-v1.5-feature` flag and tier, rendering nothing
+ * screen re-checks the `release-v1-5-feature` flag and tier, rendering nothing
  * when the feature is off — so flag-off preserves the legacy Hudu-only tab
  * (registered separately in ClientDetails).
  */

--- a/ee/server/src/components/credentials/CredentialsScreen.tsx
+++ b/ee/server/src/components/credentials/CredentialsScreen.tsx
@@ -3,7 +3,7 @@
 /**
  * Credentials vault list screen (EE-only, Pro tier).
  *
- * Gating: `release-v1.5-feature` flag, EE edition (implicit — this module is
+ * Gating: `release-v1-5-feature` flag, EE edition (implicit — this module is
  * only reachable from EE via the `@enterprise` alias), and `getCredentialsContext`
  * (tier). Off ⇒ renders nothing, so the nav-less flag-off state is preserved.
  *
@@ -125,7 +125,7 @@ function ListChrome({
 
 export function CredentialsScreen({ clientId, entityType, entityId, defaultClientId }: CredentialsScreenProps) {
   const { t } = useTranslation('msp/credentials');
-  const releaseFlag = useFeatureFlag('release-v1.5-feature', { defaultValue: false });
+  const releaseFlag = useFeatureFlag('release-v1-5-feature', { defaultValue: false });
   const flagEnabled = typeof releaseFlag === 'boolean' ? releaseFlag : releaseFlag?.enabled ?? false;
 
   const entityScoped = Boolean(entityType && entityId);

--- a/ee/server/src/components/credentials/EntityCredentialsSection.tsx
+++ b/ee/server/src/components/credentials/EntityCredentialsSection.tsx
@@ -25,7 +25,7 @@
  * // expansion, decision 2).
  *
  * The ENTIRE section — chrome included — is gated on the
- * `release-v1.5-feature` flag: flag off renders nothing. Below-Pro tenants get
+ * `release-v1-5-feature` flag: flag off renders nothing. Below-Pro tenants get
  * a one-line upgrade teaser instead of the vault (the nav item and client tab
  * are hidden for them, so this is where they learn the feature exists); the
  * full FeatureUpgradeNotice stays on the global screen.
@@ -325,7 +325,7 @@ export function EntityCredentialsSection({
   titleKey = 'credentials.section.title',
 }: EntityCredentialsSectionProps) {
   const { t } = useTranslation('msp/credentials');
-  const releaseFlag = useFeatureFlag('release-v1.5-feature', { defaultValue: false });
+  const releaseFlag = useFeatureFlag('release-v1-5-feature', { defaultValue: false });
   const flagEnabled = typeof releaseFlag === 'boolean' ? releaseFlag : releaseFlag?.enabled ?? false;
   const { hasFeature } = useTier();
   const isBento = useContentCardVariant() === 'bento';

--- a/packages/assets/src/components/tabs/AssetCredentialsSection.tsx
+++ b/packages/assets/src/components/tabs/AssetCredentialsSection.tsx
@@ -3,7 +3,7 @@
 /**
  * Asset Passwords Section — flag-gated dynamic import wrapper.
  *
- * With the `release-v1.5-feature` flag OFF this renders the exact legacy
+ * With the `release-v1-5-feature` flag OFF this renders the exact legacy
  * "Passwords & Secrets — coming soon" placeholder card that existed before the
  * credentials vault (in both EE and CE builds), so flag-off asset pages are
  * byte-preserved. With the flag ON it dynamically imports the EE/CE vault
@@ -35,7 +35,7 @@ const VaultAssetCredentialsSection = dynamic(
 
 export function AssetCredentialsSection({ assetId, clientId }: AssetCredentialsSectionProps) {
   const { t } = useTranslation('msp/assets');
-  const releaseFlag = useFeatureFlag('release-v1.5-feature', { defaultValue: false });
+  const releaseFlag = useFeatureFlag('release-v1-5-feature', { defaultValue: false });
   const flagEnabled = typeof releaseFlag === 'boolean' ? releaseFlag : releaseFlag?.enabled ?? false;
 
   if (!flagEnabled) {

--- a/packages/billing/src/components/billing-dashboard/CreditApplicationUI.tsx
+++ b/packages/billing/src/components/billing-dashboard/CreditApplicationUI.tsx
@@ -42,7 +42,7 @@ const CreditApplicationUI: React.FC<CreditApplicationUIProps> = ({
   onCancel
 }) => {
   const { t } = useTranslation('msp/credits');
-  const { enabled: creditDrawdownEnabled } = useFeatureFlag('release-v1.5-feature', {
+  const { enabled: creditDrawdownEnabled } = useFeatureFlag('release-v1-5-feature', {
     defaultValue: false,
   });
   const [availableCredits, setAvailableCredits] = useState<ICreditTracking[]>([]);

--- a/packages/billing/src/components/billing-dashboard/contracts/ContractDetail.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/ContractDetail.tsx
@@ -186,7 +186,7 @@ const ContractDetail: React.FC<ContractDetailProps> = ({
   } = useFeatureFlag('contract-simulator', {
     defaultValue: false,
   });
-  const { enabled: creditDrawdownControlsEnabled } = useFeatureFlag('release-v1.5-feature', {
+  const { enabled: creditDrawdownControlsEnabled } = useFeatureFlag('release-v1-5-feature', {
     defaultValue: false,
   });
   const contractId = (searchParams?.get('contractId') ?? resolvedContractId ?? null) as string | null;

--- a/packages/billing/src/components/billing-dashboard/contracts/ContractLines.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/ContractLines.tsx
@@ -139,7 +139,7 @@ const ContractLines: React.FC<ContractLinesProps> = ({ contract, clientId = null
   const formatContractLineType = useFormatContractLineType();
   // Flag-on line-level bucket pools (weighted-burn model). Flag off keeps the
   // existing per-service overlay UI served by the compat layer.
-  const { enabled: bucketPoolEditorEnabled } = useFeatureFlag('release-v1.5-feature', {
+  const { enabled: bucketPoolEditorEnabled } = useFeatureFlag('release-v1-5-feature', {
     defaultValue: false,
   });
   const [bucketSchedules, setBucketSchedules] = useState<Array<{

--- a/packages/billing/src/components/billing-dashboard/contracts/ContractWizard.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/ContractWizard.tsx
@@ -303,7 +303,7 @@ export function ContractWizard({
 }: ContractWizardProps) {
   const { t } = useTranslation("msp/contracts");
   const { enabled: bucketPoolEditorEnabled } = useFeatureFlag(
-    "release-v1.5-feature",
+    "release-v1-5-feature",
     { defaultValue: false },
   );
   const initialWizardDataRef = useRef<ContractWizardData | null>(null);
@@ -572,7 +572,7 @@ export function ContractWizard({
         template_id: wizardData.template_id,
       };
 
-      // The release-v1.5-feature flag selects exactly one bucket-authoring
+      // The release-v1-5-feature flag selects exactly one bucket-authoring
       // path. Flag OFF: the legacy per-service bucket_overlay payload is
       // submitted and bucket_pools is never present. Flag ON: the pool payload
       // is submitted and the conflicting legacy bucket_overlay fields are

--- a/packages/billing/src/components/billing-dashboard/contracts/PricingScheduleDialog.contract.test.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/PricingScheduleDialog.contract.test.tsx
@@ -146,7 +146,7 @@ function submitForm() {
   fireEvent.submit(document.getElementById('pricing-schedule-form') as HTMLFormElement);
 }
 
-describe('PricingScheduleDialog contract-currency custom rate (release-v1.5-feature)', () => {
+describe('PricingScheduleDialog contract-currency custom rate (release-v1-5-feature)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     featureFlagState.enabled = false;

--- a/packages/billing/src/components/billing-dashboard/contracts/PricingScheduleDialog.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/PricingScheduleDialog.tsx
@@ -43,7 +43,7 @@ export function PricingScheduleDialog({
 }: PricingScheduleDialogProps) {
   const { t } = useTranslation('msp/contracts');
   const { symbol, fractionDigits } = useCurrencyFormat();
-  const { enabled: contractCurrencyEnabled, loading: flagLoading } = useFeatureFlag('release-v1.5-feature', {
+  const { enabled: contractCurrencyEnabled, loading: flagLoading } = useFeatureFlag('release-v1-5-feature', {
     defaultValue: false,
   });
   // Flag off preserves the legacy ambient-currency behavior: two decimals, /100, ambient symbol.

--- a/packages/billing/src/components/billing-dashboard/contracts/PricingSchedules.contract.test.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/PricingSchedules.contract.test.tsx
@@ -107,7 +107,7 @@ function renderList(props: { currencyCode?: string } = {}) {
   };
 }
 
-describe('PricingSchedules contract-currency custom rate (release-v1.5-feature)', () => {
+describe('PricingSchedules contract-currency custom rate (release-v1-5-feature)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     featureFlagState.enabled = false;

--- a/packages/billing/src/components/billing-dashboard/contracts/PricingSchedules.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/PricingSchedules.tsx
@@ -44,7 +44,7 @@ const PricingSchedules: React.FC<PricingSchedulesProps> = ({ contractId, currenc
   const { t } = useTranslation('msp/contracts');
   const { locale } = useFormatters();
   const { money } = useCurrencyFormat();
-  const { enabled: contractCurrencyEnabled, loading: flagLoading } = useFeatureFlag('release-v1.5-feature', {
+  const { enabled: contractCurrencyEnabled, loading: flagLoading } = useFeatureFlag('release-v1-5-feature', {
     defaultValue: false,
   });
   // Flag off preserves the legacy ambient-currency two-decimal rendering.

--- a/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/HourlyServicesStep.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/HourlyServicesStep.tsx
@@ -25,7 +25,7 @@ interface HourlyServicesStepProps {
 
 export function HourlyServicesStep({ data, updateData }: HourlyServicesStepProps) {
   const { t } = useTranslation('msp/contracts');
-  const { enabled: bucketPoolEditorEnabled } = useFeatureFlag('release-v1.5-feature', {
+  const { enabled: bucketPoolEditorEnabled } = useFeatureFlag('release-v1-5-feature', {
     defaultValue: false,
   });
   const [bucketSchedules, setBucketSchedules] = React.useState<Array<{

--- a/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/UsageBasedServicesStep.tsx
+++ b/packages/billing/src/components/billing-dashboard/contracts/wizard-steps/UsageBasedServicesStep.tsx
@@ -24,7 +24,7 @@ interface UsageBasedServicesStepProps {
 
 export function UsageBasedServicesStep({ data, updateData }: UsageBasedServicesStepProps) {
   const { t } = useTranslation('msp/contracts');
-  const { enabled: bucketPoolEditorEnabled } = useFeatureFlag('release-v1.5-feature', {
+  const { enabled: bucketPoolEditorEnabled } = useFeatureFlag('release-v1-5-feature', {
     defaultValue: false,
   });
   const [bucketSchedules, setBucketSchedules] = React.useState<Array<{

--- a/packages/billing/src/components/settings/billing/BillingSettings.tsx
+++ b/packages/billing/src/components/settings/billing/BillingSettings.tsx
@@ -123,7 +123,7 @@ const BillingSettings: React.FC = () => {
   const { t } = useTranslation('msp/billing-settings');
   const searchParams = useSearchParams();
   const sectionParam = searchParams?.get('section');
-  const { enabled: creditDrawdownEnabled } = useFeatureFlag('release-v1.5-feature', {
+  const { enabled: creditDrawdownEnabled } = useFeatureFlag('release-v1-5-feature', {
     defaultValue: false,
   });
 

--- a/packages/billing/tests/BillingSettings.featureFlag.test.tsx
+++ b/packages/billing/tests/BillingSettings.featureFlag.test.tsx
@@ -112,7 +112,7 @@ describe("BillingSettings credit draw-down feature flag", () => {
 
     expect(await screen.findByText("General")).toBeInTheDocument();
     expect(screen.queryByTestId("credit-drawdown-settings")).not.toBeInTheDocument();
-    expect(useFeatureFlagMock).toHaveBeenCalledWith("release-v1.5-feature", {
+    expect(useFeatureFlagMock).toHaveBeenCalledWith("release-v1-5-feature", {
       defaultValue: false,
     });
   });

--- a/packages/billing/tests/contractWizardBucketPools.submission.test.tsx
+++ b/packages/billing/tests/contractWizardBucketPools.submission.test.tsx
@@ -2,7 +2,7 @@
 /**
  * ContractWizard bucket-authoring submission exclusivity (behavioral).
  *
- * The release-v1.5-feature flag must select exactly one submission path:
+ * The release-v1-5-feature flag must select exactly one submission path:
  *   - flag OFF: the legacy per-service bucket_overlay payload is submitted and
  *     `bucket_pools` is never present on the payload;
  *   - flag ON: the pool payload is submitted and no conflicting legacy

--- a/packages/billing/tests/contractWizardResume.test.tsx
+++ b/packages/billing/tests/contractWizardResume.test.tsx
@@ -26,7 +26,7 @@ vi.mock('@alga-psa/ui/lib/i18n/client', () => {
   };
 });
 
-// ContractWizard reads the release-v1.5-feature flag to select the bucket
+// ContractWizard reads the release-v1-5-feature flag to select the bucket
 // authoring path; default the flag off (legacy UI) for the resume tests.
 vi.mock('@alga-psa/ui/hooks', () => ({
   useFeatureFlag: () => ({ enabled: false, loading: false, error: null }),

--- a/packages/client-portal/src/actions/client-portal-actions/notificationActivities.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/notificationActivities.ts
@@ -55,7 +55,7 @@ export const fetchNotificationActivities = withAuth(async (
   filters: ActivityFilters = {},
 ): Promise<NotificationActivity[]> => {
   const { knex } = await createTenantKnex();
-  const priorityFeatureEnabled = await isFeatureFlagEnabled('release-v1.5-feature', {
+  const priorityFeatureEnabled = await isFeatureFlagEnabled('release-v1-5-feature', {
     tenantId: tenant,
     userId: user.user_id,
   });

--- a/packages/client-portal/src/components/billing/BucketUsageChart.contract.test.tsx
+++ b/packages/client-portal/src/components/billing/BucketUsageChart.contract.test.tsx
@@ -54,7 +54,7 @@ function bucket(overrides: Partial<ClientBucketUsageResult> = {}): ClientBucketU
   };
 }
 
-describe('BucketUsageChart remaining-first meter (release-v1.5-feature)', () => {
+describe('BucketUsageChart remaining-first meter (release-v1-5-feature)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     featureFlagState.enabled = false;

--- a/packages/client-portal/src/components/billing/BucketUsageChart.tsx
+++ b/packages/client-portal/src/components/billing/BucketUsageChart.tsx
@@ -21,7 +21,7 @@ const BucketUsageChart: React.FC<BucketUsageChartProps> = React.memo(({ bucketDa
   // The legacy (flag-off) rendering was i18n-wired on main under the
   // client-portal namespace; the flag-on meter uses features/billing keys.
   const { t: tLegacy } = useTranslation('client-portal');
-  const { enabled: remainingFirstEnabled } = useFeatureFlag('release-v1.5-feature', {
+  const { enabled: remainingFirstEnabled } = useFeatureFlag('release-v1-5-feature', {
     defaultValue: false,
   });
   const percentage = Math.round(bucketData.percentage_used);

--- a/packages/client-portal/src/components/billing/CreditsSummaryCard.contract.test.tsx
+++ b/packages/client-portal/src/components/billing/CreditsSummaryCard.contract.test.tsx
@@ -79,7 +79,7 @@ function activeCreditRow() {
   };
 }
 
-describe('CreditsSummaryCard credit history (release-v1.5-feature)', () => {
+describe('CreditsSummaryCard credit history (release-v1-5-feature)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     featureFlagState.enabled = false;

--- a/packages/client-portal/src/components/billing/CreditsSummaryCard.tsx
+++ b/packages/client-portal/src/components/billing/CreditsSummaryCard.tsx
@@ -70,12 +70,12 @@ function getCreditHistoryLabel(t: TranslateFn, entry: ClientPortalCreditHistoryE
 /**
  * Available-credit card for the portal billing overview: headline derived
  * balance plus the client's recent credit history with provenance. When the
- * release-v1.5-feature flag is on, a "View history" link opens a ledger dialog
+ * release-v1-5-feature flag is on, a "View history" link opens a ledger dialog
  * of recent credit transactions.
  */
 export default function CreditsSummaryCard({ formatCurrency, formatDate }: CreditsSummaryCardProps) {
   const { t } = useTranslation('features/billing');
-  const { enabled: historyEnabled } = useFeatureFlag('release-v1.5-feature', {
+  const { enabled: historyEnabled } = useFeatureFlag('release-v1-5-feature', {
     defaultValue: false,
   });
   const [summary, setSummary] = useState<ClientPortalCreditSummary | null>(null);

--- a/packages/client-portal/src/components/billing/HourBlocksCard.tsx
+++ b/packages/client-portal/src/components/billing/HourBlocksCard.tsx
@@ -30,7 +30,7 @@ function isActionError(value: unknown): boolean {
  */
 export default function HourBlocksCard() {
   const { t } = useTranslation('features/billing');
-  const { enabled: widgetEnabled } = useFeatureFlag('release-v1.5-feature', {
+  const { enabled: widgetEnabled } = useFeatureFlag('release-v1-5-feature', {
     defaultValue: false,
   });
   const [blocks, setBlocks] = useState<ClientPortalHourBlock[] | null>(null);

--- a/packages/client-portal/src/components/billing/PaymentUnavailable.tsx
+++ b/packages/client-portal/src/components/billing/PaymentUnavailable.tsx
@@ -44,14 +44,14 @@ function reasonKey(code: ClientPaymentErrorCode): string {
  * Failure state shown on the portal Pay page when a payment link cannot be
  * created or online payment is not configured.
  *
- * While `release-v1.5-feature` resolves it renders the existing loading
+ * While `release-v1-5-feature` resolves it renders the existing loading
  * treatment; when disabled it preserves the legacy Billing redirect; when
  * enabled it explains the failure, offers a retry for creation failures, and
  * links back to the invoices tab.
  */
 export function PaymentUnavailable({ code, invoiceId, retryable }: PaymentUnavailableProps) {
   const { t } = useTranslation('features/billing');
-  const { enabled, loading } = useFeatureFlag('release-v1.5-feature');
+  const { enabled, loading } = useFeatureFlag('release-v1-5-feature');
   const [retrying, setRetrying] = useState(false);
   const [retryMessage, setRetryMessage] = useState('');
 

--- a/packages/client-portal/src/components/dashboard/PrepaidHoursCard.contract.test.tsx
+++ b/packages/client-portal/src/components/dashboard/PrepaidHoursCard.contract.test.tsx
@@ -74,7 +74,7 @@ function bucketRow(overrides: Record<string, unknown> = {}) {
   };
 }
 
-describe('PrepaidHoursCard dashboard widget (release-v1.5-feature)', () => {
+describe('PrepaidHoursCard dashboard widget (release-v1-5-feature)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     featureFlagState.enabled = false;

--- a/packages/client-portal/src/components/dashboard/PrepaidHoursCard.tsx
+++ b/packages/client-portal/src/components/dashboard/PrepaidHoursCard.tsx
@@ -30,7 +30,7 @@ import {
  */
 export function PrepaidHoursCard() {
   const { t } = useTranslation('features/billing');
-  const { enabled: widgetEnabled } = useFeatureFlag('release-v1.5-feature', {
+  const { enabled: widgetEnabled } = useFeatureFlag('release-v1-5-feature', {
     defaultValue: false,
   });
   const [buckets, setBuckets] = useState<ClientBucketUsageResult[] | null>(null);

--- a/packages/client-portal/src/components/notifications/ClientNotificationCard.tsx
+++ b/packages/client-portal/src/components/notifications/ClientNotificationCard.tsx
@@ -59,7 +59,7 @@ export function ClientNotificationCard({
 }: ClientNotificationCardProps) {
   const { t } = useTranslation('client-portal');
   // Flag off: markup/behavior exactly as today. Flag on: priority ring/dim + indicator.
-  const { enabled: priorityEnabled } = useFeatureFlag('release-v1.5-feature');
+  const { enabled: priorityEnabled } = useFeatureFlag('release-v1-5-feature');
   const priorityCardClass = priorityEnabled
     ? activity.priority === 'high'
       ? ' ring-1 ring-rose-400'

--- a/packages/client-portal/src/components/notifications/ClientNotificationFiltersDialog.tsx
+++ b/packages/client-portal/src/components/notifications/ClientNotificationFiltersDialog.tsx
@@ -40,7 +40,7 @@ export function ClientNotificationFiltersDialog({
   onApplyFilters,
 }: ClientNotificationFiltersDialogProps) {
   const { t } = useTranslation('client-portal');
-  const { enabled: priorityEnabled } = useFeatureFlag('release-v1.5-feature');
+  const { enabled: priorityEnabled } = useFeatureFlag('release-v1-5-feature');
   const [localFilters, setLocalFilters] = useState<Partial<ActivityFilters>>(() => initialFilters);
   const [selectedCategory, setSelectedCategory] = useState<string>(initialFilters.search || 'all');
   const [selectedPriority, setSelectedPriority] = useState<PriorityFilterKey>(() => priorityKeyFromFilters(initialFilters));

--- a/packages/clients/src/components/clients/BillingConfiguration.tsx
+++ b/packages/clients/src/components/clients/BillingConfiguration.tsx
@@ -51,7 +51,7 @@ const isReturnedActionError = (value: unknown) =>
 const BillingConfiguration: React.FC<BillingConfigurationProps> = ({ client, onSave, contacts = [] }) => {
     const { t } = useTranslation('msp/clients');
     const [activeTab, setActiveTab] = useState('general');
-    const { enabled: creditDrawdownEnabled } = useFeatureFlag('release-v1.5-feature', {
+    const { enabled: creditDrawdownEnabled } = useFeatureFlag('release-v1-5-feature', {
         defaultValue: false,
     });
     const [billingConfig, setBillingConfig] = useState({

--- a/packages/clients/src/components/clients/ClientDetails.tsx
+++ b/packages/clients/src/components/clients/ClientDetails.tsx
@@ -295,7 +295,7 @@ const ClientDetails: React.FC<ClientDetailsProps> = ({
   const entraClientSyncFlag = useFeatureFlag('entra-integration-client-sync-action', {
     defaultValue: false,
   });
-  const hourBlocksFlag = useFeatureFlag('release-v1.5-feature', {
+  const hourBlocksFlag = useFeatureFlag('release-v1-5-feature', {
     defaultValue: false,
   });
   const entraSyncPermission = useEntraSyncPermission();
@@ -308,7 +308,7 @@ const ClientDetails: React.FC<ClientDetailsProps> = ({
   const shouldRenderPsaOnlyClientSurfaces = !isAlgaDeskMode;
   // F070: EE + Hudu connected + this client mapped.
   const huduClientTab = useHuduClientTab(client.client_id);
-  // Credentials vault: EE + release-v1.5-feature + tier. When visible the
+  // Credentials vault: EE + release-v1-5-feature + tier. When visible the
   // unified Passwords tab replaces the Hudu-only one; when off, the legacy tab
   // registration above is preserved exactly.
   const credentialsVaultTab = useCredentialsVaultTab();

--- a/packages/clients/src/components/clients/ClientPrepaidBalanceAlertSettings.tsx
+++ b/packages/clients/src/components/clients/ClientPrepaidBalanceAlertSettings.tsx
@@ -23,7 +23,7 @@ import {
   type PrepaidBalanceAlertSettingsInput,
 } from '../../lib/billingHelpers';
 
-const PREPAID_BALANCE_ALERT_FLAG = 'release-v1.5-feature';
+const PREPAID_BALANCE_ALERT_FLAG = 'release-v1-5-feature';
 
 interface ClientPrepaidBalanceAlertSettingsProps {
   clientId: string;
@@ -70,7 +70,7 @@ const isUsableSettingsResult = (value: unknown): value is {
 
 /**
  * Per-client prepaid balance alert policy. Fully gated behind
- * `release-v1.5-feature`: while the flag is loading, unavailable, or disabled
+ * `release-v1-5-feature`: while the flag is loading, unavailable, or disabled
  * the card renders nothing (no skeleton, spacer, or altered tab markup).
  * Saving only persists the policy; the daily 09:00 UTC scan evaluates it.
  */

--- a/packages/clients/src/components/clients/useCredentialsVaultTab.ts
+++ b/packages/clients/src/components/clients/useCredentialsVaultTab.ts
@@ -11,14 +11,14 @@ export interface CredentialsVaultTabGate {
 
 /**
  * Visibility gate for the unified client "Passwords" tab (credentials vault):
- * EE edition AND the `release-v1.5-feature` flag AND the credentials tier.
+ * EE edition AND the `release-v1-5-feature` flag AND the credentials tier.
  * The tier probe is edition-swapped (EE server action; CE stub returns
  * tierOk=false), so any probe failure resolves hidden. Flag off ⇒ the legacy
  * Hudu-only Passwords tab keeps its current registration.
  */
 export function useCredentialsVaultTab(): CredentialsVaultTabGate {
   const enabled = isEnterprise;
-  const releaseFlag = useFeatureFlag('release-v1.5-feature', { defaultValue: false });
+  const releaseFlag = useFeatureFlag('release-v1-5-feature', { defaultValue: false });
   const flagEnabled = typeof releaseFlag === 'boolean' ? releaseFlag : releaseFlag?.enabled ?? false;
 
   const [tierOk, setTierOk] = useState(false);

--- a/packages/clients/src/components/contacts/ContactCredentialsSection.tsx
+++ b/packages/clients/src/components/contacts/ContactCredentialsSection.tsx
@@ -36,7 +36,7 @@ const VaultEntityCredentialsSection = dynamic(
 );
 
 export function ContactCredentialsSection({ contactId, clientId }: ContactCredentialsSectionProps) {
-  const releaseFlag = useFeatureFlag('release-v1.5-feature', { defaultValue: false });
+  const releaseFlag = useFeatureFlag('release-v1-5-feature', { defaultValue: false });
   const flagEnabled = typeof releaseFlag === 'boolean' ? releaseFlag : releaseFlag?.enabled ?? false;
 
   if (!flagEnabled) {

--- a/packages/clients/src/lib/billingHelpers.ts
+++ b/packages/clients/src/lib/billingHelpers.ts
@@ -518,7 +518,7 @@ export const getEffectiveTaxSourceForClientAsync = withAuth(async (
 
 // ---------------------------------------------------------------------------
 // Prepaid balance alert policy (task 29.8.20). Clients UI path: independently
-// gated on release-v1.5-feature with a false default and billing_settings
+// gated on release-v1-5-feature with a false default and billing_settings
 // read/update permissions, delegating persistence to the shared module.
 // ---------------------------------------------------------------------------
 

--- a/packages/documents/src/components/DocumentCredentialsSection.tsx
+++ b/packages/documents/src/components/DocumentCredentialsSection.tsx
@@ -37,7 +37,7 @@ const VaultEntityCredentialsSection = dynamic(
 );
 
 export function DocumentCredentialsSection({ documentId }: DocumentCredentialsSectionProps) {
-  const releaseFlag = useFeatureFlag('release-v1.5-feature', { defaultValue: false });
+  const releaseFlag = useFeatureFlag('release-v1-5-feature', { defaultValue: false });
   const flagEnabled = typeof releaseFlag === 'boolean' ? releaseFlag : releaseFlag?.enabled ?? false;
 
   if (!flagEnabled) {

--- a/packages/msp-composition/src/reports/Reports.employeeUtilization.render.test.tsx
+++ b/packages/msp-composition/src/reports/Reports.employeeUtilization.render.test.tsx
@@ -42,7 +42,7 @@ vi.mock('@alga-psa/reporting/actions/helpdeskReportActions', () => ({
 }));
 
 // The reports catalog gates the deferred-revenue card behind the
-// `release-v1.5-feature` flag (defaultValue: false). Stub the hook so the
+// `release-v1-5-feature` flag (defaultValue: false). Stub the hook so the
 // catalog renders deterministically without a SessionProvider/PostHog.
 vi.mock('@alga-psa/ui/hooks/useFeatureFlag', () => ({
   useFeatureFlag: () => ({ enabled: false, loading: false, error: null }),

--- a/packages/msp-composition/src/reports/Reports.tsx
+++ b/packages/msp-composition/src/reports/Reports.tsx
@@ -1167,7 +1167,7 @@ export default function Reports({ productCode = 'psa', tier = 'pro' }: ReportsPr
   const { t } = useTranslation('msp/reports');
   const [selectedReportId, setSelectedReportId] = useState<EmbeddedReportId>('ticket-workload');
   const [rangeDays, setRangeDays] = useState<ReportRangeDays>(30);
-  const { enabled: deferredRevenueEnabled } = useFeatureFlag('release-v1.5-feature', { defaultValue: false });
+  const { enabled: deferredRevenueEnabled } = useFeatureFlag('release-v1-5-feature', { defaultValue: false });
 
   const visibleReports = useMemo(
     () =>

--- a/packages/notifications/src/components/NotificationBell.tsx
+++ b/packages/notifications/src/components/NotificationBell.tsx
@@ -19,7 +19,7 @@ function NotificationBellInner({ tenant, userId, className = '' }: { tenant: str
 
   // Configurable notification priorities (task 29.8.46) — every user-visible
   // change is gated behind this flag. Flag off reproduces today's markup exactly.
-  const { enabled: priorityEnabled } = useFeatureFlag('release-v1.5-feature');
+  const { enabled: priorityEnabled } = useFeatureFlag('release-v1-5-feature');
 
   // Use the internal notifications hook
   const {

--- a/packages/notifications/src/components/NotificationDetailView.tsx
+++ b/packages/notifications/src/components/NotificationDetailView.tsx
@@ -91,7 +91,7 @@ export function NotificationDetailView({ notification, onClose, onNavigateToDocu
   // high gets a muted attention-red left accent, low renders dimmed. The type
   // icon/styling above is unchanged. Distinct from the ticket priority rendered
   // from metadata.changes.priority. Flag off: exactly today's markup.
-  const { enabled: priorityEnabled } = useFeatureFlag('release-v1.5-feature');
+  const { enabled: priorityEnabled } = useFeatureFlag('release-v1-5-feature');
   const priorityContainerClass = priorityEnabled
     ? notification.priority === 'high'
       ? ' border-l-4 border-rose-500'

--- a/packages/notifications/src/components/settings/InternalNotificationCategories.tsx
+++ b/packages/notifications/src/components/settings/InternalNotificationCategories.tsx
@@ -111,7 +111,7 @@ function InternalNotificationCategoriesContent({
   const { t } = useTranslation('msp/settings');
   // Priority configuration is gated behind the v1.5 release flag. With the flag
   // off this component renders exactly as before (switches only).
-  const { enabled: priorityEnabled } = useFeatureFlag('release-v1.5-feature');
+  const { enabled: priorityEnabled } = useFeatureFlag('release-v1-5-feature');
   // Current state (what's displayed)
   const [categories, setCategories] = useState(initialCategories);
   const [subtypesByCategory, setSubtypesByCategory] = useState<Record<number, InternalNotificationSubtype[]>>({});

--- a/packages/notifications/src/components/settings/InternalNotificationPreferences.tsx
+++ b/packages/notifications/src/components/settings/InternalNotificationPreferences.tsx
@@ -29,7 +29,7 @@ export function InternalNotificationPreferences() {
   const { t, i18n } = useTranslation('client-portal');
   // Priority configuration is gated behind the v1.5 release flag. With the flag
   // off this component renders exactly as before (switches only).
-  const { enabled: priorityEnabled } = useFeatureFlag('release-v1.5-feature');
+  const { enabled: priorityEnabled } = useFeatureFlag('release-v1-5-feature');
   const { data: session } = useSession();
   const [categories, setCategories] = useState<InternalNotificationCategory[]>([]);
   const [subtypes, setSubtypes] = useState<Record<number, InternalNotificationSubtype[]>>({});

--- a/packages/projects/src/components/TaskCredentialsSection.tsx
+++ b/packages/projects/src/components/TaskCredentialsSection.tsx
@@ -36,7 +36,7 @@ const VaultEntityCredentialsSection = dynamic(
 );
 
 export function TaskCredentialsSection({ taskId, clientId }: TaskCredentialsSectionProps) {
-  const releaseFlag = useFeatureFlag('release-v1.5-feature', { defaultValue: false });
+  const releaseFlag = useFeatureFlag('release-v1-5-feature', { defaultValue: false });
   const flagEnabled = typeof releaseFlag === 'boolean' ? releaseFlag : releaseFlag?.enabled ?? false;
 
   if (!flagEnabled) {

--- a/packages/scheduling/src/lib/timeEntryLauncher.tsx
+++ b/packages/scheduling/src/lib/timeEntryLauncher.tsx
@@ -16,7 +16,7 @@ interface LaunchTimeEntryParams {
   context: TimeEntryWorkItemContext;
   onComplete?: () => void;
   existingEntryId?: string;
-  // release-v1.5-feature launch feedback. Absent/false reproduces the legacy
+  // release-v1-5-feature launch feedback. Absent/false reproduces the legacy
   // toast behavior exactly (plain toast, legacy copy); true switches to the
   // deduplicated long-lived blocked toast with the refreshed copy.
   enhancedLaunchFeedback?: boolean;
@@ -71,7 +71,7 @@ const deriveDefaultTimes = (context: TimeEntryWorkItemContext) => {
 };
 
 export async function launchTimeEntryForWorkItem({ openDrawer, closeDrawer, context, onComplete, existingEntryId, enhancedLaunchFeedback }: LaunchTimeEntryParams): Promise<void> {
-  // release-v1.5-feature gate: flag off keeps the exact legacy toast surface
+  // release-v1-5-feature gate: flag off keeps the exact legacy toast surface
   // (plain toast.error, legacy copy); flag on gets the deduplicated long-lived
   // blocked toast with the refreshed copy.
   const launchBlockedToast = (message: string) => {

--- a/packages/scheduling/src/providers/SchedulingProviderWithCallbacks.tsx
+++ b/packages/scheduling/src/providers/SchedulingProviderWithCallbacks.tsx
@@ -19,7 +19,7 @@ export const SchedulingProviderWithCallbacks: React.FC<SchedulingProviderWithCal
   // The v1.5 flag is resolved here (the launcher is a plain async function, not
   // a hook host) and threaded into every launch so flag-off callers keep the
   // exact legacy toast behavior.
-  const { enabled: v15Enabled } = useFeatureFlag('release-v1.5-feature', { defaultValue: false });
+  const { enabled: v15Enabled } = useFeatureFlag('release-v1-5-feature', { defaultValue: false });
   const callbacks = useMemo<SchedulingCallbacks>(() => ({
     renderAgentSchedule: (agentId: string) => <AgentScheduleView agentId={agentId} />,
     launchTimeEntry: (params) => launchTimeEntryForWorkItem({ ...params, enhancedLaunchFeedback: v15Enabled }),

--- a/packages/scheduling/tests/schedulingProvider.launchFeedbackFlag.test.ts
+++ b/packages/scheduling/tests/schedulingProvider.launchFeedbackFlag.test.ts
@@ -3,7 +3,7 @@ import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { useSchedulingCallbacks } from '@alga-psa/ui/context';
 
-// Wiring coverage for the release-v1.5-feature gate: the provider is the React
+// Wiring coverage for the release-v1-5-feature gate: the provider is the React
 // boundary that resolves the flag (the launcher is a plain async function) and
 // must thread it into every launchTimeEntry call — flag off keeps the launcher
 // on the legacy path (enhancedLaunchFeedback falsy), flag on enables it.
@@ -67,7 +67,7 @@ describe('SchedulingProviderWithCallbacks launch feedback flag wiring', () => {
       context: { workItemId: 't1', workItemType: 'ticket', workItemName: 'T1' },
     });
 
-    expect(useFeatureFlagMock).toHaveBeenCalledWith('release-v1.5-feature', { defaultValue: false });
+    expect(useFeatureFlagMock).toHaveBeenCalledWith('release-v1-5-feature', { defaultValue: false });
     expect(launchTimeEntryForWorkItem).toHaveBeenCalledTimes(1);
     expect(launchTimeEntryForWorkItem.mock.calls[0][0].enhancedLaunchFeedback).toBe(false);
   });

--- a/packages/scheduling/tests/timeEntryLauncher.launchFeedback.test.ts
+++ b/packages/scheduling/tests/timeEntryLauncher.launchFeedback.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { launchTimeEntryForWorkItem } from '../src/lib/timeEntryLauncher';
 
-// Behavioral coverage for the release-v1.5-feature gate on time-entry launch
+// Behavioral coverage for the release-v1-5-feature gate on time-entry launch
 // feedback. Flag OFF (no enhancedLaunchFeedback) must reproduce the exact
 // legacy toast surface: plain single-argument toast.error calls with the
 // legacy no-time-period copy. Flag ON switches to the deduplicated
@@ -61,7 +61,7 @@ beforeEach(() => {
   getTimeEntryById.mockResolvedValue(null);
 });
 
-describe('launchTimeEntryForWorkItem launch feedback (release-v1.5-feature)', () => {
+describe('launchTimeEntryForWorkItem launch feedback (release-v1-5-feature)', () => {
   it('flag off: uses the exact legacy plain toast and copy when no time period covers today', async () => {
     getCurrentTimePeriod.mockResolvedValueOnce(null);
 

--- a/packages/tickets/src/components/ticket/TicketCredentialsSection.tsx
+++ b/packages/tickets/src/components/ticket/TicketCredentialsSection.tsx
@@ -36,7 +36,7 @@ const VaultEntityCredentialsSection = dynamic(
 );
 
 export function TicketCredentialsSection({ ticketId, clientId }: TicketCredentialsSectionProps) {
-  const releaseFlag = useFeatureFlag('release-v1.5-feature', { defaultValue: false });
+  const releaseFlag = useFeatureFlag('release-v1-5-feature', { defaultValue: false });
   const flagEnabled = typeof releaseFlag === 'boolean' ? releaseFlag : releaseFlag?.enabled ?? false;
 
   if (!flagEnabled) {

--- a/packages/user-activities/src/actions/activityAggregationActions.ts
+++ b/packages/user-activities/src/actions/activityAggregationActions.ts
@@ -1553,7 +1553,7 @@ export async function fetchNotificationActivities(
 
     const { knex: db, tenant } = await createTenantKnex(tenantId);
     if (!tenant) throw new Error('Tenant is required');
-    const priorityFeatureEnabled = await isFeatureFlagEnabled('release-v1.5-feature', {
+    const priorityFeatureEnabled = await isFeatureFlagEnabled('release-v1-5-feature', {
       tenantId: tenant,
       userId,
     });
@@ -1602,7 +1602,7 @@ export async function fetchNotificationActivitiesPagedInternal(
 
   const { knex: db, tenant } = await createTenantKnex(tenantId);
   if (!tenant) throw new Error('Tenant is required');
-  const priorityFeatureEnabled = await isFeatureFlagEnabled('release-v1.5-feature', {
+  const priorityFeatureEnabled = await isFeatureFlagEnabled('release-v1-5-feature', {
     tenantId: tenant,
     userId,
   });

--- a/packages/user-activities/src/components/NotificationCard.tsx
+++ b/packages/user-activities/src/components/NotificationCard.tsx
@@ -75,7 +75,7 @@ const priorityLabelKey = (priority: ActivityPriority | undefined): 'high' | 'nor
 
 export function NotificationCard({ activity, onViewDetails, onActionComplete }: NotificationCardProps) {
   const { t } = useTranslation('msp/user-activities');
-  const { enabled } = useFeatureFlag('release-v1.5-feature');
+  const { enabled } = useFeatureFlag('release-v1-5-feature');
   const { openActivityDrawer } = useActivityDrawer();
   const notification = activity as NotificationActivity;
   const priority = notification.priority as ActivityPriority | undefined;

--- a/packages/user-activities/src/components/NotificationsSection.tsx
+++ b/packages/user-activities/src/components/NotificationsSection.tsx
@@ -27,7 +27,7 @@ interface NotificationsSectionProps {
   /**
    * Full-view mode (task 29.8.46, flag-gated): render the numbered server-side
    * pager and priority filter chips instead of the fixed 5-item preview. Only
-   * takes effect when the `release-v1.5-feature` flag is enabled; with the flag
+   * takes effect when the `release-v1-5-feature` flag is enabled; with the flag
    * off the component behaves exactly as before regardless of this prop.
    */
   fullMode?: boolean;
@@ -55,7 +55,7 @@ function priorityKeyToActivityPriority(key: PriorityFilterKey): ActivityPriority
 
 export function NotificationsSection({ limit = 5, onViewAll, noCard = false, fullMode = false }: NotificationsSectionProps) {
   const { t } = useTranslation('msp/user-activities');
-  const { enabled } = useFeatureFlag('release-v1.5-feature');
+  const { enabled } = useFeatureFlag('release-v1-5-feature');
   // Full-view behaviour (pager + priority chips) is only active with the flag on.
   const isFullView = enabled && fullMode;
   const { data: session } = useSession();

--- a/packages/user-activities/src/components/UserActivitiesDashboard.tsx
+++ b/packages/user-activities/src/components/UserActivitiesDashboard.tsx
@@ -19,7 +19,7 @@ import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 
 export function UserActivitiesDashboard() {
   const { t } = useTranslation('msp/user-activities');
-  const { enabled } = useFeatureFlag('release-v1.5-feature');
+  const { enabled } = useFeatureFlag('release-v1-5-feature');
   const searchParams = useSearchParams();
   // Bell "View all notifications" deep-links here with ?focus=notifications. Treat it
   // as an EPHEMERAL card-view override (task 29.8.46) — only honoured with the flag on.

--- a/packages/user-activities/src/components/filters/NotificationSectionFiltersDialog.tsx
+++ b/packages/user-activities/src/components/filters/NotificationSectionFiltersDialog.tsx
@@ -56,7 +56,7 @@ export function NotificationSectionFiltersDialog({
   onApplyFilters,
 }: NotificationSectionFiltersDialogProps) {
   const { t } = useTranslation('msp/user-activities');
-  const { enabled } = useFeatureFlag('release-v1.5-feature');
+  const { enabled } = useFeatureFlag('release-v1-5-feature');
 
   // Notification categories mapping
   const NOTIFICATION_CATEGORIES = [

--- a/server/playwright.config.ts
+++ b/server/playwright.config.ts
@@ -96,7 +96,7 @@ export default defineConfig({
             // Feature-flag overrides for e2e, forwarded from the environment when set.
             NEXT_PUBLIC_FORCE_FEATURE_FLAGS:
               process.env.NEXT_PUBLIC_FORCE_FEATURE_FLAGS ||
-              (paymentLinksEnabled ? "release-v1.5-feature:true" : ""),
+              (paymentLinksEnabled ? "release-v1-5-feature:true" : ""),
             STRIPE_API_BASE_URL: stripeEnv("STRIPE_API_BASE_URL", "http://127.0.0.1:4050"),
             STRIPE_SECRET_KEY: stripeEnv("STRIPE_SECRET_KEY", "sk_test_algasim"),
             NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: stripeEnv(

--- a/server/src/app/msp/credentials/page.tsx
+++ b/server/src/app/msp/credentials/page.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata(): Promise<Metadata> {
  * The edition/tier/release gates are the same three the nav item uses: the
  * route is server-rendered for the sidebar's "Passwords" entry, the EE
  * implementation in `ee/server/src/components/credentials/CredentialsScreen`
- * re-checks `release-v1.5-feature` + `getCredentialsContext` and renders
+ * re-checks `release-v1-5-feature` + `getCredentialsContext` and renders
  * nothing (or the tier message) when unavailable. CE builds resolve the
  * `@enterprise` import to the render-null stub.
  */

--- a/server/src/app/msp/reports/deferred-revenue/page.tsx
+++ b/server/src/app/msp/reports/deferred-revenue/page.tsx
@@ -15,14 +15,14 @@ export async function generateMetadata(): Promise<Metadata> {
 
 /**
  * Deferred-revenue / prepaid liability report. Gated behind the
- * `release-v1.5-feature` feature flag and the `reports.read` permission for
+ * `release-v1-5-feature` feature flag and the `reports.read` permission for
  * internal users; flag off (or no permission) yields a 404 so nothing about
  * the existing UI changes.
  */
 export default async function DeferredRevenueReportPage() {
   const currentUser = await getCurrentUser();
   const [flagEnabled, canReadReports] = await Promise.all([
-    checkFeatureFlag('release-v1.5-feature'),
+    checkFeatureFlag('release-v1-5-feature'),
     currentUser ? hasPermission(currentUser, 'reports', 'read') : Promise.resolve(false),
   ]);
 

--- a/server/src/components/layout/SidebarWithFeatureFlags.tsx
+++ b/server/src/components/layout/SidebarWithFeatureFlags.tsx
@@ -117,7 +117,7 @@ export default function SidebarWithFeatureFlags(props: SidebarWithFeatureFlagsPr
   const marketingFlag = useFeatureFlag('marketing-module', { defaultValue: false });
   const marketingEnabled =
     typeof marketingFlag === 'boolean' ? marketingFlag : marketingFlag?.enabled ?? false;
-  const credentialsVaultFlag = useFeatureFlag('release-v1.5-feature', { defaultValue: false });
+  const credentialsVaultFlag = useFeatureFlag('release-v1-5-feature', { defaultValue: false });
   const credentialsVaultEnabled =
     typeof credentialsVaultFlag === 'boolean'
       ? credentialsVaultFlag

--- a/server/src/lib/eventBus/subscribers/prepaidBalanceAlertSubscriber.ts
+++ b/server/src/lib/eventBus/subscribers/prepaidBalanceAlertSubscriber.ts
@@ -4,7 +4,7 @@
  * Handles PREPAID_BALANCE_ALERT_SCAN_REQUESTED published by the daily 09:00 UTC
  * maintenance handler. This subscriber is the only layer allowed to evaluate
  * the feature flag, query ledgers, resolve recipients, or invoke
- * notifications. It fails closed: while `release-v1.5-feature` is disabled or
+ * notifications. It fails closed: while `release-v1-5-feature` is disabled or
  * its checker is unavailable, the scan performs no alert/delivery/notification
  * writes.
  */
@@ -17,7 +17,7 @@ import { createTenantKnex, runWithTenant } from '@alga-psa/db';
 import { evaluatePrepaidBalanceAlertsForTenant } from './prepaidBalanceAlertEvaluator';
 import { planAndDrainDeliveriesForTenant } from './prepaidBalanceAlertDelivery';
 
-export const PREPAID_BALANCE_ALERT_FLAG = 'release-v1.5-feature';
+export const PREPAID_BALANCE_ALERT_FLAG = 'release-v1-5-feature';
 
 let isRegistered = false;
 

--- a/shared/billingClients/prepaidBalanceAlertSettings.ts
+++ b/shared/billingClients/prepaidBalanceAlertSettings.ts
@@ -9,7 +9,7 @@ import type { Knex } from 'knex';
 import { z } from 'zod';
 import { tenantDb } from '@alga-psa/db';
 
-export const PREPAID_BALANCE_ALERT_FLAG = 'release-v1.5-feature';
+export const PREPAID_BALANCE_ALERT_FLAG = 'release-v1-5-feature';
 
 export const prepaidBalanceAlertSettingsInputSchema = z
   .object({


### PR DESCRIPTION
## Why

PostHog flag keys cannot contain a dot, so `release-v1.5-feature` was never a valid key. Renamed to `release-v1-5-feature`.

## What

Pure string substitution — 134 occurrences across 75 files. Every changed line contains the flag name; nothing else was touched.

- **Runtime call sites** — `useFeatureFlag` / `checkFeatureFlag` / `isFeatureFlagEnabled` across `packages/billing`, `client-portal`, `clients`, `notifications`, `user-activities`, `scheduling`, `msp-composition`, `assets`, `documents`, `projects`, `tickets`, plus `server/src/app/msp/*` pages and `SidebarWithFeatureFlags.tsx`
- **Exported constants** — `PREPAID_BALANCE_ALERT_FLAG` in `shared/billingClients/prepaidBalanceAlertSettings.ts` and `server/src/lib/eventBus/subscribers/prepaidBalanceAlertSubscriber.ts`
- **Test harness** — the `NEXT_PUBLIC_FORCE_FEATURE_FLAGS` string in `server/playwright.config.ts`, and the string-literal assertions in `ee/server/src/__tests__/unit/credentials/credentialsCeStubs.contract.test.ts`
- **Docs** — 10 files under `docs/plans/` and the `ee/docs/plans/2026-08-15-low-balance-alerts/` PRD, features.json, tests.json, SCRATCHPAD

## Verification

- No other spelling variants existed (`release_v1_5_feature`, `releaseV15Feature`, etc.) — zero hits before and after
- No `.env` file, gitignored or otherwise, carries the flag
- `git diff` confirmed pure substitution: no changed line lacks the flag name
- Tests pass: 16 EE credential tests (including the contract test that string-matches the flag in the CE stubs) + 68 flag-related tests across billing, client-portal, scheduling, and msp-composition

## ⚠️ Deploy sequencing

**The flag still needs renaming in PostHog.** This PR only changes what the code asks for. Until the PostHog key is updated to `release-v1-5-feature`, every gated surface evaluates to its `defaultValue: false` and goes dark — credentials vault, notification priorities, deferred revenue report, prepaid balance alerts, contract currency/bucket-pool editors, and the client-portal billing cards.

Either rename the key in PostHog before merging, or accept a window where v1.5 features are hidden.