### PR TITLE
Document EE opportunity APIs in the CE spec

### DIFF
--- a/sdk/docs/openapi/alga-openapi.ce.json
+++ b/sdk/docs/openapi/alga-openapi.ce.json
@@ -272,9 +272,6 @@
       "name": "online-meetings"
     },
     {
-      "name": "opportunities"
-    },
-    {
       "name": "platform-feature-flags"
     },
     {
@@ -101616,6 +101613,1422 @@
         }
       }
     },
+    "/api/v1/opportunities/forecast": {
+      "get": {
+        "summary": "Get forecast band",
+        "description": "Returns floor and ceiling MRR/NRR with per-deal composition for a period. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
+        "tags": [
+          "Opportunities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
+          "x-rbac-resource": "opportunities",
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            },
+            "required": true,
+            "name": "start",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            },
+            "required": true,
+            "name": "end",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiSuccessV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Opportunity or nested resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Opportunity state conflicts with the requested operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/calibration": {
+      "get": {
+        "summary": "Get seller calibration",
+        "description": "Returns declared-confidence outcomes and new-logo agreement attach rate per seller. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
+        "tags": [
+          "Opportunities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
+          "x-rbac-resource": "opportunities",
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiArraySuccessV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Opportunity or nested resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Opportunity state conflicts with the requested operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/meeting-sessions": {
+      "post": {
+        "summary": "Start meeting session",
+        "description": "Starts or resumes the caller’s same-day pipeline meeting session. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
+        "tags": [
+          "Opportunities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
+          "x-rbac-resource": "opportunities",
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "201": {
+            "description": "Operation succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiSuccessV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Opportunity or nested resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Opportunity state conflicts with the requested operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/meeting-sessions/active": {
+      "get": {
+        "summary": "Get active meeting session",
+        "description": "Returns the caller’s resumable same-day meeting session and reviews. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
+        "tags": [
+          "Opportunities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
+          "x-rbac-resource": "opportunities",
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiSuccessV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Opportunity or nested resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Opportunity state conflicts with the requested operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/meeting-sessions/{sessionId}/reviews": {
+      "post": {
+        "summary": "Mark deal reviewed",
+        "description": "Creates or updates the review marker for a deal in a meeting session. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
+        "tags": [
+          "Opportunities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
+          "x-rbac-resource": "opportunities",
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "sessionId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OpportunityMeetingReviewBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Operation succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiSuccessV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Opportunity or nested resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Opportunity state conflicts with the requested operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/{id}/commitments": {
+      "get": {
+        "summary": "List commitments",
+        "description": "Lists the promises recorded for an opportunity. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
+        "tags": [
+          "Opportunities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
+          "x-rbac-resource": "opportunities",
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Opportunity UUID from opportunities.opportunity_id."
+            },
+            "required": true,
+            "description": "Opportunity UUID from opportunities.opportunity_id.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiArraySuccessV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Opportunity or nested resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Opportunity state conflicts with the requested operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create commitment",
+        "description": "Records an unresolved promise on an opportunity. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
+        "tags": [
+          "Opportunities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
+          "x-rbac-resource": "opportunities",
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Opportunity UUID from opportunities.opportunity_id."
+            },
+            "required": true,
+            "description": "Opportunity UUID from opportunities.opportunity_id.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OpportunityCommitmentCreateBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Operation succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiSuccessV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Opportunity or nested resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Opportunity state conflicts with the requested operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/{id}/commitments/{commitmentId}": {
+      "put": {
+        "summary": "Update commitment",
+        "description": "Edits or resolves a commitment to a downstream artifact or explicit decline. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
+        "tags": [
+          "Opportunities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
+          "x-rbac-resource": "opportunities",
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "commitmentId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OpportunityCommitmentUpdateBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Operation succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiSuccessV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Opportunity or nested resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Opportunity state conflicts with the requested operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete commitment",
+        "description": "Deletes a commitment. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
+        "tags": [
+          "Opportunities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
+          "x-rbac-resource": "opportunities",
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "commitmentId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Operation succeeded with no response body."
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Opportunity or nested resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Opportunity state conflicts with the requested operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/qbr/{clientId}": {
+      "get": {
+        "summary": "Get QBR trigger pack",
+        "description": "Assembles renewal, aging/EOL asset, ticket-trend, and whitespace triggers for an account. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
+        "tags": [
+          "Opportunities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
+          "x-rbac-resource": "opportunities",
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "clientId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiSuccessV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Opportunity or nested resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Opportunity state conflicts with the requested operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/qbr/{clientId}/opportunities": {
+      "post": {
+        "summary": "Create QBR opportunities",
+        "description": "Batch-creates typed opportunities from current QBR trigger keys. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
+        "tags": [
+          "Opportunities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
+          "x-rbac-resource": "opportunities",
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "clientId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OpportunityQbrCreateBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Operation succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiSuccessV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Opportunity or nested resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Opportunity state conflicts with the requested operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/qbr/yield": {
+      "get": {
+        "summary": "Get QBR yield",
+        "description": "Returns fired, created, and won trigger counts by account and account manager. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
+        "tags": [
+          "Opportunities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
+          "x-rbac-resource": "opportunities",
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiArraySuccessV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Opportunity or nested resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Opportunity state conflicts with the requested operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/rollups": {
+      "get": {
+        "summary": "Get seller rollups",
+        "description": "Returns period pipeline, outcomes, and attach rate by seller. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
+        "tags": [
+          "Opportunities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
+          "x-rbac-resource": "opportunities",
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            },
+            "required": true,
+            "name": "start",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            },
+            "required": true,
+            "name": "end",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiArraySuccessV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Opportunity or nested resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Opportunity state conflicts with the requested operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/marketing/campaigns": {
       "get": {
         "summary": "List marketing campaigns",
@@ -106489,6 +107902,112 @@
     "/api/v1/inventory/counts/{sessionId}/submit": {
       "post": {
         "summary": "Submit a cycle count session",
+        "tags": [
+          "Inventory v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-rbac-resource": "cycle_count",
+          "x-rbac-action": "update"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "sessionId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryLooseSuccessV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Product access, RBAC, or location scope denied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Inventory resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Inventory state or uniqueness conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/inventory/counts/{sessionId}/cancel": {
+      "post": {
+        "summary": "Cancel a cycle count session",
+        "description": "Cancels an in-progress cycle count and returns the cancelled session. Quantities already recorded against the session stay on it but are never applied to stock levels, since only approval posts them. Cancelling an already-cancelled session returns it unchanged; an approved session cannot be cancelled.",
         "tags": [
           "Inventory v1"
         ],
@@ -119127,66 +120646,6 @@
         }
       }
     },
-    "/api/v1/inventory/counts/{sessionId}/cancel": {
-      "post": {
-        "summary": "POST v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "inventory"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "requestBody": {
-          "description": "Placeholder request body",
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlaceholderObject"
-              },
-              "description": "Placeholder request body"
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/v1/mcp/agents": {
       "delete": {
         "summary": "DELETE v1",
@@ -121012,686 +122471,6 @@
         "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
         "tags": [
           "mobile"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "requestBody": {
-          "description": "Placeholder request body",
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlaceholderObject"
-              },
-              "description": "Placeholder request body"
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/opportunities/calibration": {
-      "get": {
-        "summary": "GET v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "opportunities"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/opportunities/forecast": {
-      "get": {
-        "summary": "GET v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "opportunities"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/opportunities/meeting-sessions": {
-      "post": {
-        "summary": "POST v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "opportunities"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "requestBody": {
-          "description": "Placeholder request body",
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlaceholderObject"
-              },
-              "description": "Placeholder request body"
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/opportunities/meeting-sessions/active": {
-      "get": {
-        "summary": "GET v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "opportunities"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/opportunities/meeting-sessions/{sessionId}/reviews": {
-      "post": {
-        "summary": "POST v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "opportunities"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "requestBody": {
-          "description": "Placeholder request body",
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlaceholderObject"
-              },
-              "description": "Placeholder request body"
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/opportunities/qbr/yield": {
-      "get": {
-        "summary": "GET v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "opportunities"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/opportunities/qbr/{clientId}": {
-      "get": {
-        "summary": "GET v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "opportunities"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/opportunities/qbr/{clientId}/opportunities": {
-      "post": {
-        "summary": "POST v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "opportunities"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "requestBody": {
-          "description": "Placeholder request body",
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlaceholderObject"
-              },
-              "description": "Placeholder request body"
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/opportunities/rollups": {
-      "get": {
-        "summary": "GET v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "opportunities"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/opportunities/{id}/commitments": {
-      "get": {
-        "summary": "GET v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "opportunities"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "summary": "POST v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "opportunities"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "requestBody": {
-          "description": "Placeholder request body",
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlaceholderObject"
-              },
-              "description": "Placeholder request body"
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/opportunities/{id}/commitments/{commitmentId}": {
-      "delete": {
-        "summary": "DELETE v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "opportunities"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "204": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "summary": "PUT v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "opportunities"
         ],
         "extensions": {
           "x-generated-from": "docs/openapi/route-inventory.json",

--- a/sdk/docs/openapi/alga-openapi.ce.yaml
+++ b/sdk/docs/openapi/alga-openapi.ce.yaml
@@ -94,7 +94,6 @@ tags:
   - name: meta
   - name: mobile
   - name: online-meetings
-  - name: opportunities
   - name: platform-feature-flags
   - name: platform-notifications
   - name: platform-reports
@@ -67755,6 +67754,959 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/OpportunityApiErrorV1"
+  /api/v1/opportunities/forecast:
+    get:
+      summary: Get forecast band
+      description: "Returns floor and ceiling MRR/NRR with per-deal composition for a
+        period. Requires opportunity management: Community Edition answers 403
+        `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403
+        `TIER_ACCESS_DENIED`."
+      tags:
+        - Opportunities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
+        x-rbac-resource: opportunities
+        x-tier-feature: OPPORTUNITY_MANAGEMENT
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            pattern: ^\d{4}-\d{2}-\d{2}$
+          required: true
+          name: start
+          in: query
+        - schema:
+            type: string
+            pattern: ^\d{4}-\d{2}-\d{2}$
+          required: true
+          name: end
+          in: query
+      responses:
+        "200":
+          description: Operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiSuccessV1"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "403":
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "404":
+          description: Opportunity or nested resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "409":
+          description: Opportunity state conflicts with the requested operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+  /api/v1/opportunities/calibration:
+    get:
+      summary: Get seller calibration
+      description: "Returns declared-confidence outcomes and new-logo agreement attach
+        rate per seller. Requires opportunity management: Community Edition
+        answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer
+        403 `TIER_ACCESS_DENIED`."
+      tags:
+        - Opportunities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
+        x-rbac-resource: opportunities
+        x-tier-feature: OPPORTUNITY_MANAGEMENT
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiArraySuccessV1"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "403":
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "404":
+          description: Opportunity or nested resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "409":
+          description: Opportunity state conflicts with the requested operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+  /api/v1/opportunities/meeting-sessions:
+    post:
+      summary: Start meeting session
+      description: "Starts or resumes the caller’s same-day pipeline meeting session.
+        Requires opportunity management: Community Edition answers 403
+        `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403
+        `TIER_ACCESS_DENIED`."
+      tags:
+        - Opportunities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
+        x-rbac-resource: opportunities
+        x-tier-feature: OPPORTUNITY_MANAGEMENT
+      x-alga-products:
+        - psa
+      responses:
+        "201":
+          description: Operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiSuccessV1"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "403":
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "404":
+          description: Opportunity or nested resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "409":
+          description: Opportunity state conflicts with the requested operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+  /api/v1/opportunities/meeting-sessions/active:
+    get:
+      summary: Get active meeting session
+      description: "Returns the caller’s resumable same-day meeting session and
+        reviews. Requires opportunity management: Community Edition answers 403
+        `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403
+        `TIER_ACCESS_DENIED`."
+      tags:
+        - Opportunities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
+        x-rbac-resource: opportunities
+        x-tier-feature: OPPORTUNITY_MANAGEMENT
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiSuccessV1"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "403":
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "404":
+          description: Opportunity or nested resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "409":
+          description: Opportunity state conflicts with the requested operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+  /api/v1/opportunities/meeting-sessions/{sessionId}/reviews:
+    post:
+      summary: Mark deal reviewed
+      description: "Creates or updates the review marker for a deal in a meeting
+        session. Requires opportunity management: Community Edition answers 403
+        `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403
+        `TIER_ACCESS_DENIED`."
+      tags:
+        - Opportunities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
+        x-rbac-resource: opportunities
+        x-tier-feature: OPPORTUNITY_MANAGEMENT
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+          required: true
+          name: sessionId
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OpportunityMeetingReviewBodyV1"
+      responses:
+        "200":
+          description: Operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiSuccessV1"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "403":
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "404":
+          description: Opportunity or nested resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "409":
+          description: Opportunity state conflicts with the requested operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+  /api/v1/opportunities/{id}/commitments:
+    get:
+      summary: List commitments
+      description: "Lists the promises recorded for an opportunity. Requires
+        opportunity management: Community Edition answers 403
+        `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403
+        `TIER_ACCESS_DENIED`."
+      tags:
+        - Opportunities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
+        x-rbac-resource: opportunities
+        x-tier-feature: OPPORTUNITY_MANAGEMENT
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Opportunity UUID from opportunities.opportunity_id.
+          required: true
+          description: Opportunity UUID from opportunities.opportunity_id.
+          name: id
+          in: path
+      responses:
+        "200":
+          description: Operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiArraySuccessV1"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "403":
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "404":
+          description: Opportunity or nested resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "409":
+          description: Opportunity state conflicts with the requested operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+    post:
+      summary: Create commitment
+      description: "Records an unresolved promise on an opportunity. Requires
+        opportunity management: Community Edition answers 403
+        `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403
+        `TIER_ACCESS_DENIED`."
+      tags:
+        - Opportunities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
+        x-rbac-resource: opportunities
+        x-tier-feature: OPPORTUNITY_MANAGEMENT
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Opportunity UUID from opportunities.opportunity_id.
+          required: true
+          description: Opportunity UUID from opportunities.opportunity_id.
+          name: id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OpportunityCommitmentCreateBodyV1"
+      responses:
+        "201":
+          description: Operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiSuccessV1"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "403":
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "404":
+          description: Opportunity or nested resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "409":
+          description: Opportunity state conflicts with the requested operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+  /api/v1/opportunities/{id}/commitments/{commitmentId}:
+    put:
+      summary: Update commitment
+      description: "Edits or resolves a commitment to a downstream artifact or
+        explicit decline. Requires opportunity management: Community Edition
+        answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer
+        403 `TIER_ACCESS_DENIED`."
+      tags:
+        - Opportunities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
+        x-rbac-resource: opportunities
+        x-tier-feature: OPPORTUNITY_MANAGEMENT
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+          required: true
+          name: id
+          in: path
+        - schema:
+            type: string
+            format: uuid
+          required: true
+          name: commitmentId
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OpportunityCommitmentUpdateBodyV1"
+      responses:
+        "200":
+          description: Operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiSuccessV1"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "403":
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "404":
+          description: Opportunity or nested resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "409":
+          description: Opportunity state conflicts with the requested operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+    delete:
+      summary: Delete commitment
+      description: "Deletes a commitment. Requires opportunity management: Community
+        Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro
+        answer 403 `TIER_ACCESS_DENIED`."
+      tags:
+        - Opportunities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
+        x-rbac-resource: opportunities
+        x-tier-feature: OPPORTUNITY_MANAGEMENT
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+          required: true
+          name: id
+          in: path
+        - schema:
+            type: string
+            format: uuid
+          required: true
+          name: commitmentId
+          in: path
+      responses:
+        "204":
+          description: Operation succeeded with no response body.
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "403":
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "404":
+          description: Opportunity or nested resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "409":
+          description: Opportunity state conflicts with the requested operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+  /api/v1/opportunities/qbr/{clientId}:
+    get:
+      summary: Get QBR trigger pack
+      description: "Assembles renewal, aging/EOL asset, ticket-trend, and whitespace
+        triggers for an account. Requires opportunity management: Community
+        Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro
+        answer 403 `TIER_ACCESS_DENIED`."
+      tags:
+        - Opportunities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
+        x-rbac-resource: opportunities
+        x-tier-feature: OPPORTUNITY_MANAGEMENT
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+          required: true
+          name: clientId
+          in: path
+      responses:
+        "200":
+          description: Operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiSuccessV1"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "403":
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "404":
+          description: Opportunity or nested resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "409":
+          description: Opportunity state conflicts with the requested operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+  /api/v1/opportunities/qbr/{clientId}/opportunities:
+    post:
+      summary: Create QBR opportunities
+      description: "Batch-creates typed opportunities from current QBR trigger keys.
+        Requires opportunity management: Community Edition answers 403
+        `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403
+        `TIER_ACCESS_DENIED`."
+      tags:
+        - Opportunities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
+        x-rbac-resource: opportunities
+        x-tier-feature: OPPORTUNITY_MANAGEMENT
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+          required: true
+          name: clientId
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OpportunityQbrCreateBodyV1"
+      responses:
+        "201":
+          description: Operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiSuccessV1"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "403":
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "404":
+          description: Opportunity or nested resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "409":
+          description: Opportunity state conflicts with the requested operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+  /api/v1/opportunities/qbr/yield:
+    get:
+      summary: Get QBR yield
+      description: "Returns fired, created, and won trigger counts by account and
+        account manager. Requires opportunity management: Community Edition
+        answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer
+        403 `TIER_ACCESS_DENIED`."
+      tags:
+        - Opportunities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
+        x-rbac-resource: opportunities
+        x-tier-feature: OPPORTUNITY_MANAGEMENT
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiArraySuccessV1"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "403":
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "404":
+          description: Opportunity or nested resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "409":
+          description: Opportunity state conflicts with the requested operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+  /api/v1/opportunities/rollups:
+    get:
+      summary: Get seller rollups
+      description: "Returns period pipeline, outcomes, and attach rate by seller.
+        Requires opportunity management: Community Edition answers 403
+        `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403
+        `TIER_ACCESS_DENIED`."
+      tags:
+        - Opportunities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
+        x-rbac-resource: opportunities
+        x-tier-feature: OPPORTUNITY_MANAGEMENT
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            pattern: ^\d{4}-\d{2}-\d{2}$
+          required: true
+          name: start
+          in: query
+        - schema:
+            type: string
+            pattern: ^\d{4}-\d{2}-\d{2}$
+          required: true
+          name: end
+          in: query
+      responses:
+        "200":
+          description: Operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiArraySuccessV1"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "403":
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "404":
+          description: Opportunity or nested resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "409":
+          description: Opportunity state conflicts with the requested operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
   /api/v1/marketing/campaigns:
     get:
       summary: List marketing campaigns
@@ -70834,6 +71786,75 @@ paths:
   /api/v1/inventory/counts/{sessionId}/submit:
     post:
       summary: Submit a cycle count session
+      tags:
+        - Inventory v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-rbac-resource: cycle_count
+        x-rbac-action: update
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+          required: true
+          name: sessionId
+          in: path
+      responses:
+        "200":
+          description: Operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryLooseSuccessV1"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryApiErrorV1"
+        "403":
+          description: Product access, RBAC, or location scope denied.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryApiErrorV1"
+        "404":
+          description: Inventory resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryApiErrorV1"
+        "409":
+          description: Inventory state or uniqueness conflict.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryApiErrorV1"
+  /api/v1/inventory/counts/{sessionId}/cancel:
+    post:
+      summary: Cancel a cycle count session
+      description: Cancels an in-progress cycle count and returns the cancelled
+        session. Quantities already recorded against the session stay on it but
+        are never applied to stock levels, since only approval posts them.
+        Cancelling an already-cancelled session returns it unchanged; an
+        approved session cannot be cancelled.
       tags:
         - Inventory v1
       security:
@@ -79051,45 +80072,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/inventory/counts/{sessionId}/cancel:
-    post:
-      summary: POST v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - inventory
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      requestBody:
-        description: Placeholder request body
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PlaceholderObject"
-            description: Placeholder request body
-      responses:
-        "201":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
   /api/v1/mcp/agents:
     delete:
       summary: DELETE v1
@@ -80279,447 +81261,6 @@ paths:
         inventory. Replace with canonical OpenAPI metadata.
       tags:
         - mobile
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      requestBody:
-        description: Placeholder request body
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PlaceholderObject"
-            description: Placeholder request body
-      responses:
-        "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/opportunities/calibration:
-    get:
-      summary: GET v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - opportunities
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/opportunities/forecast:
-    get:
-      summary: GET v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - opportunities
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/opportunities/meeting-sessions:
-    post:
-      summary: POST v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - opportunities
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      requestBody:
-        description: Placeholder request body
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PlaceholderObject"
-            description: Placeholder request body
-      responses:
-        "201":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/opportunities/meeting-sessions/active:
-    get:
-      summary: GET v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - opportunities
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/opportunities/meeting-sessions/{sessionId}/reviews:
-    post:
-      summary: POST v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - opportunities
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      requestBody:
-        description: Placeholder request body
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PlaceholderObject"
-            description: Placeholder request body
-      responses:
-        "201":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/opportunities/qbr/yield:
-    get:
-      summary: GET v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - opportunities
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/opportunities/qbr/{clientId}:
-    get:
-      summary: GET v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - opportunities
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/opportunities/qbr/{clientId}/opportunities:
-    post:
-      summary: POST v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - opportunities
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      requestBody:
-        description: Placeholder request body
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PlaceholderObject"
-            description: Placeholder request body
-      responses:
-        "201":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/opportunities/rollups:
-    get:
-      summary: GET v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - opportunities
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/opportunities/{id}/commitments:
-    get:
-      summary: GET v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - opportunities
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-    post:
-      summary: POST v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - opportunities
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      requestBody:
-        description: Placeholder request body
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PlaceholderObject"
-            description: Placeholder request body
-      responses:
-        "201":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/opportunities/{id}/commitments/{commitmentId}:
-    delete:
-      summary: DELETE v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - opportunities
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "204":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-    put:
-      summary: PUT v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - opportunities
       extensions:
         x-generated-from: docs/openapi/route-inventory.json
         x-placeholder: true

--- a/sdk/docs/openapi/alga-openapi.ee.json
+++ b/sdk/docs/openapi/alga-openapi.ee.json
@@ -101619,7 +101619,7 @@
     "/api/v1/opportunities/forecast": {
       "get": {
         "summary": "Get forecast band",
-        "description": "Returns floor and ceiling MRR/NRR with per-deal composition for a period.",
+        "description": "Returns floor and ceiling MRR/NRR with per-deal composition for a period. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
         "tags": [
           "Opportunities v1"
         ],
@@ -101633,8 +101633,7 @@
           "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
           "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
           "x-rbac-resource": "opportunities",
-          "x-tier-feature": "OPPORTUNITY_MANAGEMENT",
-          "x-edition": "EE"
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
         },
         "x-alga-products": [
           "psa"
@@ -101691,7 +101690,7 @@
             }
           },
           "403": {
-            "description": "RBAC denied for the opportunities resource action.",
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
             "content": {
               "application/json": {
                 "schema": {
@@ -101736,7 +101735,7 @@
     "/api/v1/opportunities/calibration": {
       "get": {
         "summary": "Get seller calibration",
-        "description": "Returns declared-confidence outcomes and new-logo agreement attach rate per seller.",
+        "description": "Returns declared-confidence outcomes and new-logo agreement attach rate per seller. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
         "tags": [
           "Opportunities v1"
         ],
@@ -101750,8 +101749,7 @@
           "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
           "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
           "x-rbac-resource": "opportunities",
-          "x-tier-feature": "OPPORTUNITY_MANAGEMENT",
-          "x-edition": "EE"
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
         },
         "x-alga-products": [
           "psa"
@@ -101788,7 +101786,7 @@
             }
           },
           "403": {
-            "description": "RBAC denied for the opportunities resource action.",
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
             "content": {
               "application/json": {
                 "schema": {
@@ -101833,7 +101831,7 @@
     "/api/v1/opportunities/meeting-sessions": {
       "post": {
         "summary": "Start meeting session",
-        "description": "Starts or resumes the caller’s same-day pipeline meeting session.",
+        "description": "Starts or resumes the caller’s same-day pipeline meeting session. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
         "tags": [
           "Opportunities v1"
         ],
@@ -101847,8 +101845,7 @@
           "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
           "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
           "x-rbac-resource": "opportunities",
-          "x-tier-feature": "OPPORTUNITY_MANAGEMENT",
-          "x-edition": "EE"
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
         },
         "x-alga-products": [
           "psa"
@@ -101885,7 +101882,7 @@
             }
           },
           "403": {
-            "description": "RBAC denied for the opportunities resource action.",
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
             "content": {
               "application/json": {
                 "schema": {
@@ -101930,7 +101927,7 @@
     "/api/v1/opportunities/meeting-sessions/active": {
       "get": {
         "summary": "Get active meeting session",
-        "description": "Returns the caller’s resumable same-day meeting session and reviews.",
+        "description": "Returns the caller’s resumable same-day meeting session and reviews. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
         "tags": [
           "Opportunities v1"
         ],
@@ -101944,8 +101941,7 @@
           "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
           "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
           "x-rbac-resource": "opportunities",
-          "x-tier-feature": "OPPORTUNITY_MANAGEMENT",
-          "x-edition": "EE"
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
         },
         "x-alga-products": [
           "psa"
@@ -101982,7 +101978,7 @@
             }
           },
           "403": {
-            "description": "RBAC denied for the opportunities resource action.",
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
             "content": {
               "application/json": {
                 "schema": {
@@ -102027,7 +102023,7 @@
     "/api/v1/opportunities/meeting-sessions/{sessionId}/reviews": {
       "post": {
         "summary": "Mark deal reviewed",
-        "description": "Creates or updates the review marker for a deal in a meeting session.",
+        "description": "Creates or updates the review marker for a deal in a meeting session. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
         "tags": [
           "Opportunities v1"
         ],
@@ -102041,8 +102037,7 @@
           "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
           "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
           "x-rbac-resource": "opportunities",
-          "x-tier-feature": "OPPORTUNITY_MANAGEMENT",
-          "x-edition": "EE"
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
         },
         "x-alga-products": [
           "psa"
@@ -102100,7 +102095,7 @@
             }
           },
           "403": {
-            "description": "RBAC denied for the opportunities resource action.",
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
             "content": {
               "application/json": {
                 "schema": {
@@ -102145,7 +102140,7 @@
     "/api/v1/opportunities/{id}/commitments": {
       "get": {
         "summary": "List commitments",
-        "description": "Lists the promises recorded for an opportunity.",
+        "description": "Lists the promises recorded for an opportunity. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
         "tags": [
           "Opportunities v1"
         ],
@@ -102159,8 +102154,7 @@
           "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
           "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
           "x-rbac-resource": "opportunities",
-          "x-tier-feature": "OPPORTUNITY_MANAGEMENT",
-          "x-edition": "EE"
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
         },
         "x-alga-products": [
           "psa"
@@ -102210,7 +102204,7 @@
             }
           },
           "403": {
-            "description": "RBAC denied for the opportunities resource action.",
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
             "content": {
               "application/json": {
                 "schema": {
@@ -102253,7 +102247,7 @@
       },
       "post": {
         "summary": "Create commitment",
-        "description": "Records an unresolved promise on an opportunity.",
+        "description": "Records an unresolved promise on an opportunity. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
         "tags": [
           "Opportunities v1"
         ],
@@ -102267,8 +102261,7 @@
           "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
           "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
           "x-rbac-resource": "opportunities",
-          "x-tier-feature": "OPPORTUNITY_MANAGEMENT",
-          "x-edition": "EE"
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
         },
         "x-alga-products": [
           "psa"
@@ -102328,7 +102321,7 @@
             }
           },
           "403": {
-            "description": "RBAC denied for the opportunities resource action.",
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
             "content": {
               "application/json": {
                 "schema": {
@@ -102373,7 +102366,7 @@
     "/api/v1/opportunities/{id}/commitments/{commitmentId}": {
       "put": {
         "summary": "Update commitment",
-        "description": "Edits or resolves a commitment to a downstream artifact or explicit decline.",
+        "description": "Edits or resolves a commitment to a downstream artifact or explicit decline. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
         "tags": [
           "Opportunities v1"
         ],
@@ -102387,8 +102380,7 @@
           "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
           "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
           "x-rbac-resource": "opportunities",
-          "x-tier-feature": "OPPORTUNITY_MANAGEMENT",
-          "x-edition": "EE"
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
         },
         "x-alga-products": [
           "psa"
@@ -102455,7 +102447,7 @@
             }
           },
           "403": {
-            "description": "RBAC denied for the opportunities resource action.",
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
             "content": {
               "application/json": {
                 "schema": {
@@ -102498,7 +102490,7 @@
       },
       "delete": {
         "summary": "Delete commitment",
-        "description": "Deletes a commitment.",
+        "description": "Deletes a commitment. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
         "tags": [
           "Opportunities v1"
         ],
@@ -102512,8 +102504,7 @@
           "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
           "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
           "x-rbac-resource": "opportunities",
-          "x-tier-feature": "OPPORTUNITY_MANAGEMENT",
-          "x-edition": "EE"
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
         },
         "x-alga-products": [
           "psa"
@@ -102563,7 +102554,7 @@
             }
           },
           "403": {
-            "description": "RBAC denied for the opportunities resource action.",
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
             "content": {
               "application/json": {
                 "schema": {
@@ -102608,7 +102599,7 @@
     "/api/v1/opportunities/qbr/{clientId}": {
       "get": {
         "summary": "Get QBR trigger pack",
-        "description": "Assembles renewal, aging/EOL asset, ticket-trend, and whitespace triggers for an account.",
+        "description": "Assembles renewal, aging/EOL asset, ticket-trend, and whitespace triggers for an account. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
         "tags": [
           "Opportunities v1"
         ],
@@ -102622,8 +102613,7 @@
           "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
           "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
           "x-rbac-resource": "opportunities",
-          "x-tier-feature": "OPPORTUNITY_MANAGEMENT",
-          "x-edition": "EE"
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
         },
         "x-alga-products": [
           "psa"
@@ -102671,7 +102661,7 @@
             }
           },
           "403": {
-            "description": "RBAC denied for the opportunities resource action.",
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
             "content": {
               "application/json": {
                 "schema": {
@@ -102716,7 +102706,7 @@
     "/api/v1/opportunities/qbr/{clientId}/opportunities": {
       "post": {
         "summary": "Create QBR opportunities",
-        "description": "Batch-creates typed opportunities from current QBR trigger keys.",
+        "description": "Batch-creates typed opportunities from current QBR trigger keys. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
         "tags": [
           "Opportunities v1"
         ],
@@ -102730,8 +102720,7 @@
           "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
           "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
           "x-rbac-resource": "opportunities",
-          "x-tier-feature": "OPPORTUNITY_MANAGEMENT",
-          "x-edition": "EE"
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
         },
         "x-alga-products": [
           "psa"
@@ -102789,7 +102778,7 @@
             }
           },
           "403": {
-            "description": "RBAC denied for the opportunities resource action.",
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
             "content": {
               "application/json": {
                 "schema": {
@@ -102834,7 +102823,7 @@
     "/api/v1/opportunities/qbr/yield": {
       "get": {
         "summary": "Get QBR yield",
-        "description": "Returns fired, created, and won trigger counts by account and account manager.",
+        "description": "Returns fired, created, and won trigger counts by account and account manager. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
         "tags": [
           "Opportunities v1"
         ],
@@ -102848,8 +102837,7 @@
           "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
           "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
           "x-rbac-resource": "opportunities",
-          "x-tier-feature": "OPPORTUNITY_MANAGEMENT",
-          "x-edition": "EE"
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
         },
         "x-alga-products": [
           "psa"
@@ -102886,7 +102874,7 @@
             }
           },
           "403": {
-            "description": "RBAC denied for the opportunities resource action.",
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
             "content": {
               "application/json": {
                 "schema": {
@@ -102931,7 +102919,7 @@
     "/api/v1/opportunities/rollups": {
       "get": {
         "summary": "Get seller rollups",
-        "description": "Returns period pipeline, outcomes, and attach rate by seller.",
+        "description": "Returns period pipeline, outcomes, and attach rate by seller. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
         "tags": [
           "Opportunities v1"
         ],
@@ -102945,8 +102933,7 @@
           "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
           "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
           "x-rbac-resource": "opportunities",
-          "x-tier-feature": "OPPORTUNITY_MANAGEMENT",
-          "x-edition": "EE"
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
         },
         "x-alga-products": [
           "psa"
@@ -103003,7 +102990,7 @@
             }
           },
           "403": {
-            "description": "RBAC denied for the opportunities resource action.",
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
             "content": {
               "application/json": {
                 "schema": {
@@ -107918,6 +107905,112 @@
     "/api/v1/inventory/counts/{sessionId}/submit": {
       "post": {
         "summary": "Submit a cycle count session",
+        "tags": [
+          "Inventory v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-rbac-resource": "cycle_count",
+          "x-rbac-action": "update"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "sessionId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryLooseSuccessV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Product access, RBAC, or location scope denied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Inventory resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Inventory state or uniqueness conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/inventory/counts/{sessionId}/cancel": {
+      "post": {
+        "summary": "Cancel a cycle count session",
+        "description": "Cancels an in-progress cycle count and returns the cancelled session. Quantities already recorded against the session stay on it but are never applied to stock levels, since only approval posts them. Cancelling an already-cancelled session returns it unchanged; an approved session cannot be cancelled.",
         "tags": [
           "Inventory v1"
         ],
@@ -120696,66 +120789,6 @@
         ],
         "responses": {
           "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/inventory/counts/{sessionId}/cancel": {
-      "post": {
-        "summary": "POST v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "inventory"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "requestBody": {
-          "description": "Placeholder request body",
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlaceholderObject"
-              },
-              "description": "Placeholder request body"
-            }
-          }
-        },
-        "responses": {
-          "201": {
             "description": "Placeholder success response",
             "content": {
               "application/json": {

--- a/sdk/docs/openapi/alga-openapi.ee.yaml
+++ b/sdk/docs/openapi/alga-openapi.ee.yaml
@@ -67758,7 +67758,10 @@ paths:
   /api/v1/opportunities/forecast:
     get:
       summary: Get forecast band
-      description: Returns floor and ceiling MRR/NRR with per-deal composition for a period.
+      description: "Returns floor and ceiling MRR/NRR with per-deal composition for a
+        period. Requires opportunity management: Community Edition answers 403
+        `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403
+        `TIER_ACCESS_DENIED`."
       tags:
         - Opportunities v1
       security:
@@ -67769,7 +67772,6 @@ paths:
         x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
         x-rbac-resource: opportunities
         x-tier-feature: OPPORTUNITY_MANAGEMENT
-        x-edition: EE
       x-alga-products:
         - psa
       parameters:
@@ -67805,7 +67807,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/OpportunityApiErrorV1"
         "403":
-          description: RBAC denied for the opportunities resource action.
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
           content:
             application/json:
               schema:
@@ -67831,8 +67836,10 @@ paths:
   /api/v1/opportunities/calibration:
     get:
       summary: Get seller calibration
-      description: Returns declared-confidence outcomes and new-logo agreement attach
-        rate per seller.
+      description: "Returns declared-confidence outcomes and new-logo agreement attach
+        rate per seller. Requires opportunity management: Community Edition
+        answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer
+        403 `TIER_ACCESS_DENIED`."
       tags:
         - Opportunities v1
       security:
@@ -67843,7 +67850,6 @@ paths:
         x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
         x-rbac-resource: opportunities
         x-tier-feature: OPPORTUNITY_MANAGEMENT
-        x-edition: EE
       x-alga-products:
         - psa
       responses:
@@ -67866,7 +67872,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/OpportunityApiErrorV1"
         "403":
-          description: RBAC denied for the opportunities resource action.
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
           content:
             application/json:
               schema:
@@ -67892,7 +67901,10 @@ paths:
   /api/v1/opportunities/meeting-sessions:
     post:
       summary: Start meeting session
-      description: Starts or resumes the caller’s same-day pipeline meeting session.
+      description: "Starts or resumes the caller’s same-day pipeline meeting session.
+        Requires opportunity management: Community Edition answers 403
+        `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403
+        `TIER_ACCESS_DENIED`."
       tags:
         - Opportunities v1
       security:
@@ -67903,7 +67915,6 @@ paths:
         x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
         x-rbac-resource: opportunities
         x-tier-feature: OPPORTUNITY_MANAGEMENT
-        x-edition: EE
       x-alga-products:
         - psa
       responses:
@@ -67926,7 +67937,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/OpportunityApiErrorV1"
         "403":
-          description: RBAC denied for the opportunities resource action.
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
           content:
             application/json:
               schema:
@@ -67952,7 +67966,10 @@ paths:
   /api/v1/opportunities/meeting-sessions/active:
     get:
       summary: Get active meeting session
-      description: Returns the caller’s resumable same-day meeting session and reviews.
+      description: "Returns the caller’s resumable same-day meeting session and
+        reviews. Requires opportunity management: Community Edition answers 403
+        `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403
+        `TIER_ACCESS_DENIED`."
       tags:
         - Opportunities v1
       security:
@@ -67963,7 +67980,6 @@ paths:
         x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
         x-rbac-resource: opportunities
         x-tier-feature: OPPORTUNITY_MANAGEMENT
-        x-edition: EE
       x-alga-products:
         - psa
       responses:
@@ -67986,7 +68002,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/OpportunityApiErrorV1"
         "403":
-          description: RBAC denied for the opportunities resource action.
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
           content:
             application/json:
               schema:
@@ -68012,7 +68031,10 @@ paths:
   /api/v1/opportunities/meeting-sessions/{sessionId}/reviews:
     post:
       summary: Mark deal reviewed
-      description: Creates or updates the review marker for a deal in a meeting session.
+      description: "Creates or updates the review marker for a deal in a meeting
+        session. Requires opportunity management: Community Edition answers 403
+        `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403
+        `TIER_ACCESS_DENIED`."
       tags:
         - Opportunities v1
       security:
@@ -68023,7 +68045,6 @@ paths:
         x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
         x-rbac-resource: opportunities
         x-tier-feature: OPPORTUNITY_MANAGEMENT
-        x-edition: EE
       x-alga-products:
         - psa
       parameters:
@@ -68059,7 +68080,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/OpportunityApiErrorV1"
         "403":
-          description: RBAC denied for the opportunities resource action.
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
           content:
             application/json:
               schema:
@@ -68085,7 +68109,10 @@ paths:
   /api/v1/opportunities/{id}/commitments:
     get:
       summary: List commitments
-      description: Lists the promises recorded for an opportunity.
+      description: "Lists the promises recorded for an opportunity. Requires
+        opportunity management: Community Edition answers 403
+        `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403
+        `TIER_ACCESS_DENIED`."
       tags:
         - Opportunities v1
       security:
@@ -68096,7 +68123,6 @@ paths:
         x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
         x-rbac-resource: opportunities
         x-tier-feature: OPPORTUNITY_MANAGEMENT
-        x-edition: EE
       x-alga-products:
         - psa
       parameters:
@@ -68128,7 +68154,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/OpportunityApiErrorV1"
         "403":
-          description: RBAC denied for the opportunities resource action.
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
           content:
             application/json:
               schema:
@@ -68153,7 +68182,10 @@ paths:
                 $ref: "#/components/schemas/OpportunityApiErrorV1"
     post:
       summary: Create commitment
-      description: Records an unresolved promise on an opportunity.
+      description: "Records an unresolved promise on an opportunity. Requires
+        opportunity management: Community Edition answers 403
+        `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403
+        `TIER_ACCESS_DENIED`."
       tags:
         - Opportunities v1
       security:
@@ -68164,7 +68196,6 @@ paths:
         x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
         x-rbac-resource: opportunities
         x-tier-feature: OPPORTUNITY_MANAGEMENT
-        x-edition: EE
       x-alga-products:
         - psa
       parameters:
@@ -68202,7 +68233,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/OpportunityApiErrorV1"
         "403":
-          description: RBAC denied for the opportunities resource action.
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
           content:
             application/json:
               schema:
@@ -68228,8 +68262,10 @@ paths:
   /api/v1/opportunities/{id}/commitments/{commitmentId}:
     put:
       summary: Update commitment
-      description: Edits or resolves a commitment to a downstream artifact or explicit
-        decline.
+      description: "Edits or resolves a commitment to a downstream artifact or
+        explicit decline. Requires opportunity management: Community Edition
+        answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer
+        403 `TIER_ACCESS_DENIED`."
       tags:
         - Opportunities v1
       security:
@@ -68240,7 +68276,6 @@ paths:
         x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
         x-rbac-resource: opportunities
         x-tier-feature: OPPORTUNITY_MANAGEMENT
-        x-edition: EE
       x-alga-products:
         - psa
       parameters:
@@ -68282,7 +68317,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/OpportunityApiErrorV1"
         "403":
-          description: RBAC denied for the opportunities resource action.
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
           content:
             application/json:
               schema:
@@ -68307,7 +68345,9 @@ paths:
                 $ref: "#/components/schemas/OpportunityApiErrorV1"
     delete:
       summary: Delete commitment
-      description: Deletes a commitment.
+      description: "Deletes a commitment. Requires opportunity management: Community
+        Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro
+        answer 403 `TIER_ACCESS_DENIED`."
       tags:
         - Opportunities v1
       security:
@@ -68318,7 +68358,6 @@ paths:
         x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
         x-rbac-resource: opportunities
         x-tier-feature: OPPORTUNITY_MANAGEMENT
-        x-edition: EE
       x-alga-products:
         - psa
       parameters:
@@ -68350,7 +68389,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/OpportunityApiErrorV1"
         "403":
-          description: RBAC denied for the opportunities resource action.
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
           content:
             application/json:
               schema:
@@ -68376,8 +68418,10 @@ paths:
   /api/v1/opportunities/qbr/{clientId}:
     get:
       summary: Get QBR trigger pack
-      description: Assembles renewal, aging/EOL asset, ticket-trend, and whitespace
-        triggers for an account.
+      description: "Assembles renewal, aging/EOL asset, ticket-trend, and whitespace
+        triggers for an account. Requires opportunity management: Community
+        Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro
+        answer 403 `TIER_ACCESS_DENIED`."
       tags:
         - Opportunities v1
       security:
@@ -68388,7 +68432,6 @@ paths:
         x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
         x-rbac-resource: opportunities
         x-tier-feature: OPPORTUNITY_MANAGEMENT
-        x-edition: EE
       x-alga-products:
         - psa
       parameters:
@@ -68418,7 +68461,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/OpportunityApiErrorV1"
         "403":
-          description: RBAC denied for the opportunities resource action.
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
           content:
             application/json:
               schema:
@@ -68444,7 +68490,10 @@ paths:
   /api/v1/opportunities/qbr/{clientId}/opportunities:
     post:
       summary: Create QBR opportunities
-      description: Batch-creates typed opportunities from current QBR trigger keys.
+      description: "Batch-creates typed opportunities from current QBR trigger keys.
+        Requires opportunity management: Community Edition answers 403
+        `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403
+        `TIER_ACCESS_DENIED`."
       tags:
         - Opportunities v1
       security:
@@ -68455,7 +68504,6 @@ paths:
         x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
         x-rbac-resource: opportunities
         x-tier-feature: OPPORTUNITY_MANAGEMENT
-        x-edition: EE
       x-alga-products:
         - psa
       parameters:
@@ -68491,7 +68539,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/OpportunityApiErrorV1"
         "403":
-          description: RBAC denied for the opportunities resource action.
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
           content:
             application/json:
               schema:
@@ -68517,8 +68568,10 @@ paths:
   /api/v1/opportunities/qbr/yield:
     get:
       summary: Get QBR yield
-      description: Returns fired, created, and won trigger counts by account and
-        account manager.
+      description: "Returns fired, created, and won trigger counts by account and
+        account manager. Requires opportunity management: Community Edition
+        answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer
+        403 `TIER_ACCESS_DENIED`."
       tags:
         - Opportunities v1
       security:
@@ -68529,7 +68582,6 @@ paths:
         x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
         x-rbac-resource: opportunities
         x-tier-feature: OPPORTUNITY_MANAGEMENT
-        x-edition: EE
       x-alga-products:
         - psa
       responses:
@@ -68552,7 +68604,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/OpportunityApiErrorV1"
         "403":
-          description: RBAC denied for the opportunities resource action.
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
           content:
             application/json:
               schema:
@@ -68578,7 +68633,10 @@ paths:
   /api/v1/opportunities/rollups:
     get:
       summary: Get seller rollups
-      description: Returns period pipeline, outcomes, and attach rate by seller.
+      description: "Returns period pipeline, outcomes, and attach rate by seller.
+        Requires opportunity management: Community Edition answers 403
+        `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403
+        `TIER_ACCESS_DENIED`."
       tags:
         - Opportunities v1
       security:
@@ -68589,7 +68647,6 @@ paths:
         x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
         x-rbac-resource: opportunities
         x-tier-feature: OPPORTUNITY_MANAGEMENT
-        x-edition: EE
       x-alga-products:
         - psa
       parameters:
@@ -68625,7 +68682,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/OpportunityApiErrorV1"
         "403":
-          description: RBAC denied for the opportunities resource action.
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
           content:
             application/json:
               schema:
@@ -71727,6 +71787,75 @@ paths:
   /api/v1/inventory/counts/{sessionId}/submit:
     post:
       summary: Submit a cycle count session
+      tags:
+        - Inventory v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-rbac-resource: cycle_count
+        x-rbac-action: update
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+          required: true
+          name: sessionId
+          in: path
+      responses:
+        "200":
+          description: Operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryLooseSuccessV1"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryApiErrorV1"
+        "403":
+          description: Product access, RBAC, or location scope denied.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryApiErrorV1"
+        "404":
+          description: Inventory resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryApiErrorV1"
+        "409":
+          description: Inventory state or uniqueness conflict.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryApiErrorV1"
+  /api/v1/inventory/counts/{sessionId}/cancel:
+    post:
+      summary: Cancel a cycle count session
+      description: Cancels an in-progress cycle count and returns the cancelled
+        session. Quantities already recorded against the session stay on it but
+        are never applied to stock levels, since only approval posts them.
+        Cancelling an already-cancelled session returns it unchanged; an
+        approved session cannot be cancelled.
       tags:
         - Inventory v1
       security:
@@ -80058,45 +80187,6 @@ paths:
         - psa
       responses:
         "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/inventory/counts/{sessionId}/cancel:
-    post:
-      summary: POST v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - inventory
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      requestBody:
-        description: Placeholder request body
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PlaceholderObject"
-            description: Placeholder request body
-      responses:
-        "201":
           description: Placeholder success response
           content:
             application/json:

--- a/sdk/docs/openapi/alga-openapi.json
+++ b/sdk/docs/openapi/alga-openapi.json
@@ -272,9 +272,6 @@
       "name": "online-meetings"
     },
     {
-      "name": "opportunities"
-    },
-    {
       "name": "platform-feature-flags"
     },
     {
@@ -101616,6 +101613,1422 @@
         }
       }
     },
+    "/api/v1/opportunities/forecast": {
+      "get": {
+        "summary": "Get forecast band",
+        "description": "Returns floor and ceiling MRR/NRR with per-deal composition for a period. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
+        "tags": [
+          "Opportunities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
+          "x-rbac-resource": "opportunities",
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            },
+            "required": true,
+            "name": "start",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            },
+            "required": true,
+            "name": "end",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiSuccessV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Opportunity or nested resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Opportunity state conflicts with the requested operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/calibration": {
+      "get": {
+        "summary": "Get seller calibration",
+        "description": "Returns declared-confidence outcomes and new-logo agreement attach rate per seller. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
+        "tags": [
+          "Opportunities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
+          "x-rbac-resource": "opportunities",
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiArraySuccessV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Opportunity or nested resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Opportunity state conflicts with the requested operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/meeting-sessions": {
+      "post": {
+        "summary": "Start meeting session",
+        "description": "Starts or resumes the caller’s same-day pipeline meeting session. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
+        "tags": [
+          "Opportunities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
+          "x-rbac-resource": "opportunities",
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "201": {
+            "description": "Operation succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiSuccessV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Opportunity or nested resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Opportunity state conflicts with the requested operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/meeting-sessions/active": {
+      "get": {
+        "summary": "Get active meeting session",
+        "description": "Returns the caller’s resumable same-day meeting session and reviews. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
+        "tags": [
+          "Opportunities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
+          "x-rbac-resource": "opportunities",
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiSuccessV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Opportunity or nested resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Opportunity state conflicts with the requested operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/meeting-sessions/{sessionId}/reviews": {
+      "post": {
+        "summary": "Mark deal reviewed",
+        "description": "Creates or updates the review marker for a deal in a meeting session. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
+        "tags": [
+          "Opportunities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
+          "x-rbac-resource": "opportunities",
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "sessionId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OpportunityMeetingReviewBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Operation succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiSuccessV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Opportunity or nested resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Opportunity state conflicts with the requested operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/{id}/commitments": {
+      "get": {
+        "summary": "List commitments",
+        "description": "Lists the promises recorded for an opportunity. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
+        "tags": [
+          "Opportunities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
+          "x-rbac-resource": "opportunities",
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Opportunity UUID from opportunities.opportunity_id."
+            },
+            "required": true,
+            "description": "Opportunity UUID from opportunities.opportunity_id.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiArraySuccessV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Opportunity or nested resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Opportunity state conflicts with the requested operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create commitment",
+        "description": "Records an unresolved promise on an opportunity. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
+        "tags": [
+          "Opportunities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
+          "x-rbac-resource": "opportunities",
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Opportunity UUID from opportunities.opportunity_id."
+            },
+            "required": true,
+            "description": "Opportunity UUID from opportunities.opportunity_id.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OpportunityCommitmentCreateBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Operation succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiSuccessV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Opportunity or nested resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Opportunity state conflicts with the requested operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/{id}/commitments/{commitmentId}": {
+      "put": {
+        "summary": "Update commitment",
+        "description": "Edits or resolves a commitment to a downstream artifact or explicit decline. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
+        "tags": [
+          "Opportunities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
+          "x-rbac-resource": "opportunities",
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "commitmentId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OpportunityCommitmentUpdateBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Operation succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiSuccessV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Opportunity or nested resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Opportunity state conflicts with the requested operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete commitment",
+        "description": "Deletes a commitment. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
+        "tags": [
+          "Opportunities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
+          "x-rbac-resource": "opportunities",
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "commitmentId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Operation succeeded with no response body."
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Opportunity or nested resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Opportunity state conflicts with the requested operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/qbr/{clientId}": {
+      "get": {
+        "summary": "Get QBR trigger pack",
+        "description": "Assembles renewal, aging/EOL asset, ticket-trend, and whitespace triggers for an account. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
+        "tags": [
+          "Opportunities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
+          "x-rbac-resource": "opportunities",
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "clientId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiSuccessV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Opportunity or nested resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Opportunity state conflicts with the requested operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/qbr/{clientId}/opportunities": {
+      "post": {
+        "summary": "Create QBR opportunities",
+        "description": "Batch-creates typed opportunities from current QBR trigger keys. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
+        "tags": [
+          "Opportunities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
+          "x-rbac-resource": "opportunities",
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "clientId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OpportunityQbrCreateBodyV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Operation succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiSuccessV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Opportunity or nested resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Opportunity state conflicts with the requested operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/qbr/yield": {
+      "get": {
+        "summary": "Get QBR yield",
+        "description": "Returns fired, created, and won trigger counts by account and account manager. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
+        "tags": [
+          "Opportunities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
+          "x-rbac-resource": "opportunities",
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiArraySuccessV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Opportunity or nested resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Opportunity state conflicts with the requested operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/opportunities/rollups": {
+      "get": {
+        "summary": "Get seller rollups",
+        "description": "Returns period pipeline, outcomes, and attach rate by seller. Requires opportunity management: Community Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403 `TIER_ACCESS_DENIED`.",
+        "tags": [
+          "Opportunities v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-tenant-header": "x-tenant-id (optional; inferred from API key when omitted)",
+          "x-rbac-resource": "opportunities",
+          "x-tier-feature": "OPPORTUNITY_MANAGEMENT"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            },
+            "required": true,
+            "name": "start",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            },
+            "required": true,
+            "name": "end",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiArraySuccessV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Opportunity or nested resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Opportunity state conflicts with the requested operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/marketing/campaigns": {
       "get": {
         "summary": "List marketing campaigns",
@@ -106489,6 +107902,112 @@
     "/api/v1/inventory/counts/{sessionId}/submit": {
       "post": {
         "summary": "Submit a cycle count session",
+        "tags": [
+          "Inventory v1"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "extensions": {
+          "x-tenant-scoped": true,
+          "x-auth-mechanism": "x-api-key validated in ApiBaseController.authenticate()",
+          "x-rbac-resource": "cycle_count",
+          "x-rbac-action": "update"
+        },
+        "x-alga-products": [
+          "psa"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "sessionId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryLooseSuccessV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation or request parsing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryApiErrorV1"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "API key missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryApiErrorV1"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Product access, RBAC, or location scope denied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryApiErrorV1"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Inventory resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryApiErrorV1"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Inventory state or uniqueness conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryApiErrorV1"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected controller or service failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryApiErrorV1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/inventory/counts/{sessionId}/cancel": {
+      "post": {
+        "summary": "Cancel a cycle count session",
+        "description": "Cancels an in-progress cycle count and returns the cancelled session. Quantities already recorded against the session stay on it but are never applied to stock levels, since only approval posts them. Cancelling an already-cancelled session returns it unchanged; an approved session cannot be cancelled.",
         "tags": [
           "Inventory v1"
         ],
@@ -119127,66 +120646,6 @@
         }
       }
     },
-    "/api/v1/inventory/counts/{sessionId}/cancel": {
-      "post": {
-        "summary": "POST v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "inventory"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "requestBody": {
-          "description": "Placeholder request body",
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlaceholderObject"
-              },
-              "description": "Placeholder request body"
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/v1/mcp/agents": {
       "delete": {
         "summary": "DELETE v1",
@@ -121012,686 +122471,6 @@
         "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
         "tags": [
           "mobile"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "requestBody": {
-          "description": "Placeholder request body",
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlaceholderObject"
-              },
-              "description": "Placeholder request body"
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/opportunities/calibration": {
-      "get": {
-        "summary": "GET v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "opportunities"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/opportunities/forecast": {
-      "get": {
-        "summary": "GET v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "opportunities"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/opportunities/meeting-sessions": {
-      "post": {
-        "summary": "POST v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "opportunities"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "requestBody": {
-          "description": "Placeholder request body",
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlaceholderObject"
-              },
-              "description": "Placeholder request body"
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/opportunities/meeting-sessions/active": {
-      "get": {
-        "summary": "GET v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "opportunities"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/opportunities/meeting-sessions/{sessionId}/reviews": {
-      "post": {
-        "summary": "POST v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "opportunities"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "requestBody": {
-          "description": "Placeholder request body",
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlaceholderObject"
-              },
-              "description": "Placeholder request body"
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/opportunities/qbr/yield": {
-      "get": {
-        "summary": "GET v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "opportunities"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/opportunities/qbr/{clientId}": {
-      "get": {
-        "summary": "GET v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "opportunities"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/opportunities/qbr/{clientId}/opportunities": {
-      "post": {
-        "summary": "POST v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "opportunities"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "requestBody": {
-          "description": "Placeholder request body",
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlaceholderObject"
-              },
-              "description": "Placeholder request body"
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/opportunities/rollups": {
-      "get": {
-        "summary": "GET v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "opportunities"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/opportunities/{id}/commitments": {
-      "get": {
-        "summary": "GET v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "opportunities"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "200": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "summary": "POST v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "opportunities"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "requestBody": {
-          "description": "Placeholder request body",
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlaceholderObject"
-              },
-              "description": "Placeholder request body"
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/opportunities/{id}/commitments/{commitmentId}": {
-      "delete": {
-        "summary": "DELETE v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "opportunities"
-        ],
-        "extensions": {
-          "x-generated-from": "docs/openapi/route-inventory.json",
-          "x-placeholder": true
-        },
-        "x-alga-products": [
-          "psa"
-        ],
-        "responses": {
-          "204": {
-            "description": "Placeholder success response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaceholderObject"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "summary": "PUT v1",
-        "description": "This operation was generated automatically from the route inventory. Replace with canonical OpenAPI metadata.",
-        "tags": [
-          "opportunities"
         ],
         "extensions": {
           "x-generated-from": "docs/openapi/route-inventory.json",

--- a/sdk/docs/openapi/alga-openapi.yaml
+++ b/sdk/docs/openapi/alga-openapi.yaml
@@ -94,7 +94,6 @@ tags:
   - name: meta
   - name: mobile
   - name: online-meetings
-  - name: opportunities
   - name: platform-feature-flags
   - name: platform-notifications
   - name: platform-reports
@@ -67755,6 +67754,959 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/OpportunityApiErrorV1"
+  /api/v1/opportunities/forecast:
+    get:
+      summary: Get forecast band
+      description: "Returns floor and ceiling MRR/NRR with per-deal composition for a
+        period. Requires opportunity management: Community Edition answers 403
+        `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403
+        `TIER_ACCESS_DENIED`."
+      tags:
+        - Opportunities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
+        x-rbac-resource: opportunities
+        x-tier-feature: OPPORTUNITY_MANAGEMENT
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            pattern: ^\d{4}-\d{2}-\d{2}$
+          required: true
+          name: start
+          in: query
+        - schema:
+            type: string
+            pattern: ^\d{4}-\d{2}-\d{2}$
+          required: true
+          name: end
+          in: query
+      responses:
+        "200":
+          description: Operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiSuccessV1"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "403":
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "404":
+          description: Opportunity or nested resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "409":
+          description: Opportunity state conflicts with the requested operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+  /api/v1/opportunities/calibration:
+    get:
+      summary: Get seller calibration
+      description: "Returns declared-confidence outcomes and new-logo agreement attach
+        rate per seller. Requires opportunity management: Community Edition
+        answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer
+        403 `TIER_ACCESS_DENIED`."
+      tags:
+        - Opportunities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
+        x-rbac-resource: opportunities
+        x-tier-feature: OPPORTUNITY_MANAGEMENT
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiArraySuccessV1"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "403":
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "404":
+          description: Opportunity or nested resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "409":
+          description: Opportunity state conflicts with the requested operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+  /api/v1/opportunities/meeting-sessions:
+    post:
+      summary: Start meeting session
+      description: "Starts or resumes the caller’s same-day pipeline meeting session.
+        Requires opportunity management: Community Edition answers 403
+        `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403
+        `TIER_ACCESS_DENIED`."
+      tags:
+        - Opportunities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
+        x-rbac-resource: opportunities
+        x-tier-feature: OPPORTUNITY_MANAGEMENT
+      x-alga-products:
+        - psa
+      responses:
+        "201":
+          description: Operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiSuccessV1"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "403":
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "404":
+          description: Opportunity or nested resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "409":
+          description: Opportunity state conflicts with the requested operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+  /api/v1/opportunities/meeting-sessions/active:
+    get:
+      summary: Get active meeting session
+      description: "Returns the caller’s resumable same-day meeting session and
+        reviews. Requires opportunity management: Community Edition answers 403
+        `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403
+        `TIER_ACCESS_DENIED`."
+      tags:
+        - Opportunities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
+        x-rbac-resource: opportunities
+        x-tier-feature: OPPORTUNITY_MANAGEMENT
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiSuccessV1"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "403":
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "404":
+          description: Opportunity or nested resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "409":
+          description: Opportunity state conflicts with the requested operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+  /api/v1/opportunities/meeting-sessions/{sessionId}/reviews:
+    post:
+      summary: Mark deal reviewed
+      description: "Creates or updates the review marker for a deal in a meeting
+        session. Requires opportunity management: Community Edition answers 403
+        `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403
+        `TIER_ACCESS_DENIED`."
+      tags:
+        - Opportunities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
+        x-rbac-resource: opportunities
+        x-tier-feature: OPPORTUNITY_MANAGEMENT
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+          required: true
+          name: sessionId
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OpportunityMeetingReviewBodyV1"
+      responses:
+        "200":
+          description: Operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiSuccessV1"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "403":
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "404":
+          description: Opportunity or nested resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "409":
+          description: Opportunity state conflicts with the requested operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+  /api/v1/opportunities/{id}/commitments:
+    get:
+      summary: List commitments
+      description: "Lists the promises recorded for an opportunity. Requires
+        opportunity management: Community Edition answers 403
+        `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403
+        `TIER_ACCESS_DENIED`."
+      tags:
+        - Opportunities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
+        x-rbac-resource: opportunities
+        x-tier-feature: OPPORTUNITY_MANAGEMENT
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Opportunity UUID from opportunities.opportunity_id.
+          required: true
+          description: Opportunity UUID from opportunities.opportunity_id.
+          name: id
+          in: path
+      responses:
+        "200":
+          description: Operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiArraySuccessV1"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "403":
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "404":
+          description: Opportunity or nested resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "409":
+          description: Opportunity state conflicts with the requested operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+    post:
+      summary: Create commitment
+      description: "Records an unresolved promise on an opportunity. Requires
+        opportunity management: Community Edition answers 403
+        `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403
+        `TIER_ACCESS_DENIED`."
+      tags:
+        - Opportunities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
+        x-rbac-resource: opportunities
+        x-tier-feature: OPPORTUNITY_MANAGEMENT
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Opportunity UUID from opportunities.opportunity_id.
+          required: true
+          description: Opportunity UUID from opportunities.opportunity_id.
+          name: id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OpportunityCommitmentCreateBodyV1"
+      responses:
+        "201":
+          description: Operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiSuccessV1"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "403":
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "404":
+          description: Opportunity or nested resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "409":
+          description: Opportunity state conflicts with the requested operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+  /api/v1/opportunities/{id}/commitments/{commitmentId}:
+    put:
+      summary: Update commitment
+      description: "Edits or resolves a commitment to a downstream artifact or
+        explicit decline. Requires opportunity management: Community Edition
+        answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer
+        403 `TIER_ACCESS_DENIED`."
+      tags:
+        - Opportunities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
+        x-rbac-resource: opportunities
+        x-tier-feature: OPPORTUNITY_MANAGEMENT
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+          required: true
+          name: id
+          in: path
+        - schema:
+            type: string
+            format: uuid
+          required: true
+          name: commitmentId
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OpportunityCommitmentUpdateBodyV1"
+      responses:
+        "200":
+          description: Operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiSuccessV1"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "403":
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "404":
+          description: Opportunity or nested resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "409":
+          description: Opportunity state conflicts with the requested operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+    delete:
+      summary: Delete commitment
+      description: "Deletes a commitment. Requires opportunity management: Community
+        Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro
+        answer 403 `TIER_ACCESS_DENIED`."
+      tags:
+        - Opportunities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
+        x-rbac-resource: opportunities
+        x-tier-feature: OPPORTUNITY_MANAGEMENT
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+          required: true
+          name: id
+          in: path
+        - schema:
+            type: string
+            format: uuid
+          required: true
+          name: commitmentId
+          in: path
+      responses:
+        "204":
+          description: Operation succeeded with no response body.
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "403":
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "404":
+          description: Opportunity or nested resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "409":
+          description: Opportunity state conflicts with the requested operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+  /api/v1/opportunities/qbr/{clientId}:
+    get:
+      summary: Get QBR trigger pack
+      description: "Assembles renewal, aging/EOL asset, ticket-trend, and whitespace
+        triggers for an account. Requires opportunity management: Community
+        Edition answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro
+        answer 403 `TIER_ACCESS_DENIED`."
+      tags:
+        - Opportunities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
+        x-rbac-resource: opportunities
+        x-tier-feature: OPPORTUNITY_MANAGEMENT
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+          required: true
+          name: clientId
+          in: path
+      responses:
+        "200":
+          description: Operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiSuccessV1"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "403":
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "404":
+          description: Opportunity or nested resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "409":
+          description: Opportunity state conflicts with the requested operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+  /api/v1/opportunities/qbr/{clientId}/opportunities:
+    post:
+      summary: Create QBR opportunities
+      description: "Batch-creates typed opportunities from current QBR trigger keys.
+        Requires opportunity management: Community Edition answers 403
+        `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403
+        `TIER_ACCESS_DENIED`."
+      tags:
+        - Opportunities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
+        x-rbac-resource: opportunities
+        x-tier-feature: OPPORTUNITY_MANAGEMENT
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+          required: true
+          name: clientId
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OpportunityQbrCreateBodyV1"
+      responses:
+        "201":
+          description: Operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiSuccessV1"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "403":
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "404":
+          description: Opportunity or nested resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "409":
+          description: Opportunity state conflicts with the requested operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+  /api/v1/opportunities/qbr/yield:
+    get:
+      summary: Get QBR yield
+      description: "Returns fired, created, and won trigger counts by account and
+        account manager. Requires opportunity management: Community Edition
+        answers 403 `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer
+        403 `TIER_ACCESS_DENIED`."
+      tags:
+        - Opportunities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
+        x-rbac-resource: opportunities
+        x-tier-feature: OPPORTUNITY_MANAGEMENT
+      x-alga-products:
+        - psa
+      responses:
+        "200":
+          description: Operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiArraySuccessV1"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "403":
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "404":
+          description: Opportunity or nested resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "409":
+          description: Opportunity state conflicts with the requested operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+  /api/v1/opportunities/rollups:
+    get:
+      summary: Get seller rollups
+      description: "Returns period pipeline, outcomes, and attach rate by seller.
+        Requires opportunity management: Community Edition answers 403
+        `ENTERPRISE_EDITION_REQUIRED`, and plans below Pro answer 403
+        `TIER_ACCESS_DENIED`."
+      tags:
+        - Opportunities v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-tenant-header: x-tenant-id (optional; inferred from API key when omitted)
+        x-rbac-resource: opportunities
+        x-tier-feature: OPPORTUNITY_MANAGEMENT
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            pattern: ^\d{4}-\d{2}-\d{2}$
+          required: true
+          name: start
+          in: query
+        - schema:
+            type: string
+            pattern: ^\d{4}-\d{2}-\d{2}$
+          required: true
+          name: end
+          in: query
+      responses:
+        "200":
+          description: Operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiArraySuccessV1"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "403":
+          description: RBAC denied for the opportunities resource action, or the caller’s
+            edition and plan do not include opportunity management
+            (`ENTERPRISE_EDITION_REQUIRED` in Community Edition;
+            `TIER_ACCESS_DENIED` below the Pro plan).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "404":
+          description: Opportunity or nested resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "409":
+          description: Opportunity state conflicts with the requested operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpportunityApiErrorV1"
   /api/v1/marketing/campaigns:
     get:
       summary: List marketing campaigns
@@ -70834,6 +71786,75 @@ paths:
   /api/v1/inventory/counts/{sessionId}/submit:
     post:
       summary: Submit a cycle count session
+      tags:
+        - Inventory v1
+      security:
+        - ApiKeyAuth: []
+      extensions:
+        x-tenant-scoped: true
+        x-auth-mechanism: x-api-key validated in ApiBaseController.authenticate()
+        x-rbac-resource: cycle_count
+        x-rbac-action: update
+      x-alga-products:
+        - psa
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+          required: true
+          name: sessionId
+          in: path
+      responses:
+        "200":
+          description: Operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryLooseSuccessV1"
+        "400":
+          description: Validation or request parsing failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryApiErrorV1"
+        "401":
+          description: API key missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryApiErrorV1"
+        "403":
+          description: Product access, RBAC, or location scope denied.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryApiErrorV1"
+        "404":
+          description: Inventory resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryApiErrorV1"
+        "409":
+          description: Inventory state or uniqueness conflict.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryApiErrorV1"
+        "500":
+          description: Unexpected controller or service failure.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InventoryApiErrorV1"
+  /api/v1/inventory/counts/{sessionId}/cancel:
+    post:
+      summary: Cancel a cycle count session
+      description: Cancels an in-progress cycle count and returns the cancelled
+        session. Quantities already recorded against the session stay on it but
+        are never applied to stock levels, since only approval posts them.
+        Cancelling an already-cancelled session returns it unchanged; an
+        approved session cannot be cancelled.
       tags:
         - Inventory v1
       security:
@@ -79051,45 +80072,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/inventory/counts/{sessionId}/cancel:
-    post:
-      summary: POST v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - inventory
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      requestBody:
-        description: Placeholder request body
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PlaceholderObject"
-            description: Placeholder request body
-      responses:
-        "201":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
   /api/v1/mcp/agents:
     delete:
       summary: DELETE v1
@@ -80279,447 +81261,6 @@ paths:
         inventory. Replace with canonical OpenAPI metadata.
       tags:
         - mobile
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      requestBody:
-        description: Placeholder request body
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PlaceholderObject"
-            description: Placeholder request body
-      responses:
-        "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/opportunities/calibration:
-    get:
-      summary: GET v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - opportunities
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/opportunities/forecast:
-    get:
-      summary: GET v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - opportunities
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/opportunities/meeting-sessions:
-    post:
-      summary: POST v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - opportunities
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      requestBody:
-        description: Placeholder request body
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PlaceholderObject"
-            description: Placeholder request body
-      responses:
-        "201":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/opportunities/meeting-sessions/active:
-    get:
-      summary: GET v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - opportunities
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/opportunities/meeting-sessions/{sessionId}/reviews:
-    post:
-      summary: POST v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - opportunities
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      requestBody:
-        description: Placeholder request body
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PlaceholderObject"
-            description: Placeholder request body
-      responses:
-        "201":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/opportunities/qbr/yield:
-    get:
-      summary: GET v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - opportunities
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/opportunities/qbr/{clientId}:
-    get:
-      summary: GET v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - opportunities
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/opportunities/qbr/{clientId}/opportunities:
-    post:
-      summary: POST v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - opportunities
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      requestBody:
-        description: Placeholder request body
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PlaceholderObject"
-            description: Placeholder request body
-      responses:
-        "201":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/opportunities/rollups:
-    get:
-      summary: GET v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - opportunities
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/opportunities/{id}/commitments:
-    get:
-      summary: GET v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - opportunities
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "200":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-    post:
-      summary: POST v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - opportunities
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      requestBody:
-        description: Placeholder request body
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PlaceholderObject"
-            description: Placeholder request body
-      responses:
-        "201":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/opportunities/{id}/commitments/{commitmentId}:
-    delete:
-      summary: DELETE v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - opportunities
-      extensions:
-        x-generated-from: docs/openapi/route-inventory.json
-        x-placeholder: true
-      x-alga-products:
-        - psa
-      responses:
-        "204":
-          description: Placeholder success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlaceholderObject"
-        "401":
-          description: Authentication required
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-    put:
-      summary: PUT v1
-      description: This operation was generated automatically from the route
-        inventory. Replace with canonical OpenAPI metadata.
-      tags:
-        - opportunities
       extensions:
         x-generated-from: docs/openapi/route-inventory.json
         x-placeholder: true

--- a/server/src/lib/api/openapi/routes/inventoryV1.ts
+++ b/server/src/lib/api/openapi/routes/inventoryV1.ts
@@ -73,6 +73,8 @@ export function registerInventoryV1Routes(registry: ApiOpenApiRegistry) {
     query?: ZodTypeAny;
     body?: boolean;
     successStatus?: 200 | 201;
+    /** Optional prose for operations whose behavior is not obvious from the summary. */
+    description?: string;
   };
 
   const defs: Def[] = [
@@ -88,6 +90,7 @@ export function registerInventoryV1Routes(registry: ApiOpenApiRegistry) {
     { method: 'get', path: '/api/v1/inventory/counts/{sessionId}', summary: 'Get a cycle count session', resource: 'cycle_count', action: 'read', params: CountParams },
     { method: 'post', path: '/api/v1/inventory/counts/{sessionId}/records', summary: 'Record a cycle count quantity', resource: 'cycle_count', action: 'update', params: CountParams, body: true },
     { method: 'post', path: '/api/v1/inventory/counts/{sessionId}/submit', summary: 'Submit a cycle count session', resource: 'cycle_count', action: 'update', params: CountParams },
+    { method: 'post', path: '/api/v1/inventory/counts/{sessionId}/cancel', summary: 'Cancel a cycle count session', resource: 'cycle_count', action: 'update', params: CountParams, description: 'Cancels an in-progress cycle count and returns the cancelled session. Quantities already recorded against the session stay on it but are never applied to stock levels, since only approval posts them. Cancelling an already-cancelled session returns it unchanged; an approved session cannot be cancelled.' },
     { method: 'get', path: '/api/v1/inventory/purchase-orders', summary: 'List purchase orders', resource: 'purchase_order', action: 'read', query: ListQuery },
     { method: 'get', path: '/api/v1/inventory/purchase-orders/{poId}', summary: 'Get a purchase order', resource: 'purchase_order', action: 'read', params: PurchaseOrderParams },
     { method: 'post', path: '/api/v1/inventory/purchase-orders/{poId}/lines/{lineId}/receive', summary: 'Receive a purchase-order line', resource: 'purchase_order', action: 'update', params: PurchaseOrderLineParams, body: true },
@@ -101,6 +104,7 @@ export function registerInventoryV1Routes(registry: ApiOpenApiRegistry) {
       method: def.method,
       path: def.path,
       summary: def.summary,
+      ...(def.description ? { description: def.description } : {}),
       tags: [tag],
       security: [{ ApiKeyAuth: [] }],
       request: {

--- a/server/src/lib/api/openapi/routes/opportunitiesV1.ts
+++ b/server/src/lib/api/openapi/routes/opportunitiesV1.ts
@@ -165,7 +165,17 @@ export function registerOpportunitiesV1Routes(registry: ApiOpenApiRegistry) {
     query?: ZodTypeAny;
     successStatus?: 200 | 201 | 204;
     params?: ZodTypeAny;
-    edition?: 'both' | 'ee';
+    /**
+     * Opportunity management is an EE capability gated by
+     * TIER_FEATURES.OPPORTUNITY_MANAGEMENT. These operations are still registered in
+     * BOTH editions on purpose: the route files live in the CE tree and answer with a
+     * structured 403 `ENTERPRISE_EDITION_REQUIRED` rather than 404, so a CE caller can
+     * reach them and deserves to find out why they failed. Registering them CE-side
+     * also keeps the generator's route-inventory scan from backfilling "GET v1"
+     * placeholders over them, which is what the public developer portal was rendering
+     * (it consumes the CE spec).
+     */
+    tierGated?: true;
   };
 
   const defs: Def[] = [
@@ -188,19 +198,19 @@ export function registerOpportunitiesV1Routes(registry: ApiOpenApiRegistry) {
     { method: 'post', path: '/api/v1/opportunities/suggestions/{id}/accept', summary: 'Accept opportunity suggestion', description: 'Creates a prefilled opportunity and atomically marks the suggestion accepted.', body: AcceptSuggestionBody, successStatus: 201, params: OpportunitySuggestionParams },
     { method: 'post', path: '/api/v1/opportunities/suggestions/{id}/dismiss', summary: 'Dismiss opportunity suggestion', description: 'Dismisses the suggestion and permanently preserves its dedupe key.', params: OpportunitySuggestionParams },
     { method: 'post', path: '/api/v1/opportunities/suggestions/{id}/snooze', summary: 'Snooze opportunity suggestion', description: 'Hides the suggestion until the requested future timestamp.', body: SnoozeSuggestionBody, params: OpportunitySuggestionParams },
-    { method: 'get', path: '/api/v1/opportunities/forecast', summary: 'Get forecast band', description: 'Returns floor and ceiling MRR/NRR with per-deal composition for a period.', query: ManagementPeriodQuery, edition: 'ee' },
-    { method: 'get', path: '/api/v1/opportunities/calibration', summary: 'Get seller calibration', description: 'Returns declared-confidence outcomes and new-logo agreement attach rate per seller.', edition: 'ee' },
-    { method: 'post', path: '/api/v1/opportunities/meeting-sessions', summary: 'Start meeting session', description: 'Starts or resumes the caller’s same-day pipeline meeting session.', successStatus: 201, edition: 'ee' },
-    { method: 'get', path: '/api/v1/opportunities/meeting-sessions/active', summary: 'Get active meeting session', description: 'Returns the caller’s resumable same-day meeting session and reviews.', edition: 'ee' },
-    { method: 'post', path: '/api/v1/opportunities/meeting-sessions/{sessionId}/reviews', summary: 'Mark deal reviewed', description: 'Creates or updates the review marker for a deal in a meeting session.', body: MeetingReviewBody, params: OpportunityMeetingSessionParams, edition: 'ee' },
-    { method: 'get', path: '/api/v1/opportunities/{id}/commitments', summary: 'List commitments', description: 'Lists the promises recorded for an opportunity.', params: OpportunityIdParam, edition: 'ee' },
-    { method: 'post', path: '/api/v1/opportunities/{id}/commitments', summary: 'Create commitment', description: 'Records an unresolved promise on an opportunity.', body: CommitmentCreateBody, params: OpportunityIdParam, successStatus: 201, edition: 'ee' },
-    { method: 'put', path: '/api/v1/opportunities/{id}/commitments/{commitmentId}', summary: 'Update commitment', description: 'Edits or resolves a commitment to a downstream artifact or explicit decline.', body: CommitmentUpdateBody, params: OpportunityCommitmentParams, edition: 'ee' },
-    { method: 'delete', path: '/api/v1/opportunities/{id}/commitments/{commitmentId}', summary: 'Delete commitment', description: 'Deletes a commitment.', params: OpportunityCommitmentParams, successStatus: 204, edition: 'ee' },
-    { method: 'get', path: '/api/v1/opportunities/qbr/{clientId}', summary: 'Get QBR trigger pack', description: 'Assembles renewal, aging/EOL asset, ticket-trend, and whitespace triggers for an account.', params: OpportunityQbrClientParams, edition: 'ee' },
-    { method: 'post', path: '/api/v1/opportunities/qbr/{clientId}/opportunities', summary: 'Create QBR opportunities', description: 'Batch-creates typed opportunities from current QBR trigger keys.', body: QbrCreateBody, params: OpportunityQbrClientParams, successStatus: 201, edition: 'ee' },
-    { method: 'get', path: '/api/v1/opportunities/qbr/yield', summary: 'Get QBR yield', description: 'Returns fired, created, and won trigger counts by account and account manager.', edition: 'ee' },
-    { method: 'get', path: '/api/v1/opportunities/rollups', summary: 'Get seller rollups', description: 'Returns period pipeline, outcomes, and attach rate by seller.', query: ManagementPeriodQuery, edition: 'ee' },
+    { method: 'get', path: '/api/v1/opportunities/forecast', summary: 'Get forecast band', description: 'Returns floor and ceiling MRR/NRR with per-deal composition for a period.', query: ManagementPeriodQuery, tierGated: true },
+    { method: 'get', path: '/api/v1/opportunities/calibration', summary: 'Get seller calibration', description: 'Returns declared-confidence outcomes and new-logo agreement attach rate per seller.', tierGated: true },
+    { method: 'post', path: '/api/v1/opportunities/meeting-sessions', summary: 'Start meeting session', description: 'Starts or resumes the caller’s same-day pipeline meeting session.', successStatus: 201, tierGated: true },
+    { method: 'get', path: '/api/v1/opportunities/meeting-sessions/active', summary: 'Get active meeting session', description: 'Returns the caller’s resumable same-day meeting session and reviews.', tierGated: true },
+    { method: 'post', path: '/api/v1/opportunities/meeting-sessions/{sessionId}/reviews', summary: 'Mark deal reviewed', description: 'Creates or updates the review marker for a deal in a meeting session.', body: MeetingReviewBody, params: OpportunityMeetingSessionParams, tierGated: true },
+    { method: 'get', path: '/api/v1/opportunities/{id}/commitments', summary: 'List commitments', description: 'Lists the promises recorded for an opportunity.', params: OpportunityIdParam, tierGated: true },
+    { method: 'post', path: '/api/v1/opportunities/{id}/commitments', summary: 'Create commitment', description: 'Records an unresolved promise on an opportunity.', body: CommitmentCreateBody, params: OpportunityIdParam, successStatus: 201, tierGated: true },
+    { method: 'put', path: '/api/v1/opportunities/{id}/commitments/{commitmentId}', summary: 'Update commitment', description: 'Edits or resolves a commitment to a downstream artifact or explicit decline.', body: CommitmentUpdateBody, params: OpportunityCommitmentParams, tierGated: true },
+    { method: 'delete', path: '/api/v1/opportunities/{id}/commitments/{commitmentId}', summary: 'Delete commitment', description: 'Deletes a commitment.', params: OpportunityCommitmentParams, successStatus: 204, tierGated: true },
+    { method: 'get', path: '/api/v1/opportunities/qbr/{clientId}', summary: 'Get QBR trigger pack', description: 'Assembles renewal, aging/EOL asset, ticket-trend, and whitespace triggers for an account.', params: OpportunityQbrClientParams, tierGated: true },
+    { method: 'post', path: '/api/v1/opportunities/qbr/{clientId}/opportunities', summary: 'Create QBR opportunities', description: 'Batch-creates typed opportunities from current QBR trigger keys.', body: QbrCreateBody, params: OpportunityQbrClientParams, successStatus: 201, tierGated: true },
+    { method: 'get', path: '/api/v1/opportunities/qbr/yield', summary: 'Get QBR yield', description: 'Returns fired, created, and won trigger counts by account and account manager.', tierGated: true },
+    { method: 'get', path: '/api/v1/opportunities/rollups', summary: 'Get seller rollups', description: 'Returns period pipeline, outcomes, and attach rate by seller.', query: ManagementPeriodQuery, tierGated: true },
   ];
 
   for (const def of defs) {
@@ -229,7 +239,12 @@ export function registerOpportunitiesV1Routes(registry: ApiOpenApiRegistry) {
           },
       400: { description: 'Validation or request parsing failure.', schema: ApiError },
       401: { description: 'API key missing or invalid.', schema: ApiError },
-      403: { description: 'RBAC denied for the opportunities resource action.', schema: ApiError },
+      403: {
+        description: def.tierGated
+          ? 'RBAC denied for the opportunities resource action, or the caller’s edition and plan do not include opportunity management (`ENTERPRISE_EDITION_REQUIRED` in Community Edition; `TIER_ACCESS_DENIED` below the Pro plan).'
+          : 'RBAC denied for the opportunities resource action.',
+        schema: ApiError,
+      },
       404: { description: 'Opportunity or nested resource not found.', schema: ApiError },
       409: { description: 'Opportunity state conflicts with the requested operation.', schema: ApiError },
       500: { description: 'Unexpected controller or service failure.', schema: ApiError },
@@ -239,7 +254,9 @@ export function registerOpportunitiesV1Routes(registry: ApiOpenApiRegistry) {
       method: def.method,
       path: def.path,
       summary: def.summary,
-      description: def.description,
+      description: def.tierGated
+        ? `${def.description} Requires opportunity management: Community Edition answers 403 \`ENTERPRISE_EDITION_REQUIRED\`, and plans below Pro answer 403 \`TIER_ACCESS_DENIED\`.`
+        : def.description,
       tags: [tag],
       security: [{ ApiKeyAuth: [] }],
       request: {
@@ -253,9 +270,9 @@ export function registerOpportunitiesV1Routes(registry: ApiOpenApiRegistry) {
         'x-auth-mechanism': 'x-api-key validated in ApiBaseController.authenticate()',
         'x-tenant-header': 'x-tenant-id (optional; inferred from API key when omitted)',
         'x-rbac-resource': 'opportunities',
-        ...(def.edition === 'ee' ? { 'x-tier-feature': 'OPPORTUNITY_MANAGEMENT' } : {}),
+        ...(def.tierGated ? { 'x-tier-feature': 'OPPORTUNITY_MANAGEMENT' } : {}),
       },
-      edition: def.edition ?? 'both',
+      edition: 'both',
     });
   }
 }

--- a/server/src/test/unit/api/opportunityOpenApi.test.ts
+++ b/server/src/test/unit/api/opportunityOpenApi.test.ts
@@ -29,6 +29,19 @@ describe('opportunities v1 OpenAPI registration', () => {
       'POST /api/v1/opportunities/suggestions/{id}/accept',
       'POST /api/v1/opportunities/suggestions/{id}/dismiss',
       'POST /api/v1/opportunities/suggestions/{id}/snooze',
+      'GET /api/v1/opportunities/forecast',
+      'GET /api/v1/opportunities/calibration',
+      'POST /api/v1/opportunities/meeting-sessions',
+      'GET /api/v1/opportunities/meeting-sessions/active',
+      'POST /api/v1/opportunities/meeting-sessions/{sessionId}/reviews',
+      'GET /api/v1/opportunities/{id}/commitments',
+      'POST /api/v1/opportunities/{id}/commitments',
+      'PUT /api/v1/opportunities/{id}/commitments/{commitmentId}',
+      'DELETE /api/v1/opportunities/{id}/commitments/{commitmentId}',
+      'GET /api/v1/opportunities/qbr/{clientId}',
+      'POST /api/v1/opportunities/qbr/{clientId}/opportunities',
+      'GET /api/v1/opportunities/qbr/yield',
+      'GET /api/v1/opportunities/rollups',
     ]);
     expect(routes.every((route) => route.extensions?.['x-rbac-resource'] === 'opportunities')).toBe(true);
     expect(routes.find((route) => route.path.endsWith('/unlink'))?.responses[204]?.emptyBody).toBe(true);
@@ -80,5 +93,42 @@ describe('opportunities v1 OpenAPI registration', () => {
     expect(baseDocument.paths?.['/api/v1/interactions']?.post).toBeDefined();
     expect(baseDocument.paths?.['/api/v1/inventory/counts']?.get).toBeDefined();
     expect(baseDocument.paths?.['/api/v1/inventory/counts']?.post).toBeDefined();
+  });
+
+  // Management endpoints are EE-only behavior but CE-visible surface: the CE routes
+  // answer 403 instead of 404, so the CE spec has to describe them and say why.
+  it('documents the tier-gated management endpoints in the CE document with a denial-aware 403', () => {
+    const document = generateBaseDocument({
+      title: 'Alga API Test',
+      version: '1.0.0',
+      edition: 'ce',
+    });
+
+    const tierGated: Array<[string, 'get' | 'post' | 'put' | 'delete']> = [
+      ['/api/v1/opportunities/forecast', 'get'],
+      ['/api/v1/opportunities/calibration', 'get'],
+      ['/api/v1/opportunities/meeting-sessions', 'post'],
+      ['/api/v1/opportunities/meeting-sessions/active', 'get'],
+      ['/api/v1/opportunities/meeting-sessions/{sessionId}/reviews', 'post'],
+      ['/api/v1/opportunities/{id}/commitments', 'get'],
+      ['/api/v1/opportunities/{id}/commitments', 'post'],
+      ['/api/v1/opportunities/{id}/commitments/{commitmentId}', 'put'],
+      ['/api/v1/opportunities/{id}/commitments/{commitmentId}', 'delete'],
+      ['/api/v1/opportunities/qbr/{clientId}', 'get'],
+      ['/api/v1/opportunities/qbr/{clientId}/opportunities', 'post'],
+      ['/api/v1/opportunities/qbr/yield', 'get'],
+      ['/api/v1/opportunities/rollups', 'get'],
+    ];
+
+    for (const [path, method] of tierGated) {
+      const operation = (document.paths?.[path] as Record<string, any> | undefined)?.[method];
+      expect(operation, `${method.toUpperCase()} ${path}`).toBeDefined();
+      // Never the generator's route-inventory placeholder ("GET v1").
+      expect(operation.summary, `${method.toUpperCase()} ${path}`).not.toMatch(/^(GET|POST|PUT|DELETE) v1$/);
+      expect(operation.description).toContain('ENTERPRISE_EDITION_REQUIRED');
+      expect(operation.description).toContain('TIER_ACCESS_DENIED');
+      expect(operation.responses?.['403']?.description).toContain('ENTERPRISE_EDITION_REQUIRED');
+      expect(operation.tags).toEqual(['Opportunities v1']);
+    }
   });
 });


### PR DESCRIPTION
The 13 opportunity management operations (forecast, calibration, meeting-sessions, commitments, QBR, rollups) were marked edition:'ee', which did not actually remove them from the CE spec — the generator's route-inventory scan backfilled them as bare "GET v1" placeholders under a stray lowercase `opportunities` tag. That is what the public developer portal was rendering, since it consumes the CE spec.

Register them in both editions behind a `tierGated` flag instead. Their route files live in the CE tree and answer a structured 403 rather than 404, so a CE caller can reach them and deserves to find out why. The descriptions and the 403 now name both denial codes: ENTERPRISE_EDITION_REQUIRED in Community Edition, TIER_ACCESS_DENIED below the Pro plan. All 32 operations now sit under `Opportunities v1`.

Also document POST /inventory/counts/{sessionId}/cancel, which was being backfilled the same way, and extend the opportunities OpenAPI contract test to cover the tier-gated operations and assert they never regress to placeholder summaries.

Regenerated all six spec files. The semantic diff is confined to these 14 operations — no paths, schemas, or unrelated operations changed.

The Cheshire Cat faded from the registry until only "GET v1" hung grinning in the tree: thirteen doors with no names, and a second lowercase signpost pointing at all of them at once. We have given each door a knob, a summary, and a courteous 403 explaining that one must be Pro to enter — and cancelled a cycle count without disturbing a single grain upon the shelf, since only approval may post them. 🐈🚪🔑