### PR TITLE
Tax rate deletion: raw SQL error leaked to dialog + un-cascaded composite mapping FK

### DIFF
--- a/packages/billing/src/actions/taxRateActions.ts
+++ b/packages/billing/src/actions/taxRateActions.ts
@@ -14,6 +14,8 @@ import { assertPsaOnlyTenantAccess, ProductAccessError } from '@shared/services/
 import {
   actionError,
   permissionError,
+  isActionMessageError,
+  isActionPermissionError,
   type ActionMessageError,
   type ActionPermissionError,
 } from '@alga-psa/ui/lib/errorHandling';
@@ -41,6 +43,11 @@ function taxRateActionErrorFrom(error: unknown): TaxRateActionError | null {
         return actionError('Tax rate ID is required for updates.');
       case 'Tax rate not found':
         return actionError('Tax rate not found.');
+      // Thrown by deleteTaxRate's in-transaction guards; intentionally
+      // user-visible, so keep the wording rather than degrading to the
+      // generic delete fallback.
+      case 'Tax rate not found or already deleted.':
+        return actionError('Tax rate not found or already deleted.');
     }
   }
 
@@ -252,11 +259,37 @@ export const deleteTaxRate = withAuth(async (user, { tenant }, taxRateId: string
     };
   } catch (error: any) {
     console.error('Error processing tax rate deletion:', error);
+
+    // Never echo error.message to the client: raw Postgres/Knex failures here
+    // carry the interpolated SQL statement, which DeleteEntityDialog renders
+    // verbatim. Only messages this action recognises are user-visible.
+    const expected: unknown = taxRateActionErrorFrom(error);
+    if (isActionPermissionError(expected)) {
+      return {
+        success: false,
+        canDelete: false,
+        code: 'PERMISSION_DENIED',
+        message: expected.permissionError,
+        dependencies: [],
+        alternatives: []
+      };
+    }
+    if (isActionMessageError(expected)) {
+      return {
+        success: false,
+        canDelete: false,
+        code: 'VALIDATION_FAILED',
+        message: expected.actionError,
+        dependencies: [],
+        alternatives: []
+      };
+    }
+
     return {
       success: false,
       canDelete: false,
       code: 'VALIDATION_FAILED',
-      message: error?.message || 'Failed to process tax rate deletion request.',
+      message: 'Failed to delete tax rate. Please refresh and try again.',
       dependencies: [],
       alternatives: []
     };

--- a/packages/billing/tests/taxRateActions.deleteErrorLeak.test.ts
+++ b/packages/billing/tests/taxRateActions.deleteErrorLeak.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const createTenantKnex = vi.fn();
+const deleteEntityWithValidation = vi.fn();
+
+vi.mock('@alga-psa/db', () => ({
+  createTenantKnex: (...args: any[]) => createTenantKnex(...args),
+  tenantDb: vi.fn(),
+  withTransaction: vi.fn(),
+}));
+
+vi.mock('@alga-psa/core/server', () => ({
+  deleteEntityWithValidation: (...args: any[]) => deleteEntityWithValidation(...args),
+}));
+
+vi.mock('@alga-psa/auth', () => ({
+  withAuth:
+    (fn: any) =>
+    (...args: any[]) =>
+      fn({ id: 'user-1' }, { tenant: 'tenant-1' }, ...args),
+}));
+
+vi.mock('@alga-psa/auth/rbac', () => ({
+  hasPermission: vi.fn(() => true),
+}));
+
+vi.mock('@shared/services/productAccessGuard', () => ({
+  assertPsaOnlyTenantAccess: vi.fn(async () => undefined),
+  ProductAccessError: class ProductAccessError extends Error {},
+}));
+
+async function loadDeleteTaxRate() {
+  const mod = await import('../src/actions/taxRateActions');
+  return mod.deleteTaxRate;
+}
+
+describe('deleteTaxRate error handling', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createTenantKnex.mockResolvedValue({ knex: vi.fn() });
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('T034: an unmapped database error never leaks SQL to the client', async () => {
+    // Shape of a real Knex/Postgres failure: the interpolated statement is
+    // prefixed onto the message, and DeleteEntityDialog renders `message` verbatim.
+    const dbError: any = new Error(
+      'delete from "tax_components" where "tax_rate_id" = \'rate-a\' - update or delete on table "tax_components" violates foreign key constraint "composite_tax_mappings_tax_component_id_foreign" on table "composite_tax_mappings"'
+    );
+    dbError.code = '23503x';
+    deleteEntityWithValidation.mockRejectedValue(dbError);
+
+    const deleteTaxRate = await loadDeleteTaxRate();
+    const result: any = await deleteTaxRate('rate-a');
+
+    expect(result.success).toBe(false);
+    expect(result.canDelete).toBe(false);
+    expect(result.code).toBe('VALIDATION_FAILED');
+    expect(result.message).toBe('Failed to delete tax rate. Please refresh and try again.');
+    expect(result.message).not.toMatch(/select|insert|update|delete from/i);
+    expect(result.message).not.toContain('composite_tax_mappings_tax_component_id_foreign');
+    // Still logged server-side for diagnostics.
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('T035: a select-statement error message is not echoed back', async () => {
+    deleteEntityWithValidation.mockRejectedValue(
+      new Error('select * from "tax_rates" where "tenant" = \'tenant-1\' - column does not exist')
+    );
+
+    const deleteTaxRate = await loadDeleteTaxRate();
+    const result: any = await deleteTaxRate('rate-a');
+
+    expect(result.message).toBe('Failed to delete tax rate. Please refresh and try again.');
+    expect(result.message).not.toContain('select * from');
+  });
+
+  it('T036: the in-transaction not-found guard stays user-visible', async () => {
+    deleteEntityWithValidation.mockRejectedValue(new Error('Tax rate not found or already deleted.'));
+
+    const deleteTaxRate = await loadDeleteTaxRate();
+    const result: any = await deleteTaxRate('rate-a');
+
+    expect(result.code).toBe('VALIDATION_FAILED');
+    expect(result.message).toBe('Tax rate not found or already deleted.');
+  });
+
+  it('T037: permission-flavoured errors surface as PERMISSION_DENIED', async () => {
+    deleteEntityWithValidation.mockRejectedValue(new Error('Permission denied: Cannot delete tax rates'));
+
+    const deleteTaxRate = await loadDeleteTaxRate();
+    const result: any = await deleteTaxRate('rate-a');
+
+    expect(result.code).toBe('PERMISSION_DENIED');
+    expect(result.message).toBe('Permission denied: Cannot delete tax rates');
+    expect(result.dependencies).toEqual([]);
+    expect(result.alternatives).toEqual([]);
+  });
+});

--- a/packages/core/src/config/deletion/index.test.ts
+++ b/packages/core/src/config/deletion/index.test.ts
@@ -13,6 +13,25 @@ function makeTrx() {
   return { trx, builder };
 }
 
+// makeTrx()'s builder has no `join`; joined countQueries need one that records
+// the join clauses so the tenant-scoping `andOn` can be asserted.
+function makeJoinTrx(count = 0) {
+  const joinClause = {
+    on: vi.fn().mockReturnThis(),
+    andOn: vi.fn().mockReturnThis()
+  };
+  const builder: any = {};
+  builder.join = vi.fn((_table: string, callback: (this: typeof joinClause) => void) => {
+    callback.call(joinClause);
+    return builder;
+  });
+  builder.where = vi.fn().mockReturnValue(builder);
+  builder.count = vi.fn().mockReturnValue(builder);
+  builder.first = vi.fn().mockResolvedValue({ count: String(count) });
+  const trx = vi.fn().mockReturnValue(builder) as unknown as Knex;
+  return { trx, builder, joinClause };
+}
+
 describe('deletion configs', () => {
   it('T019: client config has correct foreign keys', () => {
     const config = DELETION_CONFIGS.client;
@@ -181,6 +200,49 @@ describe('deletion configs', () => {
       entity_id: 'id-1',
       entity_type: 'project'
     });
+  });
+
+  it('T031: tax rate config exposes composite_tax_mapping dependency with a countQuery', () => {
+    const dep = DELETION_CONFIGS.tax_rate.dependencies.find((d) => d.type === 'composite_tax_mapping');
+
+    expect(dep, 'tax_rate should have composite_tax_mapping dep').toBeDefined();
+    expect(dep?.table).toBe('composite_tax_mappings');
+    expect(dep?.label).toBe('composite tax mapping');
+    // Indirect relationship (tax_rates -> tax_components -> composite_tax_mappings),
+    // so it must not degrade to a plain foreignKey count.
+    expect(dep?.foreignKey).toBeUndefined();
+    expect(dep?.countQuery).toBeDefined();
+  });
+
+  it('T032: composite_tax_mapping countQuery joins through tax_components and is tenant-scoped', async () => {
+    const dep = DELETION_CONFIGS.tax_rate.dependencies.find((d) => d.type === 'composite_tax_mapping');
+    const { trx, builder, joinClause } = makeJoinTrx(2);
+
+    const count = await dep?.countQuery?.(trx, { tenant: 'tenant-1', entityId: 'rate-a' });
+
+    expect(trx).toHaveBeenCalledWith('composite_tax_mappings as ctm');
+    expect(builder.join).toHaveBeenCalledTimes(2);
+    expect(builder.join.mock.calls[0][0]).toBe('tax_components as tc');
+    expect(builder.join.mock.calls[1][0]).toBe('tax_rates as owner');
+    expect(joinClause.on).toHaveBeenCalledWith('tc.tax_component_id', '=', 'ctm.tax_component_id');
+    expect(joinClause.on).toHaveBeenCalledWith('owner.tax_rate_id', '=', 'ctm.composite_tax_id');
+    // composite_tax_mappings has no tenant column of its own, so the owning
+    // composite rate is pinned to the component's tenant.
+    expect(joinClause.andOn).toHaveBeenCalledWith('owner.tenant', '=', 'tc.tenant');
+    expect(builder.where).toHaveBeenNthCalledWith(1, 'tc.tenant', 'tenant-1');
+    expect(builder.where).toHaveBeenNthCalledWith(2, { 'tc.tax_rate_id': 'rate-a' });
+    expect(count).toBe(2);
+  });
+
+  it('T033: composite_tax_mapping countQuery excludes mappings owned by the rate being deleted', async () => {
+    const dep = DELETION_CONFIGS.tax_rate.dependencies.find((d) => d.type === 'composite_tax_mapping');
+    const { trx, builder } = makeJoinTrx(0);
+
+    await dep?.countQuery?.(trx, { tenant: 'tenant-1', entityId: 'rate-a' });
+
+    // Without this exclusion a composite rate that maps its own components
+    // would block its own deletion — those mappings are cascaded by deleteTaxRate.
+    expect(builder.where).toHaveBeenCalledWith('ctm.composite_tax_id', '!=', 'rate-a');
   });
 
   it('asset config has no blocking dependencies (cascaded by deleteAsset)', () => {

--- a/packages/core/src/config/deletion/index.ts
+++ b/packages/core/src/config/deletion/index.ts
@@ -54,6 +54,39 @@ const countContractLineServiceDeps = async (
   return Number(result?.count ?? 0);
 };
 
+// composite_tax_mappings has no `tenant` column of its own (verified against the
+// live schema; @alga-psa/db registers it as scope 'tenantViaParent' through
+// tax_rates.composite_tax_id). So both sides are tenant-scoped through their
+// parents: tax_components.tenant for the components owned by the rate being
+// deleted, and the owning composite tax_rates row for the mapping itself.
+//
+// The relationship is indirect — tax_rates -> tax_components.tax_rate_id ->
+// composite_tax_mappings.tax_component_id — so a plain `foreignKey` dependency
+// cannot express it.
+const countCompositeTaxComponentUsage = async (
+  trx: Knex | Knex.Transaction,
+  options: { tenant: string; entityId: string }
+): Promise<number> => {
+  const result = await trx('composite_tax_mappings as ctm')
+    .join('tax_components as tc', function () {
+      this.on('tc.tax_component_id', '=', 'ctm.tax_component_id');
+    })
+    .join('tax_rates as owner', function () {
+      this.on('owner.tax_rate_id', '=', 'ctm.composite_tax_id')
+        .andOn('owner.tenant', '=', 'tc.tenant');
+    })
+    .where('tc.tenant', options.tenant)
+    .where({ 'tc.tax_rate_id': options.entityId })
+    // Mappings owned by the rate being deleted are cascaded by deleteTaxRate
+    // before the components are removed, so counting them here would falsely
+    // block a composite rate from deleting its own component mappings.
+    .where('ctm.composite_tax_id', '!=', options.entityId)
+    .count<{ count: string }>('* as count')
+    .first();
+
+  return Number(result?.count ?? 0);
+};
+
 const countTimeEntryBilling = async (
   trx: Knex | Knex.Transaction,
   options: { tenant: string; entityId: string }
@@ -431,7 +464,17 @@ export const DELETION_CONFIGS: Record<string, EntityDeletionConfig> = {
     dependencies: [
       { type: 'client_tax_rate', table: 'client_tax_rates', foreignKey: 'tax_rate_id', label: 'client tax assignment' },
       { type: 'time_entry', table: 'time_entries', foreignKey: 'tax_rate_id', label: 'time entry' },
-      { type: 'service', table: 'service_catalog', foreignKey: 'tax_rate_id', label: 'service' }
+      { type: 'service', table: 'service_catalog', foreignKey: 'tax_rate_id', label: 'service' },
+      {
+        // This rate's tax_components are referenced by *other* composite rates'
+        // mappings. deleteTaxRate deletes this rate's components, which would
+        // raise 23503 on composite_tax_mappings_tax_component_id_foreign
+        // (NO ACTION) mid-transaction. Block with a friendly count instead.
+        type: 'composite_tax_mapping',
+        table: 'composite_tax_mappings',
+        label: 'composite tax mapping',
+        countQuery: countCompositeTaxComponentUsage
+      }
     ]
   },
   asset: {


### PR DESCRIPTION
## Summary

Deleting a tax rate could surface a raw Postgres/Knex error string — including the interpolated SQL statement and the constraint name — in `DeleteEntityDialog`, which renders the server's `message` verbatim. Two server-side causes, both fixed:

1. **Raw error leak.** `deleteTaxRate`'s catch block returned `error?.message` directly to the client. It now routes through `taxRateActionErrorFrom`, which only emits recognised, user-safe text; anything unmapped falls back to a static `"Failed to delete tax rate. Please refresh and try again."` message. Permission-flavoured errors map to `PERMISSION_DENIED`, everything else to `VALIDATION_FAILED`. The existing in-transaction `"Tax rate not found or already deleted."` guard is added to the switch so it stays user-visible instead of degrading to the generic fallback.

2. **Un-cascaded FK.** The delete transaction cascades `composite_tax_mappings` only by `composite_tax_id`, then deletes the rate's `tax_components`. If another composite rate maps one of those components, `composite_tax_mappings_tax_component_id_foreign` (`NO ACTION`) raises `23503` mid-transaction. A new validated dependency on `DELETION_CONFIGS.tax_rate` counts that usage via a custom `countQuery` (joining `composite_tax_mappings` → `tax_components` → owning `tax_rates`, tenant-scoped through the parents since `composite_tax_mappings` has no `tenant` column of its own) so the user gets an actionable `"N composite tax mappings"` block in the dialog instead of an exception. The count excludes mappings owned by the rate being deleted, since those are cascaded by `deleteTaxRate` itself.

Because `preCheckDeletion` and `deleteEntityWithValidation` both run `validateDeletion` against this config, the fix covers both the pre-check dialog and the post-confirm path.

## Files changed
- `packages/billing/src/actions/taxRateActions.ts` — route delete errors through `taxRateActionErrorFrom` instead of echoing `error.message`
- `packages/core/src/config/deletion/index.ts` — add `composite_tax_mapping` dependency with tenant-scoped `countQuery`
- `packages/billing/tests/taxRateActions.deleteErrorLeak.test.ts` (new) — unit coverage for the error-leak fix (T034–T037)
- `packages/core/src/config/deletion/index.test.ts` — unit coverage for the new dependency's countQuery (T031–T033)

## Test plan
- [x] Unit tests: `taxRateActions.deleteErrorLeak.test.ts` (T034–T037) and `deletion/index.test.ts` (T031–T033)
- [x] **SMOKE TEST PASSED** — all planned flows exercised through the real running product (dev server on `localhost:3726`, real Postgres, real Google Chrome via Playwright, logged in as `glinda@emeraldcity.oz`, Billing > Tax Rates):
  - **Flow 1 (new validated dependency):** deleting a rate whose components are mapped by another composite rate is blocked in the dialog with `"This tax rate has associated records that must be removed or reassigned first: 2 composite tax mappings."` — no SQL, no constraint name. Rate confirmed still present in the DB.
  - **Flow 2 (post-confirm 23503, the actual leak site):** reproduced a genuine mid-transaction FK violation (via an uncommitted conflicting row held in a separate psql transaction, invisible to the pre-check, then committed after Confirm). Dialog rendered safe text with no SQL or constraint name; transaction rolled back correctly. Note: this hits `taxRateActionErrorFrom`'s existing `23503` region-flavoured branch rather than the new static fallback — the wording is misleading for a composite-mapping failure specifically, though still safe. Worth a follow-up wording fix, filed as a note rather than blocking this PR.
  - **Flow 2b (in-transaction guard):** row deleted directly in the DB between dialog-open and Confirm → dialog shows `"Tax rate not found or already deleted."`, confirming the new switch case stays user-visible.
  - **Flow 3 (self-exclusion):** a composite rate that only maps its own components still deletes cleanly end-to-end, components cascade.
  - **Flow 4 (regression check):** a plain unencumbered rate still deletes end-to-end through the dialog.
  - Every dialog string across all flows was checked for SQL verbs, `violates foreign key constraint`, `update or delete on table`, constraint names, and quoted table names — zero hits.