### PR TITLE
Gmail Pub/Sub inbound email: silent failures, base-URL drift, and trial setup burden

### DIFF
--- a/docs/inbound-email/setup/gmail-google-cloud-prerequisites.md
+++ b/docs/inbound-email/setup/gmail-google-cloud-prerequisites.md
@@ -1,0 +1,77 @@
+# Google Cloud Prerequisites for Gmail Inbound Email
+
+Gmail delivers inbound mail to Alga by publishing a notification to a Pub/Sub topic, which pushes an HTTPS request to this instance. Six things have to be true in Google Cloud before that chain works. Alga provisions the topic and subscription itself; everything below is what it cannot create on your behalf.
+
+Work through this before adding a Gmail provider under **Settings → Email Providers**. If a mailbox is already connected and mail has stopped, run **Run Gmail Delivery Diagnostics** from the provider card menu — it checks each item here against live Google state and names the one that is wrong.
+
+## 1. A Google Cloud project with two APIs enabled
+
+Create or pick a project, then enable:
+
+- **Gmail API** — for the mailbox watch and message reads.
+- **Cloud Pub/Sub API** — for the topic and push subscription.
+
+Note the **project ID** (not the display name). Alga stores it per tenant and uses it to address every resource below.
+
+## 2. An OAuth client for the mailbox
+
+Create an **OAuth 2.0 Client ID** of type *Web application*. Its authorized redirect URI must exactly match the one shown in **Settings → Integrations → Providers** — typically `https://<your-alga-host>/api/auth/google/callback`.
+
+Keep the client ID and client secret; both go into the Google integration screen.
+
+## 3. A published consent screen
+
+Configure the OAuth consent screen and then **publish** it.
+
+This is the single most common cause of a Gmail provider that works for a week and then dies. While the consent screen is in **Testing**, Google expires refresh tokens after **seven days**. When that happens the mailbox stops ingesting and the provider reports an authentication failure that no amount of reconnecting will fix for longer than another week.
+
+An internal-only consent screen (available on Google Workspace) is published by definition and does not have this limit.
+
+## 4. A service account key for Pub/Sub provisioning
+
+Create a service account in the same project and download a **JSON key**. Alga authenticates as this service account to create the topic and subscription, and Google signs each push with its identity.
+
+Grant it on the project:
+
+- `roles/pubsub.admin` — or, if you prefer narrower grants, permissions covering `pubsub.topics.create`, `pubsub.topics.get`, `pubsub.topics.getIamPolicy`, `pubsub.topics.setIamPolicy`, `pubsub.subscriptions.create`, `pubsub.subscriptions.get`, and `pubsub.subscriptions.update`.
+
+The `setIamPolicy` permissions matter more than they look: Alga uses them to complete step 5, and setup fails outright without them.
+
+## 5. Publisher rights for Gmail's own service account
+
+Gmail publishes as `gmail-api-push@system.gserviceaccount.com`. That account needs `roles/pubsub.publisher` on the tenant's topic (`gmail-notifications-<tenant-id>`).
+
+Alga grants this automatically during setup using the key from step 4. Grant it by hand only if you have deliberately withheld `setIamPolicy` from that service account.
+
+Without this binding, Gmail rejects the watch registration and no notification is ever published — the mailbox looks configured and stays empty.
+
+## 6. A publicly reachable HTTPS address for this Alga instance
+
+Pub/Sub push only delivers to a public HTTPS endpoint with a resolvable name. Alga derives that address from the first of these that is set, checking both the environment and the app secret store:
+
+1. `NGROK_URL`
+2. `NEXT_PUBLIC_BASE_URL`
+3. `NEXTAUTH_URL`
+4. `PUBLIC_WEBHOOK_BASE_URL`
+
+The resolved value becomes both the push endpoint and the OIDC audience Google signs its token with — and the audience this instance checks that token against. The two are generated from the same normalization (lowercase scheme and host, no default port, no trailing slash), so they agree as long as the address itself is right.
+
+Change the address later and existing subscriptions keep pushing to the old one, where every request is rejected as unauthorized. After any hostname change, run **Refresh Pub/Sub & Watch** on each Gmail provider.
+
+Setup refuses to provision against `localhost`, a private network address, or a plain-HTTP URL, because Google could never deliver there. For local development, an ngrok tunnel in `NGROK_URL` is a supported way to get a real public address.
+
+## Keeping delivery alive
+
+A Gmail watch expires **seven days** after it is registered. Enterprise Edition renews watches on a schedule. Community Edition does not: the provider card warns as expiry approaches and again once it has passed, and **Refresh Pub/Sub & Watch** re-registers it. Plan on doing that weekly, or watch for the warning.
+
+## When something is wrong
+
+**Run Gmail Delivery Diagnostics** (provider card menu) reports each of the following as pass, warn, or fail, with what to do about it:
+
+- the public base URL this instance resolved, and where it came from
+- the tenant's service account key
+- the Pub/Sub topic
+- the publisher binding for `gmail-api-push@system.gserviceaccount.com`
+- the subscription's push endpoint and OIDC audience, showing expected and actual values side by side when they differ
+- the Gmail watch and its expiry
+- when a push was last accepted

--- a/docs/inbound-email/setup/gmail-google-cloud-prerequisites.md
+++ b/docs/inbound-email/setup/gmail-google-cloud-prerequisites.md
@@ -37,6 +37,8 @@ Grant it on the project:
 
 The `setIamPolicy` permissions matter more than they look: Alga uses them to complete step 5, and setup fails outright without them.
 
+Alga stores this key — along with the OAuth client secret and the mailbox's refresh token — as a tenant secret. On Kubernetes, check where those land before you upload anything: with `secrets_provider.writeProvider: filesystem` and no `SECRET_FS_BASE_PATH`, they are written to pod-local scratch and vanish on the next restart, taking the mailbox connection with them. Multi-replica installs should write to Vault (`secrets_provider.writeProvider: vault`); the `tenantSecrets.persistence` volume in the Helm chart is a single-replica option only, and `helm/values.yaml` explains why.
+
 ## 5. Publisher rights for Gmail's own service account
 
 Gmail publishes as `gmail-api-push@system.gserviceaccount.com`. That account needs `roles/pubsub.publisher` on the tenant's topic (`gmail-notifications-<tenant-id>`).
@@ -55,6 +57,8 @@ Pub/Sub push only delivers to a public HTTPS endpoint with a resolvable name. Al
 4. `PUBLIC_WEBHOOK_BASE_URL`
 
 The resolved value becomes both the push endpoint and the OIDC audience Google signs its token with — and the audience this instance checks that token against. The two are generated from the same normalization (lowercase scheme and host, no default port, no trailing slash), so they agree as long as the address itself is right.
+
+Give an origin only — `https://alga.example.com`, not `https://alga.example.com/alga`. The webhook route path is appended for you. A base URL carrying a path prefix is rejected outright, because provisioning and verification would each add the route path to it differently and the mismatch would surface only as an unexplained 401. Serving Alga under a path prefix is not supported for Gmail push delivery.
 
 Change the address later and existing subscriptions keep pushing to the old one, where every request is rejected as unauthorized. After any hostname change, run **Refresh Pub/Sub & Watch** on each Gmail provider.
 

--- a/docs/inbound-email/setup/gmail.md
+++ b/docs/inbound-email/setup/gmail.md
@@ -6,9 +6,13 @@ This guide walks an administrator through connecting a Gmail mailbox to the syst
 
 ## Prerequisites
 
+Set these up first — see [Google Cloud Prerequisites for Gmail Inbound Email](./gmail-google-cloud-prerequisites.md) for the details, including the consent-screen setting that otherwise kills the connection after seven days.
+
 * Google Cloud project with the **Gmail API** and **Pub/Sub API** enabled.
 * A tenant-owned OAuth client (Client ID + Client Secret) created in Google Cloud Console.
-* A tenant-owned service account key JSON (for Pub/Sub provisioning) available for upload/paste.
+* A **published** OAuth consent screen.
+* A tenant-owned service account key JSON (for Pub/Sub provisioning) available for upload/paste, with permission to set IAM policy on the topic.
+* A publicly reachable HTTPS address for this instance. Setup fails rather than provisioning a subscription Google could never deliver to.
 
 ## End-to-End Flow
 
@@ -47,10 +51,13 @@ curl -X POST \
      https://<host>/api/email/refresh-watch
 ```
 
-This bypasses the 24-hour cool-down by setting `force=true`.
+Every run re-provisions and re-verifies: the topic, the publisher binding, the subscription's push endpoint and audience, and the Gmail watch. A response with `success: false` carries the specific failure in `error`.
 
 ## Troubleshooting
 
+Start with **Run Gmail Delivery Diagnostics** in the provider card menu. It checks live Google state against what this instance expects and names the failing step.
+
 * **OAuth fails** – confirm the tenant’s OAuth client includes the redirect URI shown in **Settings → Integrations → Providers**.
-* **No messages arriving** – check `google_email_provider_config.pubsub_initialised_at` and `watch_expiration`. Use *Refresh Watch* if either is stale.
-* **Pub/Sub provisioning fails** – confirm the uploaded service account has the required IAM permissions on the tenant’s Google Cloud project.
+* **No messages arriving** – the watch expires seven days after registration and is renewed on a schedule only in Enterprise Edition. The provider card warns before and after expiry; *Refresh Pub/Sub & Watch* re-registers it.
+* **Deliveries rejected as unauthorized** – the subscription's OIDC audience no longer matches this instance's address, usually after a hostname change. Diagnostics prints both values; *Refresh Pub/Sub & Watch* rewrites the push configuration.
+* **Pub/Sub provisioning fails** – confirm the uploaded service account has the required IAM permissions, including `pubsub.topics.setIamPolicy`, on the tenant’s Google Cloud project.

--- a/docs/plans/2026-08-18-gmail-pubsub-inbound-silent-failures-plan.md
+++ b/docs/plans/2026-08-18-gmail-pubsub-inbound-silent-failures-plan.md
@@ -24,6 +24,8 @@ Add `packages/integrations/src/utils/email/gmailPubSub.ts` as the single source 
 
 Provisioning, verification, and diagnostics all build the push endpoint and the audience from this one function, so the two strings are equal by construction rather than by coincidence. Setup **refuses** a loopback, private-network, or plain-HTTP address instead of falling back to `http://localhost:3000`; `NGROK_URL` (written by the ngrok-sync container to `/app/ngrok/url`) remains the sanctioned local-development escape hatch.
 
+The scope of the unification is deliberately the *push* path — the endpoint Google delivers to and the audience it signs. The OAuth **redirect URI** base (`.../api/auth/google/callback`, derived in `persistGoogleConfig`) is a distinct concern with different failure modes (it is checked by Google's consent flow, not by our JWT verification), so it is intentionally left on its own env-or-secret derivation and not routed through this helper. That fourth site is flagged in code with `// LEVERAGE: pattern base-url-resolution` as a candidate for a later, broader base-URL layer; folding it in is out of scope here because it cannot cause the silent-audience-mismatch failure this card targets.
+
 Errors are typed and written to be read straight off the provider card: `GmailPubSubConfigurationError` for a base URL/name that cannot be derived, `GmailPubSubSetupError` for a provisioning step that failed against Google, each message naming the resource and the missing permission.
 
 ### 2. Nothing reports success it did not verify
@@ -32,6 +34,8 @@ Errors are typed and written to be read straight off the provider card: `GmailPu
 - `setupPubSub` reads the subscription back after creating it and fails when the push endpoint or the OIDC audience does not match what it just provisioned.
 - `registerWatch` already reported failure by return value; that value was being discarded. It is now read, and a failed or skipped `watch()` sets `success: false` with the underlying Google message attached (`configureGmailProvider.ts`).
 - Every outcome — success or failure — is written to `email_providers.status` / `error_message`, because the card renders from the row.
+- One coordination rule with the existing auth-pause lifecycle (from the auto-pause card): a provider that was auto-paused on repeated auth failures has its status/error text owned by `EmailProviderLifecycleService`'s recovery path. The honest-status write here therefore **skips** rows where `inbound_paused_at` is set with `inbound_pause_reason = 'auth_failure'`, captured as `pausedForAuthFailure` at the start of the call. For those providers a failed configure sets `authFailureRecovery = 'failed'` with reconnect-oriented copy instead of overwriting the paused row. This keeps the two owners of the row from fighting over it while still making a non-recovering reconnect report failure rather than success.
+- A missing OAuth token is now a failure for every provider, paused or not: without tokens there is no watch, so provisioning a topic delivers nothing. The earlier "success if Pub/Sub was configured" partial-success branch is removed.
 
 ### 3. Re-save honestly re-provisions; no fake cooldown
 
@@ -39,7 +43,9 @@ The 24-hour `pubsub_initialised_at` guard (`configureGmailProvider.ts:69-93`) th
 
 ### 4. A real health check: `runGmailDiagnostics`
 
-Add `GmailDiagnosticsService` plus an action and a `GmailDiagnosticsDialog`, in the shape of the Microsoft 365 precedent. It checks, and prints expected-vs-actual where they differ: the base URL, the service-account key, the topic, the publisher binding, the subscription's push endpoint and audience, the watch and its expiry, and **when a push was last accepted**. That last signal comes from a new `google_email_provider_config.last_push_received_at` column, written by the webhook route after JWT verification — the only end-to-end proof that Google can actually reach the endpoint. Interfaces live in `shared/interfaces/gmail-diagnostics.interfaces.ts`.
+Add `GmailDiagnosticsService` (exporting `runGmailDeliveryDiagnostics`) plus a `runGmailDiagnostics` action and a `GmailDiagnosticsDialog`, in the shape of the Microsoft 365 precedent. It checks, and prints expected-vs-actual where they differ: the base URL, the service-account key, the topic, the publisher binding, the subscription's push endpoint and audience, the watch and its expiry, and **when a push was last accepted**. That last signal comes from a new `google_email_provider_config.last_push_received_at` column (an additive, idempotent `hasColumn`-guarded migration), written by the webhook route after JWT verification — the only end-to-end proof that Google can actually reach the endpoint. Interfaces live in `shared/interfaces/gmail-diagnostics.interfaces.ts`.
+
+The diagnostics dialog is the on-demand deep check. The provider card also carries an always-on, passive watch-health banner that does not require opening the dialog: `EmailProviderCard` renders three distinct states from the stored `watch_expiration` — expired ("Gmail is no longer sending new mail here"), missing ("Gmail push delivery is not registered"), and expiring within a day — each naming the mailbox and offering **Refresh Pub/Sub & Watch** as the one-click remedy. This is what makes the 7-day expiry visible on stacks without the renewal scheduler (see Non-goals).
 
 ### 5. Webhook route: fail loud on a configured-but-unusable base URL
 
@@ -63,7 +69,7 @@ Add `docs/inbound-email/setup/gmail-google-cloud-prerequisites.md` and extend `d
 ## Non-goals (scoped as follow-up)
 
 - **Platform / shared Google app path.** Google remains tenant-owned in this card. A hosted platform-credential path mirroring Microsoft's `providerReadiness.ts:60-102` — so a trial user need not bring their own GCP project — is the highest-leverage fix for trial failure but is a larger change; documenting the prerequisites (§7) is the interim answer.
-- **CE-safe watch renewal.** The 7-day renewal remains EE-Temporal-scheduled. A CE/non-Temporal renewal path is a known gap; diagnostics (§4) at least surfaces an imminent/expired watch instead of letting it die silently.
+- **CE-safe watch renewal.** The 7-day renewal remains EE-Temporal-scheduled. A CE/non-Temporal renewal path is a known gap; the passive card banner and diagnostics (§4) at least surface an imminent/expired watch with a one-click Refresh remedy instead of letting it die silently, but the tenant must act on it.
 - No change to the shared ingestion/ticket-processing pipeline.
 
 ## Review risks

--- a/docs/plans/2026-08-18-gmail-pubsub-inbound-silent-failures-plan.md
+++ b/docs/plans/2026-08-18-gmail-pubsub-inbound-silent-failures-plan.md
@@ -1,0 +1,72 @@
+# Gmail Pub/Sub inbound email: silent failures, base-URL drift, and trial setup burden
+
+## Goal
+
+Make a Gmail inbound provider incapable of reporting "connected" while no mail is arriving. Every step that can break push delivery — the topic IAM grant, the Gmail `watch()` registration, the OIDC audience the webhook verifies — must fail loudly, write its outcome to the provider row the card renders from, and be re-checkable on demand. Where the failure is a genuine configuration fault (no public endpoint, a base URL that cannot be reached), setup must refuse rather than fall back to an address that can never receive a push.
+
+## Grounded constraints
+
+- The downstream pipeline is fully shared. Microsoft, Google, and IMAP all converge on `enqueueUnifiedInboundEmailQueueJob` (`shared/services/email/unifiedInboundEmailQueue.ts:339`). Nothing in this card touches ingestion or ticket processing; the entire divergence is Google setup and push delivery. Do not add a Gmail-specific processing path.
+- Gmail push delivery survives on one invariant: the audience Google signs its OIDC token with at provisioning time must be byte-identical to the audience the webhook route checks it against. A trailing slash, an uppercase host, an explicit `:443`, or a path prefix on one side turns every push into a 401 that no part of the product currently notices.
+- Three independent base-URL derivations existed and disagreed: provisioning preferred `NEXT_PUBLIC_BASE_URL` first and fell back to `http://localhost:3000` (`configureGmailProvider.ts:14-17`); webhook verification preferred `NEXTAUTH_URL` first (`googleWebhookHandler.ts:185-186`); the action layer read through `getAppSecret` while the other two read `process.env` (`emailProviderActions.ts:191-203`). Any drift between them was invisible until no mail arrived.
+- The provider card renders from the `email_providers` row, not from an action's return value. An outcome that is only returned and never persisted cannot be shown. Success/failure must be written to `email_providers.status` / `error_message`.
+- Microsoft 365 already has the precedent this card should follow: a diagnostics action + dialog, and — structurally — a platform-credential fallback path (`providerReadiness.ts:60-102`). Google is always tenant-owned with no shared-app fallback, which is the root of the trial setup burden; the diagnostics precedent is adoptable now, the platform-app precedent is a larger follow-up (see Non-goals).
+- Gmail watches expire after seven days and are renewed by an EE-Temporal-scheduled handler (`setupSchedules.ts:486`, `googleGmailWatchRenewalHandler.ts`). A CE/non-Temporal stack has no renewal path; that is a real gap but is scoped as follow-up, not silently assumed away.
+- The tenant secret write path must not regress the standard Helm install. `server.replicaCount` defaults to 2 with `maxUnavailable: 0 / maxSurge: 1` and no anti-affinity; no `ReadWriteMany` StorageClass exists on these clusters. A shared single-attach PVC does not fix the durability problem — it reproduces it behind a volume that looks solved.
+
+## Design
+
+### 1. One base-URL / naming derivation, used by all three callers
+
+Add `packages/integrations/src/utils/email/gmailPubSub.ts` as the single source of truth for the public address and Pub/Sub naming. It resolves the base URL from a fixed precedence — `NGROK_URL`, `NEXT_PUBLIC_BASE_URL`, `NEXTAUTH_URL`, `PUBLIC_WEBHOOK_BASE_URL` — each read from `process.env` first and the app secret store second, so a value set either way resolves identically regardless of which caller asks.
+
+`normalizeGmailBaseUrl` reduces the value to a canonical origin: lowercase scheme and host, no default port, no query, no fragment, **no path**. A path component is rejected, not preserved — provisioning appends the fixed `GOOGLE_WEBHOOK_PATH` while verification appends `request.nextUrl.pathname`, so a prefix carried on the base would be doubled on one side and dropped on the other, and the mismatch would surface only as a 401. Serving Alga under a path prefix is therefore explicitly unsupported for Gmail push, and setup says so.
+
+Provisioning, verification, and diagnostics all build the push endpoint and the audience from this one function, so the two strings are equal by construction rather than by coincidence. Setup **refuses** a loopback, private-network, or plain-HTTP address instead of falling back to `http://localhost:3000`; `NGROK_URL` (written by the ngrok-sync container to `/app/ngrok/url`) remains the sanctioned local-development escape hatch.
+
+Errors are typed and written to be read straight off the provider card: `GmailPubSubConfigurationError` for a base URL/name that cannot be derived, `GmailPubSubSetupError` for a provisioning step that failed against Google, each message naming the resource and the missing permission.
+
+### 2. Nothing reports success it did not verify
+
+- The publisher IAM grant for `gmail-api-push@system.gserviceaccount.com` (`setupPubSub.ts`) **throws** on failure, naming the topic and `roles/pubsub.publisher`, instead of warning and continuing.
+- `setupPubSub` reads the subscription back after creating it and fails when the push endpoint or the OIDC audience does not match what it just provisioned.
+- `registerWatch` already reported failure by return value; that value was being discarded. It is now read, and a failed or skipped `watch()` sets `success: false` with the underlying Google message attached (`configureGmailProvider.ts`).
+- Every outcome — success or failure — is written to `email_providers.status` / `error_message`, because the card renders from the row.
+
+### 3. Re-save honestly re-provisions; no fake cooldown
+
+The 24-hour `pubsub_initialised_at` guard (`configureGmailProvider.ts:69-93`) that returned `pubsubConfigured` / `watchRegistered = true` without checking anything is removed. Every save and every "Refresh Pub/Sub & Watch" re-provisions and re-verifies. A user re-saving to fix a problem gets a real answer, not a cached "success" from the run that first broke.
+
+### 4. A real health check: `runGmailDiagnostics`
+
+Add `GmailDiagnosticsService` plus an action and a `GmailDiagnosticsDialog`, in the shape of the Microsoft 365 precedent. It checks, and prints expected-vs-actual where they differ: the base URL, the service-account key, the topic, the publisher binding, the subscription's push endpoint and audience, the watch and its expiry, and **when a push was last accepted**. That last signal comes from a new `google_email_provider_config.last_push_received_at` column, written by the webhook route after JWT verification — the only end-to-end proof that Google can actually reach the endpoint. Interfaces live in `shared/interfaces/gmail-diagnostics.interfaces.ts`.
+
+### 5. Webhook route: fail loud on a configured-but-unusable base URL
+
+The Google webhook handler no longer silently degrades to `request.nextUrl.origin` (the container-internal address, which can never match the signed audience) when a base URL is configured but unusable — it rejects with the configuration fault stated in the log. The distinct case of *no* base URL configured at all keeps the request-origin fallback, but with a warning that says plainly it only matches when Pub/Sub was provisioned against that same origin. The base is normalized to an origin here too, and a path component is rejected rather than preserved, so a prefix can reach the audience from exactly one source.
+
+### 6. Tenant secret durability without a deadlocking default
+
+`tenantSecrets.persistence` defaults **off**. `ReadWriteMany` is unavailable on these clusters (every StorageClass is node-local or single-attach block storage), and a node-local volume shared by two replicas reproduces the exact bug this card removes — a secret written by one replica unreadable by the other — now hidden behind a PVC. Multi-replica installs must write tenant secrets to Vault (`secrets_provider.writeProvider=vault`); the optional claim is for single-replica installs where the filesystem provider is genuinely the write path, and `sharedTenantSecrets` remains the appliance answer. The chart **fails to render** when `tenantSecrets.persistence.enabled` is combined with `replicaCount > 1`, rather than emitting manifests that deadlock at apply time on `FailedAttachVolume`. Default rendering is byte-identical to the pre-change chart (zero occurrences of `tenant-secrets` or `SECRET_FS_BASE_PATH`).
+
+### 7. Document the GCP prerequisites
+
+Add `docs/inbound-email/setup/gmail-google-cloud-prerequisites.md` and extend `docs/inbound-email/setup/gmail.md`: the GCP project, OAuth client, service-account key with topic IAM, the public HTTPS endpoint requirement, and the OAuth consent screen in Production (a Testing-mode consent screen kills the refresh token in 7 days). This is the burden IMAP avoids; documenting it is the near-term mitigation ahead of a platform Google app path.
+
+## Behavioral tests
+
+- `gmailPubSub.test.ts`: normalization (trailing slash, uppercase host, default-port `:443`, query/fragment stripped), rejection of loopback / private / plain-HTTP / path-carrying bases, and that a prefix arriving via the request path appears in the audience exactly once.
+- `googleWebhookUnifiedQueue.integration.test.ts`: a verified push updates `last_push_received_at` and enqueues through the shared queue.
+- `inboundAuthPauseReconnectSave.integration.test.ts`: re-save re-provisions rather than short-circuiting on the removed cooldown.
+- Helm: `tenantSecrets.persistence.enabled + replicaCount > 1` fails to render; default render contains no tenant-secret artifacts.
+
+## Non-goals (scoped as follow-up)
+
+- **Platform / shared Google app path.** Google remains tenant-owned in this card. A hosted platform-credential path mirroring Microsoft's `providerReadiness.ts:60-102` — so a trial user need not bring their own GCP project — is the highest-leverage fix for trial failure but is a larger change; documenting the prerequisites (§7) is the interim answer.
+- **CE-safe watch renewal.** The 7-day renewal remains EE-Temporal-scheduled. A CE/non-Temporal renewal path is a known gap; diagnostics (§4) at least surfaces an imminent/expired watch instead of letting it die silently.
+- No change to the shared ingestion/ticket-processing pipeline.
+
+## Review risks
+
+- Base-URL precedence changes which env var wins for existing installs; the fixed order (`NGROK_URL` → `NEXT_PUBLIC_BASE_URL` → `NEXTAUTH_URL` → `PUBLIC_WEBHOOK_BASE_URL`) must match what current tenants have provisioned against, or a re-save will re-point the audience. The diagnostics expected-vs-actual print exists partly to make that visible.
+- Turning warn-only steps into hard failures means installs that were "green but dead" will now show red on first save. That is the intended behavior, but it is a visible change for anyone who was silently broken.

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -106,6 +106,10 @@ spec:
           hostPath:
             path: {{ .Values.sharedTenantSecrets.hostPath }}
             type: DirectoryOrCreate
+        {{- else if .Values.tenantSecrets.persistence.enabled }}
+        - name: tenant-secrets
+          persistentVolumeClaim:
+            claimName: {{ .Values.tenantSecrets.persistence.existingClaim | default (printf "%s-tenant-secrets" (include "sebastian.fullname" .)) }}
         {{- end }}
       {{- if or .Values.setup.runMigrations .Values.setup.runSeeds }}
       initContainers:
@@ -955,6 +959,9 @@ spec:
           {{- if .Values.sharedTenantSecrets.enabled }}
           - name: SECRET_FS_BASE_PATH
             value: "{{ .Values.sharedTenantSecrets.mountPath }}"
+          {{- else if .Values.tenantSecrets.persistence.enabled }}
+          - name: SECRET_FS_BASE_PATH
+            value: "{{ .Values.tenantSecrets.mountPath }}"
           {{- end }}
           {{- if .Values.secrets_provider.envPrefix }}
           - name: SECRET_ENV_PREFIX
@@ -987,7 +994,7 @@ spec:
             value: "{{ .Values.secrets_provider.vault.tenantSecretPathTemplate }}"
           {{- end }}
           {{- end }}
-          {{- if or (and .Values.server.persistence.enabled (not .Values.config.storage.providers.s3.enabled)) .Values.sharedTenantSecrets.enabled }}
+          {{- if or (and .Values.server.persistence.enabled (not .Values.config.storage.providers.s3.enabled)) .Values.sharedTenantSecrets.enabled .Values.tenantSecrets.persistence.enabled }}
           volumeMounts:
             {{- if and .Values.server.persistence.enabled (not .Values.config.storage.providers.s3.enabled) }}
             - name: storage-volume
@@ -996,6 +1003,9 @@ spec:
             {{- if .Values.sharedTenantSecrets.enabled }}
             - name: shared-tenant-secrets
               mountPath: {{ .Values.sharedTenantSecrets.mountPath }}
+            {{- else if .Values.tenantSecrets.persistence.enabled }}
+            - name: tenant-secrets
+              mountPath: {{ .Values.tenantSecrets.mountPath }}
             {{- end }}
           {{- end }}
           ports:

--- a/helm/templates/tenant-secrets-pvc.yaml
+++ b/helm/templates/tenant-secrets-pvc.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.tenantSecrets.persistence.enabled (not .Values.tenantSecrets.persistence.existingClaim) (not .Values.sharedTenantSecrets.enabled) (not .Values.devEnv.enabled) (not (include "sebastian.hostedEnvEnabled" .)) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "sebastian.fullname" . }}-tenant-secrets
+  namespace: {{ include "sebastian.namespace" . }}
+  labels:
+    {{- include "sebastian.labels" . | nindent 4 }}
+  {{- with .Values.tenantSecrets.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- $existingPVC := lookup "v1" "PersistentVolumeClaim" (include "sebastian.namespace" .) (printf "%s-tenant-secrets" (include "sebastian.fullname" .)) }}
+  {{- if and $existingPVC $existingPVC.spec.volumeName }}
+  volumeName: {{ $existingPVC.spec.volumeName }}
+  {{- end }}
+  accessModes:
+    {{- range .Values.tenantSecrets.persistence.accessModes }}
+    - {{ . | quote }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.tenantSecrets.persistence.size | quote }}
+  {{- if .Values.tenantSecrets.persistence.storageClass }}
+  {{- if (eq "-" .Values.tenantSecrets.persistence.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.tenantSecrets.persistence.storageClass | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/templates/tenant-secrets-pvc.yaml
+++ b/helm/templates/tenant-secrets-pvc.yaml
@@ -1,3 +1,13 @@
+{{- /*
+  The tenant-secrets claim is single-attach on every StorageClass these clusters
+  offer, so a second server replica either fails to attach it or — worse — runs
+  against a separate node-local copy and cannot read what the first replica
+  wrote. Refuse the combination outright instead of rendering a manifest that
+  deadlocks the rollout at apply time.
+*/ -}}
+{{- if and .Values.tenantSecrets.persistence.enabled (not .Values.sharedTenantSecrets.enabled) (gt (int .Values.server.replicaCount) 1) }}
+{{- fail (printf "tenantSecrets.persistence.enabled requires server.replicaCount=1 (currently %d): the claim is single-attach, so extra replicas cannot attach it and would not share the secrets written to it. Use secrets_provider.writeProvider=vault for multi-replica installs, or sharedTenantSecrets on the single-node appliance." (int .Values.server.replicaCount)) }}
+{{- end }}
 {{- if and .Values.tenantSecrets.persistence.enabled (not .Values.tenantSecrets.persistence.existingClaim) (not .Values.sharedTenantSecrets.enabled) (not .Values.devEnv.enabled) (not (include "sebastian.hostedEnvEnabled" .)) }}
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -512,11 +512,30 @@ secrets_provider:
 # a hostPath into the server pod and points the filesystem secret provider at it
 # via SECRET_FS_BASE_PATH, so tenant secrets the server writes are visible to
 # other appliance services (e.g. email-service) that mount the same hostPath.
-# Disabled by default → cloud/hosted rendering is unchanged.
+# Takes precedence over tenantSecrets.persistence below.
 sharedTenantSecrets:
   enabled: false
   hostPath: /var/lib/alga-appliance/tenant-secrets
   mountPath: /shared-tenant-secrets
+
+# Durable home for tenant secrets the server writes at runtime — Google service
+# account keys, OAuth client credentials, and refresh tokens among them. The
+# default write provider is `filesystem`, and with no SECRET_FS_BASE_PATH set the
+# provider falls back to the read-only /run/secrets mount or to pod-local
+# scratch. Either way a tenant reconnects Gmail, the pod restarts, and the
+# credentials are gone. A claim-backed path is therefore the default; set
+# sharedTenantSecrets.enabled on the appliance, or persistence.enabled=false when
+# secrets are written to Vault instead.
+tenantSecrets:
+  mountPath: /var/lib/alga/tenant-secrets
+  persistence:
+    enabled: true
+    existingClaim: ""
+    size: 1Gi
+    accessModes:
+      - ReadWriteOnce
+    storageClass: ""
+    annotations: {}
 
 # Development environment configuration
 devEnv:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -519,22 +519,41 @@ sharedTenantSecrets:
   mountPath: /shared-tenant-secrets
 
 # Durable home for tenant secrets the server writes at runtime — Google service
-# account keys, OAuth client credentials, and refresh tokens among them. The
-# default write provider is `filesystem`, and with no SECRET_FS_BASE_PATH set the
+# account keys, OAuth client credentials, and refresh tokens among them. With
+# secrets_provider.writeProvider=filesystem and no SECRET_FS_BASE_PATH set, the
 # provider falls back to the read-only /run/secrets mount or to pod-local
-# scratch. Either way a tenant reconnects Gmail, the pod restarts, and the
-# credentials are gone. A claim-backed path is therefore the default; set
-# sharedTenantSecrets.enabled on the appliance, or persistence.enabled=false when
-# secrets are written to Vault instead.
+# scratch, so a tenant reconnects Gmail, the pod restarts, and the credentials
+# are gone.
+#
+# READ BEFORE ENABLING — this claim is safe only on a SINGLE-REPLICA install.
+# server.replicaCount defaults to 2 and the chart sets no anti-affinity, so the
+# replicas can land on different nodes. Every StorageClass these clusters offer
+# (local-path, microk8s-hostpath, nm-thin/LINSTOR, ceph-rbd) is node-local or
+# single-attach block storage — ReadWriteMany is not available anywhere — which
+# means with two replicas:
+#   * the second replica blocks in ContainerCreating on FailedAttachVolume, and
+#   * the RollingUpdate surge pod (maxUnavailable: 0 / maxSurge: 1) cannot
+#     attach the volume the outgoing pods still hold, deadlocking the rollout.
+# Worse, even co-located replicas backed by a node-local volume reproduce the
+# very bug this setting exists to fix: a secret written by one replica is
+# invisible to the other. A volume only one replica can reach is not a fix.
+#
+# So: leave this off for multi-replica installs and write secrets to Vault
+# (secrets_provider.writeProvider=vault) instead. Turn it on only where the
+# filesystem provider is genuinely the write path and exactly one server replica
+# runs — set server.replicaCount=1 alongside it. On the single-node appliance,
+# use sharedTenantSecrets above rather than this.
 tenantSecrets:
   mountPath: /var/lib/alga/tenant-secrets
   persistence:
-    enabled: true
+    enabled: false
     existingClaim: ""
     size: 1Gi
     accessModes:
       - ReadWriteOnce
-    storageClass: ""
+    # Node-local by default, matching the rest of the chart. Any value here is
+    # still single-attach — see the replica constraint above.
+    storageClass: "local-path"
     annotations: {}
 
 # Development environment configuration

--- a/packages/integrations/src/actions/email-actions/configureGmailProvider.ts
+++ b/packages/integrations/src/actions/email-actions/configureGmailProvider.ts
@@ -5,28 +5,16 @@ import { setupPubSub } from './setupPubSub';
 import { GmailWebhookService } from '../../services/email/GmailWebhookService';
 import type { GoogleEmailProviderConfig } from '../../components/email/types';
 import type { EmailProviderConfig } from '@alga-psa/shared/interfaces/inbound-email.interfaces';
-
-/**
- * Generate standardized Pub/Sub topic and subscription names for a tenant
- */
-function generatePubSubNames(tenantId: string) {
-  // Use ngrok URL in development if available
-  const baseUrl = process.env.NGROK_URL || 
-                  process.env.NEXT_PUBLIC_BASE_URL || 
-                  process.env.NEXTAUTH_URL ||
-                  'http://localhost:3000';
-  
-  return {
-    topicName: `gmail-notifications-${tenantId}`,
-    subscriptionName: `gmail-webhook-${tenantId}`,
-    webhookUrl: `${baseUrl}/api/email/webhooks/google`
-  };
-}
+import { getGmailPubSubNames } from '../../utils/email/gmailPubSub';
 
 interface ConfigureGmailProviderOptions {
   tenant: string;
   providerId: string;
   projectId: string;
+  /**
+   * Retained for callers that request an explicit refresh. Configuration is
+   * always verified end to end now, so this no longer changes what runs.
+   */
   force?: boolean;
 }
 
@@ -47,10 +35,12 @@ export interface ConfigureGmailProviderResult {
 
 /**
  * Configure Gmail provider with Pub/Sub and webhook registration.
- * This is the single orchestrator for Gmail provider setup that ensures
- * exactly one Pub/Sub initialization per logical trigger.
+ * This is the single orchestrator for Gmail provider setup.
  *
- * Returns a result object indicating what succeeded/failed so the UI can inform the user.
+ * Every field of the returned result reflects work this call actually did and
+ * verified. `success` is true only when Pub/Sub is provisioned with a push
+ * endpoint that matches this instance *and* a Gmail watch is registered
+ * against it; anything less carries an error the administrator can act on.
  */
 export async function configureGmailProvider({
   tenant,
@@ -70,6 +60,11 @@ export async function configureGmailProvider({
     return result;
   }
 
+  // Whether this provider was auto-paused on auth failures when the call
+  // started. The lifecycle recovery owns that row's status, so the honest-status
+  // write below must stay out of its way.
+  let pausedForAuthFailure = false;
+
   try {
     await runWithTenant(tenant, async () => {
       // Capture the pre-watch history cursor and pause state before any
@@ -82,39 +77,15 @@ export async function configureGmailProvider({
         boundaryDb.table('google_email_provider_config').where({ email_provider_id: providerId }).first('history_id'),
       ]);
       const savedHistoryId = boundaryGoogleConfig?.history_id ? String(boundaryGoogleConfig.history_id) : null;
-      const pausedForAuthFailure = Boolean(
+      pausedForAuthFailure = Boolean(
         boundaryProvider?.inbound_paused_at && boundaryProvider.inbound_pause_reason === 'auth_failure'
       );
 
-      // Check if Pub/Sub was already initialized recently (within 24 hours) unless force=true
-      // or the provider is paused for auth failure (reconnect must re-establish the watch).
-      if (!force && !pausedForAuthFailure) {
-        const {knex} = await createTenantKnex(tenant);
-        const db = tenantDb(knex, tenant);
-        const config = await db.table('google_email_provider_config')
-          .select('pubsub_initialised_at')
-          .where('email_provider_id', providerId)
-          .first() as GoogleEmailProviderConfig | undefined;
-
-        if (config?.pubsub_initialised_at) {
-          const initialisedAt = new Date(config.pubsub_initialised_at);
-          const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
-          
-          if (initialisedAt > twentyFourHoursAgo) {
-            console.log(`⏭️ Skipping Pub/Sub setup for Gmail provider ${providerId} - already initialized within 24 hours`, {
-              tenant,
-              providerId,
-              pubsub_initialised_at: config.pubsub_initialised_at
-            });
-            result.success = true;
-            result.pubsubConfigured = true;
-            result.watchRegistered = true;
-            return;
-          }
-        }
-      }
-
-      const pubsubNames = generatePubSubNames(tenant);
+      // There is deliberately no "configured recently, skip it" shortcut here.
+      // Claiming a working watch without checking is what let broken Gmail
+      // providers sit green for days; provisioning is idempotent, so the honest
+      // answer costs a few API calls and nothing else.
+      const pubsubNames = await getGmailPubSubNames(tenant);
       console.log(`🔧 Configuring Gmail provider ${providerId} with Pub/Sub:`, {
         tenant,
         providerId,
@@ -178,17 +149,15 @@ export async function configureGmailProvider({
             hasRefreshToken: !!googleConfig.refresh_token
           });
           result.warnings.push('OAuth tokens missing - Gmail watch registration skipped');
-          // Without tokens the watch — and the auth-pause recovery behind
-          // it — cannot be re-established. For a provider auto-paused on
-          // auth failures this exit is a failed reconnect that must not
-          // masquerade as success over a still-paused mailbox; for everyone
-          // else it stays the historical warning-tolerant partial success.
+          // Without tokens there is no watch, so no mail will ever arrive —
+          // Pub/Sub being provisioned changes nothing about that. This is a
+          // failure for every provider, paused or not.
+          result.success = false;
           if (pausedForAuthFailure) {
             result.authFailureRecovery = 'failed';
-            result.success = false;
             result.error = 'Gmail reconnection failed: OAuth authorization is required. Reconnect the mailbox and try again.';
           } else {
-            result.success = result.pubsubConfigured; // Still considered success if pubsub was configured
+            result.error = 'Gmail watch could not be registered: the mailbox has not completed Google OAuth authorization. Connect the mailbox and try again.';
           }
           return;
         }
@@ -231,14 +200,20 @@ export async function configureGmailProvider({
 
         const gmailWebhookService = new GmailWebhookService();
         
-        // Register the Gmail watch
-        await gmailWebhookService.registerWatch(emailProviderConfig, {
+        // Register the Gmail watch. registerWatch reports failure by return
+        // value rather than by throwing, so the result has to be read — an
+        // unchecked call here is a watch that silently never existed.
+        const watchResult = await gmailWebhookService.registerWatch(emailProviderConfig, {
           projectId,
           topicName: pubsubNames.topicName,
           subscriptionName: pubsubNames.subscriptionName,
           webhookUrl: pubsubNames.webhookUrl
         });
-        
+
+        if (!watchResult.success) {
+          throw new Error(watchResult.error || 'Gmail watch registration failed.');
+        }
+
         // Update the main provider's last_sync_at to reflect successful configuration
         await db.table('email_providers')
           .where('id', providerId)
@@ -305,20 +280,16 @@ export async function configureGmailProvider({
           error: errorMessage,
           stack: watchError instanceof Error ? watchError.stack : undefined
         });
-        // Record the error but don't throw - provider is saved, Pub/Sub may still work
-        result.warnings.push('Gmail watch registration failed. Reconnect the mailbox or retry setup after verifying Google permissions.');
-        // For a provider auto-paused on auth failures this catch is the
-        // revoked/invalid-credential case: delivery was not re-established,
-        // recovery never ran, and the caller must not report success over a
-        // still-paused mailbox. Non-paused providers keep the historical
-        // warning-tolerant partial success.
+        // No watch means Gmail publishes nothing, so a provisioned topic buys
+        // the tenant exactly nothing. The provider row stays saved — the
+        // administrator can retry — but the call reports what it is.
+        result.watchRegistered = false;
+        result.success = false;
+        result.error = pausedForAuthFailure
+          ? `Gmail reconnection failed. Reconnect the mailbox and try again. Google reported: ${errorMessage}`
+          : `Gmail watch registration failed, so no mail will be delivered. Verify the mailbox's Google authorization and the Pub/Sub topic permissions, then retry. Google reported: ${errorMessage}`;
         if (pausedForAuthFailure) {
           result.authFailureRecovery = 'failed';
-          result.success = false;
-          result.error = 'Gmail reconnection failed. Reconnect the mailbox and try again.';
-        } else {
-          // If Pub/Sub was configured, we're partially successful
-          result.success = result.pubsubConfigured;
         }
       }
     });
@@ -334,6 +305,33 @@ export async function configureGmailProvider({
     // This is a critical failure - Pub/Sub setup failed
     result.error = errorMessage || 'Unable to configure Gmail Pub/Sub.';
     result.success = false;
+  }
+
+  // The provider card renders from the stored row, not from this result.
+  // Leaving that row at "connected" after a failed configure reproduces the
+  // exact lie this orchestrator exists to remove, so the outcome is persisted.
+  // Providers auto-paused on auth failures are skipped: the lifecycle recovery
+  // owns their status and error text.
+  if (!pausedForAuthFailure) {
+    try {
+      await runWithTenant(tenant, async () => {
+        const { knex } = await createTenantKnex(tenant);
+        await tenantDb(knex, tenant)
+          .table('email_providers')
+          .where('id', providerId)
+          .update(
+            result.success
+              ? { status: 'connected', error_message: null, updated_at: knex.fn.now() }
+              : {
+                  status: 'error',
+                  error_message: result.error || 'Gmail inbound delivery is not configured.',
+                  updated_at: knex.fn.now(),
+                }
+          );
+      });
+    } catch (statusError) {
+      console.error(`Failed to record Gmail configuration outcome for provider ${providerId}:`, statusError);
+    }
   }
 
   return result;

--- a/packages/integrations/src/actions/email-actions/emailProviderActions.ts
+++ b/packages/integrations/src/actions/email-actions/emailProviderActions.ts
@@ -18,6 +18,9 @@ import { configureGmailProvider, type ConfigureGmailProviderResult } from './con
 import { EmailWebhookMaintenanceService } from '@alga-psa/shared/services/email/EmailWebhookMaintenanceService';
 import { hasPermission } from '@alga-psa/auth/rbac';
 import { getWebhookBaseUrl } from '../../utils/email/webhookHelpers';
+import { gmailSubscriptionName, gmailTopicName } from '../../utils/email/gmailPubSub';
+import { runGmailDeliveryDiagnostics } from '../../services/email/GmailDiagnosticsService';
+import type { GmailDiagnosticsReport } from '@alga-psa/shared/interfaces/gmail-diagnostics.interfaces';
 import {
   actionError,
   type ActionMessageError,
@@ -184,24 +187,6 @@ export interface EmailProviderSetupResult {
   setupWarnings?: string[];
 }
 
-
-/**
- * Generate standardized Pub/Sub topic and subscription names for a tenant
- */
-async function generatePubSubNames(tenantId: string) {
-  // Use ngrok URL in development if available
-  const secretProvider = await getSecretProviderInstance();
-  const baseUrl = await secretProvider.getAppSecret('NGROK_URL') || 
-                  await secretProvider.getAppSecret('NEXT_PUBLIC_BASE_URL') || 
-                  await secretProvider.getAppSecret('NEXTAUTH_URL') ||
-                  'http://localhost:3000';
-  
-  return {
-    topicName: `gmail-notifications-${tenantId}`,
-    subscriptionName: `gmail-webhook-${tenantId}`,
-    webhookUrl: `${baseUrl}/api/email/webhooks/google`
-  };
-}
 
 /**
  * Shared column list for provider queries
@@ -520,6 +505,9 @@ async function persistGoogleConfig(
     throwExpectedEmailProviderError('Google Cloud project ID is not configured for this tenant. Configure Google settings first.');
   }
 
+  // LEVERAGE: pattern base-url-resolution — fourth site deriving a public base
+  // URL from env-or-app-secret; the Gmail Pub/Sub path now owns one in
+  // utils/email/gmailPubSub, but OAuth redirect URIs still hand-roll it.
   const baseUrl =
     process.env.NEXT_PUBLIC_BASE_URL ||
     (await secretProvider.getAppSecret('NEXT_PUBLIC_BASE_URL')) ||
@@ -527,10 +515,15 @@ async function persistGoogleConfig(
     (await secretProvider.getAppSecret('NEXTAUTH_URL')) ||
     'http://localhost:3000';
   const effectiveRedirectUri = `${baseUrl}/api/auth/google/callback`;
-  
-  // Generate standardized Pub/Sub names
-  const pubsubNames = await generatePubSubNames(tenant);
-  
+
+  // Topic and subscription names only depend on the tenant. Resolving the push
+  // base URL is left to configureGmailProvider, which is the step that has to
+  // fail loudly when the instance is not publicly reachable.
+  const pubsubNames = {
+    topicName: gmailTopicName(tenant),
+    subscriptionName: gmailSubscriptionName(tenant),
+  };
+
   // Prepare config payload
   const labelFiltersArray = config.label_filters || [];
   const configPayload = {
@@ -785,11 +778,12 @@ export const getEmailProviders = withAuth(async (
             'token_expires_at',
             'history_id',
             'watch_expiration',
+            'last_push_received_at',
             'created_at',
             'updated_at'
           )
           .first();
-        
+
         if (googleConfig) {
           googleConfig.label_filters = googleConfig.label_filters || [];
           provider.googleConfig = googleConfig;
@@ -1652,6 +1646,59 @@ export const retryMicrosoftSubscriptionRenewal = withAuth(async (
     return {
       success: false,
       message: microsoft365ActionErrorMessage(error, 'Microsoft subscription renewal failed. Please try again.'),
+    };
+  }
+});
+
+/**
+ * Check whether inbound Gmail delivery is actually working for a provider.
+ *
+ * Deliberately reports state it has just read from Google rather than state the
+ * database claims: a provider row can say "connected" while every push is being
+ * rejected for a mismatched audience.
+ */
+export const runGmailDiagnostics = withAuth(async (
+  user,
+  { tenant },
+  providerId: string
+): Promise<{ success: boolean; report?: GmailDiagnosticsReport; error?: string }> => {
+  try {
+    const { knex } = await createTenantKnex();
+    const db = tenantDb(knex, tenant);
+
+    const permitted = await hasPermission(user, 'ticket_settings', 'update', knex);
+    if (!permitted) {
+      return { success: false, error: 'Permission denied: Cannot run Gmail diagnostics' };
+    }
+
+    const provider = await db.table('email_providers')
+      .where({ id: providerId })
+      .first();
+
+    if (!provider) {
+      return { success: false, error: 'Provider not found' };
+    }
+
+    if (provider.provider_type !== 'google') {
+      return { success: false, error: 'Diagnostics are only available for Gmail providers' };
+    }
+
+    const googleConfig = await db.table('google_email_provider_config')
+      .where({ email_provider_id: providerId })
+      .first();
+
+    const report = await runGmailDeliveryDiagnostics({
+      tenant,
+      provider: { id: provider.id, mailbox: provider.mailbox },
+      googleConfig: googleConfig || null,
+    });
+
+    return { success: true, report };
+  } catch (error: any) {
+    console.error('Gmail diagnostics failed:', error);
+    return {
+      success: false,
+      error: error?.message ? String(error.message) : 'Failed to run Gmail diagnostics. Please try again.',
     };
   }
 });

--- a/packages/integrations/src/actions/email-actions/setupPubSub.ts
+++ b/packages/integrations/src/actions/email-actions/setupPubSub.ts
@@ -2,6 +2,11 @@
 
 import { google } from 'googleapis';
 import { getSecretProviderInstance } from '@alga-psa/core/secrets';
+import {
+  GMAIL_PUBLISHER_ROLE,
+  GMAIL_PUSH_SERVICE_ACCOUNT,
+  GmailPubSubSetupError,
+} from '../../utils/email/gmailPubSub';
 
 export interface SetupPubSubRequest {
   tenantId: string;
@@ -11,7 +16,18 @@ export interface SetupPubSubRequest {
   webhookUrl: string;
 }
 
-export async function setupPubSub(request: SetupPubSubRequest) {
+export interface SetupPubSubResult {
+  success: true;
+  topicPath: string;
+  subscriptionPath: string;
+  webhookUrl: string;
+  /** Push endpoint read back from Google after provisioning. */
+  pushEndpoint: string;
+  /** OIDC audience read back from Google after provisioning. */
+  audience: string;
+}
+
+export async function setupPubSub(request: SetupPubSubRequest): Promise<SetupPubSubResult> {
   console.log(`🔧 Starting Pub/Sub setup for project ${request.projectId}:`, {
     topicName: request.topicName,
     subscriptionName: request.subscriptionName,
@@ -79,7 +95,9 @@ export async function setupPubSub(request: SetupPubSubRequest) {
       }
     }
 
-    // Ensure Gmail can publish test messages to the topic
+    // Ensure Gmail can publish to the topic. Without this binding Gmail's
+    // watch() call is rejected and no notification is ever published, so a
+    // failure here is a failure of the whole setup — not a warning.
     try {
       console.log('🔐 Ensuring Gmail push service has publisher role on topic');
       const getPolicyResp = await pubsub.projects.topics.getIamPolicy({
@@ -88,8 +106,8 @@ export async function setupPubSub(request: SetupPubSubRequest) {
 
       const policy = getPolicyResp.data || ({} as any);
       const bindings = Array.isArray(policy.bindings) ? policy.bindings : [];
-      const member = 'serviceAccount:gmail-api-push@system.gserviceaccount.com';
-      const role = 'roles/pubsub.publisher';
+      const member = `serviceAccount:${GMAIL_PUSH_SERVICE_ACCOUNT}`;
+      const role = GMAIL_PUBLISHER_ROLE;
 
       const existing = bindings.find((b: any) => b.role === role);
       if (existing) {
@@ -111,8 +129,14 @@ export async function setupPubSub(request: SetupPubSubRequest) {
         }
       } as any);
       console.log('✅ Gmail publisher role ensured on topic');
-    } catch (iamErr) {
-      console.warn('⚠️ Failed to ensure Gmail publisher role on topic. Gmail watch may fail.', iamErr);
+    } catch (iamErr: any) {
+      const detail = iamErr?.message ? String(iamErr.message) : String(iamErr);
+      throw new GmailPubSubSetupError(
+        `Could not grant ${GMAIL_PUBLISHER_ROLE} to ${GMAIL_PUSH_SERVICE_ACCOUNT} on ${topicPath}. ` +
+          'Without that binding Gmail cannot publish notifications and no inbound mail will arrive. ' +
+          'The service account Alga authenticates with needs pubsub.topics.getIamPolicy and ' +
+          `pubsub.topics.setIamPolicy on this topic (roles/pubsub.admin covers both). Google reported: ${detail}`
+      );
     }
 
     // Create subscription if it doesn't exist
@@ -187,14 +211,35 @@ export async function setupPubSub(request: SetupPubSubRequest) {
       }
     }
 
+    // Read the subscription back rather than trusting the write. A push
+    // endpoint or audience that does not match what the webhook route verifies
+    // against produces a 401 on every delivery, which is exactly the silent
+    // failure this setup path exists to prevent.
+    const verified = await pubsub.projects.subscriptions.get({
+      subscription: subscriptionPath
+    });
+    const pushEndpoint = verified.data.pushConfig?.pushEndpoint || '';
+    const audience = verified.data.pushConfig?.oidcToken?.audience || '';
+
+    if (pushEndpoint !== request.webhookUrl || audience !== request.webhookUrl) {
+      throw new GmailPubSubSetupError(
+        `Pub/Sub subscription ${subscriptionPath} is not delivering to this Alga instance. ` +
+          `Expected push endpoint and OIDC audience ${request.webhookUrl}, but Google reports ` +
+          `push endpoint ${pushEndpoint || '(none)'} and audience ${audience || '(none)'}. ` +
+          'Delete the subscription in Google Cloud and run setup again, or correct the base URL Alga is configured with.'
+      );
+    }
+
     console.log(`✅ Pub/Sub setup completed successfully for project ${request.projectId}`);
-    const result = {
+    const result: SetupPubSubResult = {
       success: true,
       topicPath,
       subscriptionPath,
-      webhookUrl: request.webhookUrl
+      webhookUrl: request.webhookUrl,
+      pushEndpoint,
+      audience
     };
-    
+
     console.log('📋 Final configuration:', result);
     return result;
 
@@ -209,15 +254,26 @@ export async function setupPubSub(request: SetupPubSubRequest) {
         webhookUrl: request.webhookUrl
       }
     });
+    // Messages built above are already written for the administrator; passing
+    // them through is the whole point of raising them.
+    if (error instanceof GmailPubSubSetupError) {
+      throw error;
+    }
+
     if (error instanceof Error) {
       if (error.message === 'GOOGLE_SERVICE_ACCOUNT_MISSING') {
-        throw new Error('Google service account credentials are not configured for this tenant.');
+        throw new GmailPubSubSetupError('Google service account credentials are not configured for this tenant.');
       }
       if (error.message === 'GOOGLE_SERVICE_ACCOUNT_INVALID_JSON') {
-        throw new Error('Google service account credentials are not valid JSON.');
+        throw new GmailPubSubSetupError('Google service account credentials are not valid JSON.');
       }
     }
 
-    throw new Error('Unable to configure Google Pub/Sub. Check the Google Cloud project, service account permissions, and webhook settings.');
+    const detail = error?.message ? String(error.message) : String(error);
+    throw new GmailPubSubSetupError(
+      `Unable to configure Google Pub/Sub topic ${request.topicName} in project ${request.projectId}. ` +
+        'Check the Google Cloud project, the service account permissions, and the webhook base URL. ' +
+        `Google reported: ${detail}`
+    );
   }
 }

--- a/packages/integrations/src/actions/index.ts
+++ b/packages/integrations/src/actions/index.ts
@@ -63,7 +63,8 @@ export {
   resyncImapProvider,
   testEmailProviderConnection,
   retryMicrosoftSubscriptionRenewal,
-  runMicrosoft365Diagnostics
+  runMicrosoft365Diagnostics,
+  runGmailDiagnostics
 } from './email-actions/emailProviderActions';
 export {
   pauseEmailProvider,

--- a/packages/integrations/src/components/email/EmailProviderCard.tsx
+++ b/packages/integrations/src/components/email/EmailProviderCard.tsx
@@ -91,26 +91,37 @@ export function EmailProviderCard({
   const { t } = useTranslation('msp/email-providers');
   const authFailurePaused = Boolean(provider.inboundPausedAt) && provider.inboundPauseReason === 'auth_failure';
 
-  const getExpirationStatus = (activeProvider: EmailProvider) => {
-    if (activeProvider.providerType !== 'microsoft' || !activeProvider.microsoftConfig?.webhook_expires_at) {
+  // Gmail watches last seven days. Renewal is scheduled by the Enterprise
+  // Edition workflow engine, so on Community Edition a lapsed watch is the
+  // point where inbound mail stops without anything else changing — the card
+  // has to say so rather than keep showing "Active".
+  const watchExpiresAt =
+    provider.providerType === 'microsoft'
+      ? provider.microsoftConfig?.webhook_expires_at
+      : provider.providerType === 'google'
+      ? provider.googleConfig?.watch_expiration
+      : undefined;
+
+  const hoursUntilExpiry = watchExpiresAt
+    ? (new Date(watchExpiresAt).getTime() - Date.now()) / (1000 * 60 * 60)
+    : null;
+
+  const getExpirationStatus = () => {
+    if (hoursUntilExpiry === null || Number.isNaN(hoursUntilExpiry)) {
       return null;
     }
-    const expiresAt = new Date(activeProvider.microsoftConfig.webhook_expires_at);
-    const now = new Date();
-    const diffMs = expiresAt.getTime() - now.getTime();
-    const diffHours = diffMs / (1000 * 60 * 60);
 
-    if (diffHours < 0) {
+    if (hoursUntilExpiry < 0) {
       return { label: t('providerCard.subscription.expired', { defaultValue: 'Expired' }), color: 'text-red-500' };
     }
-    if (diffHours < 24) {
+    if (hoursUntilExpiry < 24) {
       return {
-        label: t('providerCard.subscription.expiresInHours', { defaultValue: 'Expires in {{count}}h', count: Math.ceil(diffHours) }),
+        label: t('providerCard.subscription.expiresInHours', { defaultValue: 'Expires in {{count}}h', count: Math.ceil(hoursUntilExpiry) }),
         color: 'text-yellow-600'
       };
     }
     return {
-      label: t('providerCard.subscription.expiresInDays', { defaultValue: 'Expires in {{count}}d', count: Math.ceil(diffHours / 24) }),
+      label: t('providerCard.subscription.expiresInDays', { defaultValue: 'Expires in {{count}}d', count: Math.ceil(hoursUntilExpiry / 24) }),
       color: 'text-muted-foreground'
     };
   };
@@ -186,8 +197,19 @@ export function EmailProviderCard({
     return t('providerCard.lastSync.daysAgo', { defaultValue: '{{count}}d ago', count: Math.floor(diffMins / 1440) });
   };
 
-  const expirationStatus = getExpirationStatus(provider);
+  const expirationStatus = getExpirationStatus();
   const interactionBusy = busy || reconnecting;
+
+  const gmailWatchLapsed =
+    provider.providerType === 'google' && hoursUntilExpiry !== null && !Number.isNaN(hoursUntilExpiry) && hoursUntilExpiry < 0;
+  const gmailWatchExpiringSoon =
+    provider.providerType === 'google' &&
+    hoursUntilExpiry !== null &&
+    !Number.isNaN(hoursUntilExpiry) &&
+    hoursUntilExpiry >= 0 &&
+    hoursUntilExpiry < 24;
+  const gmailWatchMissing =
+    provider.providerType === 'google' && provider.isActive && Boolean(provider.googleConfig) && !watchExpiresAt;
 
   return (
     <Card className={`transition-all ${!provider.isActive ? 'opacity-60' : ''}`}>
@@ -226,10 +248,20 @@ export function EmailProviderCard({
                     : t('providerCard.actions.testConnection', { defaultValue: 'Test Connection' })}
                 </DropdownMenuItem>
                 {provider.providerType === 'google' && (
-                  <DropdownMenuItem onClick={() => onRefreshWatchSubscription(provider)} disabled={interactionBusy}>
-                    <Repeat className="h-4 w-4 mr-2" />
-                    {t('providerCard.actions.refreshWatch', { defaultValue: 'Refresh Pub/Sub & Watch' })}
-                  </DropdownMenuItem>
+                  <>
+                    <DropdownMenuItem onClick={() => onRefreshWatchSubscription(provider)} disabled={interactionBusy}>
+                      <Repeat className="h-4 w-4 mr-2" />
+                      {t('providerCard.actions.refreshWatch', { defaultValue: 'Refresh Pub/Sub & Watch' })}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      id={`run-gmail-diagnostics-${provider.id}`}
+                      onClick={() => onRunDiagnostics(provider)}
+                      disabled={interactionBusy}
+                    >
+                      <Stethoscope className="h-4 w-4 mr-2" />
+                      {t('providerCard.actions.runGmailDiagnostics', { defaultValue: 'Run Gmail Delivery Diagnostics' })}
+                    </DropdownMenuItem>
+                  </>
                 )}
                 {provider.providerType === 'microsoft' && (
                   <>
@@ -396,6 +428,58 @@ export function EmailProviderCard({
         ) : provider.inboundPausedAt && (
           <Alert id={`provider-paused-help-${provider.id}`} className="mt-3">
             <AlertDescription>{t('providerCard.pausedHelp')}</AlertDescription>
+          </Alert>
+        )}
+
+        {(gmailWatchLapsed || gmailWatchExpiringSoon || gmailWatchMissing) && !provider.inboundPausedAt && (
+          <Alert
+            id={`provider-gmail-watch-warning-${provider.id}`}
+            variant={gmailWatchExpiringSoon ? 'warning' : 'destructive'}
+            className="mt-3"
+            role="alert"
+          >
+            <AlertDescription>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <strong>
+                    {gmailWatchLapsed
+                      ? t('providerCard.gmailWatch.expiredTitle', { defaultValue: 'Gmail is no longer sending new mail here' })
+                      : gmailWatchMissing
+                      ? t('providerCard.gmailWatch.missingTitle', { defaultValue: 'Gmail push delivery is not registered' })
+                      : t('providerCard.gmailWatch.expiringTitle', { defaultValue: 'Gmail push delivery expires within a day' })}
+                  </strong>
+                  <p className="mt-1">
+                    {gmailWatchLapsed
+                      ? t('providerCard.gmailWatch.expiredDescription', {
+                          defaultValue:
+                            'The Gmail watch for {{mailbox}} expired, so Google has stopped publishing notifications. Messages are not lost — they remain in the mailbox. Refresh Pub/Sub & Watch to resume delivery.',
+                          mailbox: provider.mailbox,
+                        })
+                      : gmailWatchMissing
+                      ? t('providerCard.gmailWatch.missingDescription', {
+                          defaultValue:
+                            'No Gmail watch is registered for {{mailbox}}, so no inbound mail will arrive. Refresh Pub/Sub & Watch to register one.',
+                          mailbox: provider.mailbox,
+                        })
+                      : t('providerCard.gmailWatch.expiringDescription', {
+                          defaultValue:
+                            'Gmail watches last seven days. Refresh Pub/Sub & Watch before this one lapses, or inbound mail will stop without further notice.',
+                        })}
+                  </p>
+                </div>
+                <Button
+                  id={`refresh-gmail-watch-${provider.id}`}
+                  variant={gmailWatchExpiringSoon ? 'outline' : 'destructive'}
+                  size="sm"
+                  onClick={() => onRefreshWatchSubscription(provider)}
+                  disabled={interactionBusy}
+                  className="shrink-0"
+                >
+                  <Repeat className="h-4 w-4 mr-2" />
+                  {t('providerCard.actions.refreshWatch', { defaultValue: 'Refresh Pub/Sub & Watch' })}
+                </Button>
+              </div>
+            </AlertDescription>
           </Alert>
         )}
 

--- a/packages/integrations/src/components/email/EmailProviderConfiguration.tsx
+++ b/packages/integrations/src/components/email/EmailProviderConfiguration.tsx
@@ -26,6 +26,7 @@ import { ProviderSetupWizardDialog } from './ProviderSetupWizardDialog';
 import { InboundTicketDefaultsManager } from './admin/InboundTicketDefaultsManager';
 import { InboundEmailRulesManager } from './admin/InboundEmailRulesManager';
 import { Microsoft365DiagnosticsDialog } from './admin/Microsoft365DiagnosticsDialog';
+import { GmailDiagnosticsDialog } from './admin/GmailDiagnosticsDialog';
 import { DrawerOutlet, DrawerProvider, useDrawer } from '@alga-psa/ui';
 import LoadingIndicator from '@alga-psa/ui/components/LoadingIndicator';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
@@ -697,7 +698,12 @@ function EmailProviderConfigurationContent({
               microsoftEmailSetup={microsoftEmailSetup}
             />
             <Microsoft365DiagnosticsDialog
-              isOpen={diagnosticsOpen}
+              isOpen={diagnosticsOpen && diagnosticsProvider?.providerType === 'microsoft'}
+              onClose={() => setDiagnosticsOpen(false)}
+              provider={diagnosticsProvider}
+            />
+            <GmailDiagnosticsDialog
+              isOpen={diagnosticsOpen && diagnosticsProvider?.providerType === 'google'}
               onClose={() => setDiagnosticsOpen(false)}
               provider={diagnosticsProvider}
             />

--- a/packages/integrations/src/components/email/admin/GmailDiagnosticsDialog.tsx
+++ b/packages/integrations/src/components/email/admin/GmailDiagnosticsDialog.tsx
@@ -1,0 +1,255 @@
+/**
+ * Gmail Inbound Delivery Diagnostics Dialog
+ * Checks live Google state — topic, publisher permission, push audience, watch,
+ * and last accepted push — against what this instance expects.
+ */
+
+'use client';
+
+import React from 'react';
+import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
+import { Dialog, DialogContent, DialogDescription, DialogHeader } from '@alga-psa/ui/components/Dialog';
+import { Button } from '@alga-psa/ui/components/Button';
+import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
+import { Badge } from '@alga-psa/ui/components/Badge';
+import LoadingIndicator from '@alga-psa/ui/components/LoadingIndicator';
+import { CheckCircle, AlertCircle, XCircle, Clock, Copy } from 'lucide-react';
+import type { EmailProvider } from '../types';
+import { runGmailDiagnostics } from '@alga-psa/integrations/actions';
+import type { GmailDiagnosticsReport, GmailDiagnosticsStep } from '@alga-psa/shared/interfaces/gmail-diagnostics.interfaces';
+
+function statusIcon(status: GmailDiagnosticsStep['status']) {
+  switch (status) {
+    case 'pass':
+      return <CheckCircle className="h-4 w-4 text-green-600" />;
+    case 'warn':
+      return <AlertCircle className="h-4 w-4 text-yellow-600" />;
+    case 'fail':
+      return <XCircle className="h-4 w-4 text-red-600" />;
+    case 'skip':
+    default:
+      return <Clock className="h-4 w-4 text-muted-foreground" />;
+  }
+}
+
+export function GmailDiagnosticsDialog({
+  isOpen,
+  onClose,
+  provider,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  provider: EmailProvider | null;
+}) {
+  const { t } = useTranslation('msp/admin');
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [report, setReport] = React.useState<GmailDiagnosticsReport | null>(null);
+  const [copied, setCopied] = React.useState(false);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    const run = async () => {
+      if (!isOpen || !provider) return;
+      if (provider.providerType !== 'google') return;
+
+      setLoading(true);
+      setError(null);
+      setReport(null);
+      setCopied(false);
+
+      try {
+        const result = await runGmailDiagnostics(provider.id);
+        if (cancelled) return;
+        if (!result.success || !result.report) {
+          setError(result.error || t('gmailDiagnostics.states.diagnosticsFailed', { defaultValue: 'Diagnostics failed' }));
+          return;
+        }
+        setReport(result.report);
+      } catch (e: any) {
+        if (cancelled) return;
+        setError(e?.message || t('gmailDiagnostics.states.diagnosticsFailed', { defaultValue: 'Diagnostics failed' }));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, provider?.id]);
+
+  const copySupportBundle = async () => {
+    if (!report) return;
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(report.supportBundle, null, 2));
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch (e) {
+      setCopied(false);
+    }
+  };
+
+  const renderStatusBadge = (status: GmailDiagnosticsStep['status']) => {
+    switch (status) {
+      case 'pass':
+        return <Badge variant="success">{t('gmailDiagnostics.statuses.pass', { defaultValue: 'Pass' })}</Badge>;
+      case 'warn':
+        return <Badge variant="warning">{t('gmailDiagnostics.statuses.warn', { defaultValue: 'Warn' })}</Badge>;
+      case 'fail':
+        return <Badge variant="error">{t('gmailDiagnostics.statuses.fail', { defaultValue: 'Fail' })}</Badge>;
+      case 'skip':
+      default:
+        return <Badge variant="secondary">{t('gmailDiagnostics.statuses.skip', { defaultValue: 'Skip' })}</Badge>;
+    }
+  };
+
+  const overallStatusKey = `gmailDiagnostics.statuses.${report?.summary.overallStatus ?? 'skip'}`;
+  const audienceMismatch = Boolean(
+    report?.summary.expectedWebhookUrl &&
+      report.summary.actualAudience &&
+      report.summary.expectedWebhookUrl !== report.summary.actualAudience
+  );
+
+  const footer = (
+    <div className="flex justify-end space-x-2">
+      <Button id="gmail-diag-close" variant="outline" onClick={onClose}>
+        {t('common.actions.close', { defaultValue: 'Close' })}
+      </Button>
+    </div>
+  );
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      title={t('gmailDiagnostics.title', { defaultValue: 'Gmail Delivery Diagnostics' })}
+      id="gmail-diagnostics"
+      footer={footer}
+    >
+      <DialogContent className="max-w-4xl">
+        <DialogHeader>
+          <DialogDescription>
+            {t('gmailDiagnostics.description', {
+              defaultValue:
+                'Checks the Pub/Sub topic, its permissions, the push endpoint and audience, the Gmail watch, and when a push last arrived.',
+            })}
+          </DialogDescription>
+        </DialogHeader>
+
+        {provider && (
+          <div className="text-sm text-muted-foreground mb-4">
+            {t('gmailDiagnostics.labels.provider', { defaultValue: 'Provider:' })}{' '}
+            <span className="font-medium text-foreground">{provider.providerName}</span> ·{' '}
+            {t('gmailDiagnostics.labels.mailbox', { defaultValue: 'Mailbox:' })}{' '}
+            <span className="font-medium text-foreground">{provider.mailbox}</span>
+          </div>
+        )}
+
+        {loading && (
+          <div className="flex items-center justify-center p-6">
+            <LoadingIndicator
+              layout="stacked"
+              text={t('gmailDiagnostics.states.running', { defaultValue: 'Running diagnostics...' })}
+              spinnerProps={{ size: 'md' }}
+            />
+          </div>
+        )}
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {report && (
+          <div className="space-y-4">
+            <div className="flex items-center justify-between gap-3">
+              <div className="text-sm">
+                {t('gmailDiagnostics.labels.overall', { defaultValue: 'Overall:' })}{' '}
+                <span className="font-medium">
+                  {t(overallStatusKey, { defaultValue: report.summary.overallStatus.toUpperCase() })}
+                </span>
+              </div>
+              <Button id="gmail-diag-copy-bundle" variant="outline" size="sm" onClick={copySupportBundle}>
+                <Copy className="h-4 w-4 mr-2" />
+                {copied
+                  ? t('gmailDiagnostics.actions.copied', { defaultValue: 'Copied' })
+                  : t('gmailDiagnostics.actions.copySupportBundle', { defaultValue: 'Copy Support Bundle' })}
+              </Button>
+            </div>
+
+            {audienceMismatch && (
+              <Alert variant="destructive" id="gmail-diag-audience-mismatch">
+                <AlertDescription>
+                  <div className="font-medium mb-1">
+                    {t('gmailDiagnostics.audienceMismatch.title', { defaultValue: 'Push audience does not match this instance' })}
+                  </div>
+                  <div className="text-sm">
+                    {t('gmailDiagnostics.audienceMismatch.expected', { defaultValue: 'Expected:' })}{' '}
+                    <code className="font-mono">{report.summary.expectedWebhookUrl}</code>
+                  </div>
+                  <div className="text-sm">
+                    {t('gmailDiagnostics.audienceMismatch.actual', { defaultValue: 'Google is using:' })}{' '}
+                    <code className="font-mono">{report.summary.actualAudience}</code>
+                  </div>
+                </AlertDescription>
+              </Alert>
+            )}
+
+            {report.recommendations?.length > 0 && (
+              <Alert>
+                <AlertDescription>
+                  <div className="font-medium mb-1">
+                    {t('gmailDiagnostics.labels.recommendations', { defaultValue: 'Recommendations' })}
+                  </div>
+                  <ul className="list-disc pl-5 space-y-1">
+                    {report.recommendations.map((r) => (
+                      <li key={r}>{r}</li>
+                    ))}
+                  </ul>
+                </AlertDescription>
+              </Alert>
+            )}
+
+            <div className="border rounded-md divide-y">
+              {report.steps.map((step) => (
+                <details key={step.id} className="p-3">
+                  <summary className="cursor-pointer select-none flex items-center justify-between gap-3">
+                    <div className="flex items-center gap-2 min-w-0">
+                      {statusIcon(step.status)}
+                      <span className="font-medium truncate">{step.title}</span>
+                      <span className="text-xs text-muted-foreground">({step.durationMs}ms)</span>
+                    </div>
+                    <div className="shrink-0">{renderStatusBadge(step.status)}</div>
+                  </summary>
+                  <div className="mt-2 text-sm space-y-2">
+                    {step.remediation && <div>{step.remediation}</div>}
+                    {step.error && (
+                      <div className="text-destructive bg-destructive/10 border border-destructive/30 rounded p-2">
+                        <div className="font-medium">
+                          {t('gmailDiagnostics.labels.error', { defaultValue: 'Error' })}
+                        </div>
+                        <div>{step.error.message}</div>
+                        <div className="text-xs mt-1">
+                          {step.error.status ? `status: ${step.error.status}` : ''}
+                          {step.error.code ? ` · code: ${step.error.code}` : ''}
+                        </div>
+                      </div>
+                    )}
+                    {step.data && (
+                      <pre className="text-xs bg-muted rounded p-2 overflow-auto">
+                        {JSON.stringify(step.data, null, 2)}
+                      </pre>
+                    )}
+                  </div>
+                </details>
+              ))}
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/integrations/src/components/email/admin/index.ts
+++ b/packages/integrations/src/components/email/admin/index.ts
@@ -2,3 +2,4 @@ export * from './EmailSettings';
 export * from './EmailSenderIdentityCards';
 export * from './InboundTicketDefaultsManager';
 export * from './Microsoft365DiagnosticsDialog';
+export * from './GmailDiagnosticsDialog';

--- a/packages/integrations/src/components/email/types.ts
+++ b/packages/integrations/src/components/email/types.ts
@@ -70,7 +70,11 @@ export interface GoogleEmailProviderConfig {
   token_expires_at?: string;
   history_id?: string;
   watch_expiration?: string;
+  /** Last verified Pub/Sub push accepted for this mailbox. */
+  last_push_received_at?: string;
   pubsub_initialised_at?: string;
+  pubsub_topic_name?: string | null;
+  pubsub_subscription_name?: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/packages/integrations/src/services/email/GmailDiagnosticsService.ts
+++ b/packages/integrations/src/services/email/GmailDiagnosticsService.ts
@@ -1,0 +1,426 @@
+/**
+ * Gmail inbound delivery diagnostics.
+ *
+ * Answers one question for an administrator: is mail actually going to arrive?
+ * Every step checks live Google state against the values this instance derives
+ * from {@link ../../utils/email/gmailPubSub}, so an audience or endpoint that
+ * drifted shows up as a mismatch with both sides printed rather than as a
+ * provider card that just says "connected".
+ */
+
+import { google } from 'googleapis';
+import { getSecretProviderInstance } from '@alga-psa/core/secrets';
+import type {
+  DiagnosticsStepStatus,
+  GmailDiagnosticsReport,
+  GmailDiagnosticsStep,
+} from '@alga-psa/shared/interfaces/gmail-diagnostics.interfaces';
+import {
+  GMAIL_PUBLISHER_ROLE,
+  GMAIL_PUSH_SERVICE_ACCOUNT,
+  buildGmailWebhookUrl,
+  gmailSubscriptionName,
+  gmailTopicName,
+  requireGmailWebhookBaseUrl,
+} from '../../utils/email/gmailPubSub';
+
+const WATCH_WARNING_WINDOW_MS = 24 * 60 * 60 * 1000;
+const PUSH_STALENESS_WARNING_MS = 7 * 24 * 60 * 60 * 1000;
+
+export interface GmailDiagnosticsInput {
+  tenant: string;
+  provider: {
+    id: string;
+    mailbox: string;
+  };
+  googleConfig: {
+    project_id?: string | null;
+    pubsub_topic_name?: string | null;
+    pubsub_subscription_name?: string | null;
+    watch_expiration?: string | Date | null;
+    last_push_received_at?: string | Date | null;
+  } | null;
+}
+
+interface StepRecorder {
+  steps: GmailDiagnosticsStep[];
+  run<T>(
+    id: string,
+    title: string,
+    fn: () => Promise<{ status: DiagnosticsStepStatus; data?: Record<string, unknown>; remediation?: string; value?: T }>,
+    onError: (error: any) => { remediation: string; status?: DiagnosticsStepStatus }
+  ): Promise<T | undefined>;
+}
+
+function createRecorder(): StepRecorder {
+  const steps: GmailDiagnosticsStep[] = [];
+
+  return {
+    steps,
+    async run(id, title, fn, onError) {
+      const startedAt = new Date();
+      try {
+        const outcome = await fn();
+        steps.push({
+          id,
+          title,
+          status: outcome.status,
+          startedAt: startedAt.toISOString(),
+          durationMs: Date.now() - startedAt.getTime(),
+          remediation: outcome.remediation,
+          data: outcome.data,
+        });
+        return outcome.value;
+      } catch (error: any) {
+        const handled = onError(error);
+        steps.push({
+          id,
+          title,
+          status: handled.status ?? 'fail',
+          startedAt: startedAt.toISOString(),
+          durationMs: Date.now() - startedAt.getTime(),
+          remediation: handled.remediation,
+          error: {
+            message: error?.message ? String(error.message) : String(error),
+            code: error?.code !== undefined ? String(error.code) : undefined,
+            status: typeof error?.status === 'number' ? error.status : undefined,
+          },
+        });
+        return undefined;
+      }
+    },
+  };
+}
+
+function toIso(value: string | Date | null | undefined): string | undefined {
+  if (!value) return undefined;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+
+function worstStatus(steps: GmailDiagnosticsStep[]): DiagnosticsStepStatus {
+  if (steps.some((s) => s.status === 'fail')) return 'fail';
+  if (steps.some((s) => s.status === 'warn')) return 'warn';
+  if (steps.every((s) => s.status === 'skip')) return 'skip';
+  return 'pass';
+}
+
+/**
+ * Run the full delivery checklist for one Gmail provider.
+ */
+export async function runGmailDeliveryDiagnostics(
+  input: GmailDiagnosticsInput
+): Promise<GmailDiagnosticsReport> {
+  const { tenant, provider, googleConfig } = input;
+  const recorder = createRecorder();
+  const now = Date.now();
+
+  const projectId = googleConfig?.project_id || undefined;
+  const topicName = googleConfig?.pubsub_topic_name || gmailTopicName(tenant);
+  const subscriptionName = googleConfig?.pubsub_subscription_name || gmailSubscriptionName(tenant);
+  const watchExpiration = toIso(googleConfig?.watch_expiration);
+  const lastPushReceivedAt = toIso(googleConfig?.last_push_received_at);
+
+  let expectedWebhookUrl: string | undefined;
+  let actualPushEndpoint: string | undefined;
+  let actualAudience: string | undefined;
+
+  // 1. Public base URL — the value every other check is measured against.
+  await recorder.run<string>(
+    'base-url',
+    'Public base URL for push delivery',
+    async () => {
+      const resolved = await requireGmailWebhookBaseUrl();
+      expectedWebhookUrl = buildGmailWebhookUrl(resolved.baseUrl);
+      return {
+        status: 'pass' as const,
+        data: {
+          baseUrl: resolved.baseUrl,
+          source: resolved.source,
+          expectedWebhookUrl,
+        },
+        value: resolved.baseUrl,
+      };
+    },
+    () => ({
+      remediation:
+        'Set NEXT_PUBLIC_BASE_URL (or NGROK_URL for local development) to the public HTTPS address of this Alga instance, then run Refresh Pub/Sub & Watch. Google will not deliver to an address it cannot reach.',
+    })
+  );
+
+  // 2. Service account credentials.
+  const credentials = await recorder.run<Record<string, any>>(
+    'service-account',
+    'Google service account credentials',
+    async () => {
+      const secretProvider = await getSecretProviderInstance();
+      const raw = await secretProvider.getTenantSecret(tenant, 'google_service_account_key');
+      if (!raw) {
+        throw new Error('No google_service_account_key is stored for this tenant.');
+      }
+      const parsed = JSON.parse(raw);
+      return {
+        status: 'pass' as const,
+        data: { clientEmail: parsed.client_email, projectId: parsed.project_id },
+        value: parsed,
+      };
+    },
+    () => ({
+      remediation:
+        'Upload a valid Google service account key (JSON) for this tenant in the Google integration settings. The key must belong to the same Google Cloud project as the Pub/Sub topic.',
+    })
+  );
+
+  const canQueryGoogle = Boolean(credentials && projectId);
+
+  let pubsub: ReturnType<typeof google.pubsub> | null = null;
+  if (canQueryGoogle) {
+    try {
+      const auth = new google.auth.GoogleAuth({
+        credentials: credentials as any,
+        scopes: ['https://www.googleapis.com/auth/pubsub', 'https://www.googleapis.com/auth/cloud-platform'],
+      });
+      pubsub = google.pubsub({ version: 'v1', auth: (await auth.getClient()) as any });
+    } catch {
+      pubsub = null;
+    }
+  }
+
+  const topicPath = projectId ? `projects/${projectId}/topics/${topicName}` : undefined;
+  const subscriptionPath = projectId ? `projects/${projectId}/subscriptions/${subscriptionName}` : undefined;
+
+  const skipGoogleStep = (title: string, id: string) =>
+    recorder.run(
+      id,
+      title,
+      async () => ({
+        status: 'skip' as const,
+        remediation: projectId
+          ? 'Could not authenticate to Google Cloud with the stored service account key; fix that first.'
+          : 'No Google Cloud project ID is configured for this provider. Set it in the Google integration settings.',
+      }),
+      () => ({ remediation: 'Google Cloud could not be queried.' })
+    );
+
+  // 3. Topic exists.
+  if (pubsub && topicPath) {
+    await recorder.run(
+      'topic',
+      'Pub/Sub topic exists',
+      async () => {
+        const response = await pubsub!.projects.topics.get({ topic: topicPath });
+        return { status: 'pass' as const, data: { topic: response.data.name || topicPath } };
+      },
+      (error) => ({
+        remediation:
+          error?.code === 404
+            ? `Topic ${topicPath} does not exist. Run Refresh Pub/Sub & Watch to create it, or create it manually in Google Cloud.`
+            : `Could not read topic ${topicPath}. Grant the service account roles/pubsub.viewer (or roles/pubsub.admin) on the project.`,
+      })
+    );
+
+    // 4. Publisher binding for Gmail's own service account.
+    await recorder.run(
+      'topic-iam',
+      'Gmail may publish to the topic',
+      async () => {
+        const response = await pubsub!.projects.topics.getIamPolicy({ resource: topicPath } as any);
+        const bindings = Array.isArray(response.data.bindings) ? response.data.bindings : [];
+        const member = `serviceAccount:${GMAIL_PUSH_SERVICE_ACCOUNT}`;
+        const granted = bindings.some(
+          (b: any) => b.role === GMAIL_PUBLISHER_ROLE && Array.isArray(b.members) && b.members.includes(member)
+        );
+
+        return {
+          status: (granted ? 'pass' : 'fail') as DiagnosticsStepStatus,
+          data: { role: GMAIL_PUBLISHER_ROLE, member, granted },
+          remediation: granted
+            ? undefined
+            : `Grant ${GMAIL_PUBLISHER_ROLE} to ${GMAIL_PUSH_SERVICE_ACCOUNT} on ${topicPath}. Without it Gmail's watch call is rejected and nothing is ever published.`,
+        };
+      },
+      () => ({
+        remediation: `Could not read the IAM policy of ${topicPath}. The service account needs pubsub.topics.getIamPolicy (roles/pubsub.admin covers it).`,
+      })
+    );
+
+    // 5. Subscription push endpoint and OIDC audience.
+    await recorder.run(
+      'subscription',
+      'Push subscription targets this instance',
+      async () => {
+        const response = await pubsub!.projects.subscriptions.get({ subscription: subscriptionPath! });
+        actualPushEndpoint = response.data.pushConfig?.pushEndpoint || undefined;
+        actualAudience = response.data.pushConfig?.oidcToken?.audience || undefined;
+
+        const data: Record<string, unknown> = {
+          subscription: response.data.name || subscriptionPath,
+          topic: response.data.topic,
+          expectedWebhookUrl,
+          actualPushEndpoint: actualPushEndpoint ?? null,
+          actualAudience: actualAudience ?? null,
+          serviceAccountEmail: response.data.pushConfig?.oidcToken?.serviceAccountEmail ?? null,
+        };
+
+        if (!expectedWebhookUrl) {
+          return {
+            status: 'warn' as const,
+            data,
+            remediation:
+              'The subscription exists, but this instance has no usable public base URL to compare it against. Fix the base URL check above first.',
+          };
+        }
+
+        const endpointMatches = actualPushEndpoint === expectedWebhookUrl;
+        const audienceMatches = actualAudience === expectedWebhookUrl;
+
+        if (endpointMatches && audienceMatches) {
+          return { status: 'pass' as const, data };
+        }
+
+        const mismatches: string[] = [];
+        if (!endpointMatches) {
+          mismatches.push(`push endpoint is ${actualPushEndpoint || '(none)'} but should be ${expectedWebhookUrl}`);
+        }
+        if (!audienceMatches) {
+          mismatches.push(`OIDC audience is ${actualAudience || '(none)'} but should be ${expectedWebhookUrl}`);
+        }
+
+        return {
+          status: 'fail' as const,
+          data,
+          remediation:
+            `The subscription ${mismatches.join(', and the ')}. Every push signed with the wrong audience is rejected with 401 and the message is dropped. ` +
+            'Run Refresh Pub/Sub & Watch to rewrite the push configuration, or correct the base URL this instance is configured with.',
+        };
+      },
+      (error) => ({
+        remediation:
+          error?.code === 404
+            ? `Subscription ${subscriptionPath} does not exist, so Google has nowhere to deliver. Run Refresh Pub/Sub & Watch to create it.`
+            : `Could not read subscription ${subscriptionPath}. Grant the service account roles/pubsub.viewer on the project.`,
+      })
+    );
+  } else {
+    await skipGoogleStep('Pub/Sub topic exists', 'topic');
+    await skipGoogleStep('Gmail may publish to the topic', 'topic-iam');
+    await skipGoogleStep('Push subscription targets this instance', 'subscription');
+  }
+
+  // 6. Gmail watch registration. Gmail has no "read my watch" API, so the
+  // expiration recorded when the watch was registered is the only evidence.
+  await recorder.run(
+    'watch',
+    'Gmail watch is registered and current',
+    async () => {
+      if (!watchExpiration) {
+        return {
+          status: 'fail' as const,
+          data: { watchExpiration: null },
+          remediation:
+            'No Gmail watch has been registered for this mailbox, so Gmail publishes nothing. Run Refresh Pub/Sub & Watch.',
+        };
+      }
+
+      const expiresAt = new Date(watchExpiration).getTime();
+      const remainingMs = expiresAt - now;
+      const data = {
+        watchExpiration,
+        remainingHours: Math.round(remainingMs / (60 * 60 * 1000)),
+      };
+
+      if (remainingMs <= 0) {
+        return {
+          status: 'fail' as const,
+          data,
+          remediation:
+            'The Gmail watch has expired, so Gmail has stopped publishing notifications for this mailbox. Run Refresh Pub/Sub & Watch. Gmail watches last seven days and are renewed automatically only on Enterprise Edition, so Community Edition needs this refresh weekly.',
+        };
+      }
+
+      if (remainingMs < WATCH_WARNING_WINDOW_MS) {
+        return {
+          status: 'warn' as const,
+          data,
+          remediation:
+            'The Gmail watch expires within a day. Run Refresh Pub/Sub & Watch before it lapses — once expired, Gmail silently stops publishing.',
+        };
+      }
+
+      return { status: 'pass' as const, data };
+    },
+    () => ({ remediation: 'The stored watch expiration could not be read. Run Refresh Pub/Sub & Watch.' })
+  );
+
+  // 7. Evidence that pushes are actually landing.
+  await recorder.run(
+    'push-delivery',
+    'Push notifications are arriving',
+    async () => {
+      if (!lastPushReceivedAt) {
+        return {
+          status: 'warn' as const,
+          data: { lastPushReceivedAt: null },
+          remediation:
+            'This instance has never accepted a push for this mailbox. That is expected on a mailbox that has received no mail since setup; otherwise it points at the subscription or audience checks above.',
+        };
+      }
+
+      const ageMs = now - new Date(lastPushReceivedAt).getTime();
+      const data = { lastPushReceivedAt, ageHours: Math.round(ageMs / (60 * 60 * 1000)) };
+
+      if (ageMs > PUSH_STALENESS_WARNING_MS) {
+        return {
+          status: 'warn' as const,
+          data,
+          remediation:
+            'No push has arrived in over a week. On a mailbox that receives mail regularly this usually means the watch lapsed or the subscription now points somewhere else.',
+        };
+      }
+
+      return { status: 'pass' as const, data };
+    },
+    () => ({ remediation: 'The last push timestamp could not be read.' })
+  );
+
+  const steps = recorder.steps;
+  const recommendations = steps
+    .filter((step) => step.status === 'fail' || step.status === 'warn')
+    .map((step) => step.remediation)
+    .filter((r): r is string => Boolean(r));
+
+  return {
+    createdAt: new Date().toISOString(),
+    summary: {
+      providerId: provider.id,
+      tenantId: tenant,
+      providerType: 'google',
+      mailbox: provider.mailbox,
+      projectId,
+      topicName,
+      subscriptionName,
+      expectedWebhookUrl,
+      actualPushEndpoint,
+      actualAudience,
+      watchExpiration,
+      lastPushReceivedAt,
+      overallStatus: worstStatus(steps),
+    },
+    steps,
+    recommendations,
+    supportBundle: {
+      providerId: provider.id,
+      tenant,
+      mailbox: provider.mailbox,
+      projectId,
+      topicPath,
+      subscriptionPath,
+      expectedWebhookUrl,
+      actualPushEndpoint,
+      actualAudience,
+      watchExpiration,
+      lastPushReceivedAt,
+      steps: steps.map(({ id, status, durationMs, data, error }) => ({ id, status, durationMs, data, error })),
+    },
+  };
+}

--- a/packages/integrations/src/utils/email/gmailPubSub.test.ts
+++ b/packages/integrations/src/utils/email/gmailPubSub.test.ts
@@ -1,0 +1,174 @@
+/**
+ * The audience Google signs a push token with and the audience the webhook
+ * route checks it against are the same string or delivery silently 401s.
+ * These tests pin the normalization rules that keep them the same string.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getAppSecretMock = vi.fn(async (_key: string) => undefined as string | undefined);
+
+vi.mock('@alga-psa/core/secrets', () => ({
+  getSecretProviderInstance: async () => ({
+    getAppSecret: (key: string) => getAppSecretMock(key),
+  }),
+}));
+
+import {
+  GOOGLE_WEBHOOK_PATH,
+  GmailPubSubConfigurationError,
+  buildGmailWebhookUrl,
+  describeUnreachableGmailBaseUrl,
+  getGmailPubSubNames,
+  normalizeGmailBaseUrl,
+  requireGmailWebhookBaseUrl,
+  resolveGmailWebhookBaseUrl,
+} from './gmailPubSub';
+
+const BASE_URL_ENV = ['NGROK_URL', 'NEXT_PUBLIC_BASE_URL', 'NEXTAUTH_URL', 'PUBLIC_WEBHOOK_BASE_URL'];
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const key of BASE_URL_ENV) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  getAppSecretMock.mockReset();
+  getAppSecretMock.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  for (const key of BASE_URL_ENV) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+});
+
+describe('normalizeGmailBaseUrl', () => {
+  it.each([
+    ['https://alga.example.com/', 'https://alga.example.com'],
+    ['https://alga.example.com///', 'https://alga.example.com'],
+    ['HTTPS://ALGA.EXAMPLE.COM', 'https://alga.example.com'],
+    ['https://alga.example.com:443', 'https://alga.example.com'],
+    ['http://alga.example.com:80', 'http://alga.example.com'],
+    ['  https://alga.example.com  ', 'https://alga.example.com'],
+    ['https://alga.example.com?x=1#frag', 'https://alga.example.com'],
+  ])('collapses %s to %s', (input, expected) => {
+    expect(normalizeGmailBaseUrl(input)).toBe(expected);
+  });
+
+  it('keeps a non-default port', () => {
+    expect(normalizeGmailBaseUrl('https://alga.example.com:8443/')).toBe('https://alga.example.com:8443');
+  });
+
+  it('preserves a path prefix so both sides agree on it', () => {
+    expect(normalizeGmailBaseUrl('https://example.com/alga/')).toBe('https://example.com/alga');
+  });
+
+  it.each(['', 'not-a-url', 'alga.example.com', 'ftp://alga.example.com'])(
+    'rejects %s rather than guessing',
+    (input) => {
+      expect(() => normalizeGmailBaseUrl(input)).toThrow(GmailPubSubConfigurationError);
+    }
+  );
+});
+
+describe('buildGmailWebhookUrl', () => {
+  it('produces the same string from the base URL and from the request path', () => {
+    const fromProvisioning = buildGmailWebhookUrl('https://alga.example.com/');
+    const fromVerification = buildGmailWebhookUrl('HTTPS://alga.example.com:443', GOOGLE_WEBHOOK_PATH);
+    expect(fromProvisioning).toBe('https://alga.example.com/api/email/webhooks/google');
+    expect(fromVerification).toBe(fromProvisioning);
+  });
+});
+
+describe('describeUnreachableGmailBaseUrl', () => {
+  it.each([
+    'http://alga.example.com',
+    'https://localhost',
+    'https://127.0.0.1',
+    'https://10.1.2.3',
+    'https://192.168.1.5',
+    'https://172.20.0.4',
+    'https://alga.local',
+    'https://alga-server',
+  ])('flags %s as unreachable by Pub/Sub push', (url) => {
+    expect(describeUnreachableGmailBaseUrl(url)).toBeTruthy();
+  });
+
+  it('accepts a public HTTPS address', () => {
+    expect(describeUnreachableGmailBaseUrl('https://alga.example.com')).toBeNull();
+  });
+
+  it('accepts an ngrok tunnel', () => {
+    expect(describeUnreachableGmailBaseUrl('https://abc123.ngrok-free.app')).toBeNull();
+  });
+});
+
+describe('resolveGmailWebhookBaseUrl', () => {
+  it('prefers NGROK_URL over every other source', async () => {
+    process.env.NGROK_URL = 'https://tunnel.ngrok-free.app';
+    process.env.NEXT_PUBLIC_BASE_URL = 'https://public.example.com';
+    process.env.NEXTAUTH_URL = 'https://auth.example.com';
+
+    await expect(resolveGmailWebhookBaseUrl()).resolves.toEqual({
+      baseUrl: 'https://tunnel.ngrok-free.app',
+      source: 'NGROK_URL',
+    });
+  });
+
+  it('prefers NEXT_PUBLIC_BASE_URL over NEXTAUTH_URL', async () => {
+    process.env.NEXT_PUBLIC_BASE_URL = 'https://public.example.com';
+    process.env.NEXTAUTH_URL = 'https://auth.example.com';
+
+    await expect(resolveGmailWebhookBaseUrl()).resolves.toEqual({
+      baseUrl: 'https://public.example.com',
+      source: 'NEXT_PUBLIC_BASE_URL',
+    });
+  });
+
+  it('reads the same key from app secrets when the environment is silent', async () => {
+    getAppSecretMock.mockImplementation(async (key: string) =>
+      key === 'NEXT_PUBLIC_BASE_URL' ? 'https://secret.example.com/' : undefined
+    );
+
+    await expect(resolveGmailWebhookBaseUrl()).resolves.toEqual({
+      baseUrl: 'https://secret.example.com',
+      source: 'NEXT_PUBLIC_BASE_URL (app secret)',
+    });
+  });
+
+  it('returns null when nothing is configured', async () => {
+    await expect(resolveGmailWebhookBaseUrl()).resolves.toBeNull();
+  });
+});
+
+describe('requireGmailWebhookBaseUrl', () => {
+  it('refuses to fall back to localhost', async () => {
+    await expect(requireGmailWebhookBaseUrl()).rejects.toThrow(/No base URL is configured/);
+  });
+
+  it('refuses an address Google cannot push to', async () => {
+    process.env.NEXT_PUBLIC_BASE_URL = 'http://localhost:3000';
+    await expect(requireGmailWebhookBaseUrl()).rejects.toThrow(/publicly reachable HTTPS endpoint/);
+  });
+});
+
+describe('getGmailPubSubNames', () => {
+  it('derives every name and the push audience from one place', async () => {
+    process.env.NEXT_PUBLIC_BASE_URL = 'https://alga.example.com/';
+
+    await expect(getGmailPubSubNames('tenant-1')).resolves.toEqual({
+      baseUrl: 'https://alga.example.com',
+      source: 'NEXT_PUBLIC_BASE_URL',
+      topicName: 'gmail-notifications-tenant-1',
+      subscriptionName: 'gmail-webhook-tenant-1',
+      webhookUrl: 'https://alga.example.com/api/email/webhooks/google',
+    });
+  });
+
+  it('fails loudly on a localhost instance instead of provisioning a dead subscription', async () => {
+    process.env.NEXTAUTH_URL = 'http://localhost:3000';
+    await expect(getGmailPubSubNames('tenant-1')).rejects.toThrow(GmailPubSubConfigurationError);
+  });
+});

--- a/packages/integrations/src/utils/email/gmailPubSub.test.ts
+++ b/packages/integrations/src/utils/email/gmailPubSub.test.ts
@@ -61,14 +61,21 @@ describe('normalizeGmailBaseUrl', () => {
     expect(normalizeGmailBaseUrl('https://alga.example.com:8443/')).toBe('https://alga.example.com:8443');
   });
 
-  it('preserves a path prefix so both sides agree on it', () => {
-    expect(normalizeGmailBaseUrl('https://example.com/alga/')).toBe('https://example.com/alga');
-  });
-
   it.each(['', 'not-a-url', 'alga.example.com', 'ftp://alga.example.com'])(
     'rejects %s rather than guessing',
     (input) => {
       expect(() => normalizeGmailBaseUrl(input)).toThrow(GmailPubSubConfigurationError);
+    }
+  );
+
+  // The base URL contributes the origin and nothing else. If it could also
+  // carry a path prefix, provisioning (which appends a fixed route path) and
+  // verification (which appends the request path) would disagree about how many
+  // times the prefix appears, and the mismatch would only show up as a 401.
+  it.each(['https://example.com/alga', 'https://example.com/alga/'])(
+    'rejects the path prefix in %s instead of silently doubling or dropping it',
+    (input) => {
+      expect(() => normalizeGmailBaseUrl(input)).toThrow(/path prefix is not supported/i);
     }
   );
 });
@@ -79,6 +86,15 @@ describe('buildGmailWebhookUrl', () => {
     const fromVerification = buildGmailWebhookUrl('HTTPS://alga.example.com:443', GOOGLE_WEBHOOK_PATH);
     expect(fromProvisioning).toBe('https://alga.example.com/api/email/webhooks/google');
     expect(fromVerification).toBe(fromProvisioning);
+  });
+
+  // With the origin as the only thing the base contributes, a prefix can reach
+  // the audience from exactly one source — the request path — so it can never
+  // appear twice.
+  it('takes any path prefix from the request path alone, never doubling it', () => {
+    expect(buildGmailWebhookUrl('https://alga.example.com', '/alga/api/email/webhooks/google')).toBe(
+      'https://alga.example.com/alga/api/email/webhooks/google'
+    );
   });
 });
 

--- a/packages/integrations/src/utils/email/gmailPubSub.ts
+++ b/packages/integrations/src/utils/email/gmailPubSub.ts
@@ -72,9 +72,16 @@ function isDevelopment(): boolean {
 }
 
 /**
- * Reduce a base URL to its canonical form: lowercase scheme and host, no
- * default port, no query or fragment, no trailing slash. Any path component is
- * preserved so instances mounted under a prefix stay self-consistent.
+ * Reduce a base URL to its canonical origin: lowercase scheme and host, no
+ * default port, no query, no fragment, no path.
+ *
+ * A path component is rejected rather than kept. Provisioning appends the fixed
+ * {@link GOOGLE_WEBHOOK_PATH}; verification appends `request.nextUrl.pathname`.
+ * If the base also carried a prefix, only one of those two would end up with it
+ * once — the other would double it or drop it, depending on how the app is
+ * mounted — and the resulting audience mismatch would be invisible. Serving
+ * Alga under a path prefix is therefore unsupported for Gmail push; the origin
+ * is the only part of the base URL that both sides may contribute.
  */
 export function normalizeGmailBaseUrl(raw: string): string {
   const trimmed = (raw ?? '').trim();
@@ -104,9 +111,17 @@ export function normalizeGmailBaseUrl(raw: string): string {
     (protocol === 'https:' && url.port === '443') ||
     (protocol === 'http:' && url.port === '80');
   const authority = portIsDefault ? host : `${host}:${url.port}`;
-  const path = url.pathname.replace(/\/+$/, '');
 
-  return `${protocol}//${authority}${path}`;
+  const path = url.pathname.replace(/\/+$/, '');
+  if (path) {
+    throw new GmailPubSubConfigurationError(
+      `"${trimmed}" includes the path "${path}". The Gmail webhook base URL must be an origin only ` +
+        `(for example https://alga.example.com); the webhook route path is appended automatically. ` +
+        'Serving Alga under a path prefix is not supported for Gmail push delivery.'
+    );
+  }
+
+  return `${protocol}//${authority}`;
 }
 
 /**

--- a/packages/integrations/src/utils/email/gmailPubSub.ts
+++ b/packages/integrations/src/utils/email/gmailPubSub.ts
@@ -1,0 +1,265 @@
+/**
+ * Gmail Pub/Sub naming and base-URL derivation.
+ *
+ * Gmail push delivery survives on one invariant: the audience Google signs its
+ * OIDC token with at provisioning time must be byte-identical to the audience
+ * the webhook route checks that token against. A single character of drift —
+ * a trailing slash, an uppercase host, an explicit `:443` — turns every push
+ * into a 401 that no part of the product notices. Provisioning, verification,
+ * and diagnostics therefore all derive their strings from this module.
+ */
+
+import fs from 'fs';
+import { getSecretProviderInstance } from '@alga-psa/core/secrets';
+
+/** Route the Google Pub/Sub push subscription delivers to. */
+export const GOOGLE_WEBHOOK_PATH = '/api/email/webhooks/google';
+
+/** Google-owned service account that publishes Gmail notifications. */
+export const GMAIL_PUSH_SERVICE_ACCOUNT = 'gmail-api-push@system.gserviceaccount.com';
+
+/** Role that service account needs on the tenant's topic. */
+export const GMAIL_PUBLISHER_ROLE = 'roles/pubsub.publisher';
+
+/**
+ * Base-URL sources in fixed precedence order. Each is read from `process.env`
+ * first and from the app secret store second, so a value set either way
+ * resolves identically no matter which caller asks.
+ */
+export const GMAIL_BASE_URL_KEYS = [
+  'NGROK_URL',
+  'NEXT_PUBLIC_BASE_URL',
+  'NEXTAUTH_URL',
+  'PUBLIC_WEBHOOK_BASE_URL',
+] as const;
+
+// Written by the ngrok-sync container in local development.
+const NGROK_URL_FILE = '/app/ngrok/url';
+
+const LOOPBACK_HOSTS = new Set([
+  'localhost',
+  '127.0.0.1',
+  '0.0.0.0',
+  '::1',
+  'host.docker.internal',
+]);
+
+/**
+ * A base URL or Pub/Sub name could not be derived. Callers surface the message
+ * verbatim to the administrator — it is written to be actionable.
+ */
+export class GmailPubSubConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'GmailPubSubConfigurationError';
+  }
+}
+
+/**
+ * A Pub/Sub provisioning step failed against Google. The message names the
+ * resource and the missing permission so it can be read straight from the
+ * provider card without a log dive.
+ */
+export class GmailPubSubSetupError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'GmailPubSubSetupError';
+  }
+}
+
+function isDevelopment(): boolean {
+  return process.env.NODE_ENV === 'development' || process.env.APP_ENV === 'development';
+}
+
+/**
+ * Reduce a base URL to its canonical form: lowercase scheme and host, no
+ * default port, no query or fragment, no trailing slash. Any path component is
+ * preserved so instances mounted under a prefix stay self-consistent.
+ */
+export function normalizeGmailBaseUrl(raw: string): string {
+  const trimmed = (raw ?? '').trim();
+  if (!trimmed) {
+    throw new GmailPubSubConfigurationError('The Gmail webhook base URL is empty.');
+  }
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    throw new GmailPubSubConfigurationError(
+      `"${trimmed}" is not a valid absolute URL. Use a full address such as https://alga.example.com.`
+    );
+  }
+
+  const protocol = url.protocol.toLowerCase();
+  if (protocol !== 'https:' && protocol !== 'http:') {
+    throw new GmailPubSubConfigurationError(
+      `"${trimmed}" uses the unsupported scheme "${url.protocol}". Use http or https.`
+    );
+  }
+
+  const host = url.hostname.toLowerCase();
+  const portIsDefault =
+    !url.port ||
+    (protocol === 'https:' && url.port === '443') ||
+    (protocol === 'http:' && url.port === '80');
+  const authority = portIsDefault ? host : `${host}:${url.port}`;
+  const path = url.pathname.replace(/\/+$/, '');
+
+  return `${protocol}//${authority}${path}`;
+}
+
+/**
+ * Join a normalized base URL with a route path. Both the Pub/Sub push endpoint
+ * and the audience the webhook verifies against are produced here, which is
+ * what keeps them identical.
+ */
+export function buildGmailWebhookUrl(baseUrl: string, path: string = GOOGLE_WEBHOOK_PATH): string {
+  const base = normalizeGmailBaseUrl(baseUrl);
+  const suffix = (path.startsWith('/') ? path : `/${path}`).replace(/\/+$/, '');
+  return `${base}${suffix}`;
+}
+
+/**
+ * Explain why an address cannot receive Pub/Sub push, or `null` when it can.
+ * Google only pushes to public HTTPS endpoints, so a loopback or private
+ * address means delivery will never arrive no matter how the rest is set up.
+ */
+export function describeUnreachableGmailBaseUrl(baseUrl: string): string | null {
+  const url = new URL(normalizeGmailBaseUrl(baseUrl));
+  const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+
+  if (url.protocol !== 'https:') {
+    return `${baseUrl} is not an HTTPS address.`;
+  }
+  if (LOOPBACK_HOSTS.has(host)) {
+    return `${baseUrl} points at this machine (${host}).`;
+  }
+  if (/^127\./.test(host) || host.startsWith('::1')) {
+    return `${baseUrl} points at the loopback interface.`;
+  }
+  if (/^10\./.test(host) || /^192\.168\./.test(host) || /^172\.(1[6-9]|2\d|3[01])\./.test(host)) {
+    return `${baseUrl} points at a private network address.`;
+  }
+  if (/^169\.254\./.test(host)) {
+    return `${baseUrl} points at a link-local address.`;
+  }
+  if (host.endsWith('.local') || host.endsWith('.internal') || !host.includes('.')) {
+    return `${baseUrl} points at a host name that only resolves inside this network.`;
+  }
+
+  return null;
+}
+
+export interface ResolvedGmailBaseUrl {
+  baseUrl: string;
+  /** Where the value came from, for diagnostics and error messages. */
+  source: string;
+}
+
+/**
+ * Resolve the public base URL of this Alga instance, normalized.
+ * Returns `null` when nothing is configured. Throws when a configured value
+ * exists but is unusable, because silently skipping to the next source is how
+ * provisioning and verification end up disagreeing.
+ */
+export async function resolveGmailWebhookBaseUrl(): Promise<ResolvedGmailBaseUrl | null> {
+  if (isDevelopment()) {
+    try {
+      if (fs.existsSync(NGROK_URL_FILE)) {
+        const fromFile = fs.readFileSync(NGROK_URL_FILE, 'utf-8').trim();
+        if (fromFile) {
+          return { baseUrl: normalizeGmailBaseUrl(fromFile), source: NGROK_URL_FILE };
+        }
+      }
+    } catch (error) {
+      if (error instanceof GmailPubSubConfigurationError) throw error;
+      // An unreadable ngrok file is not a configuration statement; fall through.
+    }
+  }
+
+  let secretProvider: Awaited<ReturnType<typeof getSecretProviderInstance>> | null = null;
+
+  for (const key of GMAIL_BASE_URL_KEYS) {
+    const fromEnv = process.env[key];
+    if (fromEnv && fromEnv.trim()) {
+      return { baseUrl: normalizeGmailBaseUrl(fromEnv), source: key };
+    }
+
+    if (!secretProvider) {
+      try {
+        secretProvider = await getSecretProviderInstance();
+      } catch {
+        // No secret store available; environment variables are all we have.
+        break;
+      }
+    }
+
+    const fromSecret = await secretProvider.getAppSecret(key);
+    if (fromSecret && fromSecret.trim()) {
+      return { baseUrl: normalizeGmailBaseUrl(fromSecret), source: `${key} (app secret)` };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolve the base URL and refuse anything Google cannot push to. Setup uses
+ * this: a Gmail provider configured against localhost is a broken provider, and
+ * saying so during setup is the only moment the administrator can act on it.
+ */
+export async function requireGmailWebhookBaseUrl(): Promise<ResolvedGmailBaseUrl> {
+  const resolved = await resolveGmailWebhookBaseUrl();
+
+  if (!resolved) {
+    throw new GmailPubSubConfigurationError(
+      `No base URL is configured for Gmail push delivery. Set ${GMAIL_BASE_URL_KEYS.join(' or ')} ` +
+        'to the public HTTPS address of this Alga instance.'
+    );
+  }
+
+  const unreachable = describeUnreachableGmailBaseUrl(resolved.baseUrl);
+  if (unreachable) {
+    throw new GmailPubSubConfigurationError(
+      `${unreachable} Google Pub/Sub only delivers to a publicly reachable HTTPS endpoint, so Gmail push ` +
+        `notifications would never arrive. Point ${resolved.source} at the public address of this Alga instance, ` +
+        'or set NGROK_URL to a tunnel address for local development.'
+    );
+  }
+
+  return resolved;
+}
+
+export function gmailTopicName(tenantId: string): string {
+  return `gmail-notifications-${tenantId}`;
+}
+
+export function gmailSubscriptionName(tenantId: string): string {
+  return `gmail-webhook-${tenantId}`;
+}
+
+export interface GmailPubSubNames extends ResolvedGmailBaseUrl {
+  topicName: string;
+  subscriptionName: string;
+  /** Push endpoint and OIDC audience — the same string, by construction. */
+  webhookUrl: string;
+}
+
+/**
+ * The one derivation of every Gmail Pub/Sub name and URL for a tenant.
+ */
+export async function getGmailPubSubNames(tenantId: string): Promise<GmailPubSubNames> {
+  if (!tenantId) {
+    throw new GmailPubSubConfigurationError('A tenant is required to derive Gmail Pub/Sub names.');
+  }
+
+  const resolved = await requireGmailWebhookBaseUrl();
+
+  return {
+    ...resolved,
+    topicName: gmailTopicName(tenantId),
+    subscriptionName: gmailSubscriptionName(tenantId),
+    webhookUrl: buildGmailWebhookUrl(resolved.baseUrl),
+  };
+}

--- a/packages/integrations/src/webhooks/email/handlers/googleWebhookHandler.ts
+++ b/packages/integrations/src/webhooks/email/handlers/googleWebhookHandler.ts
@@ -5,6 +5,7 @@ import { OAuth2Client } from 'google-auth-library';
 import { getSecretProviderInstance } from '@alga-psa/core/secrets';
 import { enqueueUnifiedInboundEmailQueueJob } from '@alga-psa/shared/services/email/unifiedInboundEmailQueue';
 import { persistIngressPointer } from '@alga-psa/shared/services/email/inboundEmailProducer';
+import { buildGmailWebhookUrl, resolveGmailWebhookBaseUrl } from '../../../utils/email/gmailPubSub';
 
 const PROVIDER_TENANT_DISCOVERY = 'tenant-discovery';
 
@@ -179,11 +180,20 @@ export async function handleGoogleWebhook(request: NextRequest) {
       return NextResponse.json({ success: true, message: 'No google config found' });
     }
 
-    // Verify JWT token (audience + issuer), now that we know which tenant/provider this webhook maps to
-    // Use NEXTAUTH_URL or NEXT_PUBLIC_BASE_URL for the expected audience since request.nextUrl.origin
-    // returns the container's internal URL (e.g., https://localhost:3000) instead of the public URL
-    const baseUrl = (process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_BASE_URL || '').replace(/\/$/, '');
-    const webhookUrl = baseUrl ? `${baseUrl}${request.nextUrl.pathname}` : `${request.nextUrl.origin}${request.nextUrl.pathname}`;
+    // Verify JWT token (audience + issuer), now that we know which tenant/provider this webhook maps to.
+    // The expected audience comes from the same derivation the Pub/Sub push
+    // subscription was provisioned with — request.nextUrl.origin is the
+    // container's internal address, and any drift between the two strings
+    // turns every delivery into a 401.
+    let resolvedBase: Awaited<ReturnType<typeof resolveGmailWebhookBaseUrl>> = null;
+    try {
+      resolvedBase = await resolveGmailWebhookBaseUrl();
+    } catch (baseUrlError) {
+      console.error('❌ Configured Gmail webhook base URL is unusable:', baseUrlError);
+    }
+    const webhookUrl = resolvedBase
+      ? buildGmailWebhookUrl(resolvedBase.baseUrl, request.nextUrl.pathname)
+      : `${request.nextUrl.origin}${request.nextUrl.pathname}`;
     console.log('🔐 Verifying JWT token from Pub/Sub', {
       webhookUrl,
       providerId: provider.id,
@@ -213,8 +223,28 @@ export async function handleGoogleWebhook(request: NextRequest) {
       });
       console.log('✅ JWT token verified successfully');
     } catch (error) {
-      console.error('❌ JWT verification failed:', error);
+      // The expected audience is the single most useful fact when this fails,
+      // and it is the one thing the rejected request cannot tell you.
+      console.error('❌ JWT verification failed:', {
+        expectedAudience: webhookUrl,
+        baseUrlSource: resolvedBase?.source ?? 'request origin',
+        providerId: provider.id,
+        tenant: provider.tenant,
+        error,
+      });
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // An accepted push is the only direct evidence that delivery works end to
+    // end. Diagnostics reads this back; without it "is mail arriving?" has no
+    // answer short of waiting for a ticket to appear.
+    try {
+      await tenantDb(knex, provider.tenant)
+        .table('google_email_provider_config')
+        .where('email_provider_id', provider.id)
+        .update({ last_push_received_at: new Date().toISOString() });
+    } catch (error) {
+      console.warn('Failed to record Gmail push receipt timestamp', error);
     }
 
     try {

--- a/packages/integrations/src/webhooks/email/handlers/googleWebhookHandler.ts
+++ b/packages/integrations/src/webhooks/email/handlers/googleWebhookHandler.ts
@@ -189,8 +189,32 @@ export async function handleGoogleWebhook(request: NextRequest) {
     try {
       resolvedBase = await resolveGmailWebhookBaseUrl();
     } catch (baseUrlError) {
-      console.error('❌ Configured Gmail webhook base URL is unusable:', baseUrlError);
+      // A base URL that is set but unusable is a configuration fault, not a
+      // missing value. Falling back to request.nextUrl.origin here would verify
+      // against the container-internal address, which cannot match what
+      // provisioning signed — every push would 401 with "invalid audience" and
+      // nothing would say why. Reject with the actual reason instead.
+      console.error('❌ Rejecting Gmail push: the configured webhook base URL is unusable, so the expected audience cannot be derived.', {
+        providerId: provider.id,
+        tenant: provider.tenant,
+        error: baseUrlError instanceof Error ? baseUrlError.message : String(baseUrlError),
+      });
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
+
+    if (!resolvedBase) {
+      // Nothing configured at all — the historical behavior. The request origin
+      // is the container's own address, so it only matches when Alga is reached
+      // directly (local development). Say so rather than letting a mismatch
+      // surface as a bare 401.
+      console.warn(
+        '⚠️ No Gmail webhook base URL is configured; verifying against the request origin. ' +
+          'This only matches when Pub/Sub was provisioned against that same origin — set NEXT_PUBLIC_BASE_URL ' +
+          '(or NGROK_URL for local development) to the public address of this instance.',
+        { origin: request.nextUrl.origin, providerId: provider.id, tenant: provider.tenant }
+      );
+    }
+
     const webhookUrl = resolvedBase
       ? buildGmailWebhookUrl(resolvedBase.baseUrl, request.nextUrl.pathname)
       : `${request.nextUrl.origin}${request.nextUrl.pathname}`;

--- a/server/migrations/20260818120000_add_gmail_last_push_received_at.cjs
+++ b/server/migrations/20260818120000_add_gmail_last_push_received_at.cjs
@@ -1,0 +1,27 @@
+/**
+ * Record when a Gmail Pub/Sub push was last accepted for a provider.
+ *
+ * Gmail delivery can break in ways that leave every stored field looking
+ * healthy — an expired watch, a subscription pointing at a stale audience.
+ * A timestamp written by the webhook route on each verified push is the only
+ * direct evidence that mail is actually arriving, and it is what the Gmail
+ * diagnostics check reports.
+ */
+
+exports.up = async function up(knex) {
+  const exists = await knex.schema.hasColumn('google_email_provider_config', 'last_push_received_at');
+  if (!exists) {
+    await knex.schema.table('google_email_provider_config', (table) => {
+      table.timestamp('last_push_received_at').nullable();
+    });
+  }
+};
+
+exports.down = async function down(knex) {
+  const exists = await knex.schema.hasColumn('google_email_provider_config', 'last_push_received_at');
+  if (exists) {
+    await knex.schema.table('google_email_provider_config', (table) => {
+      table.dropColumn('last_push_received_at');
+    });
+  }
+};

--- a/server/public/locales/de/msp/admin.json
+++ b/server/public/locales/de/msp/admin.json
@@ -628,5 +628,35 @@
       "error": "Fehler",
       "metadata": "Metadaten"
     }
+  },
+  "gmailDiagnostics": {
+    "title": "Gmail-Zustelldiagnose",
+    "description": "Prüft das Pub/Sub-Thema, dessen Berechtigungen, den Push-Endpunkt und die Zielgruppe, den Gmail-Watch sowie den Zeitpunkt der letzten eingegangenen Push-Nachricht.",
+    "labels": {
+      "provider": "Anbieter:",
+      "mailbox": "Postfach:",
+      "overall": "Gesamt:",
+      "recommendations": "Empfehlungen",
+      "error": "Fehler"
+    },
+    "audienceMismatch": {
+      "title": "Push-Zielgruppe stimmt nicht mit dieser Instanz überein",
+      "expected": "Erwartet:",
+      "actual": "Google verwendet:"
+    },
+    "actions": {
+      "copySupportBundle": "Supportpaket kopieren",
+      "copied": "Kopiert"
+    },
+    "states": {
+      "running": "Diagnose wird ausgeführt...",
+      "diagnosticsFailed": "Diagnose fehlgeschlagen"
+    },
+    "statuses": {
+      "pass": "Bestanden",
+      "warn": "Warnung",
+      "fail": "Fehlgeschlagen",
+      "skip": "Übersprungen"
+    }
   }
 }

--- a/server/public/locales/de/msp/email-providers.json
+++ b/server/public/locales/de/msp/email-providers.json
@@ -159,7 +159,8 @@
       "resyncMailbox": "Postfach neu synchronisieren",
       "pause": "Eingehende E-Mails pausieren",
       "resume": "Eingehende E-Mails fortsetzen",
-      "delete": "Anbieter löschen"
+      "delete": "Anbieter löschen",
+      "runGmailDiagnostics": "Gmail-Zustelldiagnose ausführen"
     },
     "feedback": {
       "paused": "Eingehende E-Mails pausiert.",
@@ -213,6 +214,14 @@
       "title": "Keine E-Mail-Anbieter konfiguriert",
       "description": "Fügen Sie einen E-Mail-Anbieter hinzu, um eingehende E-Mails als Tickets zu empfangen und zu verarbeiten.",
       "action": "E-Mail-Anbieter hinzufügen"
+    },
+    "gmailWatch": {
+      "expiredTitle": "Gmail sendet keine neuen Nachrichten mehr hierher",
+      "expiredDescription": "Der Gmail-Watch für {{mailbox}} ist abgelaufen, daher veröffentlicht Google keine Benachrichtigungen mehr. Nachrichten gehen nicht verloren — sie verbleiben im Postfach. Aktualisieren Sie Pub/Sub-Watch, um die Zustellung fortzusetzen.",
+      "missingTitle": "Gmail-Push-Zustellung ist nicht registriert",
+      "missingDescription": "Für {{mailbox}} ist kein Gmail-Watch registriert, daher gehen keine E-Mails ein. Aktualisieren Sie Pub/Sub-Watch, um einen zu registrieren.",
+      "expiringTitle": "Gmail-Push-Zustellung läuft innerhalb eines Tages ab",
+      "expiringDescription": "Ein Gmail-Watch gilt sieben Tage. Aktualisieren Sie Pub/Sub-Watch, bevor dieser abläuft, sonst bleiben eingehende E-Mails ohne weitere Meldung aus."
     }
   },
   "forms": {

--- a/server/public/locales/en/msp/admin.json
+++ b/server/public/locales/en/msp/admin.json
@@ -628,5 +628,35 @@
       "error": "Error",
       "metadata": "Metadata"
     }
+  },
+  "gmailDiagnostics": {
+    "title": "Gmail Delivery Diagnostics",
+    "description": "Checks the Pub/Sub topic, its permissions, the push endpoint and audience, the Gmail watch, and when a push last arrived.",
+    "labels": {
+      "provider": "Provider:",
+      "mailbox": "Mailbox:",
+      "overall": "Overall:",
+      "recommendations": "Recommendations",
+      "error": "Error"
+    },
+    "audienceMismatch": {
+      "title": "Push audience does not match this instance",
+      "expected": "Expected:",
+      "actual": "Google is using:"
+    },
+    "actions": {
+      "copySupportBundle": "Copy Support Bundle",
+      "copied": "Copied"
+    },
+    "states": {
+      "running": "Running diagnostics...",
+      "diagnosticsFailed": "Diagnostics failed"
+    },
+    "statuses": {
+      "pass": "Pass",
+      "warn": "Warn",
+      "fail": "Fail",
+      "skip": "Skip"
+    }
   }
 }

--- a/server/public/locales/en/msp/email-providers.json
+++ b/server/public/locales/en/msp/email-providers.json
@@ -159,7 +159,8 @@
       "resyncMailbox": "Resync Mailbox",
       "pause": "Pause inbound email",
       "resume": "Resume inbound email",
-      "delete": "Delete Provider"
+      "delete": "Delete Provider",
+      "runGmailDiagnostics": "Run Gmail Delivery Diagnostics"
     },
     "feedback": {
       "paused": "Inbound email paused.",
@@ -213,6 +214,14 @@
       "title": "No Email Providers Configured",
       "description": "Add an email provider to start receiving and processing inbound emails as tickets.",
       "action": "Add Email Provider"
+    },
+    "gmailWatch": {
+      "expiredTitle": "Gmail is no longer sending new mail here",
+      "expiredDescription": "The Gmail watch for {{mailbox}} expired, so Google has stopped publishing notifications. Messages are not lost — they remain in the mailbox. Refresh Pub/Sub & Watch to resume delivery.",
+      "missingTitle": "Gmail push delivery is not registered",
+      "missingDescription": "No Gmail watch is registered for {{mailbox}}, so no inbound mail will arrive. Refresh Pub/Sub & Watch to register one.",
+      "expiringTitle": "Gmail push delivery expires within a day",
+      "expiringDescription": "Gmail watches last seven days. Refresh Pub/Sub & Watch before this one lapses, or inbound mail will stop without further notice."
     }
   },
   "forms": {

--- a/server/public/locales/es/msp/admin.json
+++ b/server/public/locales/es/msp/admin.json
@@ -628,5 +628,35 @@
       "error": "Error",
       "metadata": "Metadatos"
     }
+  },
+  "gmailDiagnostics": {
+    "title": "Diagnósticos de entrega de Gmail",
+    "description": "Comprueba el tema de Pub/Sub, sus permisos, el punto de conexión push y su audiencia, la vigilancia de Gmail y cuándo llegó la última notificación push.",
+    "labels": {
+      "provider": "Proveedor:",
+      "mailbox": "Buzón:",
+      "overall": "General:",
+      "recommendations": "Recomendaciones",
+      "error": "Error"
+    },
+    "audienceMismatch": {
+      "title": "La audiencia del push no coincide con esta instancia",
+      "expected": "Se esperaba:",
+      "actual": "Google está usando:"
+    },
+    "actions": {
+      "copySupportBundle": "Copiar paquete de soporte",
+      "copied": "Copiado"
+    },
+    "states": {
+      "running": "Ejecutando diagnósticos...",
+      "diagnosticsFailed": "Los diagnósticos fallaron"
+    },
+    "statuses": {
+      "pass": "Aprobado",
+      "warn": "Aviso",
+      "fail": "Fallido",
+      "skip": "Omitido"
+    }
   }
 }

--- a/server/public/locales/es/msp/email-providers.json
+++ b/server/public/locales/es/msp/email-providers.json
@@ -159,7 +159,8 @@
       "resyncMailbox": "Resincronizar buzón",
       "pause": "Pausar correo entrante",
       "resume": "Reanudar correo entrante",
-      "delete": "Eliminar proveedor"
+      "delete": "Eliminar proveedor",
+      "runGmailDiagnostics": "Ejecutar diagnósticos de entrega de Gmail"
     },
     "feedback": {
       "paused": "Correo entrante en pausa.",
@@ -213,6 +214,14 @@
       "title": "No hay proveedores de correo electrónico configurados",
       "description": "Agregue un proveedor de correo electrónico para comenzar a recibir y procesar correos electrónicos entrantes como tickets.",
       "action": "Agregar proveedor de correo electrónico"
+    },
+    "gmailWatch": {
+      "expiredTitle": "Gmail ya no envía correo nuevo aquí",
+      "expiredDescription": "La vigilancia de Gmail para {{mailbox}} caducó, así que Google dejó de publicar notificaciones. Los mensajes no se pierden: permanecen en el buzón. Use Actualizar Pub/Sub y Ver para reanudar la entrega.",
+      "missingTitle": "La entrega push de Gmail no está registrada",
+      "missingDescription": "No hay ninguna vigilancia de Gmail registrada para {{mailbox}}, por lo que no llegará correo entrante. Use Actualizar Pub/Sub y Ver para registrar una.",
+      "expiringTitle": "La entrega push de Gmail caduca en menos de un día",
+      "expiringDescription": "Las vigilancias de Gmail duran siete días. Use Actualizar Pub/Sub y Ver antes de que caduque, o el correo entrante se detendrá sin más aviso."
     }
   },
   "forms": {

--- a/server/public/locales/fr/msp/admin.json
+++ b/server/public/locales/fr/msp/admin.json
@@ -628,5 +628,35 @@
       "error": "Erreur",
       "metadata": "Métadonnées"
     }
+  },
+  "gmailDiagnostics": {
+    "title": "Diagnostics de distribution Gmail",
+    "description": "Vérifie le sujet Pub/Sub, ses autorisations, le point de terminaison push et son audience, la surveillance Gmail et la date de la dernière notification push reçue.",
+    "labels": {
+      "provider": "Fournisseur :",
+      "mailbox": "Boîte mail :",
+      "overall": "Global :",
+      "recommendations": "Recommandations",
+      "error": "Erreur"
+    },
+    "audienceMismatch": {
+      "title": "L'audience du push ne correspond pas à cette instance",
+      "expected": "Attendu :",
+      "actual": "Google utilise :"
+    },
+    "actions": {
+      "copySupportBundle": "Copier l'ensemble de support",
+      "copied": "Copié"
+    },
+    "states": {
+      "running": "Exécution des diagnostics...",
+      "diagnosticsFailed": "Échec des diagnostics"
+    },
+    "statuses": {
+      "pass": "Réussi",
+      "warn": "Avertissement",
+      "fail": "Échec",
+      "skip": "Ignoré"
+    }
   }
 }

--- a/server/public/locales/fr/msp/email-providers.json
+++ b/server/public/locales/fr/msp/email-providers.json
@@ -159,7 +159,8 @@
       "resyncMailbox": "Resynchroniser la boîte aux lettres",
       "pause": "Suspendre les e-mails entrants",
       "resume": "Reprendre les e-mails entrants",
-      "delete": "Supprimer le fournisseur"
+      "delete": "Supprimer le fournisseur",
+      "runGmailDiagnostics": "Exécuter les diagnostics de distribution Gmail"
     },
     "feedback": {
       "paused": "E-mails entrants suspendus.",
@@ -213,6 +214,14 @@
       "title": "Aucun fournisseur de messagerie configuré",
       "description": "Ajoutez un fournisseur de messagerie pour commencer à recevoir et à traiter les e-mails entrants sous forme de tickets.",
       "action": "Ajouter un fournisseur de messagerie"
+    },
+    "gmailWatch": {
+      "expiredTitle": "Gmail n'envoie plus de nouveaux messages ici",
+      "expiredDescription": "La surveillance Gmail de {{mailbox}} a expiré, Google a donc cessé de publier des notifications. Aucun message n'est perdu — ils restent dans la boîte. Actualisez Pub/Sub et regardez pour rétablir la distribution.",
+      "missingTitle": "La distribution push Gmail n’est pas enregistrée",
+      "missingDescription": "Aucune surveillance Gmail n'est enregistrée pour {{mailbox}}, aucun e-mail entrant n'arrivera donc. Actualisez Pub/Sub et regardez pour en enregistrer une.",
+      "expiringTitle": "La distribution push Gmail expire dans moins d’un jour",
+      "expiringDescription": "Une surveillance Gmail dure sept jours. Actualisez Pub/Sub et regardez avant son expiration, sinon les e-mails entrants cesseront sans autre avertissement."
     }
   },
   "forms": {

--- a/server/public/locales/it/msp/admin.json
+++ b/server/public/locales/it/msp/admin.json
@@ -628,5 +628,35 @@
       "error": "Errore",
       "metadata": "Metadati"
     }
+  },
+  "gmailDiagnostics": {
+    "title": "Diagnostica di recapito Gmail",
+    "description": "Verifica l'argomento Pub/Sub, le sue autorizzazioni, l'endpoint push e il relativo destinatario, il watch di Gmail e quando è arrivata l'ultima notifica push.",
+    "labels": {
+      "provider": "Fornitore:",
+      "mailbox": "Casella di posta:",
+      "overall": "Generale:",
+      "recommendations": "Raccomandazioni",
+      "error": "Errore"
+    },
+    "audienceMismatch": {
+      "title": "Il destinatario del push non corrisponde a questa istanza",
+      "expected": "Previsto:",
+      "actual": "Google sta usando:"
+    },
+    "actions": {
+      "copySupportBundle": "Copia pacchetto di supporto",
+      "copied": "Copiato"
+    },
+    "states": {
+      "running": "Diagnostica in esecuzione...",
+      "diagnosticsFailed": "Diagnostica non riuscita"
+    },
+    "statuses": {
+      "pass": "Superato",
+      "warn": "Avviso",
+      "fail": "Non riuscito",
+      "skip": "Saltato"
+    }
   }
 }

--- a/server/public/locales/it/msp/email-providers.json
+++ b/server/public/locales/it/msp/email-providers.json
@@ -159,7 +159,8 @@
       "resyncMailbox": "Risincronizza casella di posta",
       "pause": "Sospendi email in arrivo",
       "resume": "Riprendi email in arrivo",
-      "delete": "Elimina fornitore"
+      "delete": "Elimina fornitore",
+      "runGmailDiagnostics": "Esegui la diagnostica di recapito Gmail"
     },
     "feedback": {
       "paused": "Email in arrivo sospese.",
@@ -213,6 +214,14 @@
       "title": "Nessun provider di posta elettronica configurato",
       "description": "Aggiungi un provider di posta elettronica per iniziare a ricevere ed elaborare le email in entrata come ticket.",
       "action": "Aggiungi fornitore di posta elettronica"
+    },
+    "gmailWatch": {
+      "expiredTitle": "Gmail non invia più nuova posta qui",
+      "expiredDescription": "Il watch di Gmail per {{mailbox}} è scaduto, quindi Google ha smesso di pubblicare notifiche. I messaggi non vanno persi: restano nella casella. Usa Aggiorna Pub/Sub e guarda per riprendere il recapito.",
+      "missingTitle": "Il recapito push di Gmail non è registrato",
+      "missingDescription": "Nessun watch di Gmail è registrato per {{mailbox}}, quindi non arriverà posta in entrata. Usa Aggiorna Pub/Sub e guarda per registrarne uno.",
+      "expiringTitle": "Il recapito push di Gmail scade entro un giorno",
+      "expiringDescription": "I watch di Gmail durano sette giorni. Usa Aggiorna Pub/Sub e guarda prima che scada, altrimenti la posta in entrata si fermerà senza altro preavviso."
     }
   },
   "forms": {

--- a/server/public/locales/nl/msp/admin.json
+++ b/server/public/locales/nl/msp/admin.json
@@ -628,5 +628,35 @@
       "error": "Fout",
       "metadata": "Metagegevens"
     }
+  },
+  "gmailDiagnostics": {
+    "title": "Gmail-bezorgingsdiagnose",
+    "description": "Controleert het Pub/Sub-onderwerp, de machtigingen ervan, het push-eindpunt en de bijbehorende doelgroep, de Gmail-watch en wanneer er voor het laatst een push is binnengekomen.",
+    "labels": {
+      "provider": "Aanbieder:",
+      "mailbox": "Postvak:",
+      "overall": "Algemeen:",
+      "recommendations": "Aanbevelingen",
+      "error": "Fout"
+    },
+    "audienceMismatch": {
+      "title": "De push-doelgroep komt niet overeen met deze instantie",
+      "expected": "Verwacht:",
+      "actual": "Google gebruikt:"
+    },
+    "actions": {
+      "copySupportBundle": "Ondersteuningsbundel kopiëren",
+      "copied": "Gekopieerd"
+    },
+    "states": {
+      "running": "Diagnostiek wordt uitgevoerd...",
+      "diagnosticsFailed": "Diagnostiek mislukt"
+    },
+    "statuses": {
+      "pass": "Geslaagd",
+      "warn": "Waarschuwing",
+      "fail": "Mislukt",
+      "skip": "Overgeslagen"
+    }
   }
 }

--- a/server/public/locales/nl/msp/email-providers.json
+++ b/server/public/locales/nl/msp/email-providers.json
@@ -159,7 +159,8 @@
       "resyncMailbox": "Postbus opnieuw synchroniseren",
       "pause": "Inkomende e-mail pauzeren",
       "resume": "Inkomende e-mail hervatten",
-      "delete": "Aanbieder verwijderen"
+      "delete": "Aanbieder verwijderen",
+      "runGmailDiagnostics": "Gmail-bezorgingsdiagnose uitvoeren"
     },
     "feedback": {
       "paused": "Inkomende e-mail gepauzeerd.",
@@ -213,6 +214,14 @@
       "title": "Geen e-mailproviders geconfigureerd",
       "description": "Voeg een e-mailprovider toe om inkomende e-mails als tickets te ontvangen en te verwerken.",
       "action": "E-mailprovider toevoegen"
+    },
+    "gmailWatch": {
+      "expiredTitle": "Gmail stuurt hier geen nieuwe e-mail meer heen",
+      "expiredDescription": "De Gmail-watch voor {{mailbox}} is verlopen, dus Google publiceert geen meldingen meer. Berichten gaan niet verloren — ze blijven in de mailbox. Gebruik Vernieuw Pub/Sub en kijk om de bezorging te hervatten.",
+      "missingTitle": "Gmail-pushbezorging is niet geregistreerd",
+      "missingDescription": "Er is geen Gmail-watch geregistreerd voor {{mailbox}}, dus er komt geen inkomende e-mail binnen. Gebruik Vernieuw Pub/Sub en kijk om er een te registreren.",
+      "expiringTitle": "Gmail-pushbezorging verloopt binnen een dag",
+      "expiringDescription": "Een Gmail-watch duurt zeven dagen. Gebruik Vernieuw Pub/Sub en kijk voordat deze verloopt, anders stopt inkomende e-mail zonder verdere melding."
     }
   },
   "forms": {

--- a/server/public/locales/pl/msp/admin.json
+++ b/server/public/locales/pl/msp/admin.json
@@ -630,5 +630,35 @@
       "error": "Błąd",
       "metadata": "Metadane"
     }
+  },
+  "gmailDiagnostics": {
+    "title": "Diagnostyka dostarczania Gmaila",
+    "description": "Sprawdza temat Pub/Sub, jego uprawnienia, punkt końcowy push wraz z odbiorcą tokenu, obserwację Gmaila oraz moment odebrania ostatniego powiadomienia push.",
+    "labels": {
+      "provider": "Dostawca:",
+      "mailbox": "Skrzynka pocztowa:",
+      "overall": "Ogólnie:",
+      "recommendations": "Zalecenia",
+      "error": "Błąd"
+    },
+    "audienceMismatch": {
+      "title": "Odbiorca tokenu push nie pasuje do tej instancji",
+      "expected": "Oczekiwano:",
+      "actual": "Google używa:"
+    },
+    "actions": {
+      "copySupportBundle": "Kopiuj pakiet wsparcia",
+      "copied": "Skopiowano"
+    },
+    "states": {
+      "running": "Uruchamianie diagnostyki...",
+      "diagnosticsFailed": "Diagnostyka nie powiodła się"
+    },
+    "statuses": {
+      "pass": "Zaliczono",
+      "warn": "Ostrzeżenie",
+      "fail": "Niepowodzenie",
+      "skip": "Pominięto"
+    }
   }
 }

--- a/server/public/locales/pl/msp/email-providers.json
+++ b/server/public/locales/pl/msp/email-providers.json
@@ -159,7 +159,8 @@
       "resyncMailbox": "Zsynchronizuj ponownie skrzynkę pocztową",
       "pause": "Wstrzymaj pocztę przychodzącą",
       "resume": "Wznów pocztę przychodzącą",
-      "delete": "Usuń dostawcę"
+      "delete": "Usuń dostawcę",
+      "runGmailDiagnostics": "Uruchom diagnostykę dostarczania Gmaila"
     },
     "feedback": {
       "paused": "Poczta przychodząca wstrzymana.",
@@ -213,6 +214,14 @@
       "title": "Nie skonfigurowano dostawców poczty e-mail",
       "description": "Dodaj dostawcę poczty e-mail, aby rozpocząć odbieranie i przetwarzanie przychodzących wiadomości e-mail jako zgłoszeń.",
       "action": "Dodaj dostawcę poczty e-mail"
+    },
+    "gmailWatch": {
+      "expiredTitle": "Gmail nie przesyła już tutaj nowej poczty",
+      "expiredDescription": "Obserwacja Gmaila dla {{mailbox}} wygasła, więc Google przestało publikować powiadomienia. Wiadomości nie są tracone — pozostają w skrzynce. Użyj Odśwież Pub/Sub i oglądaj, aby wznowić dostarczanie.",
+      "missingTitle": "Dostarczanie push z Gmaila nie jest zarejestrowane",
+      "missingDescription": "Dla {{mailbox}} nie zarejestrowano obserwacji Gmaila, więc żadna poczta przychodząca nie dotrze. Użyj Odśwież Pub/Sub i oglądaj, aby ją zarejestrować.",
+      "expiringTitle": "Dostarczanie push z Gmaila wygaśnie w ciągu doby",
+      "expiringDescription": "Obserwacje Gmaila trwają siedem dni. Użyj Odśwież Pub/Sub i oglądaj, zanim ta wygaśnie, w przeciwnym razie poczta przychodząca ustanie bez dalszego ostrzeżenia."
     }
   },
   "forms": {

--- a/server/public/locales/pt/msp/admin.json
+++ b/server/public/locales/pt/msp/admin.json
@@ -628,5 +628,35 @@
       "error": "Erro",
       "metadata": "Metadados"
     }
+  },
+  "gmailDiagnostics": {
+    "title": "Diagnóstico de entrega do Gmail",
+    "description": "Verifica o tópico do Pub/Sub, suas permissões, o endpoint de push e seu público, a observação do Gmail e quando o último push chegou.",
+    "labels": {
+      "provider": "Provedor:",
+      "mailbox": "Caixa de correio:",
+      "overall": "Geral:",
+      "recommendations": "Recomendações",
+      "error": "Erro"
+    },
+    "audienceMismatch": {
+      "title": "O público do push não corresponde a esta instância",
+      "expected": "Esperado:",
+      "actual": "O Google está usando:"
+    },
+    "actions": {
+      "copySupportBundle": "Copiar pacote de suporte",
+      "copied": "Copiado"
+    },
+    "states": {
+      "running": "Executando diagnóstico...",
+      "diagnosticsFailed": "Falha no diagnóstico"
+    },
+    "statuses": {
+      "pass": "Passar",
+      "warn": "Avisar",
+      "fail": "Falhar",
+      "skip": "Pular"
+    }
   }
 }

--- a/server/public/locales/pt/msp/email-providers.json
+++ b/server/public/locales/pt/msp/email-providers.json
@@ -159,7 +159,8 @@
       "resyncMailbox": "Ressincronizar caixa de correio",
       "pause": "Pausar e-mails recebidos",
       "resume": "Retomar e-mails recebidos",
-      "delete": "Excluir provedor"
+      "delete": "Excluir provedor",
+      "runGmailDiagnostics": "Executar o diagnóstico de entrega do Gmail"
     },
     "feedback": {
       "paused": "E-mails recebidos pausados.",
@@ -213,6 +214,14 @@
       "title": "Nenhum provedor de e-mail configurado",
       "description": "Adicione um provedor de e-mail para começar a receber e processar e-mails recebidos como tickets.",
       "action": "Adicionar provedor de e-mail"
+    },
+    "gmailWatch": {
+      "expiredTitle": "O Gmail não envia mais mensagens novas para cá",
+      "expiredDescription": "A observação do Gmail para {{mailbox}} expirou, então o Google parou de publicar notificações. As mensagens não são perdidas — elas permanecem na caixa de entrada. Use Atualizar Pub/Sub e assistir para retomar a entrega.",
+      "missingTitle": "A entrega push do Gmail não está registrada",
+      "missingDescription": "Nenhuma observação do Gmail está registrada para {{mailbox}}, então nenhuma mensagem recebida chegará. Use Atualizar Pub/Sub e assistir para registrar uma.",
+      "expiringTitle": "A entrega push do Gmail expira em menos de um dia",
+      "expiringDescription": "As observações do Gmail duram sete dias. Use Atualizar Pub/Sub e assistir antes que esta expire, ou as mensagens recebidas vão parar sem outro aviso."
     }
   },
   "forms": {

--- a/server/public/locales/xx/msp/admin.json
+++ b/server/public/locales/xx/msp/admin.json
@@ -628,5 +628,35 @@
       "error": "11111",
       "metadata": "11111"
     }
+  },
+  "gmailDiagnostics": {
+    "title": "11111",
+    "description": "11111",
+    "labels": {
+      "provider": "11111",
+      "mailbox": "11111",
+      "overall": "11111",
+      "recommendations": "11111",
+      "error": "11111"
+    },
+    "audienceMismatch": {
+      "title": "11111",
+      "expected": "11111",
+      "actual": "11111"
+    },
+    "actions": {
+      "copySupportBundle": "11111",
+      "copied": "11111"
+    },
+    "states": {
+      "running": "11111",
+      "diagnosticsFailed": "11111"
+    },
+    "statuses": {
+      "pass": "11111",
+      "warn": "11111",
+      "fail": "11111",
+      "skip": "11111"
+    }
   }
 }

--- a/server/public/locales/xx/msp/email-providers.json
+++ b/server/public/locales/xx/msp/email-providers.json
@@ -159,7 +159,8 @@
       "resyncMailbox": "11111",
       "pause": "11111",
       "resume": "11111",
-      "delete": "11111"
+      "delete": "11111",
+      "runGmailDiagnostics": "11111"
     },
     "feedback": {
       "paused": "11111",
@@ -213,6 +214,14 @@
       "title": "11111",
       "description": "11111",
       "action": "11111"
+    },
+    "gmailWatch": {
+      "expiredTitle": "11111",
+      "expiredDescription": "11111 {{mailbox}} 11111",
+      "missingTitle": "11111",
+      "missingDescription": "11111 {{mailbox}} 11111",
+      "expiringTitle": "11111",
+      "expiringDescription": "11111"
     }
   },
   "forms": {

--- a/server/public/locales/yy/msp/admin.json
+++ b/server/public/locales/yy/msp/admin.json
@@ -628,5 +628,35 @@
       "error": "55555",
       "metadata": "55555"
     }
+  },
+  "gmailDiagnostics": {
+    "title": "55555",
+    "description": "55555",
+    "labels": {
+      "provider": "55555",
+      "mailbox": "55555",
+      "overall": "55555",
+      "recommendations": "55555",
+      "error": "55555"
+    },
+    "audienceMismatch": {
+      "title": "55555",
+      "expected": "55555",
+      "actual": "55555"
+    },
+    "actions": {
+      "copySupportBundle": "55555",
+      "copied": "55555"
+    },
+    "states": {
+      "running": "55555",
+      "diagnosticsFailed": "55555"
+    },
+    "statuses": {
+      "pass": "55555",
+      "warn": "55555",
+      "fail": "55555",
+      "skip": "55555"
+    }
   }
 }

--- a/server/public/locales/yy/msp/email-providers.json
+++ b/server/public/locales/yy/msp/email-providers.json
@@ -159,7 +159,8 @@
       "resyncMailbox": "55555",
       "pause": "55555",
       "resume": "55555",
-      "delete": "55555"
+      "delete": "55555",
+      "runGmailDiagnostics": "55555"
     },
     "feedback": {
       "paused": "55555",
@@ -213,6 +214,14 @@
       "title": "55555",
       "description": "55555",
       "action": "55555"
+    },
+    "gmailWatch": {
+      "expiredTitle": "55555",
+      "expiredDescription": "55555 {{mailbox}} 55555",
+      "missingTitle": "55555",
+      "missingDescription": "55555 {{mailbox}} 55555",
+      "expiringTitle": "55555",
+      "expiringDescription": "55555"
     }
   },
   "forms": {

--- a/server/src/app/api/email/refresh-watch/route.ts
+++ b/server/src/app/api/email/refresh-watch/route.ts
@@ -72,9 +72,14 @@ export async function POST(request: NextRequest) {
     });
 
     if (!result.success) {
+      // configureGmailProvider builds its errors for the administrator; a
+      // generic replacement here would hide the one sentence that says which
+      // permission or URL is wrong.
       return NextResponse.json({
         success: false,
-        error: 'Gmail provider refresh failed. Check Pub/Sub and Gmail watch configuration, then try again.',
+        error: result.error || 'Gmail provider refresh failed. Check Pub/Sub and Gmail watch configuration, then try again.',
+        pubsubConfigured: result.pubsubConfigured,
+        watchRegistered: result.watchRegistered,
         warnings: result.warnings
       }, { status: 409 });
     }

--- a/server/src/test/integration/googleWebhookUnifiedQueue.integration.test.ts
+++ b/server/src/test/integration/googleWebhookUnifiedQueue.integration.test.ts
@@ -19,6 +19,7 @@ vi.mock('@alga-psa/core/secrets', () => ({
   getSecret: vi.fn(async () => null),
   getSecretProviderInstance: async () => ({
     getTenantSecret: (...args: any[]) => getTenantSecretMock(...args),
+    getAppSecret: async () => undefined,
   }),
 }));
 
@@ -45,6 +46,11 @@ function createJwt(email: string): string {
 
 describe('Google unified inbound pointer queue ingress', () => {
   beforeEach(() => {
+    // The expected audience is derived from a fixed source precedence, so the
+    // higher-priority sources have to be absent for NEXTAUTH_URL to be the one
+    // that answers.
+    delete process.env.NGROK_URL;
+    delete process.env.NEXT_PUBLIC_BASE_URL;
     process.env.NEXTAUTH_URL = 'https://example.test';
 
     enqueueUnifiedInboundEmailQueueJobMock.mockReset();

--- a/server/src/test/integration/inboundAuthPauseReconnectSave.integration.test.ts
+++ b/server/src/test/integration/inboundAuthPauseReconnectSave.integration.test.ts
@@ -125,9 +125,11 @@ vi.mock('@alga-psa/integrations/services/email/GmailWebhookService', () => ({
       gmailWatchMock.instances.push(this);
     }
     async registerWatch() {
+      // Mirrors the real service, which reports failure by return value.
       if (gmailWatchMock.registerShouldFail) {
-        throw new Error('Watch registration failed: invalid grant');
+        return { success: false, error: 'Gmail watch registration failed: invalid grant' };
       }
+      return { success: true, historyId: '5001', expiration: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString() };
     }
   },
 }));
@@ -339,6 +341,10 @@ function formGooglePayload(providerId: string, withFreshTokens = true) {
 describeDb('auth-pause reconnect save path (updateEmailProvider, DB-backed)', () => {
   beforeAll(async () => {
     wireLocalTestDbEnv();
+    // Gmail setup refuses to provision against an address Google cannot push
+    // to, so the suite has to look like a publicly reachable instance.
+    delete process.env.NGROK_URL;
+    process.env.NEXT_PUBLIC_BASE_URL = 'https://reconnect-save.example.com';
     // Scratch database instead of the shared test_database: every
     // DB-backed suite bootstrap DROPs its database, and parallel worktree
     // agents sharing the local test Postgres repeatedly dropped
@@ -614,5 +620,86 @@ describeDb('auth-pause reconnect save path (updateEmailProvider, DB-backed)', ()
     expect(result.provider.inboundPauseReason).toBeNull();
     expect(Number(result.provider.inboundAuthFailureCount)).toBe(0);
     expect(result.provider.status).toBe('connected');
+  });
+
+  it('Google: a watch failure on a healthy provider is a failed save, not a warning under a green status', async () => {
+    // The pause machinery is not involved here — this is the plain case of an
+    // administrator saving a Gmail provider whose watch cannot be registered.
+    // Pub/Sub provisioning succeeding on its own delivers no mail, so the save
+    // must not report the provider connected.
+    const providerId = await seedGoogleProvider(null);
+    gmailWatchMock.registerShouldFail = true;
+
+    const result = await updateEmailProvider(providerId, formGooglePayload(providerId), false);
+
+    expect((result as any).actionError).toBeUndefined();
+    expect((result as any).setupError).toBeTruthy();
+    // The underlying Google failure reaches the administrator verbatim.
+    expect((result as any).setupError).toContain('invalid grant');
+    expect(result.provider.status).toBe('error');
+
+    const row = await getProviderRow(providerId);
+    expect(row.status).not.toBe('connected');
+  });
+
+  it('Google: a save without OAuth tokens on a healthy provider reports failure rather than partial success', async () => {
+    const providerId = await seedGoogleProvider(null, { tokens: false });
+
+    const result = await updateEmailProvider(providerId, formGooglePayload(providerId, false), false);
+
+    expect((result as any).actionError).toBeUndefined();
+    expect((result as any).setupError).toBeTruthy();
+    expect(result.provider.status).toBe('error');
+    // The watch guard fired before any registration attempt.
+    expect(gmailWatchMock.instances).toHaveLength(0);
+  });
+
+  it('Google: a second save re-verifies instead of trusting a recent pubsub_initialised_at', async () => {
+    const providerId = await seedGoogleProvider(null);
+
+    const first = await updateEmailProvider(providerId, formGooglePayload(providerId), false);
+    expect((first as any).setupError).toBeUndefined();
+    expect(pubsubMock.calls).toHaveLength(1);
+    expect(gmailWatchMock.instances).toHaveLength(1);
+
+    // The old 24-hour cool-down returned pubsubConfigured/watchRegistered=true
+    // here without calling anything; a broken provider stayed green until the
+    // window lapsed.
+    gmailWatchMock.registerShouldFail = true;
+    const second = await updateEmailProvider(providerId, formGooglePayload(providerId), false);
+
+    expect(pubsubMock.calls).toHaveLength(2);
+    expect(gmailWatchMock.instances).toHaveLength(2);
+    expect((second as any).setupError).toBeTruthy();
+    expect(second.provider.status).toBe('error');
+  });
+
+  it('Google: the push endpoint and OIDC audience come from the configured public base URL', async () => {
+    const providerId = await seedGoogleProvider(null);
+
+    await updateEmailProvider(providerId, formGooglePayload(providerId), false);
+
+    expect(pubsubMock.calls).toHaveLength(1);
+    expect(pubsubMock.calls[0]).toMatchObject({
+      topicName: `gmail-notifications-${testTenant}`,
+      subscriptionName: `gmail-webhook-${testTenant}`,
+      webhookUrl: 'https://reconnect-save.example.com/api/email/webhooks/google',
+    });
+  });
+
+  it('Google: setup refuses to provision against an address Google cannot push to', async () => {
+    const providerId = await seedGoogleProvider(null);
+    const saved = process.env.NEXT_PUBLIC_BASE_URL;
+    process.env.NEXT_PUBLIC_BASE_URL = 'http://localhost:3000';
+
+    try {
+      const result = await updateEmailProvider(providerId, formGooglePayload(providerId), false);
+
+      expect((result as any).setupError).toMatch(/publicly reachable HTTPS endpoint/);
+      expect(result.provider.status).toBe('error');
+      expect(pubsubMock.calls).toHaveLength(0);
+    } finally {
+      process.env.NEXT_PUBLIC_BASE_URL = saved;
+    }
   });
 });

--- a/shared/interfaces/gmail-diagnostics.interfaces.ts
+++ b/shared/interfaces/gmail-diagnostics.interfaces.ts
@@ -1,0 +1,48 @@
+import type { DiagnosticsStepStatus } from './microsoft365-diagnostics.interfaces';
+
+export type { DiagnosticsStepStatus };
+
+export interface GmailDiagnosticsError {
+  message: string;
+  code?: string;
+  status?: number;
+}
+
+export interface GmailDiagnosticsStep {
+  id: string;
+  title: string;
+  status: DiagnosticsStepStatus;
+  startedAt: string;
+  durationMs: number;
+  /** What the administrator should do when this step is not a pass. */
+  remediation?: string;
+  data?: Record<string, unknown>;
+  error?: GmailDiagnosticsError;
+}
+
+export interface GmailDiagnosticsSummary {
+  providerId: string;
+  tenantId: string;
+  providerType: 'google';
+  mailbox: string;
+  projectId?: string;
+  topicName?: string;
+  subscriptionName?: string;
+  /** Push endpoint and OIDC audience this instance expects, derived once. */
+  expectedWebhookUrl?: string;
+  /** Push endpoint Google is actually configured with, when it could be read. */
+  actualPushEndpoint?: string;
+  /** OIDC audience Google actually signs tokens with, when it could be read. */
+  actualAudience?: string;
+  watchExpiration?: string;
+  lastPushReceivedAt?: string;
+  overallStatus: DiagnosticsStepStatus;
+}
+
+export interface GmailDiagnosticsReport {
+  createdAt: string;
+  summary: GmailDiagnosticsSummary;
+  steps: GmailDiagnosticsStep[];
+  recommendations: string[];
+  supportBundle: Record<string, unknown>;
+}


### PR DESCRIPTION
## Summary

Fixes silent failures in the Gmail Pub/Sub inbound-email pipeline: setup and refresh now hard-fail instead of reporting fake success, base-URL/audience derivation is unified into one helper, watch expiry is surfaced loudly, and tenant secrets no longer default onto a single-attach PV.

- **Single base-URL / OIDC-audience source of truth** (`packages/integrations/src/utils/email/gmailPubSub.ts`): provisioning, webhook JWT-audience verification, and `emailProviderActions` all resolve the public base URL and topic/subscription names from one helper, precedence `NGROK_URL > NEXT_PUBLIC_BASE_URL > NEXTAUTH_URL > PUBLIC_WEBHOOK_BASE_URL` (env, then app secret). Previously each caller derived its own URL, so a mismatch produced silent 401s on inbound webhooks.
- **Hard-fail on non-public base URL**: Gmail setup now refuses to configure Pub/Sub against `localhost`/private-IP/`http://` addresses instead of silently falling back to `http://localhost:3000`, and names the exact env var/secret it read so the operator knows what to fix.
- **Real re-verification on every save/refresh**: removed the 24h `pubsub_initialised_at` cooldown that was short-circuiting `configureGmailProvider` into a fake "already configured" success. Every save or `Refresh Pub/Sub & Watch` now re-provisions the topic/subscription/watch and reports the real result.
- **IAM/watch failures are hard errors**: `EmailProviderLifecycleService`/`EmailWebhookMaintenanceService` now persist and surface Google's actual error (e.g. IAM permission denied, `invalid_grant`) instead of a warn-only "success."
- **Gmail Delivery Diagnostics dialog** (`GmailDiagnosticsDialog.tsx` + `GmailDiagnosticsService.ts`): new 7-step live diagnostic (base URL, topic, publisher IAM binding, subscription, watch registration, watch expiry, "is push actually arriving") with per-step remediation text and real calls to `pubsub.googleapis.com`.
- **Watch-expiry visibility on CE**: expired or soon-to-expire Gmail watches now render a destructive/warning alert on the provider card instead of failing silently the next time mail should have arrived.
- **`last_push_received_at` column** (migration `20260818120000_add_gmail_last_push_received_at`): the Google webhook route stamps this after JWT verification succeeds; diagnostics reads it as delivery evidence.
- **Webhook route hardening** (`googleWebhookHandler.ts`): audience checks and unusable-base-URL configuration faults are now logged distinctly from a bad bearer token, instead of both failing the same opaque way.
- **Tenant secrets / Helm**: `tenantSecrets.persistence` now defaults to disabled and the chart hard-fails if persistence is enabled together with `replicaCount > 1`, since no RWX StorageClass exists across the target clusters (local-path, microk8s-hostpath, ceph-rbd, nm-thin/linstor are all single-attach). Multi-replica installs must set `secrets_provider.writeProvider=vault`.
- Docs: new `docs/inbound-email/setup/gmail-google-cloud-prerequisites.md`, updates to `docs/inbound-email/setup/gmail.md`, and the design plan under `docs/EE_docs/...gmail-pubsub-inbound-silent-failures-plan.md`.

## Smoke test

Ran live through the real UI (host-owned browser pane) against a dev server on the card's own worktree (`PORT=3589 npm run dev`, Postgres `127.0.0.1:6472`, tenant Oz, user `glinda@emeraldcity.oz`), with DB/HTTP verification for each step. Result: **all 9 exercised flows behaved as designed** — the old silent-success paths are gone and replaced with honest failures naming the exact cause and remediation:

1. Entered tenant Google credentials (project id, OAuth client, service-account JSON) via Settings > Integrations > Providers → status flipped to "Google: Ready", secrets landed on disk.
2. Added a Gmail provider with base URL `http://localhost:3589` → setup correctly refused with "not an HTTPS address," naming `NEXTAUTH_URL`/`NGROK_URL`; persisted to `email_providers.status='error'` with that message (previously silent success).
3. Provider card renders the persisted error plus a new destructive "Gmail push delivery is not registered" alert with a Refresh action.
4. Removed the 24h cooldown by resetting `pubsub_initialised_at`; refresh re-provisioned and failed honestly via `/api/email/refresh-watch` (409 with the real error, vs. the old code returning `pubsubConfigured/watchRegistered=true` within the cooldown window).
5. Set app secret `NGROK_URL` (with a trailing slash, to check normalization) → refresh got past the base-URL guard and hit the real Google API, which rejected the simulated service-account credential (`invalid_grant`); confirmed `NGROK_URL` (app secret) takes precedence over `NEXTAUTH_URL` (env), live.
6. Gmail Delivery Diagnostics dialog: all 7 steps ran, each making real calls to `pubsub.googleapis.com` (129–174ms) and reporting Google's actual error plus the specific IAM permission to grant; base-URL step correctly flips Fail→Pass and normalizes the trailing slash once `NGROK_URL` is set.
7. Watch-expiry alerts on CE: past expiry → destructive "Gmail is no longer sending new mail here"; expiry within 12h → warning "Gmail push delivery expires within a day."
8. Real HTTP POSTs to the webhook route: bogus bearer token → 401 with `expectedAudience`/`baseUrlSource` logged, `last_push_received_at` stays NULL; base URL pointed at a sub-path (`.../alga`) → 401 with a distinct "configured webhook base URL is unusable" log instead of silently verifying against the container-internal origin (same rejection also enforced at setup time in the UI).
9. Confirmed no regression on the Microsoft 365 card after the shared `getExpirationStatus` refactor (still shows its own expiry text, diagnostics still run).

**Fidelity compromises (disclosed):** no real GCP project was reachable, so the service-account key was a locally generated RSA key — all Google calls were real network calls, and Google's rejection (`invalid_grant`) is what exercised the hard-failure paths; the success branches of IAM grant/topic create/subscription read-back/`watch()` remain unproven against live Google. The successful-push path (`last_push_received_at` write + enqueue) needs a Google-signed OIDC token and wasn't forged, so only the negative (401 → timestamp stays NULL) side is proven. Full detail is in the card record.

One pre-existing, unrelated bug was hit and worked around (not part of this diff): a turbopack dev-mode issue in `packages/integrations/src/actions/integrations/rmmIntegrationStatusActions.ts` (commit `c000babf67`) 500s every action from the integrations barrel; temporarily patched locally to run the smoke test, then reverted (`git status` clean on this branch).

## Test plan

- [x] Manual smoke test of all flows above against a live dev server and real Google Pub/Sub API
- [ ] CI checks (owned by the follow-up CI Watch step)
