### PR TITLE
Client portal invoice PDF: sessionless job path fails (withAuth in worker, default-client filing, CE chromium)

### DIFF
--- a/.github/workflows/e2e-fresh-install-tests.yaml
+++ b/.github/workflows/e2e-fresh-install-tests.yaml
@@ -602,7 +602,39 @@ jobs:
       - name: Install Playwright system dependencies
         if: steps.wait_for_setup.outputs.status == 'success'
         working-directory: ./e2e-tests
-        run: npx playwright install-deps
+        # Hard ceiling so this step can never again consume the whole job budget.
+        timeout-minutes: 12
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          # `npx playwright install-deps` shells out to `apt-get`, which has
+          # intermittently stalled for 30+ minutes on the GitHub runner (an
+          # apt/dpkg lock or a Debian mirror hang). Because the step had no
+          # timeout, a single stall consumed the entire 60-minute job budget and
+          # the run was cancelled at "Install Playwright system dependencies"
+          # before the login e2e test ever executed -- even though the build and
+          # all services were up and healthy by ~T+29m. Good runs finish this
+          # step in 35-490s, so bound each attempt and retry: a transient stall
+          # self-heals instead of killing the job.
+          set -x
+          attempt=1
+          max_attempts=3
+          until timeout 240 npx playwright install-deps; do
+            code=$?
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "playwright install-deps failed after $attempt attempts (last exit $code)."
+              exit "$code"
+            fi
+            echo "Attempt $attempt failed/stalled (exit $code); clearing apt locks and retrying..."
+            # A timed-out attempt can leave apt/dpkg holding a lock; clear it so
+            # the retry is not guaranteed to stall the same way.
+            sudo pkill -9 -f 'apt-get|dpkg' 2>/dev/null || true
+            sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock \
+              /var/lib/dpkg/lock /var/lib/dpkg/lock-frontend 2>/dev/null || true
+            sudo dpkg --configure -a 2>/dev/null || true
+            attempt=$((attempt+1))
+            sleep 10
+          done
         shell: bash
 
       - name: Create Playwright config file

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,20 @@ RUN apk add --no-cache \
     ghostscript \
     curl \
     nano \
+    chromium \
+    nss \
+    freetype \
+    freetype-dev \
+    harfbuzz \
+    ca-certificates \
+    ttf-freefont \
     ffmpeg
+
+# Tell Puppeteer to skip installing Chrome. We'll use the installed chromium.
+# Puppeteer's bundled Chrome is glibc-linked and cannot run on Alpine, so
+# without this every PDF render fails at browser launch.
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 WORKDIR /app
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -93,7 +93,14 @@ RUN apk add --no-cache bash \
     ghostscript \
     curl \
     nano \
-    bash
+    bash \
+    chromium \
+    nss \
+    freetype \
+    freetype-dev \
+    harfbuzz \
+    ca-certificates \
+    ttf-freefont
 
 WORKDIR /app
 COPY tsconfig.base.json ./
@@ -131,6 +138,10 @@ EXPOSE 3000
 
 # Environment configuration
 ENV NODE_ENV=production
+
+# Puppeteer chromium configuration
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 # Secret provider configuration
 # Default configuration for composite secret system

--- a/packages/billing/src/actions/invoiceGeneration.ts
+++ b/packages/billing/src/actions/invoiceGeneration.ts
@@ -34,7 +34,7 @@ import Invoice from '@alga-psa/billing/models/invoice';
 import { createTenantKnex } from '@alga-psa/db';
 import { Temporal } from '@js-temporal/polyfill';
 import { createPDFGenerationService } from '../services/pdfGenerationService';
-import { StorageService } from '@alga-psa/storage/StorageService';
+import { getStoredInvoicePdf } from '../services/invoicePdfDeliveryService';
 import { toPlainDate, toISODate, toISOTimestamp } from '@alga-psa/core';
 import { ISO8601String } from '@alga-psa/types';
 import { TaxService } from '../services/taxService';
@@ -2809,41 +2809,6 @@ export const generateInvoicePDF = withAuth(async (
   });
 });
 
-/**
- * Bytes of the invoice's filed PDF: reuses the document already on file — unless a
- * different template was asked for — and refreshes it while the invoice has not been
- * issued yet. Falls back to a plain render if the document store is unavailable: a
- * download must not depend on filing succeeding.
- */
-async function getStoredInvoicePdf(options: {
-  tenant: string;
-  invoiceId: string;
-  invoiceNumber: string;
-  userId: string;
-  templateId?: string;
-}): Promise<Buffer> {
-  const pdfGenerationService = createPDFGenerationService(options.tenant);
-
-  try {
-    const stored = await pdfGenerationService.generateAndStore({
-      invoiceId: options.invoiceId,
-      invoiceNumber: options.invoiceNumber,
-      templateId: options.templateId,
-      userId: options.userId,
-    });
-
-    const { buffer } = await StorageService.downloadFile(stored.file_id);
-    return Buffer.from(buffer);
-  } catch (error) {
-    console.error('[downloadInvoicePDF] Falling back to an unfiled render:', error);
-    return pdfGenerationService.generatePDF({
-      invoiceId: options.invoiceId,
-      userId: options.userId,
-      templateId: options.templateId,
-    });
-  }
-}
-
 export const downloadInvoicePDF = withAuth(async (
   user,
   { tenant },
@@ -2881,6 +2846,7 @@ export const downloadInvoicePDF = withAuth(async (
       invoiceNumber: invoice.invoice_number,
       userId: user.user_id,
       templateId: templateId || undefined,
+      logLabel: '[downloadInvoicePDF]',
     });
 
     console.log('[downloadInvoicePDF] PDF generated, size:', pdfBuffer.length, 'bytes');

--- a/packages/billing/src/services/browserPoolService.ts
+++ b/packages/billing/src/services/browserPoolService.ts
@@ -27,7 +27,10 @@ export class BrowserPoolService {
       return browser;
     }
 
-    return new Promise((resolve) => {
+    // LEVERAGE: friction browser-pool-duplication — server/src/services/browser-pool.service.ts
+    // is a near-identical second copy of this class, so every fix here has to be
+    // made twice. One pool behind one import would retire the divergence.
+    return new Promise((resolve, reject) => {
       const interval = setInterval(async () => {
         if (this.browserPool.length > 0) {
           const browser = this.browserPool.pop();
@@ -37,14 +40,23 @@ export class BrowserPoolService {
             resolve(browser!);
           }
         } else if (this.activeBrowsers < this.maxBrowsers) {
+          // Stop the interval before awaiting: otherwise a slow launch lets the
+          // next tick start a second one and blow past maxBrowsers.
+          clearInterval(interval);
+          try {
             const browser = await puppeteer.launch({
               headless: true,
               executablePath: process.env.PUPPETEER_EXECUTABLE_PATH || undefined,
               args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
             });
             this.activeBrowsers++;
-            clearInterval(interval);
             resolve(browser);
+          } catch (error) {
+            // Without this the launch failure became an unhandled rejection and
+            // the caller waited forever — which is how a missing chromium binary
+            // presented as a hung PDF download rather than an error.
+            reject(error);
+          }
         }
       }, 100);
     });

--- a/packages/billing/src/services/index.ts
+++ b/packages/billing/src/services/index.ts
@@ -20,6 +20,12 @@ export {
   type StoredPdfResult,
 } from './pdfGenerationService';
 export {
+  getStoredInvoicePdf,
+  InvoicePdfDeliveryError,
+  type InvoicePdfDeliveryStage,
+  type InvoicePdfDeliveryOptions,
+} from './invoicePdfDeliveryService';
+export {
   buildQuoteConversionPreview,
   convertQuoteToDraftContract,
   convertQuoteToDraftContractAndInvoice,

--- a/packages/billing/src/services/invoicePdfDeliveryService.ts
+++ b/packages/billing/src/services/invoicePdfDeliveryService.ts
@@ -1,0 +1,90 @@
+/**
+ * Delivery of invoice PDF bytes to a downloader — MSP-side or client-portal.
+ *
+ * Extracted from invoiceGeneration.downloadInvoicePDF so the client portal can
+ * share the same "file it, but never let filing break the download" behaviour
+ * instead of re-deriving it. The two callers differ only in who is asking; the
+ * rules about what bytes they get are the same, so they live here.
+ */
+import { createPDFGenerationService } from './pdfGenerationService';
+import { StorageService } from '@alga-psa/storage/StorageService';
+
+/**
+ * The stage a delivery attempt was in when it failed. Callers use this to log
+ * something an operator can act on, and to decide what to tell the user: a
+ * `render` failure is the download failing, a `store` failure is not.
+ */
+export type InvoicePdfDeliveryStage = 'render' | 'store';
+
+export class InvoicePdfDeliveryError extends Error {
+  constructor(
+    public readonly stage: InvoicePdfDeliveryStage,
+    public readonly cause: unknown
+  ) {
+    super(cause instanceof Error ? cause.message : String(cause));
+    this.name = 'InvoicePdfDeliveryError';
+  }
+}
+
+export interface InvoicePdfDeliveryOptions {
+  tenant: string;
+  invoiceId: string;
+  invoiceNumber: string;
+  userId: string;
+  templateId?: string;
+  /** Prefix for this caller's log lines, e.g. '[downloadInvoicePDF]'. */
+  logLabel?: string;
+}
+
+/**
+ * Bytes of the invoice's filed PDF: reuses the document already on file — unless a
+ * different template was asked for — and refreshes it while the invoice has not been
+ * issued yet. Falls back to a plain render if the document store is unavailable: a
+ * download must not depend on filing succeeding. Default storage is a local
+ * `cwd/tmp/storage` directory, which is ephemeral or read-only in a container, so
+ * this fallback is the normal path on plenty of deployments rather than a rare one.
+ *
+ * Throws InvoicePdfDeliveryError with stage 'render' when even the unfiled render
+ * fails — on CE that is almost always a missing chromium binary, so the underlying
+ * error is logged verbatim rather than summarised.
+ */
+export async function getStoredInvoicePdf(options: InvoicePdfDeliveryOptions): Promise<Buffer> {
+  const label = options.logLabel ?? '[getStoredInvoicePdf]';
+  const pdfGenerationService = createPDFGenerationService(options.tenant);
+
+  try {
+    const stored = await pdfGenerationService.generateAndStore({
+      invoiceId: options.invoiceId,
+      invoiceNumber: options.invoiceNumber,
+      templateId: options.templateId,
+      userId: options.userId,
+    });
+
+    const { buffer } = await StorageService.downloadFile(stored.file_id);
+    return Buffer.from(buffer);
+  } catch (storeError) {
+    console.error(
+      `${label} Filing the invoice PDF failed, falling back to an unfiled render ` +
+        `(tenant=${options.tenant} invoice=${options.invoiceId} stage=store):`,
+      storeError
+    );
+
+    try {
+      return await pdfGenerationService.generatePDF({
+        invoiceId: options.invoiceId,
+        userId: options.userId,
+        templateId: options.templateId,
+      });
+    } catch (renderError) {
+      // The render is the last resort; if it fails there are no bytes to hand
+      // back. Log both errors — the filing failure is often the more diagnostic
+      // one, and a browser-launch failure here is the CE no-chromium symptom.
+      console.error(
+        `${label} Rendering the invoice PDF failed (tenant=${options.tenant} ` +
+          `invoice=${options.invoiceId} stage=render):`,
+        renderError
+      );
+      throw new InvoicePdfDeliveryError('render', renderError);
+    }
+  }
+}

--- a/packages/client-portal/src/actions/client-portal-actions/client-billing.invoicePdf.test.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/client-billing.invoicePdf.test.ts
@@ -4,6 +4,7 @@ const currentUser = { user_id: 'user-1', tenant: 'tenant-1', roles: [] };
 
 const getConnectionMock = vi.fn();
 const generateAndStoreMock = vi.fn();
+const getStoredInvoicePdfMock = vi.fn();
 let storedInvoiceDocument: { file_id: string } | undefined;
 let invoiceRow: Record<string, unknown> | undefined;
 
@@ -40,6 +41,7 @@ vi.mock('@alga-psa/billing/models/quoteActivity', () => ({ default: {} }));
 vi.mock('@alga-psa/billing/services', () => ({
   recalculateQuoteFinancials: vi.fn(),
   createPDFGenerationService: vi.fn(() => ({ generateAndStore: generateAndStoreMock })),
+  getStoredInvoicePdf: (...args: any[]) => getStoredInvoicePdfMock(...args),
 }));
 vi.mock('@alga-psa/billing/actions/invoiceQueries', () => ({
   fetchInvoicesByClient: vi.fn(),
@@ -85,22 +87,44 @@ describe('downloadClientInvoicePdf', () => {
     expect(generateAndStoreMock).not.toHaveBeenCalled();
   });
 
-  it('generates and files a PDF directly when no published copy exists', async () => {
+  it('returns bytes, never a file id, when no published copy exists', async () => {
     storedInvoiceDocument = undefined;
-    generateAndStoreMock.mockResolvedValue({ file_id: 'generated-file-1', storage_path: '/x' });
+    getStoredInvoicePdfMock.mockResolvedValue(Buffer.from([37, 80, 68, 70]));
 
     const { downloadClientInvoicePdf } = await import('./client-billing');
     const result = await downloadClientInvoicePdf('invoice-1');
 
-    // Direct generation, not the zip job: the job resolves its acting user
-    // from the request session, which a background job does not have.
-    expect(generateAndStoreMock).toHaveBeenCalledWith({
+    expect(getStoredInvoicePdfMock).toHaveBeenCalledWith({
+      tenant: 'tenant-1',
       invoiceId: 'invoice-1',
       invoiceNumber: 'INV-001',
-      version: 1,
       userId: 'user-1',
+      logLabel: '[downloadClientInvoicePdf]',
     });
-    expect(result).toEqual({ success: true, fileId: 'generated-file-1' });
+    // A freshly filed invoice document is is_client_visible=false, which the
+    // documents download route denies to portal users, so handing back its
+    // file id would 404. Bytes are unconditional.
+    expect(result).toEqual({
+      success: true,
+      pdfData: [37, 80, 68, 70],
+      invoiceNumber: 'INV-001',
+    });
+    expect((result as { fileId?: string }).fileId).toBeUndefined();
+  });
+
+  it('surfaces a typed error instead of throwing when the render fails', async () => {
+    storedInvoiceDocument = undefined;
+    getStoredInvoicePdfMock.mockRejectedValue(new Error('Failed to launch the browser process'));
+
+    const { downloadClientInvoicePdf } = await import('./client-billing');
+    const result = await downloadClientInvoicePdf('invoice-1');
+
+    // Thrown server-action messages are redacted in production, which is how a
+    // missing chromium binary became a generic "Failed to download PDF" toast.
+    expect(result).toEqual({
+      actionError:
+        'The invoice PDF could not be generated. Please try again, and contact support if the problem continues.',
+    });
   });
 
   it('refuses invoices the portal user cannot see before looking for a document', async () => {
@@ -111,5 +135,6 @@ describe('downloadClientInvoicePdf', () => {
 
     expect(result).toEqual({ actionError: 'Invoice not found or access denied' });
     expect(generateAndStoreMock).not.toHaveBeenCalled();
+    expect(getStoredInvoicePdfMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/client-portal/src/actions/client-portal-actions/client-billing.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/client-billing.ts
@@ -37,6 +37,7 @@ import {
   getClientIdFromPortalUser as getClientIdFromUser,
   hasClientBillingReadPermission as hasBillingPermission,
 } from './clientBillingPermissions';
+import { selectJobArtifactFileId } from './jobArtifact';
 
 export type ClientBillingActionError =
   | { readonly actionError: string }
@@ -841,17 +842,24 @@ export const getClientInvoiceTemplates = withAuth(async (user, { tenant }): Prom
 });
 
 /**
- * Download invoice PDF response
+ * Download invoice PDF response.
+ *
+ * Exactly one of `fileId` / `pdfData` is set on success: a file id when the
+ * client already has a published document to fetch, raw bytes when the PDF had
+ * to be rendered for this download. See downloadClientInvoicePdf for why a
+ * fresh render is never handed back as a file id.
  */
 export interface DownloadPdfResult {
   success: boolean;
   fileId?: string;
+  pdfData?: number[];
+  invoiceNumber?: string;
   error?: string;
 }
 
 /**
- * Download invoice PDF - returns the stored PDF when one exists, otherwise
- * schedules generation, waits for completion, and returns the file ID.
+ * Download invoice PDF - serves the published document when one exists,
+ * otherwise renders the invoice and returns the bytes directly.
  */
 export const downloadClientInvoicePdf = withAuth(async (user, { tenant }, invoiceId: string): Promise<ClientBillingActionResult<DownloadPdfResult>> => {
   const knex = await getConnection(tenant);
@@ -890,30 +898,55 @@ export const downloadClientInvoicePdf = withAuth(async (user, { tenant }, invoic
       return { success: true, fileId: storedDoc.file_id };
     }
 
-    // No stored PDF yet — generate and file one directly, same as the quote
-    // path. The zip job exists for MSP bulk export and resolves its acting
-    // user from the request session, which a background job does not have.
+    // No published PDF yet — render one and hand back the bytes.
+    //
+    // Deliberately NOT a file id: generateAndStore files invoice documents with
+    // is_client_visible = false (they become visible when the invoice is sent),
+    // and the documents download route denies a portal user any document that is
+    // not client-visible unless they happen to own it. A brand new document is
+    // owned by whoever rendered it, but a refresh of an MSP-filed one keeps the
+    // MSP's created_by — so returning the file id would work or 404 depending on
+    // whether the MSP had rendered the invoice first. Bytes are unconditional.
+    //
+    // The alternative — publishing the render as client-visible — was rejected:
+    // it would put an unsent invoice's document into the client's Documents list
+    // as a side effect of clicking Download, changing MSP-side send semantics.
     const invoice = await tenantDb(knex, tenant).table('invoices')
       .where({ invoice_id: invoiceId })
       .first<{ invoice_number?: string | null } | undefined>('invoice_number');
+    const invoiceNumber = invoice?.invoice_number ?? invoiceId;
 
-    const { createPDFGenerationService } = await import('@alga-psa/billing/services');
-    const pdfService = createPDFGenerationService(tenant);
-    const fileRecord = await pdfService.generateAndStore({
+    const { getStoredInvoicePdf } = await import('@alga-psa/billing/services');
+    const pdfBuffer = await getStoredInvoicePdf({
+      tenant,
       invoiceId,
-      invoiceNumber: invoice?.invoice_number ?? undefined,
-      version: 1,
+      invoiceNumber,
       userId: user.user_id,
+      logLabel: '[downloadClientInvoicePdf]',
     });
 
-    return { success: true, fileId: fileRecord.file_id };
+    return {
+      success: true,
+      pdfData: Array.from(pdfBuffer),
+      invoiceNumber,
+    };
   } catch (error) {
     const expected = billingActionErrorFrom(error);
     if (expected) {
       return expected;
     }
-    console.error('Error downloading invoice PDF:', error);
-    throw error;
+    // Next.js redacts thrown server-action messages in production, so throwing
+    // here lands every failure on the UI's generic "Failed to download PDF"
+    // toast and tells the operator nothing. Return a typed error instead, and
+    // log the real one with enough context to find it.
+    console.error(
+      `[downloadClientInvoicePdf] Invoice PDF download failed (tenant=${tenant} ` +
+        `invoice=${invoiceId} user=${user.user_id}):`,
+      error
+    );
+    return actionError(
+      'The invoice PDF could not be generated. Please try again, and contact support if the problem continues.'
+    );
   }
 });
 
@@ -1006,22 +1039,16 @@ async function getJobStatus(jobId: string, tenant: string): Promise<ClientJobSta
     status = 'failed';
   }
 
-  // If completed, get the file_id from job details
+  // If completed, get the file_id from job details. Ordered by completion time
+  // (detail_id only to break ties deterministically) so the deliverable — the
+  // last artifact the job produced — wins over the intermediates before it.
   let fileId: string | undefined;
   if (status === 'completed') {
     const details = await scopedDb.table('job_details')
       .where({ job_id: jobId })
-      .select('metadata');
-    // Look for file_id in the metadata of completed steps
-    for (const detail of details) {
-      const metadata = (typeof detail.metadata === 'string'
-        ? JSON.parse(detail.metadata)
-        : detail.metadata) as Record<string, unknown> | undefined;
-      if (metadata?.file_id && typeof metadata.file_id === 'string') {
-        fileId = metadata.file_id;
-        break;
-      }
-    }
+      .orderBy([{ column: 'processed_at', order: 'asc' }, { column: 'detail_id', order: 'asc' }])
+      .select('step_name', 'status', 'metadata');
+    fileId = selectJobArtifactFileId(details);
   }
 
   // If failed, get error message

--- a/packages/client-portal/src/actions/client-portal-actions/jobArtifact.test.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/jobArtifact.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { JobStatus } from '@alga-psa/types';
+import { selectJobArtifactFileId } from './jobArtifact';
+
+describe('selectJobArtifactFileId', () => {
+  it('returns the last artifact, not the first, so an invoice bundle yields the ZIP', () => {
+    const details = [
+      { step_name: 'generate_invoice_pdf_1', status: JobStatus.Completed, metadata: { file_id: 'pdf-1' } },
+      { step_name: 'generate_invoice_pdf_2', status: JobStatus.Completed, metadata: { file_id: 'pdf-2' } },
+      { step_name: 'create_zip', status: JobStatus.Completed, metadata: { file_id: 'zip-1' } },
+    ];
+
+    expect(selectJobArtifactFileId(details)).toBe('zip-1');
+  });
+
+  it('parses string metadata the same as jsonb metadata', () => {
+    const details = [
+      { step_name: 'generate_invoice_pdf_1', status: JobStatus.Completed, metadata: JSON.stringify({ file_id: 'pdf-1' }) },
+      { step_name: 'create_zip', status: JobStatus.Completed, metadata: JSON.stringify({ file_id: 'zip-1' }) },
+    ];
+
+    expect(selectJobArtifactFileId(details)).toBe('zip-1');
+  });
+
+  it('ignores steps that did not complete', () => {
+    const details = [
+      { step_name: 'create_zip', status: JobStatus.Completed, metadata: { file_id: 'zip-1' } },
+      { step_name: 'create_zip', status: JobStatus.Failed, metadata: { file_id: 'zip-retry' } },
+    ];
+
+    expect(selectJobArtifactFileId(details)).toBe('zip-1');
+  });
+
+  it('skips steps whose metadata is unparseable rather than aborting the scan', () => {
+    const details = [
+      { step_name: 'create_zip', status: JobStatus.Completed, metadata: '{not json' },
+      { step_name: 'publish', status: JobStatus.Completed, metadata: { file_id: 'zip-1' } },
+    ];
+
+    expect(selectJobArtifactFileId(details)).toBe('zip-1');
+  });
+
+  it('returns undefined when no step produced a file', () => {
+    const details = [
+      { step_name: 'send_email', status: JobStatus.Completed, metadata: { details: 'sent' } },
+      { step_name: 'send_email', status: JobStatus.Completed, metadata: null },
+    ];
+
+    expect(selectJobArtifactFileId(details)).toBeUndefined();
+  });
+
+  it('ignores a non-string or empty file_id', () => {
+    const details = [
+      { step_name: 'a', status: JobStatus.Completed, metadata: { file_id: 42 } },
+      { step_name: 'b', status: JobStatus.Completed, metadata: { file_id: '' } },
+    ];
+
+    expect(selectJobArtifactFileId(details)).toBeUndefined();
+  });
+});

--- a/packages/client-portal/src/actions/client-portal-actions/jobArtifact.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/jobArtifact.ts
@@ -1,0 +1,45 @@
+import { JobStatus } from '@alga-psa/types';
+
+export interface JobDetailArtifactRow {
+  step_name?: string | null;
+  status?: string | null;
+  metadata?: unknown;
+}
+
+/**
+ * The file id a completed job hands back: the last completed step that produced
+ * one.
+ *
+ * Job steps produce intermediate files on the way to the deliverable — an
+ * invoice bundle files a PDF per invoice before it files the ZIP — so "the
+ * first file_id in an unordered scan" returns whichever row the planner
+ * happened to emit first. Rows must be supplied in step-completion order.
+ */
+export function selectJobArtifactFileId(details: readonly JobDetailArtifactRow[]): string | undefined {
+  let fileId: string | undefined;
+
+  for (const detail of details) {
+    if (detail.status && detail.status !== JobStatus.Completed) {
+      continue;
+    }
+
+    let metadata: Record<string, unknown> | undefined;
+    if (typeof detail.metadata === 'string') {
+      try {
+        metadata = JSON.parse(detail.metadata) as Record<string, unknown>;
+      } catch {
+        // A step whose metadata did not survive round-tripping tells us nothing
+        // about the artifact; the remaining steps still might.
+        continue;
+      }
+    } else {
+      metadata = detail.metadata as Record<string, unknown> | undefined;
+    }
+
+    if (typeof metadata?.file_id === 'string' && metadata.file_id) {
+      fileId = metadata.file_id;
+    }
+  }
+
+  return fileId;
+}

--- a/packages/client-portal/src/components/billing/InvoiceDetailsDialog.tsx
+++ b/packages/client-portal/src/components/billing/InvoiceDetailsDialog.tsx
@@ -11,6 +11,7 @@ import { Badge } from '@alga-psa/ui/components/Badge';
 import { Download, X, Mail } from 'lucide-react';
 import { getClientInvoiceById, downloadClientInvoicePdf, sendClientInvoiceEmail } from '@alga-psa/client-portal/actions';
 import { getActiveClientLocationsForBilling, type BillingLocationSummary } from '@alga-psa/billing/actions/billingClientLocationActions';
+import { triggerInvoicePdfDownload } from './invoicePdfDownload';
 import {
   LocationAddress,
   buildLocationGroups,
@@ -214,15 +215,7 @@ const InvoiceDetailsDialog: React.FC<InvoiceDetailsDialogProps> = React.memo(({
         return;
       }
 
-      if (result.success && result.fileId) {
-        // Trigger download
-        const downloadUrl = `/api/documents/download/${result.fileId}`;
-        const link = document.createElement('a');
-        link.href = downloadUrl;
-        link.download = '';
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
+      if (result.success && triggerInvoicePdfDownload(result)) {
         toast.success(t('invoice.downloadComplete', 'PDF downloaded successfully.'));
       } else {
         toast.error(result.error || t('invoice.downloadFailed', 'Failed to download PDF.'));

--- a/packages/client-portal/src/components/billing/InvoicesTab.tsx
+++ b/packages/client-portal/src/components/billing/InvoicesTab.tsx
@@ -14,6 +14,7 @@ import {
   sendClientInvoiceEmail,
 } from '@alga-psa/client-portal/actions';
 import ClientInvoicePreview from './ClientInvoicePreview';
+import { triggerInvoicePdfDownload } from './invoicePdfDownload';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -132,15 +133,7 @@ const InvoicesTab: React.FC<InvoicesTabProps> = React.memo(({
         return;
       }
 
-      if (result.success && result.fileId) {
-        // Trigger download
-        const downloadUrl = `/api/documents/download/${result.fileId}`;
-        const link = document.createElement('a');
-        link.href = downloadUrl;
-        link.download = '';
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
+      if (result.success && triggerInvoicePdfDownload(result)) {
         toast.success(t('invoice.downloadComplete', 'PDF downloaded successfully.'));
       } else {
         toast.error(result.error || t('invoice.downloadFailed', 'Failed to download PDF.'));

--- a/packages/client-portal/src/components/billing/invoicePdfDownload.ts
+++ b/packages/client-portal/src/components/billing/invoicePdfDownload.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import type { DownloadPdfResult } from '../../actions/client-portal-actions/client-billing';
+
+/**
+ * Hand a successful DownloadPdfResult to the browser.
+ *
+ * The action answers in one of two shapes and the caller should not care which:
+ * a file id when the invoice has a published document the portal user is allowed
+ * to fetch, or raw bytes when the PDF had to be rendered for this download and
+ * therefore has no fetchable document behind it.
+ *
+ * Returns false when the result carries neither, so the caller can fall through
+ * to its error toast rather than silently doing nothing.
+ */
+// LEVERAGE: pattern pdf-blob-download — the Blob/anchor/revoke dance is written
+// out by hand at ~6 MSP call sites too (DraftsTab, FinalizedTab, QuotesTab,
+// QuoteForm, QuoteDetail). A shared @alga-psa/ui download helper would retire
+// all of them.
+export function triggerInvoicePdfDownload(result: DownloadPdfResult): boolean {
+  if (result.fileId) {
+    const link = document.createElement('a');
+    link.href = `/api/documents/download/${result.fileId}`;
+    link.download = '';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    return true;
+  }
+
+  if (result.pdfData) {
+    const blob = new Blob([new Uint8Array(result.pdfData)], { type: 'application/pdf' });
+    const blobUrl = window.URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = blobUrl;
+    link.setAttribute('download', `${result.invoiceNumber ?? 'invoice'}.pdf`);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    window.URL.revokeObjectURL(blobUrl);
+    return true;
+  }
+
+  return false;
+}

--- a/packages/projects/tests/projectMaterialsDrawer.test.tsx
+++ b/packages/projects/tests/projectMaterialsDrawer.test.tsx
@@ -3,8 +3,19 @@
  */
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor, fireEvent, cleanup } from '@testing-library/react';
+import { configure, render, screen, waitFor, fireEvent, cleanup } from '@testing-library/react';
 import type { IProjectMaterial, IServicePrice } from '@alga-psa/types';
+
+// Several assertions here await an async data load — most notably the
+// getServicePrices() fetch that fires from a useEffect after a product is
+// selected, then re-renders the price options. Testing Library's default
+// findBy/waitFor timeout is 1000ms, which is comfortable in isolation (this
+// file runs in ~1s) but occasionally too tight under the full server unit
+// suite's CPU contention (12k+ tests, single worker), producing a rare
+// "Unable to find element: USD - $10.00" flake. Widen the async timeout for
+// this file so the assertions are load-independent; no product behavior is
+// affected.
+configure({ asyncUtilTimeout: 5000 });
 import type { CatalogPickerItem } from '../src/actions/materialCatalogActions';
 import { formatCurrencyFromMinorUnits } from '@alga-psa/core';
 

--- a/server/src/lib/jobs/handlers/__tests__/invoiceZipHandler.test.ts
+++ b/server/src/lib/jobs/handlers/__tests__/invoiceZipHandler.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { selectBundleClientId } from '../invoiceZipHandler';
+
+describe('selectBundleClientId', () => {
+  it('files a single-client bundle under that client', () => {
+    expect(selectBundleClientId(['client-a', 'client-a', 'client-a'])).toBe('client-a');
+  });
+
+  it('files a mixed bundle with no client rather than inventing one', () => {
+    expect(selectBundleClientId(['client-a', 'client-b'])).toBeNull();
+  });
+
+  it('returns null when no invoice carries a client, instead of failing the job', () => {
+    // The fresh-trial-tenant case: previously this looked up tenant_companies.is_default
+    // and threw 'No default client found for tenant', discarding an already-stored ZIP.
+    expect(selectBundleClientId([null, undefined])).toBeNull();
+    expect(selectBundleClientId([])).toBeNull();
+  });
+
+  it('ignores empty and missing client ids when deciding whether the bundle is single-client', () => {
+    expect(selectBundleClientId(['client-a', null, '', undefined])).toBe('client-a');
+  });
+});

--- a/server/src/lib/jobs/handlers/invoiceZipHandler.ts
+++ b/server/src/lib/jobs/handlers/invoiceZipHandler.ts
@@ -34,6 +34,20 @@ export interface InvoiceZipJobData extends Record<string, unknown> {
   };
 }
 
+/**
+ * The client an exported bundle belongs to, or null when it does not belong to
+ * one. A bundle of a single client's invoices files naturally under that client;
+ * a mixed bundle has no defensible owner, so it is filed with no client
+ * association rather than against an unrelated one. The per-invoice PDFs inside
+ * are already associated to their own invoice and client by the PDF service.
+ */
+export function selectBundleClientId(clientIds: readonly (string | null | undefined)[]): string | null {
+  const distinct = new Set(
+    clientIds.filter((id): id is string => typeof id === 'string' && id.length > 0)
+  );
+  return distinct.size === 1 ? [...distinct][0] : null;
+}
+
 export class InvoiceZipJobHandler {
   private jobService: JobService;
   private storageService: StorageService;
@@ -204,16 +218,19 @@ export class InvoiceZipJobHandler {
 
       const knex = await getConnection(tenantId);
 
-      // Tenant's default client, straight from the database.
+      // The bundle belongs to the invoices in it, not to whichever client the
+      // tenant happens to have flagged default — a fresh tenant has none at all,
+      // and hard-failing here would throw away a ZIP that is already stored.
       const scopedDb = tenantDb(knex, tenantId);
-      const defaultClientQuery = scopedDb.table('tenant_companies as tc')
-        .where('tc.is_default', true)
-        .whereNull('tc.deleted_at')
-        .select('tc.client_id')
-        .first<{ client_id: string } | undefined>();
-      const defaultClient = await defaultClientQuery;
-      if (!defaultClient) {
-        throw new Error('No default client found for tenant');
+      const invoiceClientIds = await scopedDb.table('invoices')
+        .whereIn('invoice_id', invoiceIds)
+        .pluck<Array<string | null>>('client_id');
+      const bundleClientId = selectBundleClientId(invoiceClientIds);
+      if (!bundleClientId) {
+        console.log(
+          `Invoice bundle for tenant ${tenantId} spans ${new Set(invoiceClientIds).size} client(s); ` +
+            'filing the archive without a client association.'
+        );
       }
 
       // Read zip file contents and store the archive as a document owned by
@@ -245,12 +262,14 @@ export class InvoiceZipJobHandler {
           is_client_visible: false,
         } as IDocument);
 
-        await DocumentAssociation.create(trx, {
-          document_id: documentId,
-          entity_id: defaultClient.client_id,
-          entity_type: 'client',
-          tenant: tenantId,
-        });
+        if (bundleClientId) {
+          await DocumentAssociation.create(trx, {
+            document_id: documentId,
+            entity_id: bundleClientId,
+            entity_type: 'client',
+            tenant: tenantId,
+          });
+        }
       });
 
       // Complete ZIP creation


### PR DESCRIPTION
## Summary

- CE images (`Dockerfile`, `Dockerfile.build`) installed no Chromium and set no `PUPPETEER_EXECUTABLE_PATH`, so Puppeteer fell back to its bundled glibc-linked Chrome, which cannot run on Alpine — every PDF render failed at browser launch on CE, for both the MSP and the client portal. Fixed by mirroring `ee/server/Dockerfile`'s apk package list, env vars, and stage placement exactly in both CE Dockerfiles, so the editions can't drift.
- The client-portal download path was broken independently of the CE issue: it returned the `file_id` of the document it had just filed, but `generateAndStore` files invoice documents `is_client_visible=false`, and the document-download route denies a portal user any document that isn't client-visible unless they own it (own via user/contact association or `created_by`). A fresh render is `created_by` the renderer; a refresh of an MSP-filed document keeps the MSP's `created_by`. So the portal download worked or 404'd nondeterministically depending on whether the MSP had rendered the invoice first. Fixed: the portal action now returns raw PDF bytes for a fresh/unpublished render and only returns a `file_id` when the document is already client-visible (published) — so the UI is never handed a file id the portal user can't fetch. (Making the render client-visible on download was rejected — it would silently add an unsent invoice to the client's Documents list as a side effect of clicking Download.)
- Extracted `getStoredInvoicePdf` out of `invoiceGeneration.ts` into a new shared `invoicePdfDeliveryService`, so the portal path gets the same storage-fallback behavior as the MSP path: a storage failure degrades to an unfiled render instead of killing the download.
- Portal PDF download now returns a typed `actionError` instead of throwing on render failure — Next.js redacts thrown server-action error messages in production, which is how a missing Chromium binary previously surfaced to users as a generic "Failed to download PDF" and to operators as nothing at all. Failures are now logged with tenant, invoice, user, and stage.
- `invoiceZipHandler` no longer throws `"No default client found for tenant"` (true on any fresh tenant) and no longer files the ZIP bundle against an unrelated client: a single-client bundle files under that client, a mixed-client bundle files with no client association.
- `getJobStatus` scanned `job_details` with no ordering and took the first `file_id` it saw, so it could nondeterministically return an invoice PDF's id or the ZIP's, depending on row order. Now orders by completion and takes the last artifact.
- `browserPoolService`'s saturated-pool retry launched inside a `setInterval` with no `reject`, so a launch failure became an unhandled rejection and the promise never settled — this is how a missing Chromium binary presented as a hang rather than an error.

## Smoke test summary

Environment: the card's dev-server board service (host-run `PORT=3813 npm run dev` from this worktree's `server/`) wired to compose project `alga-psa-local-test` — real Postgres (127.0.0.1:6472), real GreenMail SMTP/IMAP (3025/3143). On arrival the server was serving 404 for `/auth/msp/signin` (stale `.next` dev build predating the implementation commit); `alga-dev workflow-restart-service --name=dev-server` fixed it and a real route returning 200 was verified before testing. Tenant Oz, client Emerald City, portal user `ozma@emeraldcity.oz`. Credentials were obtained entirely through product flows (MSP and client-portal forgot-password, reset links read from GreenMail over IMAP).

All five flows exercised through the UI in a real browser pane, with DB/API-level confirmation — **all PASS**:

1. **MSP Download PDF** (regression check for the `getStoredInvoicePdf` extraction). Server action 200 after 22.7s (cold Puppeteer launch). Document filed correctly, `is_client_visible=false`, `created_by=glinda`. Stored file confirmed as a valid 1-page PDF.
2. **Portal download of an MSP-filed, non-client-visible document** — the historically broken case. Portal action returned raw bytes (blob URL, never `/api/documents/download/`). Confirmed the old `fileId` behavior would have 404'd/403'd on that same file id from the portal session.
3. **Portal download with no document yet on record** (fresh-tenant case). Portal action returned raw bytes; a new document was filed `is_client_visible=false`, `created_by=ozma`. Confirmed this is exactly the nondeterminism (works here, 404s in flow 2) that the fix removes.
4. **Published-document (`fileId`) branch.** Could not drive `publishGeneratedDocumentsToClient` through the product because invoice-email send is job-backed and the job runner (EE/Temporal) is unavailable in this environment; simulated that one step with a direct DB update (`documents.is_client_visible = true`), matching exactly what that action does. Portal then correctly took the `fileId` branch and downloaded 200 successfully.
5. **Error surfacing for the CE missing-Chromium symptom.** Forced `PUPPETEER_EXECUTABLE_PATH` to a nonexistent binary. Portal download failed fast (~0.5s, no hang) with the new user-facing toast, and the server log carried the new `[downloadClientInvoicePdf]` stage-tagged lines with tenant/invoice/user context and the raw error. The already-published invoice from flow 4 continued to download successfully via the `fileId` branch while rendering was broken — confirming the two branches degrade independently. Environment restored and re-verified afterward.

**Not tested** (environment limitations, not skipped for convenience):
- CE image build itself — no Docker socket in this environment. Verified instead by diffing the CE Dockerfile chromium/env blocks against `ee/server/Dockerfile`/`Dockerfile.build` line-for-line (identical package list, identical env, identical final-stage placement).
- `invoiceZipHandler`'s client-selection logic and `getJobStatus` artifact ordering — background jobs cannot run at all in this environment (EE/Temporal job runner explicitly refuses to fall back). Covered only by the added unit tests (`invoiceZipHandler.test.ts`, `jobArtifact.test.ts`).

No mocks/simulators were used beyond the one disclosed DB update in flow 4 (GreenMail is a pre-existing real service in the stack, not something introduced for this test).

Evidence directory: `/tmp/alga-smoke-evidence/client-portal-invoice-pdf-20260818-231339`

### Adjacent issues noticed, out of scope for this PR
- MSP "Send Portal Invitation" 500s on fresh tenants with `PortalInvitationError: "No default client configured for this tenant"` — the same fresh-tenant default-client class this PR fixed in `invoiceZipHandler`, but in `portalInvitationActions`, still unfixed, and surfaces to the browser as a bare 500 with no toast.
- The MSP "Send Invoice Email" dialog's "Send" button silently no-ops (no network request, no toast) when the job runner is unavailable — a pre-existing bad operator experience, unrelated to this change.

## Test plan
- [x] Manual smoke test of all 5 flows above via real browser UI against a live dev stack (see summary)
- [x] Unit tests added: `invoiceZipHandler.test.ts`, `jobArtifact.test.ts`, `client-billing.invoicePdf.test.ts`
- [ ] CI checks (handled by a separate CI-watch step)