### PR TITLE
Filter empty unresolved billing windows

### DIFF
--- a/packages/billing/src/actions/billingAndTax.ts
+++ b/packages/billing/src/actions/billingAndTax.ts
@@ -822,7 +822,179 @@ async function fetchClientBillingMetadataById(
     );
 }
 
+type PotentialUnresolvedTimeEntry = {
+    entry_id: string;
+    start_time: Date | string;
+    end_time: Date | string;
+    project_client_id?: string | null;
+    ticket_client_id?: string | null;
+};
+
+type PotentialUnresolvedUsageRecord = {
+    usage_id: string;
+    client_id: string;
+    usage_date: Date | string;
+};
+
+type BillingPeriodWindow = {
+    period: BillingPeriodWithMeta;
+    startMs: number;
+    endMs: number;
+};
+
+function toTimestampMs(value: Date | string | null | undefined): number | null {
+    if (value == null) {
+        return null;
+    }
+
+    const timestamp = value instanceof Date ? value.getTime() : Date.parse(value);
+    return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+/**
+ * Find billing periods that can actually contain unresolved non-contract work.
+ *
+ * The previous reader invoked the full billing engine once for every open
+ * billing period, even though almost all periods contained no unresolved
+ * source rows. Large tenants therefore paid for thousands of transactions and
+ * repeated context/tax/source queries before pagination.
+ *
+ * These two tenant-scoped reads mirror the billing engine's coarse eligibility
+ * filters. They deliberately do not reproduce pricing, deterministic contract
+ * reconciliation, project-cap handling, or tax behavior; the authoritative
+ * billing-engine call still performs all of that for each populated window.
+ */
+async function filterBillingPeriodsWithPotentialUnresolvedWork(
+    trx: BillingQueryExecutor,
+    tenant: string,
+    candidateBillingPeriods: BillingPeriodWithMeta[],
+): Promise<BillingPeriodWithMeta[]> {
+    if (candidateBillingPeriods.length === 0) {
+        return [];
+    }
+
+    const windowsByClientId = new Map<string, BillingPeriodWindow[]>();
+    let earliestStart: ISO8601String | null = null;
+    let latestEnd: ISO8601String | null = null;
+
+    for (const period of candidateBillingPeriods) {
+        const start = normalizeDateOnly(period.period_start_date) as ISO8601String | null;
+        const end = normalizeDateOnly(period.period_end_date) as ISO8601String | null;
+        const startMs = toTimestampMs(start);
+        const endMs = toTimestampMs(end);
+        if (!period.client_id || !start || !end || startMs == null || endMs == null) {
+            continue;
+        }
+
+        const windows = windowsByClientId.get(period.client_id) ?? [];
+        windows.push({ period, startMs, endMs });
+        windowsByClientId.set(period.client_id, windows);
+        earliestStart = earliestStart == null || start < earliestStart ? start : earliestStart;
+        latestEnd = latestEnd == null || end > latestEnd ? end : latestEnd;
+    }
+
+    if (!earliestStart || !latestEnd || windowsByClientId.size === 0) {
+        return [];
+    }
+
+    const clientIds = Array.from(windowsByClientId.keys());
+    const db = tenantDb(trx, tenant);
+    const potentialTimeEntriesQuery = db.table('time_entries');
+    db.tenantJoin(
+        potentialTimeEntriesQuery,
+        'project_tasks',
+        'time_entries.work_item_id',
+        'project_tasks.task_id',
+        { type: 'left' },
+    );
+    db.tenantJoin(
+        potentialTimeEntriesQuery,
+        'project_phases',
+        'project_tasks.phase_id',
+        'project_phases.phase_id',
+        { type: 'left' },
+    );
+    db.tenantJoin(
+        potentialTimeEntriesQuery,
+        'projects',
+        'project_phases.project_id',
+        'projects.project_id',
+        { type: 'left' },
+    );
+    db.tenantJoin(
+        potentialTimeEntriesQuery,
+        'tickets',
+        'time_entries.work_item_id',
+        'tickets.ticket_id',
+        { type: 'left' },
+    );
+
+    const [potentialTimeEntries, potentialUsageRecords] = await Promise.all([
+        potentialTimeEntriesQuery
+            .where('time_entries.tenant', tenant)
+            .where('time_entries.invoiced', false)
+            .whereNull('time_entries.contract_line_id')
+            .whereNotNull('time_entries.service_id')
+            .where('time_entries.approval_status', 'APPROVED')
+            .where('time_entries.billable_duration', '>', 0)
+            .where('time_entries.start_time', '>=', earliestStart)
+            .where('time_entries.end_time', '<', latestEnd)
+            .select(
+                'time_entries.entry_id',
+                'time_entries.start_time',
+                'time_entries.end_time',
+                'projects.client_id as project_client_id',
+                'tickets.client_id as ticket_client_id',
+            ) as Promise<PotentialUnresolvedTimeEntry[]>,
+        db.table('usage_tracking')
+            .where('usage_tracking.tenant', tenant)
+            .whereIn('usage_tracking.client_id', clientIds)
+            .where('usage_tracking.invoiced', false)
+            .whereNull('usage_tracking.contract_line_id')
+            .whereNotNull('usage_tracking.service_id')
+            .where('usage_tracking.usage_date', '>=', earliestStart)
+            .where('usage_tracking.usage_date', '<', latestEnd)
+            .select(
+                'usage_tracking.usage_id',
+                'usage_tracking.client_id',
+                'usage_tracking.usage_date',
+            ) as Promise<PotentialUnresolvedUsageRecord[]>,
+    ]);
+
+    const populatedPeriods = new Set<BillingPeriodWithMeta>();
+    const addMatchingPeriods = (
+        clientId: string | null | undefined,
+        sourceStartMs: number | null,
+        sourceEndMs: number | null = sourceStartMs,
+    ) => {
+        if (!clientId || sourceStartMs == null || sourceEndMs == null) {
+            return;
+        }
+
+        for (const window of windowsByClientId.get(clientId) ?? []) {
+            if (sourceStartMs >= window.startMs && sourceEndMs < window.endMs) {
+                populatedPeriods.add(window.period);
+            }
+        }
+    };
+
+    for (const entry of potentialTimeEntries) {
+        const startMs = toTimestampMs(entry.start_time);
+        const endMs = toTimestampMs(entry.end_time);
+        addMatchingPeriods(entry.project_client_id, startMs, endMs);
+        addMatchingPeriods(entry.ticket_client_id, startMs, endMs);
+    }
+
+    for (const record of potentialUsageRecords) {
+        const usageDateMs = toTimestampMs(record.usage_date);
+        addMatchingPeriods(record.client_id, usageDateMs);
+    }
+
+    return candidateBillingPeriods.filter((period) => populatedPeriods.has(period));
+}
+
 async function fetchUnresolvedNonContractDueWorkRows(
+    trx: BillingQueryExecutor,
     candidateBillingPeriods: BillingPeriodWithMeta[],
     asOf: ISO8601String,
     tenant: string,
@@ -832,10 +1004,21 @@ async function fetchUnresolvedNonContractDueWorkRows(
         return [];
     }
 
+    const populatedBillingPeriods = await filterBillingPeriodsWithPotentialUnresolvedWork(
+        trx,
+        tenant,
+        candidateBillingPeriods,
+    );
+    if (populatedBillingPeriods.length === 0) {
+        return [];
+    }
+
     const billingEngine = new BillingEngine();
     const rows: IRecurringDueWorkRow[] = [];
 
-    for (const period of candidateBillingPeriods) {
+    // Keep these calls serial: BillingEngine pins a transaction on the instance
+    // and may reconcile a uniquely assignable source record as it reads it.
+    for (const period of populatedBillingPeriods) {
         if (!period.period_start_date || !period.period_end_date) {
             continue;
         }
@@ -1665,6 +1848,7 @@ export const getAvailableRecurringDueWork = withAuth(async (
             return !suppressionKey || !backfillSuppressionKeys.has(suppressionKey);
         });
         const unresolvedNonContractRows = await fetchUnresolvedNonContractDueWorkRows(
+            knex,
             candidateBillingPeriods,
             asOf,
             tenant,

--- a/packages/billing/src/actions/billingAndTax.ts
+++ b/packages/billing/src/actions/billingAndTax.ts
@@ -874,8 +874,8 @@ async function filterBillingPeriodsWithPotentialUnresolvedWork(
     }
 
     const windowsByClientId = new Map<string, BillingPeriodWindow[]>();
-    let earliestStart: ISO8601String | null = null;
-    let latestEnd: ISO8601String | null = null;
+    const periodStarts: ISO8601String[] = [];
+    const periodEnds: ISO8601String[] = [];
 
     for (const period of candidateBillingPeriods) {
         const start = normalizeDateOnly(period.period_start_date) as ISO8601String | null;
@@ -889,14 +889,20 @@ async function filterBillingPeriodsWithPotentialUnresolvedWork(
         const windows = windowsByClientId.get(period.client_id) ?? [];
         windows.push({ period, startMs, endMs });
         windowsByClientId.set(period.client_id, windows);
-        earliestStart = earliestStart == null || start < earliestStart ? start : earliestStart;
-        latestEnd = latestEnd == null || end > latestEnd ? end : latestEnd;
+        periodStarts.push(start);
+        periodEnds.push(end);
     }
 
-    if (!earliestStart || !latestEnd || windowsByClientId.size === 0) {
+    if (periodStarts.length === 0 || periodEnds.length === 0 || windowsByClientId.size === 0) {
         return [];
     }
 
+    const earliestStart = periodStarts.reduce(
+        (earliest, start) => start < earliest ? start : earliest,
+    );
+    const latestEnd = periodEnds.reduce(
+        (latest, end) => end > latest ? end : latest,
+    );
     const clientIds = Array.from(windowsByClientId.keys());
     const db = tenantDb(trx, tenant);
     const potentialTimeEntriesQuery = db.table('time_entries');

--- a/server/src/test/integration/billingInvoiceTiming.integration.test.ts
+++ b/server/src/test/integration/billingInvoiceTiming.integration.test.ts
@@ -3,7 +3,7 @@ import type { Knex } from 'knex';
 import { v4 as uuidv4 } from 'uuid';
 
 import { tenantDb } from '@alga-psa/db';
-import { createTestDbConnection } from '../../../test-utils/dbConfig';
+import { createTestDbConnection, wireLocalTestDbEnv } from '../../../test-utils/dbConfig';
 import {
   setupClientTaxConfiguration,
   assignServiceTaxRate,
@@ -168,6 +168,7 @@ describe('Billing Invoice Timing Integration', () => {
   const HOOK_TIMEOUT = 180_000;
 
   beforeAll(async () => {
+    wireLocalTestDbEnv();
     process.env.APP_ENV = process.env.APP_ENV || 'test';
     process.env.E2E_AUTH_BYPASS = 'true';
     process.env.DB_USER_ADMIN = process.env.DB_USER_ADMIN || 'postgres';
@@ -1473,6 +1474,75 @@ it('parity: recurring due-work blocks uniquely assignable unassigned hourly time
   await expect(
     generateInvoiceForSelectionInput(blockedCandidate!.members[0]!.selectorInput),
   ).rejects.toThrow('1 unapproved entry');
+}, HOOK_TIMEOUT);
+
+it('T047: DB-backed unresolved discovery hydrates only the billing period containing eligible non-contract time', async () => {
+  setupCommonMocks({ tenantId, userId: 'bulk-unresolved-discovery-user', permissionCheck: () => true });
+
+  const {
+    contextLike,
+    clientId,
+    currentPeriodStart,
+    nextPeriodStart,
+  } = await createClientWithRecurringCycles({
+    clientName: 'Bulk Unresolved Discovery Client',
+    billingCycle: 'monthly',
+    previousPeriodStart: '2024-12-01',
+    currentPeriodStart: '2025-01-01',
+    nextPeriodStart: '2025-02-01',
+  });
+  const serviceId = await createTestService(contextLike as any, {
+    service_name: 'Bulk Unresolved Discovery Service',
+    billing_method: 'hourly',
+    default_rate: 12500,
+    unit_of_measure: 'hour',
+    tax_region: 'US-NY',
+  });
+  await ensureUsdServicePrice(serviceId, 12500);
+
+  const eligibleEntry = await createApprovedTimeEntryForContractLine({
+    clientId,
+    serviceId,
+    contractLineId: null,
+    startTime: '2025-01-15T10:00:00.000Z',
+    endTime: '2025-01-15T11:00:00.000Z',
+    approvalStatus: 'APPROVED',
+    billableDuration: 60,
+  });
+  const ineligibleEntry = await createApprovedTimeEntryForContractLine({
+    clientId,
+    serviceId,
+    contractLineId: null,
+    startTime: '2024-12-15T10:00:00.000Z',
+    endTime: '2024-12-15T11:00:00.000Z',
+    approvalStatus: 'SUBMITTED',
+    billableDuration: 60,
+  });
+
+  const dueWork = await getAvailableRecurringDueWorkAction({
+    page: 1,
+    pageSize: 20,
+    searchTerm: 'Bulk Unresolved Discovery Client',
+  });
+  const unresolvedRows = dueWork.invoiceCandidates
+    .flatMap((candidate) => candidate.members)
+    .filter((member) => member.clientId === clientId && member.recordId.startsWith('unresolved:'));
+
+  expect(unresolvedRows).toHaveLength(1);
+  expect(unresolvedRows[0]).toMatchObject({
+    recordId: `unresolved:time:${eligibleEntry.entry_id}`,
+    scheduleKey: `schedule:${tenantId}:unresolved:time:${eligibleEntry.entry_id}`,
+    clientId,
+    clientName: 'Bulk Unresolved Discovery Client',
+    chargeType: 'Hourly',
+    canGenerate: true,
+    approvalBlockedEntryCount: 0,
+  });
+  expect(normalizeDateValue(unresolvedRows[0]?.invoiceWindowStart)).toBe(currentPeriodStart);
+  expect(normalizeDateValue(unresolvedRows[0]?.invoiceWindowEnd)).toBe(nextPeriodStart);
+  expect(
+    unresolvedRows.some((member) => member.recordId === `unresolved:time:${ineligibleEntry.entry_id}`),
+  ).toBe(false);
 }, HOOK_TIMEOUT);
 
 it('T002: recurring due-work does not block a window for unrelated non-approved time outside that window service-period semantics', async () => {

--- a/server/src/test/unit/billing/nonContractDueWork.integration.test.ts
+++ b/server/src/test/unit/billing/nonContractDueWork.integration.test.ts
@@ -26,9 +26,33 @@ function applyOperator(rowValue: any, operator: string, expected: any) {
       return String(rowValue) >= String(expected);
     case '<=':
       return String(rowValue) <= String(expected);
+    case '>':
+      return String(rowValue) > String(expected);
+    case '<':
+      return String(rowValue) < String(expected);
+    case '<>':
+      return rowValue !== expected;
     default:
       throw new Error(`Unsupported operator ${operator}`);
   }
+}
+
+function buildPredicate(
+  columnOrCriteria: string | Record<string, any>,
+  operatorOrValue?: any,
+  maybeValue?: any,
+) {
+  if (typeof columnOrCriteria === 'object') {
+    return (row: Row) =>
+      Object.entries(columnOrCriteria).every(([column, expected]) =>
+        row[normalizeColumn(column)] === expected,
+      );
+  }
+
+  const column = normalizeColumn(columnOrCriteria);
+  const operator = maybeValue === undefined ? '=' : operatorOrValue;
+  const expected = maybeValue === undefined ? operatorOrValue : maybeValue;
+  return (row: Row) => applyOperator(row[column], operator, expected);
 }
 
 function createQueryBuilder(rows: Row[]) {
@@ -40,29 +64,80 @@ function createQueryBuilder(rows: Row[]) {
     select: vi.fn(() => builder),
     where: vi.fn((columnOrCriteria: string | Record<string, any> | ((this: any, qb?: any) => void), operatorOrValue?: any, maybeValue?: any) => {
       if (typeof columnOrCriteria === 'function') {
-        // Grouped where callback (e.g. builder.whereNull(...).orWhere(...)).
-        // Run the callback against a permissive sub-builder without filtering.
-        const subBuilder: any = {};
-        for (const method of ['where', 'orWhere', 'whereNull', 'orWhereNull', 'whereNotNull', 'whereIn', 'orWhereIn']) {
-          subBuilder[method] = vi.fn(() => subBuilder);
-        }
-        columnOrCriteria.call(subBuilder, subBuilder);
-        return builder;
-      }
-
-      if (typeof columnOrCriteria === 'object') {
-        resultRows = resultRows.filter((row) =>
-          Object.entries(columnOrCriteria).every(([column, expected]) =>
-            row[normalizeColumn(column)] === expected,
+        const clauses: Array<{ type: 'and' | 'or'; predicate: (row: Row) => boolean }> = [];
+        const addComparison = (
+          type: 'and' | 'or',
+          nestedColumnOrCriteria: string | Record<string, any>,
+          nestedOperatorOrValue?: any,
+          nestedMaybeValue?: any,
+        ) => {
+          clauses.push({
+            type,
+            predicate: buildPredicate(
+              nestedColumnOrCriteria,
+              nestedOperatorOrValue,
+              nestedMaybeValue,
+            ),
+          });
+          return subBuilder;
+        };
+        const addNullCheck = (type: 'and' | 'or', column: string, expectNull: boolean) => {
+          const normalized = normalizeColumn(column);
+          clauses.push({
+            type,
+            predicate: (row: Row) => expectNull ? row[normalized] == null : row[normalized] != null,
+          });
+          return subBuilder;
+        };
+        const addInCheck = (type: 'and' | 'or', column: string, values: any[]) => {
+          const normalized = normalizeColumn(column);
+          clauses.push({
+            type,
+            predicate: (row: Row) => values.includes(row[normalized]),
+          });
+          return subBuilder;
+        };
+        const subBuilder: any = {
+          where: (
+            nestedColumnOrCriteria: string | Record<string, any>,
+            nestedOperatorOrValue?: any,
+            nestedMaybeValue?: any,
+          ) => addComparison(
+            'and',
+            nestedColumnOrCriteria,
+            nestedOperatorOrValue,
+            nestedMaybeValue,
           ),
+          orWhere: (
+            nestedColumnOrCriteria: string | Record<string, any>,
+            nestedOperatorOrValue?: any,
+            nestedMaybeValue?: any,
+          ) => addComparison(
+            'or',
+            nestedColumnOrCriteria,
+            nestedOperatorOrValue,
+            nestedMaybeValue,
+          ),
+          whereNull: (column: string) => addNullCheck('and', column, true),
+          orWhereNull: (column: string) => addNullCheck('or', column, true),
+          whereNotNull: (column: string) => addNullCheck('and', column, false),
+          orWhereNotNull: (column: string) => addNullCheck('or', column, false),
+          whereIn: (column: string, values: any[]) => addInCheck('and', column, values),
+          orWhereIn: (column: string, values: any[]) => addInCheck('or', column, values),
+        };
+        columnOrCriteria.call(subBuilder, subBuilder);
+        resultRows = resultRows.filter((row) =>
+          clauses.reduce((matches, clause, index) => {
+            const clauseMatches = clause.predicate(row);
+            if (index === 0) return clauseMatches;
+            return clause.type === 'or' ? matches || clauseMatches : matches && clauseMatches;
+          }, clauses.length === 0),
         );
         return builder;
       }
 
-      const column = normalizeColumn(columnOrCriteria);
-      const operator = maybeValue === undefined ? '=' : operatorOrValue;
-      const expected = maybeValue === undefined ? operatorOrValue : maybeValue;
-      resultRows = resultRows.filter((row) => applyOperator(row[column], operator, expected));
+      const predicate = buildPredicate(columnOrCriteria, operatorOrValue, maybeValue);
+      resultRows = resultRows.filter((row) => predicate(row));
       return builder;
     }),
     whereIn: vi.fn((column: string, values: any[]) => {
@@ -70,8 +145,16 @@ function createQueryBuilder(rows: Row[]) {
       resultRows = resultRows.filter((row) => values.includes(row[normalized]));
       return builder;
     }),
-    whereNull: vi.fn(() => builder),
-    whereNotNull: vi.fn(() => builder),
+    whereNull: vi.fn((column: string) => {
+      const normalized = normalizeColumn(column);
+      resultRows = resultRows.filter((row) => row[normalized] == null);
+      return builder;
+    }),
+    whereNotNull: vi.fn((column: string) => {
+      const normalized = normalizeColumn(column);
+      resultRows = resultRows.filter((row) => row[normalized] != null);
+      return builder;
+    }),
     whereRaw: vi.fn(() => builder),
     orderBy: vi.fn(() => builder),
     limit: vi.fn(() => builder),
@@ -173,11 +256,26 @@ describe('non-contract due-work reader', () => {
     ];
     mocks.rowsByTable.client_contracts = [];
     mocks.rowsByTable.recurring_service_periods = [];
+    mocks.rowsByTable.time_entries = [];
+    mocks.rowsByTable.usage_tracking = [];
 
     unresolvedSpy.mockResolvedValue([] as IBillingCharge[]);
   });
 
   it('T041: unresolved approved billable time appears as a non-contract candidate', async () => {
+    mocks.rowsByTable.time_entries = [{
+      tenant: 'tenant-1',
+      entry_id: 'te-1',
+      start_time: '2025-03-15T14:00:00.000Z',
+      end_time: '2025-03-15T16:00:00.000Z',
+      invoiced: false,
+      contract_line_id: null,
+      service_id: 'svc-time',
+      approval_status: 'APPROVED',
+      billable_duration: 120,
+      project_client_id: 'client-1',
+      ticket_client_id: null,
+    }];
     unresolvedSpy.mockResolvedValueOnce([
       {
         type: 'time',
@@ -202,14 +300,30 @@ describe('non-contract due-work reader', () => {
     const result = await getAvailableRecurringDueWork({ page: 1, pageSize: 10 });
 
     expect(result.invoiceCandidates).toHaveLength(1);
+    expect(result.invoiceCandidates[0]).toMatchObject({
+      canGenerate: true,
+      hasApprovalBlockers: false,
+      approvalBlockedEntryCount: 0,
+    });
     expect(result.invoiceCandidates[0]?.members[0]).toMatchObject({
       scheduleKey: 'schedule:tenant-1:unresolved:time:te-1',
       contractId: null,
       contractLineId: null,
+      canGenerate: true,
+      approvalBlockedEntryCount: 0,
     });
   });
 
   it('T042: unresolved approved billable usage appears as a non-contract candidate', async () => {
+    mocks.rowsByTable.usage_tracking = [{
+      tenant: 'tenant-1',
+      usage_id: 'usage-1',
+      client_id: 'client-1',
+      usage_date: '2025-03-15T14:00:00.000Z',
+      invoiced: false,
+      contract_line_id: null,
+      service_id: 'svc-usage',
+    }];
     unresolvedSpy.mockResolvedValueOnce([
       {
         type: 'usage',
@@ -232,10 +346,136 @@ describe('non-contract due-work reader', () => {
     const result = await getAvailableRecurringDueWork({ page: 1, pageSize: 10 });
 
     expect(result.invoiceCandidates).toHaveLength(1);
+    expect(result.invoiceCandidates[0]).toMatchObject({
+      canGenerate: true,
+      hasApprovalBlockers: false,
+      approvalBlockedEntryCount: 0,
+    });
     expect(result.invoiceCandidates[0]?.members[0]).toMatchObject({
       scheduleKey: 'schedule:tenant-1:unresolved:usage:usage-1',
       contractId: null,
       contractLineId: null,
     });
+  });
+
+  it('T043: skips billing-engine hydration for open periods with no unresolved sources', async () => {
+    mocks.rowsByTable.client_billing_cycles = Array.from({ length: 100 }, (_, index) => ({
+      tenant: 'tenant-1',
+      client_id: 'client-1',
+      client_name: 'Acme Co',
+      billing_cycle_id: `cycle-${index}`,
+      billing_cycle: 'monthly',
+      period_start_date: `2025-${String((index % 9) + 1).padStart(2, '0')}-01`,
+      period_end_date: `2025-${String((index % 9) + 2).padStart(2, '0')}-01`,
+      effective_date: '2025-01-01',
+      invoice_id: null,
+    }));
+
+    await getAvailableRecurringDueWork({ page: 1, pageSize: 10 });
+
+    expect(unresolvedSpy).not.toHaveBeenCalled();
+  });
+
+  it('T044: hydrates only the billing window containing a potential unresolved source', async () => {
+    mocks.rowsByTable.client_billing_cycles = [
+      {
+        tenant: 'tenant-1',
+        client_id: 'client-1',
+        client_name: 'Acme Co',
+        billing_cycle_id: 'cycle-january',
+        billing_cycle: 'monthly',
+        period_start_date: '2025-01-01',
+        period_end_date: '2025-02-01',
+        effective_date: '2025-01-01',
+        invoice_id: null,
+      },
+      {
+        tenant: 'tenant-1',
+        client_id: 'client-1',
+        client_name: 'Acme Co',
+        billing_cycle_id: 'cycle-march',
+        billing_cycle: 'monthly',
+        period_start_date: '2025-03-01',
+        period_end_date: '2025-04-01',
+        effective_date: '2025-03-01',
+        invoice_id: null,
+      },
+    ];
+    mocks.rowsByTable.time_entries = [{
+      tenant: 'tenant-1',
+      entry_id: 'te-march',
+      start_time: '2025-03-15T14:00:00.000Z',
+      end_time: '2025-03-15T15:00:00.000Z',
+      invoiced: false,
+      contract_line_id: null,
+      service_id: 'svc-time',
+      approval_status: 'APPROVED',
+      billable_duration: 60,
+      project_client_id: 'client-1',
+      ticket_client_id: null,
+    }];
+
+    await getAvailableRecurringDueWork({ page: 1, pageSize: 10 });
+
+    expect(unresolvedSpy).toHaveBeenCalledTimes(1);
+    expect(unresolvedSpy).toHaveBeenCalledWith({
+      clientId: 'client-1',
+      windowStart: '2025-03-01',
+      windowEnd: '2025-04-01',
+    });
+  });
+
+  it.each([
+    ['invoiced', { invoiced: true }],
+    ['already assigned', { contract_line_id: 'line-1' }],
+    ['not approved', { approval_status: 'SUBMITTED' }],
+    ['outside the billing window', {
+      start_time: '2025-04-02T14:00:00.000Z',
+      end_time: '2025-04-02T15:00:00.000Z',
+    }],
+    ['owned by another client', { project_client_id: 'client-2' }],
+    ['owned by another tenant', { tenant: 'tenant-2' }],
+  ])('T045: does not hydrate a time source that is %s', async (_label, overrides) => {
+    mocks.rowsByTable.time_entries = [{
+      tenant: 'tenant-1',
+      entry_id: 'te-ineligible',
+      start_time: '2025-03-15T14:00:00.000Z',
+      end_time: '2025-03-15T15:00:00.000Z',
+      invoiced: false,
+      contract_line_id: null,
+      service_id: 'svc-time',
+      approval_status: 'APPROVED',
+      billable_duration: 60,
+      project_client_id: 'client-1',
+      ticket_client_id: null,
+      ...overrides,
+    }];
+
+    await getAvailableRecurringDueWork({ page: 1, pageSize: 10 });
+
+    expect(unresolvedSpy).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['invoiced', { invoiced: true }],
+    ['already assigned', { contract_line_id: 'line-1' }],
+    ['outside the billing window', { usage_date: '2025-04-02T14:00:00.000Z' }],
+    ['owned by another client', { client_id: 'client-2' }],
+    ['owned by another tenant', { tenant: 'tenant-2' }],
+  ])('T046: does not hydrate a usage source that is %s', async (_label, overrides) => {
+    mocks.rowsByTable.usage_tracking = [{
+      tenant: 'tenant-1',
+      usage_id: 'usage-ineligible',
+      client_id: 'client-1',
+      usage_date: '2025-03-15T14:00:00.000Z',
+      invoiced: false,
+      contract_line_id: null,
+      service_id: 'svc-usage',
+      ...overrides,
+    }];
+
+    await getAvailableRecurringDueWork({ page: 1, pageSize: 10 });
+
+    expect(unresolvedSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
  Bulk-read tenant-scoped time and usage candidates, map them to client billing windows, and run authoritative BillingEngine hydration only for populated periods. Add negative and DB-backed regression coverage.

  Captain Alga plunged into Pagination Trench, lassoed 2,449 ghost periods, and fed the Billing Engine Kraken only approved time-entry tuna and unassigned usage squid. The empty windows must now count bubbles until
  quarter-end. 🐙🫧🦑