### PR TITLE
QBO tax code mapping: unreadable IDs, no Automated Sales Tax model, Intuit app onboarding

### DIFF
--- a/packages/emulators/qbo/src/core.ts
+++ b/packages/emulators/qbo/src/core.ts
@@ -26,6 +26,12 @@ export class QboWireError extends Error {
 export interface QboEmulatorConfig {
   autoApplyCredits: boolean;
   taxAdjustmentCents: number;
+  /**
+   * TaxCode id AST resolves a TAX-marked (or code-less) line to, standing in
+   * for Intuit's jurisdiction lookup. Null turns Automated Sales Tax off, so
+   * created invoices carry no TxnTaxDetail — the non-AST company file.
+   */
+  automatedSalesTaxDefaultTaxCodeId: string | null;
 }
 
 /**
@@ -64,6 +70,11 @@ export class QboEmulatorCore implements EmulatorCore {
     if (config.taxAdjustmentCents !== undefined) {
       this.sim.options.taxAdjustmentCents = config.taxAdjustmentCents;
     }
+    if (config.automatedSalesTaxDefaultTaxCodeId !== undefined) {
+      this.sim.options.automatedSalesTax = config.automatedSalesTaxDefaultTaxCodeId
+        ? { defaultTaxCodeId: config.automatedSalesTaxDefaultTaxCodeId }
+        : undefined;
+    }
     return this.config();
   }
 
@@ -71,6 +82,7 @@ export class QboEmulatorCore implements EmulatorCore {
     return {
       autoApplyCredits: Boolean(this.sim.options.autoApplyCredits),
       taxAdjustmentCents: this.sim.options.taxAdjustmentCents ?? 0,
+      automatedSalesTaxDefaultTaxCodeId: this.sim.options.automatedSalesTax?.defaultTaxCodeId ?? null,
     };
   }
 

--- a/packages/emulators/qbo/src/register.ts
+++ b/packages/emulators/qbo/src/register.ts
@@ -38,6 +38,27 @@ export function register(reg: ControlRegistry, core: QboEmulatorCore): void {
   });
 
   reg.seeder({
+    name: 'tax-rate',
+    description: 'Create a QBO TaxRate component (RateValue is a percentage: 8 means 8%)',
+    params: z.object({ name: z.string(), ratePercent: z.number(), id: z.string().optional() }),
+    run: (params) => core.sim.seedTaxRate(params),
+  });
+
+  reg.seeder({
+    name: 'tax-code',
+    description: 'Create a QBO TaxCode; pass taxRateIds for a real group, or pseudo for TAX/NON',
+    params: z.object({
+      name: z.string(),
+      id: z.string().optional(),
+      description: z.string().optional(),
+      taxRateIds: z.array(z.string()).optional(),
+      pseudo: z.boolean().optional(),
+      active: z.boolean().optional(),
+    }),
+    run: (params) => core.sim.seedTaxCode(params),
+  });
+
+  reg.seeder({
     name: 'invoice',
     description: 'Create a QBO invoice with a single sales line',
     params: z.object({
@@ -91,10 +112,12 @@ export function register(reg: ControlRegistry, core: QboEmulatorCore): void {
 
   reg.action({
     name: 'configure',
-    description: 'Toggle company behavior: AutoApplyCredit and the AST tax adjustment applied to new invoices',
+    description:
+      'Toggle company behavior: AutoApplyCredit, the AST tax adjustment, and Automated Sales Tax (pass a default TaxCode id to enable, null to disable)',
     params: z.object({
       autoApplyCredits: z.boolean().optional(),
       taxAdjustmentCents: z.number().int().optional(),
+      automatedSalesTaxDefaultTaxCodeId: z.string().nullable().optional(),
     }),
     run: (params) => core.configure(params),
   });
@@ -118,6 +141,8 @@ export function register(reg: ControlRegistry, core: QboEmulatorCore): void {
     ['credit-memos', 'CreditMemo'],
     ['payments', 'Payment'],
     ['items', 'Item'],
+    ['tax-codes', 'TaxCode'],
+    ['tax-rates', 'TaxRate'],
   ] as const) {
     reg.stateView({
       name: view,

--- a/packages/emulators/qbo/tests/smoke.test.ts
+++ b/packages/emulators/qbo/tests/smoke.test.ts
@@ -154,6 +154,132 @@ describe('qbo emulator', { shuffle: false }, () => {
     expect(((await missing.json()) as any).Fault.Error[0].code).toBe('610');
   });
 
+  // The customer bug: an Automated Sales Tax company carries a large,
+  // auto-generated tax-code table, so the mapping catalog was truncated at
+  // QBO's 100-row default and any code past it printed its bare backend Id.
+  // This drives the whole readable-label + paging + AST path over the wire.
+  it('serves a large AST tax-code catalog with readable labels, pages past 100, and computes AST tax', async () => {
+    // Self-contained: own client + freshly minted token, so this test does not
+    // depend on the OAuth test's ordering or the clock advances later tests make.
+    await controlPost('/control/qbo/seed/client', { clientId: 'tax-app', clientSecret: 'tax-secret' });
+    const minted = (await controlPost('/control/qbo/actions/mint-tokens', { clientId: 'tax-app' })).result;
+    const taxAuthed = { authorization: `Bearer ${minted.access_token}`, 'content-type': 'application/json' };
+
+    // A real California jurisdiction group: three rate components summing to 9%.
+    await controlPost('/control/qbo/seed/tax-rate', { id: 'r-state', name: 'CA State', ratePercent: 6.25 });
+    await controlPost('/control/qbo/seed/tax-rate', { id: 'r-county', name: 'Santa Clara County', ratePercent: 1 });
+    await controlPost('/control/qbo/seed/tax-rate', { id: 'r-district', name: 'SC District', ratePercent: 1.75 });
+    await controlPost('/control/qbo/seed/tax-code', {
+      id: 'CA-GROUP',
+      name: 'California Sales Tax',
+      description: 'CA state + Santa Clara county + district',
+      taxRateIds: ['r-state', 'r-county', 'r-district'],
+    });
+
+    // The auto-generated bulk an AST file carries: 120 codes push the catalog
+    // well past the 100-row page the old single-shot query stopped at.
+    for (let index = 1; index <= 120; index += 1) {
+      await controlPost('/control/qbo/seed/tax-code', {
+        id: `AUTO-${index}`,
+        name: `Auto-generated Tax ${index}`,
+        taxRateIds: ['r-state'],
+      });
+    }
+    // The pseudo codes that only exist under AST, returned with no Active field.
+    await controlPost('/control/qbo/seed/tax-code', { id: 'TAX', name: 'TAX', pseudo: true });
+    await controlPost('/control/qbo/seed/tax-code', { id: 'NON', name: 'NON', pseudo: true });
+
+    // --- Fix (a): paging + readable labels, exactly as the mapping UI reads them.
+    const pageQuery = (start: number, max: number) =>
+      encodeURIComponent(`SELECT * FROM TaxCode STARTPOSITION ${start} MAXRESULTS ${max}`);
+    const firstPage = (await (await fetch(api(`/query?query=${pageQuery(1, 100)}`), { headers: taxAuthed })).json()) as any;
+    const secondPage = (await (await fetch(api(`/query?query=${pageQuery(101, 100)}`), { headers: taxAuthed })).json()) as any;
+    const page1 = firstPage.QueryResponse.TaxCode as any[];
+    const page2 = secondPage.QueryResponse.TaxCode as any[];
+    // The 100-row default would have hidden 23 codes; paging recovers every one.
+    expect(page1).toHaveLength(100);
+    expect(page2).toHaveLength(23);
+
+    const all = [...page1, ...page2];
+    // No row is a bare Id — every code carries a human-readable Name.
+    for (const code of all) {
+      expect(typeof code.Name).toBe('string');
+      expect(code.Name.length).toBeGreaterThan(0);
+    }
+    const group = all.find((code) => code.Id === 'CA-GROUP');
+    expect(group.Name).toBe('California Sales Tax');
+    expect(group.Description).toContain('Santa Clara');
+    // The rate components (what enrichment turns into "9%") ride under the group.
+    expect(group.SalesTaxRateList.TaxRateDetail).toHaveLength(3);
+    // TAX/NON pseudo codes land on the far page; Intuit omits Active on them.
+    const pseudo = all.find((code) => code.Id === 'TAX');
+    expect(pseudo.Name).toBe('TAX');
+    expect(pseudo.Active).toBeUndefined();
+
+    // --- Fix (b): under AST, a TAX-marked line is taxed at the resolved rate.
+    await controlPost('/control/qbo/actions/configure', { automatedSalesTaxDefaultTaxCodeId: 'CA-GROUP' });
+    const astCustomer = (await controlPost('/control/qbo/seed/customer', { name: 'AST Buyer' })).result;
+
+    const taxedResp = await fetch(api('/invoice'), {
+      method: 'POST',
+      headers: taxAuthed,
+      body: JSON.stringify({
+        CustomerRef: { value: astCustomer.Id },
+        Line: [
+          {
+            DetailType: 'SalesItemLineDetail',
+            Amount: 200,
+            SalesItemLineDetail: { ItemRef: { value: 'svc' }, TaxCodeRef: { value: 'TAX' } },
+          },
+        ],
+      }),
+    });
+    const taxed = ((await taxedResp.json()) as any).Invoice;
+    // 200 * (6.25 + 1 + 1.75)% = 18, split across the three jurisdiction lines.
+    expect(taxed.TxnTaxDetail.TotalTax).toBe(18);
+    expect(taxed.TxnTaxDetail.TaxLine.map((line: any) => line.Amount)).toEqual([12.5, 2, 3.5]);
+    expect(taxed.TotalAmt).toBe(218);
+
+    // A NON-marked line is exempt even while AST is on.
+    const exemptResp = await fetch(api('/invoice'), {
+      method: 'POST',
+      headers: taxAuthed,
+      body: JSON.stringify({
+        CustomerRef: { value: astCustomer.Id },
+        Line: [
+          {
+            DetailType: 'SalesItemLineDetail',
+            Amount: 200,
+            SalesItemLineDetail: { ItemRef: { value: 'svc' }, TaxCodeRef: { value: 'NON' } },
+          },
+        ],
+      }),
+    });
+    expect(((await exemptResp.json()) as any).Invoice.TxnTaxDetail.TotalTax).toBe(0);
+
+    // --- Turning AST off returns to a plain file: invoices carry no tax detail.
+    await controlPost('/control/qbo/actions/configure', { automatedSalesTaxDefaultTaxCodeId: null });
+    const plainResp = await fetch(api('/invoice'), {
+      method: 'POST',
+      headers: taxAuthed,
+      body: JSON.stringify({
+        CustomerRef: { value: astCustomer.Id },
+        Line: [{ DetailType: 'SalesItemLineDetail', Amount: 200, SalesItemLineDetail: { ItemRef: { value: 'svc' } } }],
+      }),
+    });
+    const plain = ((await plainResp.json()) as any).Invoice;
+    expect(plain.TxnTaxDetail).toBeUndefined();
+    expect(plain.TotalAmt).toBe(200);
+
+    // The augmentation's state views expose the seeded catalog to the harness.
+    const stateCodes = (await (await fetch(`${control}/control/qbo/state/tax-codes`)).json()) as any;
+    expect(stateCodes.result.length).toBe(123);
+    const stateRates = (await (await fetch(`${control}/control/qbo/state/tax-rates`)).json()) as any;
+    expect(stateRates.result.map((rate: any) => rate.Id)).toContain('r-district');
+
+    // Leave AST off so later tests see a clean company file.
+  });
+
   it('serves preferences, companyinfo, and the CDC envelope', async () => {
     const prefs = (await (
       await fetch(api(`/query?query=${encodeURIComponent('SELECT * FROM Preferences')}`), { headers: authed })


### PR DESCRIPTION
## Summary

PR #3200 (this same branch) already merged the core fix — readable, paged, disambiguated QuickBooks tax-code mapping labels, an Automated Sales Tax (AST) per-realm mode with TAX/NON pseudo-code support, and hosted/tenant Intuit app onboarding. This follow-up PR adds test-infrastructure coverage that closes a gap the original card flagged but didn't ship:

- **`packages/emulators/qbo/src/core.ts`** — the in-repo QBO emulator now models an `automatedSalesTaxDefaultTaxCodeId` config option, so `configure` can turn Automated Sales Tax on (pointing at a default TaxCode) or off per company, matching how the billing `QboSimulator` already resolved AST internally.
- **`packages/emulators/qbo/src/register.ts`** — exposes `tax-rate` and `tax-code` seeders plus `tax-codes`/`tax-rates` state views on the emulator control surface, and wires the new `automatedSalesTaxDefaultTaxCodeId` param through the `configure` action. Previously the simulator modeled TaxCode/TaxRate but nothing could seed or inspect them through the emulator.
- **`packages/emulators/qbo/tests/smoke.test.ts`** — new wire-level test driving the customer-reported scenario end to end against the emulator's real HTTP surface: a large AST-shaped tax-code table (readable Name/Description/rate lists) served paged past QBO's 100-row default, plus AST computing `TxnTaxDetail` on TAX-marked invoice lines.

No product code changes in this PR — it's purely additive emulator/test infrastructure supporting the QBO tax-code mapping work already on `main`.

## Smoke-test results

Drove the branch through the real dev server on `http://localhost:3285` (board service dev-server, DB `127.0.0.1:6472`) against the in-repo algasim QuickBooks emulator (`packages/emulators/qbo`), wired via the repo's own `QBO_OAUTH_AUTHORIZE_URL` / `QBO_OAUTH_TOKEN_URL` / `QBO_API_BASE_URL` overrides. Real login with the dev-login banner credentials, real Intuit-protocol OAuth connect, real `/v3/company` TaxCode+TaxRate queries. No product code mocked.

**Seeded company** ("Alga Emulated Co", realm-sim): 111 TaxCodes / 8 TaxRates shaped like an AST company file — 105 auto-generated jurisdiction codes, id 101 CA-Santa Clara-Santa Clara (6%+1.25%) deliberately at catalog row ~107, ids 175/176 NM-Roosevelt-Roosevelt (duplicate names, different rate sets), 188 Burbank (6%+2.25%+0.75%), 189 inactive, 190 description-only, 301/302 identical name AND rate.

**Flows exercised and passed:**
1. Credential-source alert (source=none → source=tenant after saving tenant Intuit credentials), including the new "QuickBooks setup guide" link.
2. Real OAuth connect through the emulator — company name and token expiry rendered from live `companyinfo`/token responses.
3. AST toggle row: exactly one `<label>` in the DOM (doubled-label fix), `role=switch`, id reaches the DOM.
4. Tax-code catalog readability: e.g. "CA-Santa Clara-Santa Clara (7.25%)", "CA Los Angeles Cnty - Burbank (9%)", "Out-of-state exempt — Nexus-exempt sales outside California". Counts reconciled exactly with the emulator (109 active offered; both inactive codes excluded).
5. **Paging**: the billing `QboSimulator` only matches the paged query shape (STARTPOSITION/MAXRESULTS) and throws `SIM_UNSUPPORTED` otherwise, so the catalog loading at all proves the app sends a paged TaxCode query — the mapped code sat past row 100, exactly where the old unpaged query truncated.
6. Duplicate disambiguation: "WA-King-Seattle (6.5%) · ID 301" / "· ID 302".
7. Mapping saved: Florida → 101, DB metadata `{"externalDisplayName": "CA-Santa Clara-Santa Clara (7.25%)"}`.
8. **The customer's bug**: deactivated code 101 upstream, cleared the catalog cache via the AST toggle, reloaded — the row still read "CA-Santa Clara-Santa Clara (7.25%)" instead of the bare id "101".
9. AST mode: toggle ON → success message + DB `tenant_settings.settings.qboAutomatedSalesTax = {"realms":["realm-sim"]}`, survived a full page reload; TAX/NON pseudo codes appeared only under AST. Mapped New York → TAX (previously inexpressible), persisted as `external_entity_id='TAX'`. Toggle OFF → realms emptied, rows stayed readable even though TAX left the catalog.
10. Metadata tri-state: JSON editor seeded from the stored row; editing composed correctly (module-owned `classId` survived, `externalDisplayName` refreshed); emptying the editor genuinely cleared metadata (DB NULL) and the row degraded to the bare "TAX" — confirming clearing is real and the persisted label is what stands between the user and a raw QuickBooks id.

**Not tested:**
- The AST exporter branch (per-line `TaxCodeRef` in delegate mode) — only fires when an invoice is `tax_source='pending_external'`, which needs a tenant-wide tax-delegation flip on a shared tenant. Covered by 7 dedicated unit-test cases against `QboSimulator` (57/57 green), never against a real Intuit realm.
- The `source==='app'` (hosted shared Intuit app) alert branch — needs app-level env credentials plus a tenant with no stored credentials.
- The thrown-action-reverts-the-switch path (unit-tested; not reproducible live without breaking the server mid-click).

**Fidelity compromises (all disclosed, all reverted):**
- QuickBooks itself was the in-repo algasim emulator, since no Intuit realm is connected in this stack — it speaks the real wire protocol; OAuth and catalog calls were real HTTP.
- Added tax-code/tax-rate seeders + state views to the emulator so the branch's new TaxCode/TaxRate model could actually be seeded — this is the change shipped in this PR.
- A temporary workaround for a pre-existing, unrelated defect (`rmmIntegrationStatusActions.ts` `use server` re-export bug that breaks every `@alga-psa/integrations` server action) was used locally to unblock the QBO settings page during testing, then reverted — it is not included in this PR and remains open on `main`.

Evidence directory: `/tmp/alga-smoke-evidence/qbo-tax-code-mapping-20260819-031500` (plus a second full pass at `/tmp/alga-smoke-evidence/qbo-tax-code-mapping-20260819-222747`).

## Known follow-ups (not in this PR)
- `getQboItems` (`qboActions.ts:809`) still issues an unpaged `SELECT Id, Name FROM Item` — the same 100-row Intuit truncation this branch fixed for TaxCode/Customer.
- Editing a mapping whose code has left the catalog shows an empty tax-code picker (cosmetic — the stored id and label are preserved on save).