### PR TITLE
Make recurring due-work listing read-only and fix usage tracking load failure

### DIFF
--- a/docs/plans/2026-08-20-read-only-recurring-due-work-listing-plan.md
+++ b/docs/plans/2026-08-20-read-only-recurring-due-work-listing-plan.md
@@ -1,0 +1,314 @@
+# Read-only recurring due-work listing + attribution write boundary
+
+**Date:** 2026-08-20
+**Branch:** `feature/make-recurring-due-work-listing-read-only-and-fi`
+**Status:** proposed
+
+## Problem
+
+Opening **Billing → Invoicing → Generate** returns HTTP 500 with "Failed to load
+billing periods". The server error is PostgreSQL `42703: column "updated_at" of
+relation "usage_tracking" does not exist`.
+
+Call chain:
+
+```
+AutomaticInvoices.loadPeriods
+  -> getAvailableRecurringDueWork                          (billing:read)
+    -> fetchUnresolvedNonContractDueWorkRows
+      -> BillingEngine.calculateUnresolvedNonContractChargesForExecutionWindow
+        -> BillingEngine.calculateUnresolvedNonContractCharges   <-- writes here
+```
+
+There are two defects, one behind the other.
+
+### 1. Architectural: a read path performs hidden writes
+
+`calculateUnresolvedNonContractCharges` interleaves *deciding* which contract
+line covers a record with *persisting* that decision. For every unresolved
+`time_entries` / `usage_tracking` row in the window it issues an `UPDATE`:
+
+- unique eligible line → `contract_line_id`, `contract_line_source =
+  'reconciled_at_generation'`, `contract_line_unresolved_reason = NULL`
+- otherwise → `contract_line_source = 'unresolved'`,
+  `contract_line_unresolved_reason = <ambiguous|no_match>`
+
+Because the same method backs both the *listing* and *generation*, merely
+opening or refreshing the Generate screen mutates billing source records. Every
+refresh rewrites the same unresolved rows, and any failure in that write blocks
+the list from loading at all — which is exactly what happened. The same
+exposure exists on two further read-only paths that call `calculateBilling`:
+invoice **preview** (`previewInvoice`) and **PO overage** checks
+(`getPurchaseOrderOverageForSelectionInput`).
+
+### 2. Schema: the usage write shape was copied from the time-entry path
+
+`usage_tracking` has no `updated_at` column (nor `created_at`) — verified in
+both the migration history and a migrated database. The usage branch was
+written by copying the `time_entries` branch, `updated_at` included. Existing
+unit coverage (`billingEngine.unresolvedReconciliation.test.ts`) asserts the
+`update()` payload against a **mocked** knex builder, so it asserts the bug
+rather than catching it.
+
+Removing `updated_at` alone would silence the 500 and leave the read path
+writing. Both defects are in scope.
+
+### 3. Latent: reconciled work slips a cycle
+
+Today's write ordering is accidental. Inside `calculateBilling`, contract-line
+charges are computed *before* the non-contract section, so a record that
+reconciliation assigns to a contract line is assigned **after** the queries that
+would have billed it. It is billed by nobody in that run and only picked up on
+the next cycle. Whichever screen happened to trigger the write first determined
+when the work got billed. This plan fixes that too: reconciliation runs before
+calculation, so covered work bills in the run that discovers it.
+
+## Design
+
+Split **decide** from **persist**, then order generation as
+**reconcile → calculate → persist** inside one transaction.
+
+```
+                 ┌───────────────────────────────────────────┐
+  pure           │ resolveDeterministicContractLineSelection  │  (exists)
+                 │ + buildContractLineAttributionDecision     │  (new, pure)
+                 └───────────────────┬───────────────────────┘
+                                     │ decision (in memory)
+             ┌───────────────────────┴───────────────────────┐
+             ▼                                               ▼
+  ┌─────────────────────────┐              ┌──────────────────────────────────┐
+  │ calculateUnresolvedNon- │              │ reconcileWindowAttribution(trx)  │
+  │ ContractCharges         │              │  = resolve + apply, idempotent   │
+  │  NO WRITES              │              └──────────────┬───────────────────┘
+  └───────────┬─────────────┘                             │
+              │ listing (read-only, no reconcile)         │ generation: commit
+              ▼                                           │ preview / PO: roll back
+   Generate screen lists periods                          ▼
+                                            calculate → persist invoice
+```
+
+### Layer 1 — the decision (pure)
+
+`resolveDeterministicContractLineSelection` already exists in
+`packages/billing/src/lib/contractLineDisambiguation.shared.ts` and is pure. Add
+alongside it:
+
+```ts
+export type ContractLineAttributionDecision =
+  | { kind: RecordKind; recordId: string; action: 'assign';
+      contractLineId: string; source: ContractLineSource }
+  | { kind: RecordKind; recordId: string; action: 'mark_unresolved';
+      reason: ContractLineSelectionReason };
+
+export function buildContractLineAttributionDecision(input: {
+  kind: 'time_entry' | 'usage_record';
+  recordId: string;
+  selection: ReturnType<typeof resolveDeterministicContractLineSelection>;
+}): ContractLineAttributionDecision;
+```
+
+The unique/ambiguous/no-match classification is unchanged — it stays in the one
+shared resolver, so determinism is preserved by construction.
+
+### Layer 2 — calculation becomes side-effect free
+
+`BillingEngine.calculateUnresolvedNonContractCharges` writes nothing. It builds
+each decision in memory and uses it exactly as it uses the write today:
+
+- `assign` → the record is skipped (it belongs to a contract line), same as the
+  current `continue`
+- `mark_unresolved` → the reason is carried onto the charge via
+  `unresolved_reason`, and drives the existing `requireCatalogPricingDecision`
+  refusal (`UnresolvedCatalogPricingError`) unchanged
+
+The `billing_engine.reconcile.unresolved` log line moves to decision time and
+reports `persisted: false`; the writer emits its own line when a decision is
+applied. Every `calculateBilling` caller — listing, preview, PO overage,
+generation — is now free of writes.
+
+### Layer 3 — one schema-aware writer
+
+New module `packages/billing/src/lib/billing/contractLineAttributionWriter.ts`:
+
+```ts
+const ATTRIBUTION_TABLES = {
+  time_entry:    { table: 'time_entries',   idColumn: 'entry_id', hasUpdatedAt: true  },
+  usage_record:  { table: 'usage_tracking', idColumn: 'usage_id', hasUpdatedAt: false },
+} as const;
+
+export async function applyContractLineAttributionDecisions(
+  trx: Knex.Transaction, tenant: string,
+  decisions: ContractLineAttributionDecision[],
+): Promise<{ assigned: number; markedUnresolved: number }>;
+
+/** Resolve every unresolved record in a window and apply the decisions. */
+export async function reconcileWindowAttribution(params: {
+  trx: Knex.Transaction; tenant: string; clientId: string;
+  windowStart: ISO8601String; windowEnd: ISO8601String;
+}): Promise<{ assigned: number; markedUnresolved: number }>;
+```
+
+Properties:
+
+- **One place names each table's write shape.** The `updated_at` divergence is
+  data in a descriptor, not a copy-paste between two 200-line branches — this is
+  the layer whose absence produced the bug.
+- **Idempotent.** Assignment keeps the existing `.whereNull('contract_line_id')`
+  guard; `mark_unresolved` skips rows whose stored source/reason already match,
+  so re-running is a no-op and re-entry after a failed generation is safe.
+- **Transactional.** Takes a `Knex.Transaction`; it never opens its own.
+- **Shares the resolver** with the engine, so listing and reconciliation can
+  never disagree about which records are assignable.
+
+### Reconcile before calculate
+
+`BillingEngine` gains a transaction-pinning entry point (`initKnex` already
+short-circuits when `this.knex` is set, so this is a constructor/static
+overload, not a rewrite):
+
+```ts
+static forTransaction(trx: Knex.Transaction, tenant: string): BillingEngine;
+```
+
+One helper in `invoiceGeneration.ts` then serves all three window-billing
+callers:
+
+```ts
+async function calculateBillingWithReconciledAttribution(params: {
+  knex; tenant; selectorInputs; persistReconciliation: boolean;
+}) {
+  // withTransaction:
+  //   1. reconcileWindowAttribution(trx, ...)
+  //   2. calculateBillingForSelectionInputs({ billingEngine: BillingEngine.forTransaction(trx, tenant), ... })
+  //   3. persistReconciliation ? commit : roll back via sentinel, returning the result
+}
+```
+
+Because reconciliation commits (or rolls back) *before* the charge queries read
+`contract_line_id`, work covered by exactly one contract line is billed on the
+contract line **in this run**, at the negotiated rate, instead of slipping a
+cycle. There is no double-billing risk: the unresolved query filters
+`whereNull(contract_line_id)`, so an assigned record leaves the non-contract
+path the moment it enters the contract path.
+
+| Caller | Reconciles | Persists |
+|---|---|---|
+| `generateInvoiceForNormalizedSelectionInputs` (generation) | yes | yes — same transaction |
+| `previewInvoice` | yes | no — rolled back |
+| `getPurchaseOrderOverageForSelectionInput` | yes | no — rolled back |
+| `getAvailableRecurringDueWork` (listing) | **no** | no |
+| `calculateProjectBilling` / standalone project invoices | no change | — |
+
+Preview and the PO check reconcile-then-roll-back so that what they show is
+exactly what generation will produce; they remain observably read-only. The
+listing does not reconcile at all: it never prices contract lines from source
+records (hourly lines read "calculated at generation"), so an overlay would buy
+it nothing, and staying strictly read-only is the point of this change.
+
+`calculateProjectBilling` already skips contract-line resolution entirely under
+`projectTarget`, so the project path is untouched.
+
+### Additional write boundary: usage record create/edit
+
+`createUsageRecord` / `updateUsageRecord` already resolve a default contract
+line but never record `contract_line_source` / `contract_line_unresolved_reason`
+— asymmetric with `timeEntryCrudActions.ts:501-518`, which does. Make them write
+attribution through the shared decision. Records then arrive attributed and
+rarely need window reconciliation at all.
+
+## Behaviour change to call out
+
+Covered-but-unattributed work now bills in the run that discovers it rather than
+the next one. For the first generation after deploy, an invoice may include
+work from earlier periods that had been silently deferred — correct, but worth
+flagging in the PR description and to whoever runs the first billing cycle. No
+work is billed twice, and nothing that was previously billed stops being billed.
+
+## Deliberately not done
+
+- **Adding `updated_at` to `usage_tracking`.** Nothing reads it; adding a column
+  to a Citus-distributed table to satisfy one copy-pasted write is the wrong
+  direction. The descriptor plus a schema-conformance test is the fix.
+- **A reconciliation cron/background job.** Generation, preview, and record
+  create/edit cover every path that matters, and the unresolved review queue
+  (`unresolvedChargeActions`) already recomputes eligibility live and treats the
+  persisted reason as possibly stale.
+- **Spanning invoice persistence in the reconcile transaction.**
+  `createInvoiceFromBillingResult` opens its own transactions internally;
+  threading one through it is a large refactor of the most sensitive code in the
+  product. Reconciliation is a fact about the record, not an artifact of the
+  invoice, and it is idempotent — so committing it with the calculation and
+  letting invoice persistence follow is safe, and a failed generation leaves
+  correct, re-runnable state.
+- **Parallelising the per-period engine calls** in
+  `fetchUnresolvedNonContractDueWorkRows`. The "keep these calls serial" comment
+  is updated (reconciliation is no longer the reason), but the engine still pins
+  `this.knex` per instance, so parallelising needs a per-period engine — a
+  separate performance change.
+- **No migration.** No schema change is required.
+
+## Tests
+
+1. **Read-only listing (integration, real schema).** Attach a knex `query`
+   listener; call `getAvailableRecurringDueWork` over a window containing
+   unassigned time entries and usage records, including one usage record with a
+   uniquely eligible contract line. Assert: no non-`SELECT` statement touches
+   `time_entries` / `usage_tracking`, and a row-level snapshot of both tables is
+   byte-identical before and after. Call it twice to cover refresh.
+2. **Listing content unchanged.** The uniquely-assignable record is absent from
+   the unresolved rows; ambiguous and no-match records are present with the
+   correct `unresolved_reason`. Extends
+   `server/src/test/unit/billing/nonContractDueWork.integration.test.ts`.
+3. **Same-run billing (integration, real schema).** Generate over a window
+   holding a uniquely-assignable usage record and time entry: the invoice
+   contains them **on their contract line** at the contract rate, they are
+   marked invoiced, `contract_line_source = 'reconciled_at_generation'`, and
+   they appear exactly once across all charges. This is the production-schema
+   check too — the usage write must succeed with no `updated_at` column present.
+4. **Preview matches generation.** Preview the same window, then generate it;
+   the charge sets match. Assert preview left `time_entries` / `usage_tracking`
+   byte-identical (the reconcile transaction rolled back).
+5. **Failed generation leaves re-runnable state.** Force an abort after
+   reconciliation (e.g. `UnresolvedCatalogPricingError`): assignments are
+   consistent, no invoice exists, and re-running generation succeeds and bills
+   each record once.
+6. **Writer idempotency (unit).** Applying the same decision set twice yields
+   `{ assigned: 0, markedUnresolved: 0 }` on the second run.
+7. **Schema conformance (integration).** For every entry in
+   `ATTRIBUTION_TABLES`, assert `hasUpdatedAt` matches `information_schema
+   .columns` on the migrated database. This is the guard that would have caught
+   the original defect.
+8. **Rewrite `billingEngine.unresolvedReconciliation.test.ts`** to assert the
+   returned decisions rather than mocked `update()` payloads — the mock-shaped
+   assertion is what let a non-existent column ship.
+9. **PO overage read-only.** Statement-listener assertion on
+   `getPurchaseOrderOverageForSelectionInput`.
+
+## Verification
+
+- Local stack on this worktree (`alga-psa-local-test`, port 3151) — the dev
+  database matches production here: `usage_tracking` has no `updated_at`.
+- Seed a client with an unassigned usage record (uniquely assignable), an
+  ambiguous time entry, and a no-match entry. Load **Billing → Invoicing →
+  Generate**: periods list with no 500, and both tables are unchanged after
+  repeated refreshes. Preview the period, confirm the tables are still
+  unchanged, then generate and confirm the assignable record billed on its
+  contract line in that invoice.
+
+## Work breakdown
+
+1. Add `ContractLineAttributionDecision` + `buildContractLineAttributionDecision`
+   to `contractLineDisambiguation.shared.ts`.
+2. Add `contractLineAttributionWriter.ts`: table descriptor,
+   `applyContractLineAttributionDecisions`, `reconcileWindowAttribution`.
+3. Remove both `UPDATE` blocks from
+   `calculateUnresolvedNonContractCharges`; build decisions in memory and adjust
+   the log lines.
+4. Add `BillingEngine.forTransaction(trx, tenant)`.
+5. Add `calculateBillingWithReconciledAttribution` and route generation,
+   preview, and the PO-overage check through it.
+6. Write attribution source/reason in `createUsageRecord` / `updateUsageRecord`.
+7. Update the stale "may reconcile as it reads" comments in
+   `fetchUnresolvedNonContractDueWorkRows` and
+   `calculateUnresolvedNonContractChargesForExecutionWindow`.
+8. Tests 1-9 above.

--- a/packages/billing/src/actions/billingAndTax.ts
+++ b/packages/billing/src/actions/billingAndTax.ts
@@ -862,7 +862,8 @@ function toTimestampMs(value: Date | string | null | undefined): number | null {
  * These two tenant-scoped reads mirror the billing engine's coarse eligibility
  * filters. They deliberately do not reproduce pricing, deterministic contract
  * reconciliation, project-cap handling, or tax behavior; the authoritative
- * billing-engine call still performs all of that for each populated window.
+ * billing-engine call still performs the read-only classification and pricing
+ * for each populated window.
  */
 async function filterBillingPeriodsWithPotentialUnresolvedWork(
     trx: BillingQueryExecutor,
@@ -1022,8 +1023,8 @@ async function fetchUnresolvedNonContractDueWorkRows(
     const billingEngine = new BillingEngine();
     const rows: IRecurringDueWorkRow[] = [];
 
-    // Keep these calls serial: BillingEngine pins a transaction on the instance
-    // and may reconcile a uniquely assignable source record as it reads it.
+    // Keep these calls serial: each BillingEngine instance pins its own read
+    // connection, and the listing must not reconcile source records as it reads.
     for (const period of populatedBillingPeriods) {
         if (!period.period_start_date || !period.period_end_date) {
             continue;

--- a/packages/billing/src/actions/invoiceGeneration.ts
+++ b/packages/billing/src/actions/invoiceGeneration.ts
@@ -9,6 +9,7 @@ import { withAuth } from '@alga-psa/auth';
 import { hasPermission } from '@alga-psa/auth/rbac';
 import { getAnalyticsAsync } from '../lib/authHelpers';
 import { BillingEngine, UnresolvedCatalogPricingError } from '../lib/billing/billingEngine';
+import { reconcileWindowAttribution } from '../lib/billing/contractLineAttributionWriter';
 import { getClientDefaultBillingProfileId } from '../lib/billing/billingProfileLookup';
 import {
   getCycleBillingProfileId,
@@ -1471,6 +1472,58 @@ export async function calculateBillingForSelectionInputs(input: {
   );
 }
 
+class RollbackReconciliation extends Error {
+  constructor(readonly billingResult: IBillingResult) {
+    super('Reconciliation was intentionally rolled back after calculation.');
+    this.name = 'RollbackReconciliation';
+  }
+}
+
+/**
+ * Reconcile only at an explicit billing boundary. Generation commits the
+ * reconciliation transaction after calculation; preview and PO checks throw a
+ * sentinel so the same calculation sees the writes but the transaction rolls
+ * them back before returning.
+ */
+async function calculateBillingWithReconciledAttribution(params: {
+  knex: Knex;
+  tenant: string;
+  selectorInputs: IRecurringDueSelectionInput[];
+  persistReconciliation: boolean;
+}): Promise<IBillingResult> {
+  const canonicalSelection = assertSameRecurringSelectionWindow(params.selectorInputs);
+
+  try {
+    return await withTransaction(params.knex, async (trx: Knex.Transaction) => {
+      await reconcileWindowAttribution({
+        trx,
+        tenant: params.tenant,
+        clientId: canonicalSelection.clientId,
+        windowStart: canonicalSelection.windowStart,
+        windowEnd: canonicalSelection.windowEnd,
+      });
+
+      const billingResult = await calculateBillingForSelectionInputs({
+        billingEngine: BillingEngine.forTransaction(trx, params.tenant),
+        selectorInputs: params.selectorInputs,
+      });
+
+      if (params.persistReconciliation && billingResult.error) {
+        throw new Error(billingResult.error);
+      }
+      if (!params.persistReconciliation) {
+        throw new RollbackReconciliation(billingResult);
+      }
+      return billingResult;
+    });
+  } catch (error) {
+    if (error instanceof RollbackReconciliation) {
+      return error.billingResult;
+    }
+    throw error;
+  }
+}
+
 export async function calculateBillingForSelectionInput(input: {
   billingEngine: BillingEngine;
   selectorInput: IRecurringDueSelectionInput;
@@ -1503,10 +1556,11 @@ async function getPurchaseOrderOverageForSelectionInputInternal(params: {
   const client_id = selectorInput.clientId;
   const cycleEnd = selectorInput.windowEnd;
 
-  const billingEngine = new BillingEngine();
-  const billingResult = await calculateBillingForSelectionInput({
-    billingEngine,
-    selectorInput,
+  const billingResult = await calculateBillingWithReconciledAttribution({
+    knex,
+    tenant,
+    selectorInputs: [selectorInput],
+    persistReconciliation: false,
   });
   if (billingResult.error) {
     throw new Error(billingResult.error);
@@ -1792,10 +1846,11 @@ async function buildPreviewInvoiceForSelectionInputs(params: {
     }
   }
 
-  const billingEngine = new BillingEngine();
-  const billingResult = await calculateBillingForSelectionInputs({
-    billingEngine,
+  const billingResult = await calculateBillingWithReconciledAttribution({
+    knex,
+    tenant,
     selectorInputs,
+    persistReconciliation: false,
   });
 
   if (billingResult.error) {
@@ -2622,10 +2677,11 @@ async function generateInvoiceForNormalizedSelectionInputs(params: {
     );
   }
 
-  const billingEngine = new BillingEngine();
-  const billingResult = await calculateBillingForSelectionInputs({
-    billingEngine,
+  const billingResult = await calculateBillingWithReconciledAttribution({
+    knex,
+    tenant,
     selectorInputs: params.normalizedSelectorInputs,
+    persistReconciliation: true,
   });
   if (billingResult.error) {
     throw withRecurringWindowErrorContext(new Error(billingResult.error), normalizedSelectorInput);

--- a/packages/billing/src/actions/usageActions.ts
+++ b/packages/billing/src/actions/usageActions.ts
@@ -2,8 +2,20 @@
 
 import { Knex } from 'knex'; // Ensure Knex type is imported
 import { createTenantKnex, tenantDb } from '@alga-psa/db';
-import { determineDefaultContractLine } from '@alga-psa/billing/lib/contractLineDisambiguation';
-import { ICreateUsageRecord, IUpdateUsageRecord, IUsageFilter, IUsageRecord } from '@alga-psa/types';
+import { getEligibleContractLines } from '@alga-psa/billing/lib/contractLineDisambiguation';
+import {
+  buildContractLineAttributionDecision,
+  resolveDeterministicContractLineSelection,
+} from '../lib/contractLineDisambiguation.shared';
+import {
+  ICreateUsageRecord,
+  IUpdateUsageRecord,
+  IUsageFilter,
+  IUsageRecord,
+  CONTRACT_LINE_SOURCE_BY_SELECTION_REASON,
+  type ContractLineSelectionReason,
+  type ContractLineSource,
+} from '@alga-psa/types';
 import { revalidatePath } from 'next/cache';
 import { adjustQuantityDraw } from '@alga-psa/shared/billingClients/drawAdjustments';
 import {
@@ -29,6 +41,31 @@ function tenantScopedTable(
   table: string
 ): Knex.QueryBuilder {
   return tenantDb(conn, tenant).table(table);
+}
+
+async function resolveUsageAttribution(params: {
+  trx: Knex.Transaction;
+  tenant: string;
+  clientId: string;
+  serviceId: string;
+  usageDate: string | Date;
+}) {
+  const eligibleLines = await getEligibleContractLines(
+    params.trx,
+    params.tenant,
+    params.clientId,
+    params.serviceId,
+    params.usageDate,
+  );
+  const selection = resolveDeterministicContractLineSelection(eligibleLines);
+  return {
+    selection,
+    decision: buildContractLineAttributionDecision({
+      kind: 'usage_record',
+      recordId: 'usage-write',
+      selection,
+    }),
+  };
 }
 
 function usageActionErrorFrom(error: unknown): UsageActionError | null {
@@ -78,22 +115,30 @@ export const createUsageRecord = withAuth(async (user, { tenant }, data: ICreate
     return await knex.transaction(async (trx) => {
     // If no contract line ID is provided, try to determine the default one
     let contractLineId = data.contract_line_id;
+    let contractLineSource: ContractLineSource | null = data.contract_line_id
+      ? 'explicit'
+      : null;
+    let contractLineUnresolvedReason: ContractLineSelectionReason | null = null;
     if (!contractLineId && data.service_id && data.client_id) {
       try {
-        // Use trx for consistency if determineDefaultContractLine needs DB access within transaction
-        const defaultPlanId = await determineDefaultContractLine(
-          data.client_id,
-          data.service_id,
-          data.usage_date
-          // trx // Removed transaction argument
-        );
-
-        if (defaultPlanId) {
-          contractLineId = defaultPlanId;
+        const { selection, decision } = await resolveUsageAttribution({
+          trx,
+          tenant,
+          clientId: data.client_id,
+          serviceId: data.service_id,
+          usageDate: data.usage_date,
+        });
+        if (decision.action === 'assign') {
+          contractLineId = decision.contractLineId;
+          contractLineSource = CONTRACT_LINE_SOURCE_BY_SELECTION_REASON[selection.reason];
+        } else {
+          contractLineSource = 'unresolved';
+          contractLineUnresolvedReason = decision.reason;
         }
       } catch (error) {
         console.error('Error determining default contract line:', error);
-        // Potentially rethrow or handle if this is critical
+        contractLineSource = 'unresolved';
+        contractLineUnresolvedReason = 'error';
       }
     }
 
@@ -106,6 +151,8 @@ export const createUsageRecord = withAuth(async (user, { tenant }, data: ICreate
         quantity: data.quantity,
         usage_date: data.usage_date,
         contract_line_id: contractLineId, // Use determined or provided plan ID
+        contract_line_source: contractLineSource,
+        contract_line_unresolved_reason: contractLineUnresolvedReason,
       })
       .returning('*');
 
@@ -174,26 +221,42 @@ export const updateUsageRecord = withAuth(async (user, { tenant }, data: IUpdate
     const oldQuantity = originalRecord.quantity || 0;
 
     // 2. Determine the final contract line ID
-    let finalContractLineId = data.contract_line_id;
+    let finalContractLineId: string | null | undefined = data.contract_line_id;
+    let finalContractLineSource: ContractLineSource | null = data.contract_line_id
+      ? 'explicit'
+      : (originalRecord.contract_line_source ?? null);
+    let finalContractLineUnresolvedReason: ContractLineSelectionReason | null =
+      originalRecord.contract_line_unresolved_reason ?? null;
     // If plan ID is explicitly set to null/undefined OR not provided in update payload, try determining default
     if (finalContractLineId === null || finalContractLineId === undefined) {
       const clientIdForPlan = data.client_id || originalRecord.client_id;
       const serviceIdForPlan = data.service_id || originalRecord.service_id;
       if (clientIdForPlan && serviceIdForPlan) {
         try {
-          const defaultPlanId = await determineDefaultContractLine(
-            clientIdForPlan,
-            serviceIdForPlan,
-            data.usage_date || originalRecord.usage_date
-            // trx // Removed transaction argument
-          );
-          finalContractLineId = defaultPlanId || undefined; // Use default or undefined if none found
+          const { selection, decision } = await resolveUsageAttribution({
+            trx,
+            tenant,
+            clientId: clientIdForPlan,
+            serviceId: serviceIdForPlan,
+            usageDate: data.usage_date || originalRecord.usage_date,
+          });
+          if (decision.action === 'assign') {
+            finalContractLineId = decision.contractLineId;
+            finalContractLineSource = CONTRACT_LINE_SOURCE_BY_SELECTION_REASON[selection.reason];
+            finalContractLineUnresolvedReason = null;
+          } else {
+            finalContractLineId = null;
+            finalContractLineSource = 'unresolved';
+            finalContractLineUnresolvedReason = decision.reason;
+          }
         } catch (error) {
           console.error('Error determining default contract line during update:', error);
           finalContractLineId = originalRecord.contract_line_id; // Fallback to original if determination fails? Or keep as null? Keeping null for now.
+          finalContractLineSource = 'unresolved';
+          finalContractLineUnresolvedReason = 'error';
         }
       } else {
-         finalContractLineId = originalRecord.contract_line_id; // Fallback if client/service IDs are missing
+        finalContractLineId = originalRecord.contract_line_id; // Fallback if client/service IDs are missing
       }
     }
 
@@ -205,7 +268,8 @@ export const updateUsageRecord = withAuth(async (user, { tenant }, data: IUpdate
         ...(data.quantity !== undefined && { quantity: data.quantity }),
         ...(data.usage_date !== undefined && { usage_date: data.usage_date }),
         contract_line_id: finalContractLineId, // Always update the plan ID based on determination logic
-        // updated_at is likely handled by DB trigger/default, removed from payload
+        contract_line_source: finalContractLineSource,
+        contract_line_unresolved_reason: finalContractLineUnresolvedReason,
     };
 
 

--- a/packages/billing/src/actions/usageActions.ts
+++ b/packages/billing/src/actions/usageActions.ts
@@ -64,6 +64,7 @@ async function resolveUsageAttribution(params: {
       kind: 'usage_record',
       recordId: 'usage-write',
       selection,
+      allowBucketOverlay: true,
     }),
   };
 }
@@ -251,9 +252,12 @@ export const updateUsageRecord = withAuth(async (user, { tenant }, data: IUpdate
           }
         } catch (error) {
           console.error('Error determining default contract line during update:', error);
-          finalContractLineId = originalRecord.contract_line_id; // Fallback to original if determination fails? Or keep as null? Keeping null for now.
-          finalContractLineSource = 'unresolved';
-          finalContractLineUnresolvedReason = 'error';
+          // Resolver failure must not create a mixed attribution tuple. Keep
+          // the original line/source/reason together until a later explicit
+          // edit or reconciliation can replace the tuple atomically.
+          finalContractLineId = originalRecord.contract_line_id ?? null;
+          finalContractLineSource = originalRecord.contract_line_source ?? null;
+          finalContractLineUnresolvedReason = originalRecord.contract_line_unresolved_reason ?? null;
         }
       } else {
         finalContractLineId = originalRecord.contract_line_id; // Fallback if client/service IDs are missing

--- a/packages/billing/src/lib/billing/billingEngine.ts
+++ b/packages/billing/src/lib/billing/billingEngine.ts
@@ -107,6 +107,7 @@ import {
 import { getClientDefaultBillingProfileId } from "./billingProfileLookup";
 import { listSeparatelyBillingProfiles } from "@alga-psa/shared/billingClients/billingProfileSettings";
 import {
+  buildContractLineAttributionDecision,
   resolveDeterministicContractLineSelection,
   type ContractLineSelectionReason,
 } from "../contractLineDisambiguation.shared";
@@ -249,26 +250,6 @@ const RECURRING_TIMING_ROLLOUT_GUARD_PREFIX =
  * catalog pricing (F139). Carries the offending records so the caller can turn
  * it into an actionable message rather than a generic failure.
  */
-/**
- * Whether a contract-line selection may be written back at generation time.
- *
- * Reconcile has always accepted exactly one thing: a single eligible line.
- * Profile narrowing joins it (F135), because parallel per-profile contracts
- * carrying the same service are the multi-candidate case this feature creates
- * and the work item's profile genuinely answers it.
- *
- * The bucket-overlay tie-break does **not** join it. That rule belongs to
- * time-entry *creation*, where a person is choosing a line and an overlay is a
- * reasonable default. Applying it here would silently attach a contract line to
- * records the engine has always left unresolved — and those records then get
- * billed twice, once by the contract-line path and once by the usage path.
- */
-function isReconcilableSelection(selection: {
-  decision: string;
-}): boolean {
-  return selection.decision === "explicit" || selection.decision === "billing_profile";
-}
-
 export class UnresolvedCatalogPricingError extends Error {
   readonly items: Array<{ kind: "time_entry" | "usage_record"; id: string; label: string }>;
 
@@ -387,6 +368,13 @@ export class BillingEngine {
   constructor() {
     this.knex = null as any;
     this.tenant = null;
+  }
+
+  static forTransaction(trx: Knex.Transaction, tenant: string): BillingEngine {
+    const engine = new BillingEngine();
+    engine.knex = trx;
+    engine.tenant = tenant;
+    return engine;
   }
 
   private async initKnex() {
@@ -2559,20 +2547,12 @@ export class BillingEngine {
           eligibleLines,
           { billingProfileId: entry.work_item_billing_profile_id ?? null },
         );
-        if (selection.selectedContractLineId && isReconcilableSelection(selection)) {
-          const updatedCount = await db
-            .table("time_entries")
-            .where({
-              tenant: this.tenant,
-              entry_id: entry.entry_id,
-            })
-            .whereNull("contract_line_id")
-            .update({
-              contract_line_id: selection.selectedContractLineId,
-              contract_line_source: "reconciled_at_generation",
-              contract_line_unresolved_reason: null,
-              updated_at: this.knex.fn.now(),
-            });
+        const attributionDecision = buildContractLineAttributionDecision({
+          kind: "time_entry",
+          recordId: entry.entry_id,
+          selection,
+        });
+        if (attributionDecision.action === "assign") {
           console.info("[billing_engine.reconcile.unresolved]", {
             event: "billing_engine.reconcile.unresolved",
             recordType: "time_entry",
@@ -2581,21 +2561,22 @@ export class BillingEngine {
             recordId: entry.entry_id,
             decision: "deterministic_single_match",
             reason: selection.reason,
-            selectedContractLineId: selection.selectedContractLineId,
+            selectedContractLineId: attributionDecision.contractLineId,
             eligibleLineCount: eligibleLines.length,
-            persisted: updatedCount > 0,
+            persisted: false,
             metric: { name: "unmatched_resolved_deterministically", value: 1 },
           });
           continue;
         }
         // The reason is what distinguishes "no contract covers this service"
         // (catalog rate is honest) from "a contract does, and we could not tell
-        // which line" (catalog rate is wrong). Persisted rather than only
-        // logged, so the dashboard can say which it is (F137).
-        unresolvedReasonByRecordId.set(entry.entry_id, selection.reason);
+        // which line" (catalog rate is wrong). Carried rather than only
+        // logged, so billing can use the same reason without mutating the read
+        // path (F137).
+        unresolvedReasonByRecordId.set(entry.entry_id, attributionDecision.reason);
         if (
           requireCatalogPricingDecision &&
-          selection.reason !== "no_match" &&
+          attributionDecision.reason !== "no_match" &&
           !entry.catalog_pricing_acknowledged_at
         ) {
           blockedFromCatalogPricing.push({
@@ -2604,23 +2585,14 @@ export class BillingEngine {
             label: entry.service_name ?? entry.entry_id,
           });
         }
-        await db
-          .table("time_entries")
-          .where({ tenant: this.tenant, entry_id: entry.entry_id })
-          .whereNull("contract_line_id")
-          .update({
-            contract_line_source: "unresolved",
-            contract_line_unresolved_reason: selection.reason,
-            updated_at: this.knex.fn.now(),
-          });
         console.info("[billing_engine.reconcile.unresolved]", {
           event: "billing_engine.reconcile.unresolved",
           recordType: "time_entry",
           tenant: this.tenant,
           clientId,
           recordId: entry.entry_id,
-          decision: selection.reason === "no_match" ? "no_match" : "ambiguous",
-          reason: selection.reason,
+          decision: attributionDecision.reason === "no_match" ? "no_match" : "ambiguous",
+          reason: attributionDecision.reason,
           selectedContractLineId: null,
           eligibleLineCount: eligibleLines.length,
           persisted: false,
@@ -2794,20 +2766,12 @@ export class BillingEngine {
       // symmetrically to usage (F141).
       const usageSelection =
         resolveDeterministicContractLineSelection(eligibleLines);
-      if (usageSelection.selectedContractLineId && isReconcilableSelection(usageSelection)) {
-        const updatedCount = await db
-          .table("usage_tracking")
-          .where({
-            tenant: this.tenant,
-            usage_id: record.usage_id,
-          })
-          .whereNull("contract_line_id")
-          .update({
-            contract_line_id: usageSelection.selectedContractLineId,
-            contract_line_source: "reconciled_at_generation",
-            contract_line_unresolved_reason: null,
-            updated_at: this.knex.fn.now(),
-          });
+      const attributionDecision = buildContractLineAttributionDecision({
+        kind: "usage_record",
+        recordId: record.usage_id,
+        selection: usageSelection,
+      });
+      if (attributionDecision.action === "assign") {
         console.info("[billing_engine.reconcile.unresolved]", {
           event: "billing_engine.reconcile.unresolved",
           recordType: "usage_record",
@@ -2816,17 +2780,17 @@ export class BillingEngine {
           recordId: record.usage_id,
           decision: "deterministic_single_match",
           reason: usageSelection.reason,
-          selectedContractLineId: usageSelection.selectedContractLineId,
+          selectedContractLineId: attributionDecision.contractLineId,
           eligibleLineCount: eligibleLines.length,
-          persisted: updatedCount > 0,
+          persisted: false,
           metric: { name: "unmatched_resolved_deterministically", value: 1 },
         });
         continue;
       }
-      unresolvedReasonByRecordId.set(record.usage_id, usageSelection.reason);
+      unresolvedReasonByRecordId.set(record.usage_id, attributionDecision.reason);
       if (
         requireCatalogPricingDecision &&
-        usageSelection.reason !== "no_match" &&
+        attributionDecision.reason !== "no_match" &&
         !record.catalog_pricing_acknowledged_at
       ) {
         blockedFromCatalogPricing.push({
@@ -2835,15 +2799,6 @@ export class BillingEngine {
           label: record.service_name ?? record.usage_id,
         });
       }
-      await db
-        .table("usage_tracking")
-        .where({ tenant: this.tenant, usage_id: record.usage_id })
-        .whereNull("contract_line_id")
-        .update({
-          contract_line_source: "unresolved",
-          contract_line_unresolved_reason: usageSelection.reason,
-          updated_at: this.knex.fn.now(),
-        });
       console.info("[billing_engine.reconcile.unresolved]", {
         event: "billing_engine.reconcile.unresolved",
         recordType: "usage_record",
@@ -2851,8 +2806,8 @@ export class BillingEngine {
         clientId,
         recordId: record.usage_id,
         decision:
-          usageSelection.reason === "no_match" ? "no_match" : "ambiguous",
-        reason: usageSelection.reason,
+          attributionDecision.reason === "no_match" ? "no_match" : "ambiguous",
+        reason: attributionDecision.reason,
         selectedContractLineId: null,
         eligibleLineCount: eligibleLines.length,
         persisted: false,

--- a/packages/billing/src/lib/billing/contractLineAttributionWriter.ts
+++ b/packages/billing/src/lib/billing/contractLineAttributionWriter.ts
@@ -95,14 +95,31 @@ async function loadWindowRecords(params: {
   const { trx, tenant, clientId, windowStart, windowEnd } = params;
   const db = tenantDb(trx, tenant);
 
+  const fixedPriceProjectsQuery = db.table<any>('project_billing_configs as config');
+  db.tenantJoin(
+    fixedPriceProjectsQuery,
+    'projects',
+    'config.project_id',
+    'projects.project_id',
+  );
+  const fixedPriceProjectRows = await fixedPriceProjectsQuery
+    .where({
+      'config.billing_model': 'fixed_price',
+      'projects.client_id': clientId,
+    })
+    .distinct('config.project_id')
+    .select('config.project_id');
+  const fixedPriceProjectIds = fixedPriceProjectRows
+    .map((row: any) => row.project_id)
+    .filter((projectId: unknown): projectId is string => typeof projectId === 'string');
+
   const timeQuery = db.table<any>('time_entries');
   db.tenantJoin(timeQuery, 'project_tasks', 'time_entries.work_item_id', 'project_tasks.task_id', { type: 'left' });
   db.tenantJoin(timeQuery, 'project_phases', 'project_tasks.phase_id', 'project_phases.phase_id', { type: 'left' });
   db.tenantJoin(timeQuery, 'projects', 'project_phases.project_id', 'projects.project_id', { type: 'left' });
   db.tenantJoin(timeQuery, 'tickets', 'time_entries.work_item_id', 'tickets.ticket_id', { type: 'left' });
 
-  const [timeEntries, usageRecords] = await Promise.all([
-    timeQuery
+  const timeEntriesQuery = timeQuery
       .where('time_entries.tenant', tenant)
       .where('time_entries.invoiced', false)
       .whereNull('time_entries.contract_line_id')
@@ -113,8 +130,18 @@ async function loadWindowRecords(params: {
       .where('time_entries.end_time', '<', windowEnd)
       .where(function (this: Knex.QueryBuilder) {
         this.where('projects.client_id', clientId).orWhere('tickets.client_id', clientId);
-      })
-      .select(
+      });
+  if (fixedPriceProjectIds.length > 0) {
+    timeEntriesQuery.where(function (this: Knex.QueryBuilder) {
+      this.whereNull('projects.project_id').orWhereNotIn(
+        'projects.project_id',
+        fixedPriceProjectIds,
+      );
+    });
+  }
+
+  const [timeEntries, usageRecords] = await Promise.all([
+    timeEntriesQuery.select(
         'time_entries.entry_id',
         'time_entries.service_id',
         'time_entries.start_time',

--- a/packages/billing/src/lib/billing/contractLineAttributionWriter.ts
+++ b/packages/billing/src/lib/billing/contractLineAttributionWriter.ts
@@ -1,0 +1,267 @@
+import type { Knex } from 'knex';
+import { tenantDb } from '@alga-psa/db';
+import { toISODate, toPlainDate } from '@alga-psa/core';
+import type { ISO8601String } from '@alga-psa/types';
+import {
+  buildContractLineAttributionDecision,
+  resolveDeterministicContractLineSelection,
+  type ContractLineAttributionDecision,
+} from '../contractLineDisambiguation.shared';
+
+const ATTRIBUTION_TABLES = {
+  time_entry: {
+    table: 'time_entries',
+    idColumn: 'entry_id',
+    hasUpdatedAt: true,
+  },
+  usage_record: {
+    table: 'usage_tracking',
+    idColumn: 'usage_id',
+    hasUpdatedAt: false,
+  },
+} as const;
+
+type EligibleContractLine = {
+  client_contract_line_id: string;
+  billing_profile_id: string | null;
+  contract_billing_profile_id: string | null;
+};
+
+type AttributionWindowRecord = {
+  kind: 'time_entry' | 'usage_record';
+  recordId: string;
+  serviceId: string;
+  workDate: ISO8601String;
+  workItemBillingProfileId?: string | null;
+};
+
+/**
+ * Load candidates for the same client/service/date rule used by calculation.
+ * This helper deliberately returns candidate rows, not a selected id, so the
+ * shared resolver remains the single deterministic classification rule.
+ */
+export async function getEligibleContractLinesForServiceAtDate(params: {
+  trx: Knex.Transaction;
+  tenant: string;
+  clientId: string;
+  serviceId: string;
+  workDate: ISO8601String;
+}): Promise<EligibleContractLine[]> {
+  const { trx, tenant, clientId, serviceId, workDate } = params;
+  const db = tenantDb(trx, tenant);
+  const query = db.table('client_contracts as cc');
+  db.tenantJoin(query, 'contracts as c', 'c.contract_id', 'cc.contract_id');
+  db.tenantJoin(query, 'contract_lines as cl', 'cl.contract_id', 'c.contract_id');
+  db.tenantJoin(
+    query,
+    'contract_line_services as cls',
+    'cls.contract_line_id',
+    'cl.contract_line_id',
+  );
+
+  const rows = await query
+    .where({
+      'cc.client_id': clientId,
+      'cc.is_active': true,
+      'cls.service_id': serviceId,
+    })
+    .where('cc.start_date', '<=', workDate)
+    .where(function (this: Knex.QueryBuilder) {
+      this.whereNull('cc.end_date').orWhere('cc.end_date', '>=', workDate);
+    })
+    .distinct('cl.contract_line_id')
+    .select(
+      'cl.contract_line_id',
+      'cl.billing_profile_id',
+      'cc.billing_profile_id as contract_billing_profile_id',
+    );
+
+  return rows
+    .filter((row: any) => typeof row.contract_line_id === 'string')
+    .map((row: any) => ({
+      client_contract_line_id: row.contract_line_id,
+      billing_profile_id: row.billing_profile_id ?? null,
+      contract_billing_profile_id: row.contract_billing_profile_id ?? null,
+    }));
+}
+
+async function loadWindowRecords(params: {
+  trx: Knex.Transaction;
+  tenant: string;
+  clientId: string;
+  windowStart: ISO8601String;
+  windowEnd: ISO8601String;
+}): Promise<AttributionWindowRecord[]> {
+  const { trx, tenant, clientId, windowStart, windowEnd } = params;
+  const db = tenantDb(trx, tenant);
+
+  const timeQuery = db.table<any>('time_entries');
+  db.tenantJoin(timeQuery, 'project_tasks', 'time_entries.work_item_id', 'project_tasks.task_id', { type: 'left' });
+  db.tenantJoin(timeQuery, 'project_phases', 'project_tasks.phase_id', 'project_phases.phase_id', { type: 'left' });
+  db.tenantJoin(timeQuery, 'projects', 'project_phases.project_id', 'projects.project_id', { type: 'left' });
+  db.tenantJoin(timeQuery, 'tickets', 'time_entries.work_item_id', 'tickets.ticket_id', { type: 'left' });
+
+  const [timeEntries, usageRecords] = await Promise.all([
+    timeQuery
+      .where('time_entries.tenant', tenant)
+      .where('time_entries.invoiced', false)
+      .whereNull('time_entries.contract_line_id')
+      .whereNotNull('time_entries.service_id')
+      .where('time_entries.approval_status', 'APPROVED')
+      .where('time_entries.billable_duration', '>', 0)
+      .where('time_entries.start_time', '>=', windowStart)
+      .where('time_entries.end_time', '<', windowEnd)
+      .where(function (this: Knex.QueryBuilder) {
+        this.where('projects.client_id', clientId).orWhere('tickets.client_id', clientId);
+      })
+      .select(
+        'time_entries.entry_id',
+        'time_entries.service_id',
+        'time_entries.start_time',
+        trx.raw('COALESCE(tickets.billing_profile_id, projects.billing_profile_id) as work_item_billing_profile_id'),
+      ),
+    db.table<any>('usage_tracking')
+      .where({
+        'usage_tracking.tenant': tenant,
+        'usage_tracking.client_id': clientId,
+        'usage_tracking.invoiced': false,
+      })
+      .whereNull('usage_tracking.contract_line_id')
+      .whereNotNull('usage_tracking.service_id')
+      .where('usage_tracking.usage_date', '>=', windowStart)
+      .where('usage_tracking.usage_date', '<', windowEnd)
+      .select('usage_tracking.usage_id', 'usage_tracking.service_id', 'usage_tracking.usage_date'),
+  ]);
+
+  return [
+    ...timeEntries.map((row: any) => ({
+      kind: 'time_entry' as const,
+      recordId: row.entry_id,
+      serviceId: row.service_id,
+      workDate: toISODate(toPlainDate(row.start_time)),
+      workItemBillingProfileId: row.work_item_billing_profile_id ?? null,
+    })),
+    ...usageRecords.map((row: any) => ({
+      kind: 'usage_record' as const,
+      recordId: row.usage_id,
+      serviceId: row.service_id,
+      workDate: toISODate(toPlainDate(row.usage_date)),
+    })),
+  ];
+}
+
+/** Apply in-memory decisions using the production table-specific write shape. */
+export async function applyContractLineAttributionDecisions(
+  trx: Knex.Transaction,
+  tenant: string,
+  decisions: ContractLineAttributionDecision[],
+): Promise<{ assigned: number; markedUnresolved: number }> {
+  const db = tenantDb(trx, tenant);
+  let assigned = 0;
+  let markedUnresolved = 0;
+
+  for (const decision of decisions) {
+    const descriptor = ATTRIBUTION_TABLES[decision.kind];
+    const query = db.table<any>(descriptor.table).where({
+      tenant,
+      [descriptor.idColumn]: decision.recordId,
+    });
+
+    if (decision.action === 'assign') {
+      const updatePayload: Record<string, unknown> = {
+        contract_line_id: decision.contractLineId,
+        contract_line_source: decision.source,
+        contract_line_unresolved_reason: null,
+      };
+      if (descriptor.hasUpdatedAt) {
+        updatePayload.updated_at = trx.fn.now();
+      }
+      const updatedCount = await query.whereNull('contract_line_id').update(updatePayload);
+      if (updatedCount > 0) assigned += updatedCount;
+      continue;
+    }
+
+    const current = await query.first(
+      'contract_line_id',
+      'contract_line_source',
+      'contract_line_unresolved_reason',
+    );
+    if (!current || current.contract_line_id) continue;
+    if (
+      current.contract_line_source === 'unresolved' &&
+      current.contract_line_unresolved_reason === decision.reason
+    ) {
+      continue;
+    }
+
+    const updatePayload: Record<string, unknown> = {
+      contract_line_source: 'unresolved',
+      contract_line_unresolved_reason: decision.reason,
+    };
+    if (descriptor.hasUpdatedAt) {
+      updatePayload.updated_at = trx.fn.now();
+    }
+    const updatedCount = await query.whereNull('contract_line_id').update(updatePayload);
+    if (updatedCount > 0) markedUnresolved += updatedCount;
+  }
+
+  return { assigned, markedUnresolved };
+}
+
+/** Resolve and persist every currently unassigned record in one transaction. */
+export async function reconcileWindowAttribution(params: {
+  trx: Knex.Transaction;
+  tenant: string;
+  clientId: string;
+  windowStart: ISO8601String;
+  windowEnd: ISO8601String;
+}): Promise<{ assigned: number; markedUnresolved: number }> {
+  const records = await loadWindowRecords(params);
+  const decisions: ContractLineAttributionDecision[] = [];
+
+  for (const record of records) {
+    const eligibleLines = await getEligibleContractLinesForServiceAtDate({
+      trx: params.trx,
+      tenant: params.tenant,
+      clientId: params.clientId,
+      serviceId: record.serviceId,
+      workDate: record.workDate,
+    });
+    const selection = resolveDeterministicContractLineSelection(eligibleLines, {
+      billingProfileId: record.workItemBillingProfileId ?? null,
+    });
+    const decision = buildContractLineAttributionDecision({
+      kind: record.kind,
+      recordId: record.recordId,
+      selection,
+    });
+    decisions.push(decision);
+    console.info('[billing_engine.reconcile.unresolved]', {
+      event: 'billing_engine.reconcile.unresolved',
+      recordType: record.kind,
+      tenant: params.tenant,
+      clientId: params.clientId,
+      recordId: record.recordId,
+      decision: decision.action === 'assign' ? 'deterministic_single_match' : decision.reason,
+      reason: decision.action === 'assign' ? selection.reason : decision.reason,
+      selectedContractLineId: decision.action === 'assign' ? decision.contractLineId : null,
+      eligibleLineCount: eligibleLines.length,
+      persisted: false,
+    });
+  }
+
+  const result = await applyContractLineAttributionDecisions(
+    params.trx,
+    params.tenant,
+    decisions,
+  );
+  console.info('[billing_engine.reconcile.unresolved.persisted]', {
+    event: 'billing_engine.reconcile.unresolved.persisted',
+    tenant: params.tenant,
+    clientId: params.clientId,
+    ...result,
+  });
+  return result;
+}
+
+export { ATTRIBUTION_TABLES };

--- a/packages/billing/src/lib/contractLineDisambiguation.shared.ts
+++ b/packages/billing/src/lib/contractLineDisambiguation.shared.ts
@@ -51,6 +51,30 @@ export interface ContractLineSelectionOptions {
   billingProfileId?: string | null;
 }
 
+/** Reasons allowed by the attribution columns' production CHECK constraint. */
+export type ContractLineAttributionUnresolvedReason = Extract<
+  ContractLineSelectionReason,
+  'ambiguous' | 'no_match' | 'error'
+>;
+
+function toAttributionUnresolvedReason(
+  reason: ContractLineSelectionReason,
+): ContractLineAttributionUnresolvedReason {
+  switch (reason) {
+    case 'no_match':
+    case 'ambiguous':
+    case 'error':
+      return reason;
+    case 'bucket_overlay':
+      return 'ambiguous';
+    // A selected line is required for these successful classifications. Keep
+    // the fallback safe if a malformed selection reaches this boundary.
+    case 'single_candidate':
+    case 'billing_profile':
+      return 'ambiguous';
+  }
+}
+
 export type ContractLineAttributionDecision =
   | {
       kind: 'time_entry' | 'usage_record';
@@ -63,7 +87,7 @@ export type ContractLineAttributionDecision =
       kind: 'time_entry' | 'usage_record';
       recordId: string;
       action: 'mark_unresolved';
-      reason: ContractLineSelectionReason;
+      reason: ContractLineAttributionUnresolvedReason;
     };
 
 /**
@@ -75,18 +99,25 @@ export function buildContractLineAttributionDecision(input: {
   kind: 'time_entry' | 'usage_record';
   recordId: string;
   selection: ContractLineSelectionResult;
+  /** Usage/time-entry create/edit may persist the deterministic overlay choice. */
+  allowBucketOverlay?: boolean;
 }): ContractLineAttributionDecision {
-  const { kind, recordId, selection } = input;
+  const { kind, recordId, selection, allowBucketOverlay = false } = input;
   if (
     selection.selectedContractLineId &&
-    (selection.decision === 'explicit' || selection.decision === 'billing_profile')
+    (selection.decision === 'explicit' ||
+      selection.decision === 'billing_profile' ||
+      (allowBucketOverlay && selection.reason === 'bucket_overlay'))
   ) {
     return {
       kind,
       recordId,
       action: 'assign',
       contractLineId: selection.selectedContractLineId,
-      source: 'reconciled_at_generation',
+      source:
+        allowBucketOverlay && selection.reason === 'bucket_overlay'
+          ? 'auto_bucket_overlay'
+          : 'reconciled_at_generation',
     };
   }
 
@@ -94,7 +125,10 @@ export function buildContractLineAttributionDecision(input: {
     kind,
     recordId,
     action: 'mark_unresolved',
-    reason: selection.reason,
+    // A unique overlay is a deterministic record-write choice, but generation
+    // deliberately does not reconcile that tie-break automatically. Keep the
+    // generation proposal within the production CHECK constraint.
+    reason: toAttributionUnresolvedReason(selection.reason),
   };
 }
 

--- a/packages/billing/src/lib/contractLineDisambiguation.shared.ts
+++ b/packages/billing/src/lib/contractLineDisambiguation.shared.ts
@@ -25,7 +25,10 @@ type LineCandidate = {
  * failed, and is gated like `ambiguous`: a human decides.
  */
 export type { ContractLineSelectionReason } from '@alga-psa/types';
-import type { ContractLineSelectionReason } from '@alga-psa/types';
+import type {
+  ContractLineSelectionReason,
+  ContractLineSource,
+} from '@alga-psa/types';
 
 export interface ContractLineSelectionResult {
   selectedContractLineId: string | null;
@@ -46,6 +49,53 @@ export interface ContractLineSelectionOptions {
    * selection turn out to be the same question (F133).
    */
   billingProfileId?: string | null;
+}
+
+export type ContractLineAttributionDecision =
+  | {
+      kind: 'time_entry' | 'usage_record';
+      recordId: string;
+      action: 'assign';
+      contractLineId: string;
+      source: ContractLineSource;
+    }
+  | {
+      kind: 'time_entry' | 'usage_record';
+      recordId: string;
+      action: 'mark_unresolved';
+      reason: ContractLineSelectionReason;
+    };
+
+/**
+ * Convert the shared deterministic selection into the in-memory write proposal
+ * used by generation reconciliation. The resolver remains the only place that
+ * decides whether a candidate is unique, ambiguous, or absent.
+ */
+export function buildContractLineAttributionDecision(input: {
+  kind: 'time_entry' | 'usage_record';
+  recordId: string;
+  selection: ContractLineSelectionResult;
+}): ContractLineAttributionDecision {
+  const { kind, recordId, selection } = input;
+  if (
+    selection.selectedContractLineId &&
+    (selection.decision === 'explicit' || selection.decision === 'billing_profile')
+  ) {
+    return {
+      kind,
+      recordId,
+      action: 'assign',
+      contractLineId: selection.selectedContractLineId,
+      source: 'reconciled_at_generation',
+    };
+  }
+
+  return {
+    kind,
+    recordId,
+    action: 'mark_unresolved',
+    reason: selection.reason,
+  };
 }
 
 const belongsToProfile = (

--- a/packages/billing/tests/contractLineAttributionDecision.test.ts
+++ b/packages/billing/tests/contractLineAttributionDecision.test.ts
@@ -50,6 +50,41 @@ describe('contract-line attribution decisions', () => {
     });
   });
 
+  it('persists bucket-overlay selection only for record create/edit, not generation reconciliation', () => {
+    const selection = resolveDeterministicContractLineSelection([
+      { ...line('line-overlay'), bucket_overlay: { config_id: 'bucket-1' } },
+      line('line-other'),
+    ]);
+
+    expect(selection).toMatchObject({
+      selectedContractLineId: 'line-overlay',
+      decision: 'default',
+      reason: 'bucket_overlay',
+    });
+    expect(buildContractLineAttributionDecision({
+      kind: 'usage_record',
+      recordId: 'usage-generation',
+      selection,
+    })).toEqual({
+      kind: 'usage_record',
+      recordId: 'usage-generation',
+      action: 'mark_unresolved',
+      reason: 'ambiguous',
+    });
+    expect(buildContractLineAttributionDecision({
+      kind: 'usage_record',
+      recordId: 'usage-write',
+      selection,
+      allowBucketOverlay: true,
+    })).toEqual({
+      kind: 'usage_record',
+      recordId: 'usage-write',
+      action: 'assign',
+      contractLineId: 'line-overlay',
+      source: 'auto_bucket_overlay',
+    });
+  });
+
   it('keeps the production table write shapes schema-aware', () => {
     expect(ATTRIBUTION_TABLES).toEqual({
       time_entry: { table: 'time_entries', idColumn: 'entry_id', hasUpdatedAt: true },

--- a/packages/billing/tests/contractLineAttributionDecision.test.ts
+++ b/packages/billing/tests/contractLineAttributionDecision.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildContractLineAttributionDecision,
+  resolveDeterministicContractLineSelection,
+} from '../src/lib/contractLineDisambiguation.shared';
+import { ATTRIBUTION_TABLES } from '../src/lib/billing/contractLineAttributionWriter';
+
+const line = (id: string) => ({
+  client_contract_line_id: id,
+  billing_profile_id: null,
+  contract_billing_profile_id: null,
+});
+
+describe('contract-line attribution decisions', () => {
+  it('keeps unique, ambiguous, and no-match classification deterministic', () => {
+    const unique = buildContractLineAttributionDecision({
+      kind: 'time_entry',
+      recordId: 'entry-1',
+      selection: resolveDeterministicContractLineSelection([line('line-1')]),
+    });
+    const ambiguous = buildContractLineAttributionDecision({
+      kind: 'usage_record',
+      recordId: 'usage-1',
+      selection: resolveDeterministicContractLineSelection([line('line-a'), line('line-b')]),
+    });
+    const noMatch = buildContractLineAttributionDecision({
+      kind: 'time_entry',
+      recordId: 'entry-2',
+      selection: resolveDeterministicContractLineSelection([]),
+    });
+
+    expect(unique).toEqual({
+      kind: 'time_entry',
+      recordId: 'entry-1',
+      action: 'assign',
+      contractLineId: 'line-1',
+      source: 'reconciled_at_generation',
+    });
+    expect(ambiguous).toEqual({
+      kind: 'usage_record',
+      recordId: 'usage-1',
+      action: 'mark_unresolved',
+      reason: 'ambiguous',
+    });
+    expect(noMatch).toEqual({
+      kind: 'time_entry',
+      recordId: 'entry-2',
+      action: 'mark_unresolved',
+      reason: 'no_match',
+    });
+  });
+
+  it('keeps the production table write shapes schema-aware', () => {
+    expect(ATTRIBUTION_TABLES).toEqual({
+      time_entry: { table: 'time_entries', idColumn: 'entry_id', hasUpdatedAt: true },
+      usage_record: { table: 'usage_tracking', idColumn: 'usage_id', hasUpdatedAt: false },
+    });
+  });
+});

--- a/packages/billing/tests/contractLineAttributionWriter.test.ts
+++ b/packages/billing/tests/contractLineAttributionWriter.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { tenantDbMock } = vi.hoisted(() => ({ tenantDbMock: vi.fn() }));
+vi.mock('@alga-psa/db', () => ({ tenantDb: tenantDbMock }));
+
+import { applyContractLineAttributionDecisions } from '../src/lib/billing/contractLineAttributionWriter';
+
+function builder(firstRow: Record<string, unknown> | null = null) {
+  const query: any = {};
+  query.where = vi.fn(() => query);
+  query.whereNull = vi.fn(() => query);
+  query.first = vi.fn(async () => firstRow);
+  query.update = vi.fn(async () => 1);
+  return query;
+}
+
+describe('contract-line attribution writer', () => {
+  it('writes the time-entry and usage shapes independently', async () => {
+    const timeQuery = builder();
+    const usageQuery = builder();
+    const trx: any = {
+      fn: { now: vi.fn(() => 'NOW') },
+      table: vi.fn((table: string) => table === 'time_entries' ? timeQuery : usageQuery),
+    };
+    tenantDbMock.mockReturnValue({ table: trx.table });
+
+    const result = await applyContractLineAttributionDecisions(trx, 'tenant-1', [
+      {
+        kind: 'time_entry',
+        recordId: 'entry-1',
+        action: 'assign',
+        contractLineId: 'line-1',
+        source: 'reconciled_at_generation',
+      },
+      {
+        kind: 'usage_record',
+        recordId: 'usage-1',
+        action: 'assign',
+        contractLineId: 'line-1',
+        source: 'reconciled_at_generation',
+      },
+    ]);
+
+    expect(result).toEqual({ assigned: 2, markedUnresolved: 0 });
+    expect(timeQuery.update).toHaveBeenCalledWith({
+      contract_line_id: 'line-1',
+      contract_line_source: 'reconciled_at_generation',
+      contract_line_unresolved_reason: null,
+      updated_at: 'NOW',
+    });
+    expect(usageQuery.update).toHaveBeenCalledWith({
+      contract_line_id: 'line-1',
+      contract_line_source: 'reconciled_at_generation',
+      contract_line_unresolved_reason: null,
+    });
+  });
+
+  it('is idempotent for an already-recorded unresolved decision', async () => {
+    const usageQuery = builder({
+      contract_line_id: null,
+      contract_line_source: 'unresolved',
+      contract_line_unresolved_reason: 'ambiguous',
+    });
+    const trx: any = {
+      fn: { now: vi.fn(() => 'NOW') },
+      table: vi.fn(() => usageQuery),
+    };
+    tenantDbMock.mockReturnValue({ table: trx.table });
+
+    const result = await applyContractLineAttributionDecisions(trx, 'tenant-1', [{
+      kind: 'usage_record',
+      recordId: 'usage-1',
+      action: 'mark_unresolved',
+      reason: 'ambiguous',
+    }]);
+
+    expect(result).toEqual({ assigned: 0, markedUnresolved: 0 });
+    expect(usageQuery.update).not.toHaveBeenCalled();
+  });
+});

--- a/packages/billing/tests/usageActions.effectiveDate.test.ts
+++ b/packages/billing/tests/usageActions.effectiveDate.test.ts
@@ -174,4 +174,63 @@ describe('usage actions effective-date contract resolution', () => {
     expect(calls.updates[0]?.contract_line_source).toBe('auto_unique_service');
     expect(revalidatePathMock).toHaveBeenCalledWith('/msp/billing');
   });
+
+  it('persists bucket-overlay attribution as an assigned line on usage create', async () => {
+    const { db, calls } = createUsageDbStub();
+    createTenantKnexMock.mockResolvedValue({ knex: db });
+    getEligibleContractLinesMock.mockResolvedValue([
+      { client_contract_line_id: 'line-overlay', bucket_overlay: { config_id: 'bucket-1' } },
+      { client_contract_line_id: 'line-other' },
+    ]);
+
+    const { createUsageRecord } = await import('../src/actions/usageActions');
+
+    await (createUsageRecord as any)(
+      { user_id: 'user-1' },
+      { tenant: 'tenant-1' },
+      {
+        client_id: 'client-1',
+        service_id: 'service-1',
+        quantity: 3,
+        usage_date: '2025-02-10',
+      },
+    );
+
+    expect(calls.inserts[0]).toMatchObject({
+      contract_line_id: 'line-overlay',
+      contract_line_source: 'auto_bucket_overlay',
+      contract_line_unresolved_reason: null,
+    });
+  });
+
+  it('preserves the original attribution tuple when update resolution fails', async () => {
+    const original = {
+      usage_id: 'usage-1',
+      tenant: 'tenant-1',
+      client_id: 'client-1',
+      service_id: 'service-1',
+      quantity: 1,
+      usage_date: '2026-03-11',
+      contract_line_id: 'line-original',
+      contract_line_source: 'explicit',
+      contract_line_unresolved_reason: null,
+    };
+    const { db, calls } = createUsageDbStub({ existing: original });
+    createTenantKnexMock.mockResolvedValue({ knex: db });
+    getEligibleContractLinesMock.mockRejectedValue(new Error('resolver unavailable'));
+
+    const { updateUsageRecord } = await import('../src/actions/usageActions');
+
+    await (updateUsageRecord as any)(
+      { user_id: 'user-1' },
+      { tenant: 'tenant-1' },
+      { usage_id: 'usage-1', usage_date: '2027-08-01' },
+    );
+
+    expect(calls.updates[0]).toMatchObject({
+      contract_line_id: 'line-original',
+      contract_line_source: 'explicit',
+      contract_line_unresolved_reason: null,
+    });
+  });
 });

--- a/packages/billing/tests/usageActions.effectiveDate.test.ts
+++ b/packages/billing/tests/usageActions.effectiveDate.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const createTenantKnexMock = vi.fn();
-const determineDefaultContractLineMock = vi.fn();
+const getEligibleContractLinesMock = vi.fn();
 const revalidatePathMock = vi.fn();
 
 vi.mock('@alga-psa/auth', () => ({
@@ -21,7 +21,7 @@ vi.mock('@alga-psa/db', () => ({
 }));
 
 vi.mock('@alga-psa/billing/lib/contractLineDisambiguation', () => ({
-  determineDefaultContractLine: (...args: any[]) => determineDefaultContractLineMock(...args),
+  getEligibleContractLines: (...args: any[]) => getEligibleContractLinesMock(...args),
 }));
 
 vi.mock('next/cache', () => ({
@@ -106,7 +106,9 @@ describe('usage actions effective-date contract resolution', () => {
   it('T004: createUsageRecord resolves default line with the usage effective date', async () => {
     const { db, calls } = createUsageDbStub();
     createTenantKnexMock.mockResolvedValue({ knex: db });
-    determineDefaultContractLineMock.mockResolvedValue('line-default');
+    getEligibleContractLinesMock.mockResolvedValue([
+      { client_contract_line_id: 'line-default' },
+    ]);
 
     const { createUsageRecord } = await import('../src/actions/usageActions');
 
@@ -121,8 +123,15 @@ describe('usage actions effective-date contract resolution', () => {
       },
     );
 
-    expect(determineDefaultContractLineMock).toHaveBeenCalledWith('client-1', 'service-1', '2025-02-10');
+    expect(getEligibleContractLinesMock).toHaveBeenCalledWith(
+      db,
+      'tenant-1',
+      'client-1',
+      'service-1',
+      '2025-02-10',
+    );
     expect(calls.inserts[0]?.contract_line_id).toBe('line-default');
+    expect(calls.inserts[0]?.contract_line_source).toBe('auto_unique_service');
     expect(revalidatePathMock).toHaveBeenCalledWith('/msp/billing');
   });
 
@@ -139,7 +148,9 @@ describe('usage actions effective-date contract resolution', () => {
       },
     });
     createTenantKnexMock.mockResolvedValue({ knex: db });
-    determineDefaultContractLineMock.mockResolvedValue('line-default-next');
+    getEligibleContractLinesMock.mockResolvedValue([
+      { client_contract_line_id: 'line-default-next' },
+    ]);
 
     const { updateUsageRecord } = await import('../src/actions/usageActions');
 
@@ -152,8 +163,15 @@ describe('usage actions effective-date contract resolution', () => {
       },
     );
 
-    expect(determineDefaultContractLineMock).toHaveBeenCalledWith('client-1', 'service-1', '2027-08-01');
+    expect(getEligibleContractLinesMock).toHaveBeenCalledWith(
+      db,
+      'tenant-1',
+      'client-1',
+      'service-1',
+      '2027-08-01',
+    );
     expect(calls.updates[0]?.contract_line_id).toBe('line-default-next');
+    expect(calls.updates[0]?.contract_line_source).toBe('auto_unique_service');
     expect(revalidatePathMock).toHaveBeenCalledWith('/msp/billing');
   });
 });

--- a/packages/types/src/interfaces/usage.interfaces.ts
+++ b/packages/types/src/interfaces/usage.interfaces.ts
@@ -1,6 +1,10 @@
 import { TenantEntity } from './index';
 import type { ISO8601String } from '../lib/temporal';
-import { IService } from './billing.interfaces';
+import {
+  IService,
+  type ContractLineSelectionReason,
+  type ContractLineSource,
+} from './billing.interfaces';
 
 export interface IUsageRecord extends TenantEntity {
   usage_id: string;
@@ -11,17 +15,19 @@ export interface IUsageRecord extends TenantEntity {
   tax_region?: string;
   client_name?: string; // Joined from clients table
   service_name?: string; // Joined from service_catalog table
-  contract_line_id?: string;
+  contract_line_id?: string | null;
+  contract_line_source?: ContractLineSource | null;
+  contract_line_unresolved_reason?: ContractLineSelectionReason | null;
 }
 
 export interface ICreateUsageRecord extends Pick<IUsageRecord, 'client_id' | 'service_id' | 'quantity' | 'usage_date'> {
   comments?: string;
-  contract_line_id?: string;
+  contract_line_id?: string | null;
 }
 
 export interface IUpdateUsageRecord extends Partial<ICreateUsageRecord> {
   usage_id: string;
-  contract_line_id?: string;
+  contract_line_id?: string | null;
 }
 
 export interface IUsageFilter {

--- a/server/src/test/integration/billingInvoiceTiming.integration.test.ts
+++ b/server/src/test/integration/billingInvoiceTiming.integration.test.ts
@@ -16,6 +16,7 @@ import { createUser } from '../../../test-utils/testDataFactory';
 import { setupCommonMocks } from '../../../test-utils/testMocks';
 import { Temporal } from '@js-temporal/polyfill';
 import { BillingEngine } from '@alga-psa/billing/services';
+import { ATTRIBUTION_TABLES } from '@alga-psa/billing/lib/billing/contractLineAttributionWriter';
 import Invoice from '@alga-psa/billing/models/invoice';
 import type { IRecurringServicePeriodRecord } from '@alga-psa/types';
 import { materializeClientCadenceServicePeriods } from '@alga-psa/shared/billingClients/materializeClientCadenceServicePeriods';
@@ -41,6 +42,7 @@ let db: Knex;
 let tenantId: string;
 let generateInvoice: typeof import('@alga-psa/billing/actions/invoiceGeneration').generateInvoice;
 let generateInvoiceForSelectionInput: typeof import('@alga-psa/billing/actions/invoiceGeneration').generateInvoiceForSelectionInput;
+let generateInvoiceForSelectionInputs: typeof import('@alga-psa/billing/actions/invoiceGeneration').generateInvoiceForSelectionInputs;
 let calculateBillingForSelectionInputAction: typeof import('@alga-psa/billing/actions/invoiceGeneration').calculateBillingForSelectionInput;
 let previewInvoiceForSelectionInputAction: typeof import('@alga-psa/billing/actions/invoiceGeneration').previewInvoiceForSelectionInput;
 let getPurchaseOrderOverageForSelectionInputAction: typeof import('@alga-psa/billing/actions/invoiceGeneration').getPurchaseOrderOverageForSelectionInput;
@@ -196,6 +198,7 @@ describe('Billing Invoice Timing Integration', () => {
     ({
       generateInvoice,
       generateInvoiceForSelectionInput,
+      generateInvoiceForSelectionInputs,
       calculateBillingForSelectionInput: calculateBillingForSelectionInputAction,
       previewInvoiceForSelectionInput: previewInvoiceForSelectionInputAction,
       getPurchaseOrderOverageForSelectionInput: getPurchaseOrderOverageForSelectionInputAction,
@@ -5047,9 +5050,26 @@ it('T154: recurring due-work listing is byte-stable and performs no source-row D
     contract_line_source: null,
     contract_line_unresolved_reason: null,
   });
+  const timeServiceId = await createTestService(contextLike as any, {
+    service_name: 'Read-Only Unassigned Time',
+    billing_method: 'hourly',
+    default_rate: 12500,
+    unit_of_measure: 'hour',
+    tax_region: 'US-NY',
+  } as any);
+  const timeEntry = await createApprovedTimeEntryForContractLine({
+    clientId,
+    serviceId: timeServiceId,
+    contractLineId: null,
+    startTime: '2025-02-15T10:00:00.000Z',
+    endTime: '2025-02-15T11:00:00.000Z',
+  });
 
-  const before = await tenantTable(db, tenantId, 'usage_tracking')
+  const beforeUsage = await tenantTable(db, tenantId, 'usage_tracking')
     .where({ tenant: tenantId, usage_id: usageId })
+    .first();
+  const beforeTime = await tenantTable(db, tenantId, 'time_entries')
+    .where({ tenant: tenantId, entry_id: timeEntry.entry_id })
     .first();
   const dml: string[] = [];
   const listener = (queryData: { sql?: string }) => {
@@ -5073,11 +5093,15 @@ it('T154: recurring due-work listing is byte-stable and performs no source-row D
   });
   db.removeListener('query', listener);
 
-  const after = await tenantTable(db, tenantId, 'usage_tracking')
+  const afterUsage = await tenantTable(db, tenantId, 'usage_tracking')
     .where({ tenant: tenantId, usage_id: usageId })
     .first();
+  const afterTime = await tenantTable(db, tenantId, 'time_entries')
+    .where({ tenant: tenantId, entry_id: timeEntry.entry_id })
+    .first();
   expect(JSON.stringify(first)).toBe(JSON.stringify(second));
-  expect(after).toEqual(before);
+  expect(afterUsage).toEqual(beforeUsage);
+  expect(afterTime).toEqual(beforeTime);
   expect(dml.filter((sql) => /time_entries|usage_tracking/i.test(sql))).toEqual([]);
   expect(first.invoiceCandidates.flatMap((candidate) => candidate.members)).toEqual(
     expect.arrayContaining([
@@ -5189,6 +5213,15 @@ it('T156: generation reconciles before calculation, bills the newly covered entr
     cadenceOwner: 'contract',
   });
   await syncContractLineRecurringPeriods(line.contractLineId);
+  const usageLine = await createUsageContractLine(contextLike, {
+    serviceName: 'Same-Run Reconciliation Usage Service',
+    planName: 'Same-Run Reconciliation Usage Plan',
+    baseRateCents: 2000,
+    startDate: '2025-02-01',
+    billingTiming: 'advance',
+    cadenceOwner: 'contract',
+  });
+  await syncContractLineRecurringPeriods(usageLine.contractLineId);
   const entry = await createApprovedTimeEntryForContractLine({
     clientId,
     serviceId: line.serviceId,
@@ -5196,14 +5229,28 @@ it('T156: generation reconciles before calculation, bills the newly covered entr
     startTime: '2025-02-15T10:00:00.000Z',
     endTime: '2025-02-15T11:00:00.000Z',
   });
+  const usage = await createUsageRecordForContractLine({
+    clientId,
+    serviceId: usageLine.serviceId,
+    contractLineId: null,
+    usageDate: '2025-02-15',
+    quantity: 3,
+  });
   const dueWork = await getAvailableRecurringDueWorkAction({ page: 1, pageSize: 20, searchTerm: 'Same-Run Reconciliation Client' });
-  const dueRow = dueWork.invoiceCandidates.flatMap((candidate) => candidate.members)
+  const dueRows = dueWork.invoiceCandidates.flatMap((candidate) => candidate.members);
+  const dueRow = dueRows
     .find((row) => row.contractLineId === line.contractLineId
       && row.invoiceWindowStart === '2025-02-01'
       && row.invoiceWindowEnd === '2025-03-01');
+  const usageDueRow = dueRows
+    .find((row) => row.contractLineId === usageLine.contractLineId
+      && row.invoiceWindowStart === '2025-02-01'
+      && row.invoiceWindowEnd === '2025-03-01');
   expect(dueRow).toBeTruthy();
+  expect(usageDueRow).toBeTruthy();
 
-  const invoice = await generateInvoiceForSelectionInput(dueRow!.selectorInput);
+  const selectorInputs = [dueRow!.selectorInput, usageDueRow!.selectorInput];
+  const invoice = await generateInvoiceForSelectionInputs(selectorInputs);
   expect(invoice).toBeTruthy();
   const persistedEntry = await tenantTable(db, tenantId, 'time_entries').where({ entry_id: entry.entry_id }).first();
   expect(persistedEntry).toMatchObject({
@@ -5214,10 +5261,23 @@ it('T156: generation reconciles before calculation, bills the newly covered entr
     .where({ tenant: tenantId, entry_id: entry.entry_id })
     .select('invoice_id');
   expect(linkedCharges).toHaveLength(1);
-  await expect(generateInvoiceForSelectionInput(dueRow!.selectorInput)).resolves.toMatchObject({
+  const persistedUsage = await tenantTable(db, tenantId, 'usage_tracking')
+    .where({ tenant: tenantId, usage_id: usage.usage_id })
+    .first(['contract_line_id', 'contract_line_source', 'invoiced']);
+  expect(persistedUsage).toMatchObject({
+    contract_line_id: usageLine.contractLineId,
+    contract_line_source: 'reconciled_at_generation',
+    invoiced: true,
+  });
+  const linkedUsageCharges = await tenantTable(db, tenantId, 'invoice_usage_records')
+    .where({ tenant: tenantId, usage_id: usage.usage_id })
+    .select('invoice_id');
+  expect(linkedUsageCharges).toHaveLength(1);
+  await expect(generateInvoiceForSelectionInputs(selectorInputs)).resolves.toMatchObject({
     actionError: expect.stringMatching(/already exists|duplicate/i),
   });
   expect(await tenantTable(db, tenantId, 'invoice_time_entries').where({ entry_id: entry.entry_id })).toHaveLength(1);
+  expect(await tenantTable(db, tenantId, 'invoice_usage_records').where({ usage_id: usage.usage_id })).toHaveLength(1);
 }, HOOK_TIMEOUT);
 
 it('T157: preview and PO-overage calculation reconcile for pricing but roll back attribution writes', async () => {
@@ -5318,7 +5378,11 @@ it('T159: production schema has time-entry updated_at but no usage_tracking upda
     .whereIn('table_name', ['time_entries', 'usage_tracking'])
     .where('column_name', 'updated_at')
     .select('table_name', 'column_name');
-  expect(columns).toEqual([{ table_name: 'time_entries', column_name: 'updated_at' }]);
+  const tablesWithUpdatedAt = new Set(columns.map((column) => column.table_name));
+  for (const descriptor of Object.values(ATTRIBUTION_TABLES)) {
+    expect(tablesWithUpdatedAt.has(descriptor.table)).toBe(descriptor.hasUpdatedAt);
+  }
+  expect(tablesWithUpdatedAt.has('usage_tracking')).toBe(false);
 });
 
 });
@@ -5871,7 +5935,7 @@ async function createApprovedTimeEntryForContractLine(params: {
 async function createUsageRecordForContractLine(params: {
   clientId: string;
   serviceId: string;
-  contractLineId: string;
+  contractLineId?: string | null;
   usageDate: string;
   quantity: number;
 }) {

--- a/server/src/test/integration/billingInvoiceTiming.integration.test.ts
+++ b/server/src/test/integration/billingInvoiceTiming.integration.test.ts
@@ -2,7 +2,7 @@ import { beforeAll, afterAll, describe, it, expect, vi } from 'vitest';
 import type { Knex } from 'knex';
 import { v4 as uuidv4 } from 'uuid';
 
-import { tenantDb } from '@alga-psa/db';
+import { tenantDb, withTransaction } from '@alga-psa/db';
 import { createTestDbConnection, wireLocalTestDbEnv } from '../../../test-utils/dbConfig';
 import {
   setupClientTaxConfiguration,
@@ -43,6 +43,7 @@ let generateInvoice: typeof import('@alga-psa/billing/actions/invoiceGeneration'
 let generateInvoiceForSelectionInput: typeof import('@alga-psa/billing/actions/invoiceGeneration').generateInvoiceForSelectionInput;
 let calculateBillingForSelectionInputAction: typeof import('@alga-psa/billing/actions/invoiceGeneration').calculateBillingForSelectionInput;
 let previewInvoiceForSelectionInputAction: typeof import('@alga-psa/billing/actions/invoiceGeneration').previewInvoiceForSelectionInput;
+let getPurchaseOrderOverageForSelectionInputAction: typeof import('@alga-psa/billing/actions/invoiceGeneration').getPurchaseOrderOverageForSelectionInput;
 let getAvailableRecurringDueWorkAction: typeof import('@alga-psa/billing/actions/billingAndTax').getAvailableRecurringDueWork;
 let hardDeleteInvoiceAction: typeof import('@alga-psa/billing/actions/invoiceModification').hardDeleteInvoice;
 let syncRecurringServicePeriodsForContractLine: typeof import('@alga-psa/billing/actions/recurringServicePeriodSync').syncRecurringServicePeriodsForContractLine;
@@ -167,6 +168,16 @@ vi.mock('@alga-psa/auth/rbac', () => ({
 describe('Billing Invoice Timing Integration', () => {
   const HOOK_TIMEOUT = 180_000;
 
+  async function withRealTransactions<T>(callback: () => Promise<T>): Promise<T> {
+    const transactionMock = vi.mocked(withTransaction);
+    transactionMock.mockImplementation(async (knex: any, handler: any) => knex.transaction(handler));
+    try {
+      return await callback();
+    } finally {
+      transactionMock.mockImplementation(async (_knex: any, handler: any) => handler(db));
+    }
+  }
+
   beforeAll(async () => {
     wireLocalTestDbEnv();
     process.env.APP_ENV = process.env.APP_ENV || 'test';
@@ -187,6 +198,7 @@ describe('Billing Invoice Timing Integration', () => {
       generateInvoiceForSelectionInput,
       calculateBillingForSelectionInput: calculateBillingForSelectionInputAction,
       previewInvoiceForSelectionInput: previewInvoiceForSelectionInputAction,
+      getPurchaseOrderOverageForSelectionInput: getPurchaseOrderOverageForSelectionInputAction,
     } = await import('@alga-psa/billing/actions/invoiceGeneration'));
     ({
       getAvailableRecurringDueWork: getAvailableRecurringDueWorkAction,
@@ -5005,6 +5017,309 @@ it('T326: DB-backed mixed cadence-owner recurring obligations materialize distin
   expect(normalizeDateValue(contractRows[0]?.service_period_start)).toBe('2025-01-08');
   expect(normalizeDateValue(contractRows[0]?.invoice_window_start)).toBe('2025-01-08');
 }, HOOK_TIMEOUT);
+
+it('T154: recurring due-work listing is byte-stable and performs no source-row DML, including unassigned usage', async () => {
+  setupCommonMocks({ tenantId, userId: 'read-only-due-work-user', permissionCheck: () => true });
+
+  const { contextLike, clientId, currentPeriodStart, nextPeriodStart } = await createClientWithRecurringCycles({
+    clientName: 'Read-Only Due Work Client',
+    previousPeriodStart: '2025-01-01',
+    currentPeriodStart: '2025-02-01',
+    nextPeriodStart: '2025-03-01',
+  });
+  const serviceId = await createTestService(contextLike as any, {
+    service_name: 'Read-Only Unassigned Usage',
+    billing_method: 'usage',
+    default_rate: 125,
+    unit_of_measure: 'unit',
+    tax_region: 'US-NY',
+  } as any);
+  const usageId = uuidv4();
+  await tenantTable(db, tenantId, 'usage_tracking').insert({
+    tenant: tenantId,
+    usage_id: usageId,
+    client_id: clientId,
+    service_id: serviceId,
+    usage_date: '2025-02-15',
+    quantity: 2,
+    invoiced: false,
+    contract_line_id: null,
+    contract_line_source: null,
+    contract_line_unresolved_reason: null,
+  });
+
+  const before = await tenantTable(db, tenantId, 'usage_tracking')
+    .where({ tenant: tenantId, usage_id: usageId })
+    .first();
+  const dml: string[] = [];
+  const listener = (queryData: { sql?: string }) => {
+    if (typeof queryData.sql === 'string' && /^(update|delete|insert)\s/i.test(queryData.sql.trim())) {
+      dml.push(queryData.sql);
+    }
+  };
+  db.on('query', listener);
+
+  const first = await getAvailableRecurringDueWorkAction({
+    page: 1,
+    pageSize: 20,
+    searchTerm: 'Read-Only Due Work Client',
+    dateRange: { from: currentPeriodStart, to: nextPeriodStart },
+  });
+  const second = await getAvailableRecurringDueWorkAction({
+    page: 1,
+    pageSize: 20,
+    searchTerm: 'Read-Only Due Work Client',
+    dateRange: { from: currentPeriodStart, to: nextPeriodStart },
+  });
+  db.removeListener('query', listener);
+
+  const after = await tenantTable(db, tenantId, 'usage_tracking')
+    .where({ tenant: tenantId, usage_id: usageId })
+    .first();
+  expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+  expect(after).toEqual(before);
+  expect(dml.filter((sql) => /time_entries|usage_tracking/i.test(sql))).toEqual([]);
+  expect(first.invoiceCandidates.flatMap((candidate) => candidate.members)).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ recordId: `unresolved:usage:${usageId}`, clientId }),
+    ]),
+  );
+}, HOOK_TIMEOUT);
+
+it('T155: real-schema classification keeps unique, ambiguous, and no-match billing reads deterministic', async () => {
+  setupCommonMocks({ tenantId, userId: 'deterministic-classification-user', permissionCheck: () => true });
+
+  const uniqueClient = await createClientWithRecurringCycles({ clientName: 'Unique Classification Client' });
+  const ambiguousClient = await createClientWithRecurringCycles({ clientName: 'Ambiguous Classification Client' });
+  const noMatchClient = await createClientWithRecurringCycles({ clientName: 'No Match Classification Client' });
+  const uniqueLine = await createHourlyContractLine(uniqueClient.contextLike, {
+    serviceName: 'Unique Classification Service',
+    planName: 'Unique Classification Plan',
+    baseRateCents: 10000,
+    startDate: '2024-12-01',
+    billingTiming: 'advance',
+  });
+  const ambiguousFirst = await createHourlyContractLine(ambiguousClient.contextLike, {
+    serviceName: 'Ambiguous Classification Service',
+    planName: 'Ambiguous Classification Plan A',
+    baseRateCents: 10000,
+    startDate: '2024-12-01',
+    billingTiming: 'advance',
+  });
+  const ambiguousSecond = await createHourlyContractLine(ambiguousClient.contextLike, {
+    serviceName: 'Ambiguous Classification Service B',
+    planName: 'Ambiguous Classification Plan B',
+    baseRateCents: 10000,
+    startDate: '2024-12-01',
+    billingTiming: 'advance',
+  });
+  // Force the second line to cover the first line's service, creating the
+  // exact multi-candidate case without introducing an arbitrary tie-break.
+  await tenantTable(db, tenantId, 'contract_line_services')
+    .insert({
+      tenant: tenantId,
+      contract_line_id: ambiguousSecond.contractLineId,
+      service_id: ambiguousFirst.serviceId,
+      quantity: 1,
+      custom_rate: null,
+    });
+  const noMatchServiceId = await createTestService(noMatchClient.contextLike as any, {
+    service_name: 'No Match Classification Service',
+    billing_method: 'hourly',
+    default_rate: 10000,
+    unit_of_measure: 'hour',
+    tax_region: 'US-NY',
+  } as any);
+  await createApprovedTimeEntryForContractLine({
+    clientId: uniqueClient.clientId,
+    serviceId: uniqueLine.serviceId,
+    contractLineId: null,
+    startTime: '2025-01-15T10:00:00.000Z',
+    endTime: '2025-01-15T11:00:00.000Z',
+  });
+  await createApprovedTimeEntryForContractLine({
+    clientId: ambiguousClient.clientId,
+    serviceId: ambiguousFirst.serviceId,
+    contractLineId: null,
+    startTime: '2025-01-15T10:00:00.000Z',
+    endTime: '2025-01-15T11:00:00.000Z',
+  });
+  await createApprovedTimeEntryForContractLine({
+    clientId: noMatchClient.clientId,
+    serviceId: noMatchServiceId,
+    contractLineId: null,
+    startTime: '2025-01-15T10:00:00.000Z',
+    endTime: '2025-01-15T11:00:00.000Z',
+  });
+
+  const engine = new BillingEngine();
+  const unique = await engine.calculateUnresolvedNonContractChargesForExecutionWindow({
+    clientId: uniqueClient.clientId,
+    windowStart: '2025-01-01',
+    windowEnd: '2025-02-01',
+  });
+  const ambiguous = await engine.calculateUnresolvedNonContractChargesForExecutionWindow({
+    clientId: ambiguousClient.clientId,
+    windowStart: '2025-01-01',
+    windowEnd: '2025-02-01',
+  });
+  const noMatch = await engine.calculateUnresolvedNonContractChargesForExecutionWindow({
+    clientId: noMatchClient.clientId,
+    windowStart: '2025-01-01',
+    windowEnd: '2025-02-01',
+  });
+  expect(unique).toHaveLength(0);
+  expect(ambiguous).toEqual(expect.arrayContaining([expect.objectContaining({ unresolved_reason: 'ambiguous' })]));
+  expect(noMatch).toEqual(expect.arrayContaining([expect.objectContaining({ unresolved_reason: 'no_match' })]));
+}, HOOK_TIMEOUT);
+
+it('T156: generation reconciles before calculation, bills the newly covered entry once, and retries do not duplicate it', async () => {
+  setupCommonMocks({ tenantId, userId: 'same-run-reconciliation-user', permissionCheck: () => true });
+  const { contextLike, clientId } = await createClientWithRecurringCycles({
+    clientName: 'Same-Run Reconciliation Client',
+    currentPeriodStart: '2025-02-01',
+    nextPeriodStart: '2025-03-01',
+  });
+  const line = await createHourlyContractLine(contextLike, {
+    serviceName: 'Same-Run Reconciliation Service',
+    planName: 'Same-Run Reconciliation Plan',
+    baseRateCents: 10000,
+    startDate: '2025-02-01',
+    billingTiming: 'advance',
+    cadenceOwner: 'contract',
+  });
+  await syncContractLineRecurringPeriods(line.contractLineId);
+  const entry = await createApprovedTimeEntryForContractLine({
+    clientId,
+    serviceId: line.serviceId,
+    contractLineId: null,
+    startTime: '2025-02-15T10:00:00.000Z',
+    endTime: '2025-02-15T11:00:00.000Z',
+  });
+  const dueWork = await getAvailableRecurringDueWorkAction({ page: 1, pageSize: 20, searchTerm: 'Same-Run Reconciliation Client' });
+  const dueRow = dueWork.invoiceCandidates.flatMap((candidate) => candidate.members)
+    .find((row) => row.contractLineId === line.contractLineId
+      && row.invoiceWindowStart === '2025-02-01'
+      && row.invoiceWindowEnd === '2025-03-01');
+  expect(dueRow).toBeTruthy();
+
+  const invoice = await generateInvoiceForSelectionInput(dueRow!.selectorInput);
+  expect(invoice).toBeTruthy();
+  const persistedEntry = await tenantTable(db, tenantId, 'time_entries').where({ entry_id: entry.entry_id }).first();
+  expect(persistedEntry).toMatchObject({
+    contract_line_id: line.contractLineId,
+    contract_line_source: 'reconciled_at_generation',
+  });
+  const linkedCharges = await tenantTable(db, tenantId, 'invoice_time_entries')
+    .where({ tenant: tenantId, entry_id: entry.entry_id })
+    .select('invoice_id');
+  expect(linkedCharges).toHaveLength(1);
+  await expect(generateInvoiceForSelectionInput(dueRow!.selectorInput)).resolves.toMatchObject({
+    actionError: expect.stringMatching(/already exists|duplicate/i),
+  });
+  expect(await tenantTable(db, tenantId, 'invoice_time_entries').where({ entry_id: entry.entry_id })).toHaveLength(1);
+}, HOOK_TIMEOUT);
+
+it('T157: preview and PO-overage calculation reconcile for pricing but roll back attribution writes', async () => {
+  setupCommonMocks({ tenantId, userId: 'rollback-reconciliation-user', permissionCheck: () => true });
+  const { contextLike, clientId } = await createClientWithRecurringCycles({
+    clientName: 'Rollback Reconciliation Client',
+    currentPeriodStart: '2025-02-01',
+    nextPeriodStart: '2025-03-01',
+  });
+  const line = await createHourlyContractLine(contextLike, {
+    serviceName: 'Rollback Reconciliation Service',
+    planName: 'Rollback Reconciliation Plan',
+    baseRateCents: 10000,
+    startDate: '2025-02-01',
+    billingTiming: 'advance',
+    cadenceOwner: 'contract',
+  });
+  await syncContractLineRecurringPeriods(line.contractLineId);
+  const entry = await createApprovedTimeEntryForContractLine({
+    clientId,
+    serviceId: line.serviceId,
+    contractLineId: null,
+    startTime: '2025-02-15T10:00:00.000Z',
+    endTime: '2025-02-15T11:00:00.000Z',
+  });
+  const dueWork = await getAvailableRecurringDueWorkAction({ page: 1, pageSize: 20, searchTerm: 'Rollback Reconciliation Client' });
+  const selectorInput = dueWork.invoiceCandidates.flatMap((candidate) => candidate.members)
+    .find((row) => row.contractLineId === line.contractLineId
+      && row.invoiceWindowStart === '2025-02-01'
+      && row.invoiceWindowEnd === '2025-03-01')?.selectorInput;
+  expect(selectorInput).toBeTruthy();
+
+  const preview = await withRealTransactions(() => previewInvoiceForSelectionInputAction(selectorInput!));
+  expect(preview).toMatchObject({ success: true });
+  expect(await tenantTable(db, tenantId, 'time_entries').where({ entry_id: entry.entry_id }).first('contract_line_id'))
+    .toMatchObject({ contract_line_id: null });
+
+  await tenantTable(db, tenantId, 'client_contracts').where({ client_contract_id: line.clientContractId }).update({
+    po_amount: 1,
+    po_required: false,
+  });
+  await withRealTransactions(() => getPurchaseOrderOverageForSelectionInputAction(selectorInput!));
+  expect(await tenantTable(db, tenantId, 'time_entries').where({ entry_id: entry.entry_id }).first('contract_line_id'))
+    .toMatchObject({ contract_line_id: null });
+}, HOOK_TIMEOUT);
+
+it('T158: failed generation rolls back reconciliation and a corrected retry can reconcile once', async () => {
+  setupCommonMocks({ tenantId, userId: 'failed-generation-retry-user', permissionCheck: () => true });
+  const { contextLike, clientId } = await createClientWithRecurringCycles({
+    clientName: 'Failed Generation Retry Client',
+    currentPeriodStart: '2025-02-01',
+    nextPeriodStart: '2025-03-01',
+  });
+  const line = await createHourlyContractLine(contextLike, {
+    serviceName: 'Failed Generation Retry Service',
+    planName: 'Failed Generation Retry Plan',
+    baseRateCents: 10000,
+    startDate: '2025-02-01',
+    billingTiming: 'advance',
+    cadenceOwner: 'contract',
+  });
+  await syncContractLineRecurringPeriods(line.contractLineId);
+  const entry = await createApprovedTimeEntryForContractLine({
+    clientId,
+    serviceId: line.serviceId,
+    contractLineId: null,
+    startTime: '2025-02-15T10:00:00.000Z',
+    endTime: '2025-02-15T11:00:00.000Z',
+  });
+  const dueWork = await getAvailableRecurringDueWorkAction({ page: 1, pageSize: 20, searchTerm: 'Failed Generation Retry Client' });
+  const selectorInput = dueWork.invoiceCandidates.flatMap((candidate) => candidate.members)
+    .find((row) => row.contractLineId === line.contractLineId
+      && row.invoiceWindowStart === '2025-02-01'
+      && row.invoiceWindowEnd === '2025-03-01')?.selectorInput;
+  expect(selectorInput).toBeTruthy();
+
+  const calculationFailure = vi.spyOn(BillingEngine.prototype, 'calculateBillingForExecutionWindow')
+    .mockRejectedValue(new Error('forced calculation failure after reconciliation'));
+  let failedGeneration: unknown;
+  try {
+    failedGeneration = await withRealTransactions(() => generateInvoiceForSelectionInput(selectorInput!));
+  } catch (error) {
+    failedGeneration = error;
+  } finally {
+    calculationFailure.mockRestore();
+  }
+  expect(String(failedGeneration)).toMatch(/forced calculation failure|actionError/);
+  expect(await tenantTable(db, tenantId, 'time_entries').where({ entry_id: entry.entry_id }).first('contract_line_id'))
+    .toMatchObject({ contract_line_id: null });
+  await expect(withRealTransactions(() => generateInvoiceForSelectionInput(selectorInput!))).resolves.toBeTruthy();
+  expect(await tenantTable(db, tenantId, 'time_entries').where({ entry_id: entry.entry_id }).first('contract_line_id'))
+    .toMatchObject({ contract_line_id: line.contractLineId });
+}, HOOK_TIMEOUT);
+
+it('T159: production schema has time-entry updated_at but no usage_tracking updated_at', async () => {
+  const columns = await schemaTable(db, 'information_schema.columns', 'recurring attribution schema conformance')
+    .where({ table_schema: 'public' })
+    .whereIn('table_name', ['time_entries', 'usage_tracking'])
+    .where('column_name', 'updated_at')
+    .select('table_name', 'column_name');
+  expect(columns).toEqual([{ table_name: 'time_entries', column_name: 'updated_at' }]);
+});
 
 });
 

--- a/server/src/test/unit/billing/billingEngine.unresolvedReconciliation.test.ts
+++ b/server/src/test/unit/billing/billingEngine.unresolvedReconciliation.test.ts
@@ -36,21 +36,8 @@ function buildSelectBuilder(rows: Array<Record<string, any>>) {
   });
   builder.then = vi.fn((onFulfilled?: any, onRejected?: any) => Promise.resolve(resolvedRows).then(onFulfilled, onRejected));
   builder.first = vi.fn(async () => rows[0] ?? null);
-
-  return builder;
-}
-
-function buildUpdateBuilder() {
-  const builder: any = {};
-  const passthrough = () => builder;
-  builder.where = vi.fn((condition: any) => {
-    if (typeof condition === 'function') {
-      condition.call(builder, builder);
-    }
-    return builder;
-  });
-  builder.whereNull = vi.fn(passthrough);
   builder.update = vi.fn(async () => 1);
+
   return builder;
 }
 
@@ -73,7 +60,7 @@ describe('BillingEngine unresolved reconciliation', () => {
     });
   });
 
-  it('T005: deterministic unresolved time entry is persisted and excluded from unresolved output', async () => {
+  it('T005: deterministic time-entry attribution is proposed in memory and excluded from unresolved output', async () => {
     const clientsBuilder = buildSelectBuilder([{ client_id: 'client-1', tenant: 'tenant-1', is_tax_exempt: false, default_currency_code: 'USD' }]);
     const timeSelectBuilder = buildSelectBuilder([
       {
@@ -88,16 +75,11 @@ describe('BillingEngine unresolved reconciliation', () => {
         service_name: 'Service 1',
       },
     ]);
-    const timeUpdateBuilder = buildUpdateBuilder();
     const usageSelectBuilder = buildSelectBuilder([]);
 
-    let timeEntriesCalls = 0;
     (billingEngine as any).knex = vi.fn((table: string) => {
       if (table === 'clients') return clientsBuilder;
-      if (table === 'time_entries') {
-        timeEntriesCalls += 1;
-        return timeEntriesCalls === 1 ? timeSelectBuilder : timeUpdateBuilder;
-      }
+      if (table === 'time_entries') return timeSelectBuilder;
       if (table === 'usage_tracking') return usageSelectBuilder;
       throw new Error(`Unexpected table ${table}`);
     });
@@ -119,13 +101,10 @@ describe('BillingEngine unresolved reconciliation', () => {
     );
 
     expect(unresolved).toEqual([]);
-    expect(timeUpdateBuilder.whereNull).toHaveBeenCalledWith('contract_line_id');
-    expect(timeUpdateBuilder.update).toHaveBeenCalledWith(
-      expect.objectContaining({ contract_line_id: 'line-1' }),
-    );
+    expect(timeSelectBuilder.update).not.toHaveBeenCalled();
   });
 
-  it('T006: deterministic unresolved usage record is persisted and excluded from unresolved output', async () => {
+  it('T006: deterministic usage attribution is proposed in memory and excluded from unresolved output', async () => {
     const clientsBuilder = buildSelectBuilder([{ client_id: 'client-1', tenant: 'tenant-1', is_tax_exempt: false, default_currency_code: 'USD' }]);
     const timeSelectBuilder = buildSelectBuilder([]);
     const usageSelectBuilder = buildSelectBuilder([
@@ -140,16 +119,10 @@ describe('BillingEngine unresolved reconciliation', () => {
         service_name: 'Service 1',
       },
     ]);
-    const usageUpdateBuilder = buildUpdateBuilder();
-
-    let usageCalls = 0;
     (billingEngine as any).knex = vi.fn((table: string) => {
       if (table === 'clients') return clientsBuilder;
       if (table === 'time_entries') return timeSelectBuilder;
-      if (table === 'usage_tracking') {
-        usageCalls += 1;
-        return usageCalls === 1 ? usageSelectBuilder : usageUpdateBuilder;
-      }
+      if (table === 'usage_tracking') return usageSelectBuilder;
       throw new Error(`Unexpected table ${table}`);
     });
     (billingEngine as any).knex.fn = { now: vi.fn(() => 'NOW') };
@@ -167,10 +140,7 @@ describe('BillingEngine unresolved reconciliation', () => {
     );
 
     expect(unresolved).toEqual([]);
-    expect(usageUpdateBuilder.whereNull).toHaveBeenCalledWith('contract_line_id');
-    expect(usageUpdateBuilder.update).toHaveBeenCalledWith(
-      expect.objectContaining({ contract_line_id: 'line-2' }),
-    );
+    expect(usageSelectBuilder.update).not.toHaveBeenCalled();
   });
 
   it('T007: ambiguous/no-match rows remain unresolved while deterministic rows are reconciled', async () => {
@@ -221,21 +191,10 @@ describe('BillingEngine unresolved reconciliation', () => {
         service_name: 'Service Single Usage',
       },
     ]);
-    const timeUpdateBuilder = buildUpdateBuilder();
-    const usageUpdateBuilder = buildUpdateBuilder();
-
-    let timeCalls = 0;
-    let usageCalls = 0;
     (billingEngine as any).knex = vi.fn((table: string) => {
       if (table === 'clients') return clientsBuilder;
-      if (table === 'time_entries') {
-        timeCalls += 1;
-        return timeCalls === 1 ? timeSelectBuilder : timeUpdateBuilder;
-      }
-      if (table === 'usage_tracking') {
-        usageCalls += 1;
-        return usageCalls === 1 ? usageSelectBuilder : usageUpdateBuilder;
-      }
+      if (table === 'time_entries') return timeSelectBuilder;
+      if (table === 'usage_tracking') return usageSelectBuilder;
       throw new Error(`Unexpected table ${table}`);
     });
     (billingEngine as any).knex.fn = { now: vi.fn(() => 'NOW') };
@@ -265,11 +224,7 @@ describe('BillingEngine unresolved reconciliation', () => {
       'te-ambiguous',
       'usage-no-match',
     ]);
-    expect(timeUpdateBuilder.update).toHaveBeenCalledWith(
-      expect.objectContaining({ contract_line_id: 'line-single' }),
-    );
-    expect(usageUpdateBuilder.update).toHaveBeenCalledWith(
-      expect.objectContaining({ contract_line_id: 'line-single-usage' }),
-    );
+    expect(timeSelectBuilder.update).not.toHaveBeenCalled();
+    expect(usageSelectBuilder.update).not.toHaveBeenCalled();
   });
 });

--- a/server/src/test/unit/billing/defaultContractObservability.wiring.test.ts
+++ b/server/src/test/unit/billing/defaultContractObservability.wiring.test.ts
@@ -37,11 +37,11 @@ describe('default-contract observability wiring', () => {
     const source = readRepo('packages/billing/src/lib/billing/billingEngine.ts');
     expect(source).toContain('console.info("[billing_engine.reconcile.unresolved]"');
     expect(source).toContain('decision: "deterministic_single_match"');
-    // The decision now reads the selector's own reason rather than re-deriving
-    // it from the eligible-line count. Same two markers, but sourced from the
-    // signal that also gets persisted, so the log and the stored reason cannot
-    // drift apart (F137).
-    expect(source).toContain('decision: selection.reason === "no_match" ? "no_match" : "ambiguous"');
+    // The decision now reads the attribution decision's own reason rather than
+    // re-deriving it from the eligible-line count. Same two markers, but
+    // sourced from the signal that also gets persisted, so the log and the
+    // stored reason cannot drift apart (F137).
+    expect(source).toContain('decision: attributionDecision.reason === "no_match" ? "no_match" : "ambiguous"');
     expect(source).toContain('"unmatched_resolved_deterministically"');
     expect(source).toContain('"unresolved_ambiguous_count"');
   });

--- a/server/src/test/unit/billing/invoiceGeneration.emptyResult.test.ts
+++ b/server/src/test/unit/billing/invoiceGeneration.emptyResult.test.ts
@@ -234,6 +234,9 @@ vi.mock('../../../../../packages/billing/src/lib/billing/billingEngine', () => (
     }
   },
   BillingEngine: class {
+    static forTransaction() {
+      return new this();
+    }
     selectDueRecurringServicePeriodsForBillingWindow =
       mocks.selectDueRecurringServicePeriodsForBillingWindow;
     calculateBilling = mocks.calculateBilling;

--- a/server/src/test/unit/billing/invoiceGeneration.preview.test.ts
+++ b/server/src/test/unit/billing/invoiceGeneration.preview.test.ts
@@ -91,6 +91,7 @@ function createQueryBuilder(rows: Row[], raw: (sql: string) => string) {
       if (typeof columnOrCriteria === 'function') {
         const scopedWhere: any = {
           where: vi.fn(() => scopedWhere),
+          orWhere: vi.fn(() => scopedWhere),
           orWhereNull: vi.fn(() => scopedWhere),
         };
         columnOrCriteria.call(scopedWhere);
@@ -111,6 +112,7 @@ function createQueryBuilder(rows: Row[], raw: (sql: string) => string) {
       );
       return builder;
     }),
+    orWhere: vi.fn(() => builder),
     whereIn: vi.fn((column: string, values: any[]) => {
       const normalized = normalizeColumn(column);
       resultRows = resultRows.filter((row) => values.includes(row[normalized]));
@@ -118,6 +120,10 @@ function createQueryBuilder(rows: Row[], raw: (sql: string) => string) {
     }),
     whereNotNull: vi.fn((column: string) => {
       resultRows = resultRows.filter((row) => row[normalizeColumn(column)] != null);
+      return builder;
+    }),
+    whereNull: vi.fn((column: string) => {
+      resultRows = resultRows.filter((row) => row[normalizeColumn(column)] == null);
       return builder;
     }),
     whereNotIn: vi.fn((column: string, values: any[]) => {
@@ -349,6 +355,9 @@ vi.mock('../../../../../packages/billing/src/lib/billing/billingEngine', () => (
     }
   },
   BillingEngine: class {
+    static forTransaction() {
+      return new this();
+    }
     selectDueRecurringServicePeriodsForBillingWindow =
       mocks.selectDueRecurringServicePeriodsForBillingWindow;
     calculateBilling = mocks.calculateBilling;

--- a/server/src/test/unit/billing/invoiceGeneration.selectorInputGenerate.test.ts
+++ b/server/src/test/unit/billing/invoiceGeneration.selectorInputGenerate.test.ts
@@ -374,12 +374,23 @@ vi.mock('../../../../../packages/billing/src/lib/billing/billingEngine', () => (
     }
   },
   BillingEngine: class {
+    static forTransaction() {
+      return new this();
+    }
     selectDueRecurringServicePeriodsForBillingWindow =
       mocks.selectDueRecurringServicePeriodsForBillingWindow;
     calculateBilling = mocks.calculateBilling;
     calculateBillingForExecutionWindow = mocks.calculateBillingForExecutionWindow;
     rolloverUnapprovedTime = vi.fn(async () => undefined);
   },
+}));
+
+// Generation runs reconcile -> calculate -> persist inside one transaction.
+// Reconciliation is covered by contractLineAttributionWriter.test.ts and the
+// real-PostgreSQL billingInvoiceTiming integration suite; this filter-based
+// knex stub cannot express the writer's query shape, so it is stubbed out.
+vi.mock('../../../../../packages/billing/src/lib/billing/contractLineAttributionWriter', () => ({
+  reconcileWindowAttribution: vi.fn(async () => ({ assigned: 0, markedUnresolved: 0 })),
 }));
 
 vi.mock('@alga-psa/billing/models/invoice', () => ({

--- a/server/src/test/unit/billing/invoiceGeneration.zeroDollarFinalization.test.ts
+++ b/server/src/test/unit/billing/invoiceGeneration.zeroDollarFinalization.test.ts
@@ -320,6 +320,9 @@ vi.mock('../../../../../packages/billing/src/lib/billing/billingEngine', () => (
     }
   },
   BillingEngine: class {
+    static forTransaction() {
+      return new this();
+    }
     selectDueRecurringServicePeriodsForBillingWindow =
       mocks.selectDueRecurringServicePeriodsForBillingWindow;
     calculateBilling = mocks.calculateBilling;

--- a/server/src/test/unit/billing/systemManagedDefaultAttributionShell.wiring.test.ts
+++ b/server/src/test/unit/billing/systemManagedDefaultAttributionShell.wiring.test.ts
@@ -90,7 +90,9 @@ describe('system-managed default attribution-shell cutover wiring', () => {
     expect(billingContractLineDisambiguationSource).toContain(".orWhere('contracts.is_system_managed_default', false)");
     expect(schedulingContractLineDisambiguationSource).toContain("whereNull('contracts.is_system_managed_default')");
     expect(schedulingContractLineDisambiguationSource).toContain(".orWhere('contracts.is_system_managed_default', false)");
-    expect(usageActionsSource).toContain('determineDefaultContractLine');
+    expect(usageActionsSource).toContain("from '@alga-psa/billing/lib/contractLineDisambiguation'");
+    expect(usageActionsSource).toContain('getEligibleContractLines');
+    expect(usageActionsSource).toContain('resolveDeterministicContractLineSelection');
     // Time entries route through `resolveContractLineSelection`, the same
     // disambiguation module with the same system-managed exclusion, which
     // additionally reports *why* it could not pick a line. Both entry points


### PR DESCRIPTION
## Summary

Opening **Billing > Invoicing > Generate** was returning `Failed to load billing periods` (HTTP 500) on production. The cause: the shared recurring due-work calculation method performed hidden reconciliation **writes while merely listing due work**. For `time_entries` those writes included `updated_at` (a column that exists), but the same write shape was copied to `usage_tracking`, which has **no `updated_at` column** — producing PostgreSQL `42703` (`column updated_at of relation usage_tracking does not exist`) inside `getAvailableRecurringDueWork`.

The deeper architectural issue is that a **billing:read operation was mutating records** just by opening or refreshing the screen. Repeated reads rewrote unresolved records, and any reconciliation failure prevented the list from loading at all.

### What changed

- **Read-only due-work discovery.** The shared unresolved-charges calculation no longer issues any DML against `time_entries` or `usage_tracking`. Attributing a record (assigning a uniquely eligible contract line, or stamping `unresolved` / an unresolved reason) is now decided **in memory** and returned as a decision alongside the billing result. The Generate listing and period loading are pure reads.
- **Deterministic classification preserved.** Unique eligible-line matches (`explicit` / `billing_profile`) still assign deterministically; ambiguous multi-line and no-match cases still produce the same reason and same `catalog_pricing_acknowledged_at` blocking semantics as before. No classification semantics changed — only *when/where* the decision is written.
- **One schema-aware reconciliation writer** (`contractLineAttributionWriter.ts`). Attribution is persisted at an explicit write boundary, in the same transaction as the operation that needs it:
  - **Invoice generation** runs `reconcile -> calculate -> persist` inside the generation transaction, so covered work bills on its contract line in the run that discovers it instead of silently slipping a cycle.
  - **Preview and PO-overage checks** reconcile and then **roll back**, so they see exactly what generation would see while remaining read-only.
  - The writer updates `time_entries.updated_at` where that column exists and **never includes `updated_at` in `usage_tracking` writes** — matching the production schema (verified via `information_schema`).
- **Usage create/update attribution.** `usageActions.ts` now uses the shared deterministic disambiguation at record write time (including the bucket-overlay tie-break, which belongs to record *creation*, not to listing).
- **No migration.** The fix is purely behavioral; schema is untouched.

## Expected behavior change on the first billing cycle

Invoices may be **larger than usual** on the first cycle after this ships, because covered work that had been silently slipping a cycle (reconciliation previously could only persist when a listing happened to run with a unique match, and failed listings wrote nothing) now bills in the run that discovers it. **Nothing is billed twice; nothing previously billed stops being billed.** Please call this out to whoever runs the first cycle so it is not read as a new defect.

## Tests

- Unit: attribution decision boundary (`contractLineAttributionDecision.test.ts`), schema-aware writer (`contractLineAttributionWriter.test.ts`), usage create attribution and effective dates, preview semantics.
- Real-PostgreSQL integration (`billingInvoiceTiming.integration.test.ts`): read-only listing (repeated reads issue no DML), deterministic unique/ambiguous/no-match classification, same-run exactly-once reconciliation on generation, retry behavior, preview/PO rollback, failed-generation retry, and production-schema compatibility.

## Smoke test — QUALIFIED PASS

Real **Billing > Invoicing > Generate** loaded twice with six groups and **zero HTTP 5xx responses**. Two representative unassigned `usage_tracking` rows remained **byte-identical** after both reads, proving listing/refresh is read-only. Live `information_schema` confirmed `time_entries` has `updated_at` while `usage_tracking` does not.

Preview exercised rollback: three unassigned time entries were unchanged afterward. A Generate attempt on the only Ready fixture was safely rejected because its recurring service periods were not materialized; it created no invoice or attribution writes, so successful generation could not be completed through this seeded UI. Supplemental real-PostgreSQL T154–T159 tests passed **6/6**, covering successful same-run reconciliation, exactly-once retry behavior, deterministic unique/ambiguous/no-match classification, preview/PO rollback, failed-generation retry, and production-schema compatibility.

Nearby Drafts and Finalized invoice listings loaded successfully. No simulator or mock was used. Fidelity compromises: normal background initialization was bypassed with the repository's `E2E_SKIP_APP_INIT` flag because unrelated event-bus Redis authentication returned WRONGPASS; billing still used the real app, HTTP server, and PostgreSQL.

Evidence directory: `/tmp/alga-smoke-evidence/recurring-due-work-read-only-20260820-225603`

**Concerns:** the UI labels fixture "Smoke Replenish 20260807-211626" Ready although generation reports missing materialized periods; the expanded Emerald City group displayed two identical child rows. These appear to be existing seeded-data/state issues. The anticipated larger first billing cycle from previously deferred covered work was not directly measurable here.

## Commits

- `63fdd150e4` docs: plan read-only due-work listing and attribution write boundary
- `780e05f57b` fix(billing): make recurring due-work discovery read-only
- `b84488ffe4` fix(billing): harden recurring attribution boundaries
- `600a8f664c` test(billing): cover recurring attribution source boundaries