### PR TITLE
Fix sent quote resend and reminder actions

### DIFF
--- a/docs/plans/2026-08-21-quotes-sent-resend-reminder-plan.md
+++ b/docs/plans/2026-08-21-quotes-sent-resend-reminder-plan.md
@@ -1,0 +1,57 @@
+# Plan — Fix sent quote Resend and Send Reminder actions
+
+## Goal
+In Quotes > Sent, the row action menu's **Resend** and **Send Reminder** currently call
+`onSend(quote_id)`, which opens the Send to Client dialog whose confirmation calls
+`sendQuote()` — and `sendQuote()` rejects anything that is not draft/approved
+("Only draft or approved quotes can be sent"). Wire the two sent-status items to their
+dedicated server actions `resendQuote()` and `sendQuoteReminder()`, which already exist
+in `quoteActions.ts` and are already used correctly by Quote Detail and Quote Form.
+
+## Changes
+
+1. **`packages/billing/src/components/billing-dashboard/quotes/QuotesTab.tsx`**
+   - Add `resendQuote` and `sendQuoteReminder` to the existing import from
+     `../../../actions/quoteActions` (line 28).
+   - Add two handlers mirroring the existing `handleDuplicateQuote` pattern
+     (~line 439): clear error, call the action, on
+     `isReturnedActionError(result)` -> `setError(getErrorMessage(result))` and
+     return; on success `void loadData()`; catch -> `setError(...)` with a
+     `t()` fallback (new keys `quotesTab.errors.resend` /
+     `quotesTab.errors.sendReminder`, defaultValues so no i18n edit needed).
+   - Re-wire the two `status === 'sent'` menu items (currently ~lines 171 and
+     181): **Resend** -> `handleResendQuote(record.quote_id)`, **Send Reminder**
+     -> `handleSendReminder(record.quote_id)`. Keep the `status === 'sent'`
+     visibility guards exactly as they are.
+   - Leave `onSend` / the Send dialog untouched — it remains correct for
+     draft/approved "Send to Client".
+
+## Tests
+
+2. **New behavioral test** — `packages/billing/src/components/billing-dashboard/quotes/QuotesTab.test.tsx`,
+   following the `InvoicePreviewPanel.test.tsx` vitest + testing-library pattern:
+   - `vi.mock` `@alga-psa/billing/actions/quoteActions` (sendQuote, resendQuote,
+     sendQuoteReminder, listQuotes, etc.), `next/navigation`, and the shared
+     DataTable/CustomTabs surface as needed.
+   - Seed a `sent` quote in the Sent sub-tab. Assert:
+     - clicking the Resend menu item calls `resendQuote(quote_id)` and NOT
+       `sendQuote`.
+     - clicking the Send Reminder menu item calls `sendQuoteReminder(quote_id)`
+       and NOT `sendQuote`.
+
+## Deliberately NOT doing
+- No changes to `quoteActions.ts` — `resendQuote`/`sendQuoteReminder` already
+  exist, are auth/permission-guarded, and are correct.
+- No changes to Quote Detail / Quote Form (already correct).
+- No i18n file edits (defaultValue fallbacks render fine).
+- No server-side or schema changes.
+
+## Risks
+- `QuotesTab` pulls several server actions (`listQuotes`, templates) and the
+  DataTable surface; the test must mock those to render. Keep the test narrow:
+  menu-open + click + assert the dedicated action fired and `sendQuote` did not.
+- `'use client'` + server-action import boundary: Quote Detail already calls
+  these actions from a client component, so this is proven safe.
+- Row action menu is a Radix `DropdownMenu` inside a `DataTable` render column —
+  click-through in tests may need `userEvent` on the `resend-quote-<id>-menu-item`
+  / `remind-quote-<id>-menu-item` test ids that already exist.

--- a/packages/billing/src/components/billing-dashboard/quotes/QuotesTab.test.tsx
+++ b/packages/billing/src/components/billing-dashboard/quotes/QuotesTab.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const actionMocks = vi.hoisted(() => ({
+  createQuoteRevision: vi.fn(),
+  deleteQuote: vi.fn(),
+  downloadQuotePdf: vi.fn(),
+  duplicateQuote: vi.fn(),
+  listQuotes: vi.fn(),
+  resendQuote: vi.fn(),
+  sendQuote: vi.fn(),
+  sendQuoteReminder: vi.fn(),
+}));
+const getQuoteDocumentTemplatesMock = vi.hoisted(() => vi.fn());
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams('subtab=sent'),
+}));
+
+vi.mock('../../../actions/quoteActions', () => ({
+  createQuoteRevision: (...args: unknown[]) => actionMocks.createQuoteRevision(...args),
+  deleteQuote: (...args: unknown[]) => actionMocks.deleteQuote(...args),
+  downloadQuotePdf: (...args: unknown[]) => actionMocks.downloadQuotePdf(...args),
+  duplicateQuote: (...args: unknown[]) => actionMocks.duplicateQuote(...args),
+  listQuotes: (...args: unknown[]) => actionMocks.listQuotes(...args),
+  resendQuote: (...args: unknown[]) => actionMocks.resendQuote(...args),
+  sendQuote: (...args: unknown[]) => actionMocks.sendQuote(...args),
+  sendQuoteReminder: (...args: unknown[]) => actionMocks.sendQuoteReminder(...args),
+}));
+
+vi.mock('../../../actions/quoteDocumentTemplates', () => ({
+  getQuoteDocumentTemplates: (...args: unknown[]) => getQuoteDocumentTemplatesMock(...args),
+}));
+
+vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
+  useFormatters: () => ({
+    formatCurrency: (value: number) => `$${value.toFixed(2)}`,
+    formatDate: (value: string) => value,
+  }),
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
+  }),
+}));
+
+vi.mock('@alga-psa/ui/components/CustomTabs', () => ({
+  CustomTabs: ({ tabs, defaultTab }: { tabs: Array<{ id: string; content: React.ReactNode }>; defaultTab: string }) => (
+    <div>{tabs.find((tab) => tab.id === defaultTab)?.content}</div>
+  ),
+}));
+
+vi.mock('@alga-psa/ui/components/DataTable', () => ({
+  DataTable: ({ data, columns }: {
+    data: Array<Record<string, unknown>>;
+    columns: Array<{ dataIndex: string; render?: (value: unknown, row: Record<string, unknown>) => React.ReactNode }>;
+  }) => (
+    <table>
+      <tbody>
+        {data.map((row) => (
+          <tr key={String(row.quote_id)}>
+            {columns.map((column) => (
+              <td key={column.dataIndex}>
+                {column.render ? column.render(row[column.dataIndex], row) : String(row[column.dataIndex] ?? '')}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  ),
+}));
+
+vi.mock('@alga-psa/ui/components/DropdownMenu', () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({ children, id, onClick }: { children: React.ReactNode; id?: string; onClick?: () => void }) => (
+    <button id={id} type="button" onClick={onClick}>{children}</button>
+  ),
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('react-resizable-panels', () => ({
+  Panel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PanelGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PanelResizeHandle: () => <div />,
+}));
+
+vi.mock('@alga-psa/ui/components/ClientNameCell', () => ({
+  default: ({ clientName }: { clientName: string }) => <span>{clientName}</span>,
+}));
+
+vi.mock('./QuoteApprovalDashboard', () => ({ default: () => null }));
+vi.mock('./QuoteForm', () => ({ default: () => null }));
+vi.mock('./QuotePreviewPanel', () => ({ default: () => null }));
+vi.mock('./QuoteStatusBadge', () => ({ default: () => null }));
+
+import QuotesTab from './QuotesTab';
+
+const sentQuote = {
+  quote_id: 'quote-sent-1',
+  client_id: 'client-1',
+  client_name: 'Example Client',
+  currency_code: 'USD',
+  display_quote_number: 'Q-1001',
+  quote_date: '2026-08-20',
+  status: 'sent',
+  title: 'Sent quote',
+  total_amount: 10000,
+};
+
+describe('QuotesTab sent quote actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    actionMocks.listQuotes.mockResolvedValue({ data: [sentQuote] });
+    getQuoteDocumentTemplatesMock.mockResolvedValue([]);
+    actionMocks.resendQuote.mockResolvedValue({});
+    actionMocks.sendQuoteReminder.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('resends a sent quote with resendQuote instead of sendQuote', async () => {
+    render(<QuotesTab />);
+
+    fireEvent.click(await screen.findByText('Resend'));
+
+    await waitFor(() => expect(actionMocks.resendQuote).toHaveBeenCalledWith(sentQuote.quote_id));
+    expect(actionMocks.sendQuote).not.toHaveBeenCalled();
+  });
+
+  it('sends a sent quote reminder with sendQuoteReminder instead of sendQuote', async () => {
+    render(<QuotesTab />);
+
+    fireEvent.click(await screen.findByText('Send Reminder'));
+
+    await waitFor(() => expect(actionMocks.sendQuoteReminder).toHaveBeenCalledWith(sentQuote.quote_id));
+    expect(actionMocks.sendQuote).not.toHaveBeenCalled();
+  });
+});

--- a/packages/billing/src/components/billing-dashboard/quotes/QuotesTab.tsx
+++ b/packages/billing/src/components/billing-dashboard/quotes/QuotesTab.tsx
@@ -25,7 +25,7 @@ import { useFormatters, useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { getErrorMessage, isActionMessageError, isActionPermissionError } from '@alga-psa/ui/lib/errorHandling';
 import { MoreVertical, Edit, Send, Copy, Download, Trash2, RefreshCw, Bell, FileText, XCircle, FilePenLine } from 'lucide-react';
 import { REVISABLE_QUOTE_STATUSES, type ColumnDefinition, type IQuoteDocumentTemplate, type IQuoteListItem, type QuoteStatus } from '@alga-psa/types';
-import { listQuotes, downloadQuotePdf, deleteQuote, duplicateQuote, sendQuote, createQuoteRevision } from '../../../actions/quoteActions';
+import { listQuotes, downloadQuotePdf, deleteQuote, duplicateQuote, sendQuote, resendQuote, sendQuoteReminder, createQuoteRevision } from '../../../actions/quoteActions';
 import { getQuoteDocumentTemplates } from '../../../actions/quoteDocumentTemplates';
 import QuoteApprovalDashboard from './QuoteApprovalDashboard';
 import QuoteForm from './QuoteForm';
@@ -55,6 +55,8 @@ interface QuoteSubTabContentProps {
   onDownload: () => Promise<void>;
   onEdit: (quoteId: string) => void;
   onSend: (quoteId: string) => void;
+  onResend: (quoteId: string) => Promise<void>;
+  onSendReminder: (quoteId: string) => Promise<void>;
   onRevise: (quoteId: string) => Promise<void>;
   onDuplicate: (quoteId: string) => Promise<void>;
   onDownloadPdf: (quoteId: string) => Promise<void>;
@@ -71,6 +73,8 @@ const QuoteSubTabContent: React.FC<QuoteSubTabContentProps> = ({
   onDownload,
   onEdit,
   onSend,
+  onResend,
+  onSendReminder,
   onRevise,
   onDuplicate,
   onDownloadPdf,
@@ -168,7 +172,7 @@ const QuoteSubTabContent: React.FC<QuoteSubTabContentProps> = ({
                 )}
                 {status === 'sent' && (
                   <DropdownMenuItem
-                    onClick={() => onSend(record.quote_id)}
+                    onClick={() => void onResend(record.quote_id)}
                     className="flex items-center gap-2"
                     id={`resend-quote-${record.quote_id}-menu-item`}
                   >
@@ -178,7 +182,7 @@ const QuoteSubTabContent: React.FC<QuoteSubTabContentProps> = ({
                 )}
                 {status === 'sent' && (
                   <DropdownMenuItem
-                    onClick={() => onSend(record.quote_id)}
+                    onClick={() => void onSendReminder(record.quote_id)}
                     className="flex items-center gap-2"
                     id={`remind-quote-${record.quote_id}-menu-item`}
                   >
@@ -228,7 +232,7 @@ const QuoteSubTabContent: React.FC<QuoteSubTabContentProps> = ({
         );
       },
     },
-  ], [formatCurrency, formatDate, onDelete, onDownloadPdf, onDuplicate, onEdit, onRevise, onSend, t]);
+  ], [formatCurrency, formatDate, onDelete, onDownloadPdf, onDuplicate, onEdit, onResend, onRevise, onSend, onSendReminder, t]);
 
   if (filteredByStatus.length === 0) {
     return (
@@ -454,6 +458,44 @@ const QuotesTab: React.FC = () => {
     }
   };
 
+  const handleResendQuote = async (quoteId: string) => {
+    setError(null);
+    try {
+      const result = await resendQuote(quoteId);
+      if (isReturnedActionError(result)) {
+        setError(getErrorMessage(result));
+        return;
+      }
+      void loadData();
+    } catch (err) {
+      console.error('Failed to resend quote:', err);
+      setError(
+        err instanceof Error
+          ? err.message
+          : t('quotesTab.errors.resend', { defaultValue: 'Failed to resend quote.' }),
+      );
+    }
+  };
+
+  const handleSendReminder = async (quoteId: string) => {
+    setError(null);
+    try {
+      const result = await sendQuoteReminder(quoteId);
+      if (isReturnedActionError(result)) {
+        setError(getErrorMessage(result));
+        return;
+      }
+      void loadData();
+    } catch (err) {
+      console.error('Failed to send quote reminder:', err);
+      setError(
+        err instanceof Error
+          ? err.message
+          : t('quotesTab.errors.sendReminder', { defaultValue: 'Failed to send quote reminder.' }),
+      );
+    }
+  };
+
   const handleReviseQuote = async (quoteId: string) => {
     setError(null);
     try {
@@ -592,6 +634,8 @@ const QuotesTab: React.FC = () => {
                   onDownload={handleDownloadPdf}
                   onEdit={(id) => router.push(`/msp/billing?tab=quotes&quoteId=${id}&mode=edit`)}
                   onSend={(id) => setSendDialogState({ isOpen: true, quoteId: id })}
+                  onResend={handleResendQuote}
+                  onSendReminder={handleSendReminder}
                   onRevise={handleReviseQuote}
                   onDuplicate={handleDuplicateQuote}
                   onDownloadPdf={triggerPdfDownload}
@@ -613,6 +657,8 @@ const QuotesTab: React.FC = () => {
                   onDownload={handleDownloadPdf}
                   onEdit={(id) => router.push(`/msp/billing?tab=quotes&quoteId=${id}&mode=edit`)}
                   onSend={(id) => setSendDialogState({ isOpen: true, quoteId: id })}
+                  onResend={handleResendQuote}
+                  onSendReminder={handleSendReminder}
                   onRevise={handleReviseQuote}
                   onDuplicate={handleDuplicateQuote}
                   onDownloadPdf={triggerPdfDownload}
@@ -634,6 +680,8 @@ const QuotesTab: React.FC = () => {
                   onDownload={handleDownloadPdf}
                   onEdit={(id) => router.push(`/msp/billing?tab=quotes&quoteId=${id}&mode=edit`)}
                   onSend={(id) => setSendDialogState({ isOpen: true, quoteId: id })}
+                  onResend={handleResendQuote}
+                  onSendReminder={handleSendReminder}
                   onRevise={handleReviseQuote}
                   onDuplicate={handleDuplicateQuote}
                   onDownloadPdf={triggerPdfDownload}

--- a/server/public/locales/de/msp/quotes.json
+++ b/server/public/locales/de/msp/quotes.json
@@ -114,7 +114,9 @@
       "delete": "Das Angebot konnte nicht gelöscht werden.",
       "duplicate": "Das Angebot konnte nicht dupliziert werden.",
       "load": "Angebote konnten nicht geladen werden",
-      "send": "Angebot konnte nicht gesendet werden."
+      "send": "Angebot konnte nicht gesendet werden.",
+      "resend": "Das Angebot konnte nicht erneut gesendet werden.",
+      "sendReminder": "Die Erinnerung konnte nicht gesendet werden."
     },
     "loading": "Angebote werden geladen...",
     "rowActions": {

--- a/server/public/locales/en/msp/quotes.json
+++ b/server/public/locales/en/msp/quotes.json
@@ -114,7 +114,9 @@
       "delete": "Failed to delete quote.",
       "duplicate": "Failed to duplicate quote.",
       "load": "Failed to load quotes",
-      "send": "Failed to send quote."
+      "send": "Failed to send quote.",
+      "resend": "Failed to resend quote.",
+      "sendReminder": "Failed to send quote reminder."
     },
     "loading": "Loading quotes...",
     "rowActions": {

--- a/server/public/locales/es/msp/quotes.json
+++ b/server/public/locales/es/msp/quotes.json
@@ -114,7 +114,9 @@
       "delete": "No se pudo eliminar la cotización.",
       "duplicate": "No se pudo duplicar la cotización.",
       "load": "No se pudieron cargar las cotizaciones",
-      "send": "No se pudo enviar la cotización."
+      "send": "No se pudo enviar la cotización.",
+      "resend": "No se pudo reenviar la cotización.",
+      "sendReminder": "No se pudo enviar el recordatorio de la cotización."
     },
     "loading": "Cargando cotizaciones...",
     "rowActions": {

--- a/server/public/locales/fr/msp/quotes.json
+++ b/server/public/locales/fr/msp/quotes.json
@@ -114,7 +114,9 @@
       "delete": "Échec de la suppression du devis.",
       "duplicate": "Échec de la duplication du devis.",
       "load": "Échec du chargement des devis",
-      "send": "Échec de l'envoi du devis."
+      "send": "Échec de l'envoi du devis.",
+      "resend": "Échec de la relance du devis.",
+      "sendReminder": "Échec de l'envoi du rappel du devis."
     },
     "loading": "Chargement des devis...",
     "rowActions": {

--- a/server/public/locales/it/msp/quotes.json
+++ b/server/public/locales/it/msp/quotes.json
@@ -114,7 +114,9 @@
       "delete": "Impossibile eliminare il preventivo.",
       "duplicate": "Impossibile duplicare il preventivo.",
       "load": "Impossibile caricare le virgolette",
-      "send": "Impossibile inviare il preventivo."
+      "send": "Impossibile inviare il preventivo.",
+      "resend": "Impossibile rinviare il preventivo.",
+      "sendReminder": "Impossibile inviare il promemoria del preventivo."
     },
     "loading": "Caricamento preventivi...",
     "rowActions": {

--- a/server/public/locales/nl/msp/quotes.json
+++ b/server/public/locales/nl/msp/quotes.json
@@ -114,7 +114,9 @@
       "delete": "Kan offerte niet verwijderen.",
       "duplicate": "Kan de offerte niet dupliceren.",
       "load": "Kan offertes niet laden",
-      "send": "Kan de offerte niet verzenden."
+      "send": "Kan de offerte niet verzenden.",
+      "resend": "Kan de offerte niet opnieuw verzenden.",
+      "sendReminder": "Kan de herinnering voor de offerte niet verzenden."
     },
     "loading": "Offertes laden...",
     "rowActions": {

--- a/server/public/locales/pl/msp/quotes.json
+++ b/server/public/locales/pl/msp/quotes.json
@@ -114,7 +114,9 @@
       "delete": "Nie udało się usunąć wyceny.",
       "duplicate": "Nie udało się zduplikować wyceny.",
       "load": "Nie udało się załadować wycen",
-      "send": "Nie udało się wysłać wyceny."
+      "send": "Nie udało się wysłać wyceny.",
+      "resend": "Nie udało się ponownie wysłać wyceny.",
+      "sendReminder": "Nie udało się wysłać przypomnienia o wycenie."
     },
     "loading": "Ładowanie wycen...",
     "rowActions": {

--- a/server/public/locales/pt/msp/quotes.json
+++ b/server/public/locales/pt/msp/quotes.json
@@ -114,7 +114,9 @@
       "delete": "Falha ao excluir cotação.",
       "duplicate": "Falha ao duplicar a cotação.",
       "load": "Falha ao carregar cotações",
-      "send": "Falha ao enviar cotação."
+      "send": "Falha ao enviar cotação.",
+      "resend": "Falha ao reenviar cotação.",
+      "sendReminder": "Falha ao enviar lembrete da cotação."
     },
     "loading": "Carregando cotações...",
     "rowActions": {

--- a/server/public/locales/xx/msp/quotes.json
+++ b/server/public/locales/xx/msp/quotes.json
@@ -114,7 +114,9 @@
       "delete": "11111",
       "duplicate": "11111",
       "load": "11111",
-      "send": "11111"
+      "send": "11111",
+      "resend": "11111",
+      "sendReminder": "11111"
     },
     "loading": "11111",
     "rowActions": {

--- a/server/public/locales/yy/msp/quotes.json
+++ b/server/public/locales/yy/msp/quotes.json
@@ -114,7 +114,9 @@
       "delete": "55555",
       "duplicate": "55555",
       "load": "55555",
-      "send": "55555"
+      "send": "55555",
+      "resend": "55555",
+      "sendReminder": "55555"
     },
     "loading": "55555",
     "rowActions": {


### PR DESCRIPTION
## Summary

In **Quotes > Sent**, the row action menu's **Resend** and **Send Reminder** items were wired to `onSend(quote_id)`, which opens the ordinary *Send to Client* dialog. Its confirmation calls `sendQuote()`, and `sendQuote()` intentionally only accepts draft/approved quotes — so acting on a *sent* quote produced *"Only draft or approved quotes can be sent."*

This change wires the two sent-only menu items to their dedicated actions, which already exist in `quoteActions.ts` and are already used correctly by Quote Detail and Quote Form:

- **Resend** → `resendQuote(quote_id)`
- **Send Reminder** → `sendQuoteReminder(quote_id)`

Both handlers mirror the existing `handleDuplicateQuote` pattern: clear the error, call the action, surface `getErrorMessage(result)` on a returned action error, and reload the list on success. The sent-only menu visibility is retained, and the draft/approved **Send to Client** flow (dialog + `sendQuote()`) is unchanged.

## Changes

- `packages/billing/src/components/billing-dashboard/quotes/QuotesTab.tsx`
  - Import `resendQuote` and `sendQuoteReminder` from `quoteActions`.
  - Add `onResend` / `onSendReminder` props plumbed through `QuoteSubTabContent`.
  - Sent-row menu: `Resend` calls `onResend`, `Send Reminder` calls `onSendReminder` (previously both called `onSend`).
  - Add `handleResendQuote` and `handleSendReminder` with error handling and reload-on-success.
- `packages/billing/src/components/billing-dashboard/quotes/QuotesTab.test.tsx` — new mocked behavioral tests (Vitest + Testing Library) asserting each sent-row menu action invokes its dedicated action (`resendQuote` / `sendQuoteReminder`) with the quote id and **does not** call `sendQuote`.
- `docs/plans/2026-08-21-quotes-sent-resend-reminder-plan.md` — the implementation plan.

## Smoke test results — PASS

Exercised the real application on port 3621 with this worktree's Next.js server and the running `alga-psa-local-test` services.

Flows exercised:
- Sent-row menu showed **Resend** and **Send Reminder**, without **Send to Client**.
- **Resend** completed without the former status error or send dialog. PostgreSQL recorded exactly one `resent` activity with `email_sent=true`; GreenMail received UID 69, subject "Quote SMOKE-RR-20260820-2341 from Oz".
- **Send Reminder** completed likewise. PostgreSQL recorded exactly one `reminder_sent` activity with `email_sent=true`; GreenMail received UID 70 with the reminder subject.
- Quote Activity Log displayed both dedicated activities.
- Nearby regression check passed: a draft row still showed **Send to Client** and opened the ordinary Send Quote dialog; it was canceled without mutation.

**Fidelity:** actions were driven through the real UI and verified through PostgreSQL and SMTP delivery. Because the tenant had no sent quotes, one sent-state fixture was inserted directly in the dev database. Outbound mail used the stack's existing GreenMail simulator; no custom simulator or mock was used.

**Environment/concerns:** the server remains answering on 3621 and GreenMail readiness returns 200. The host server had to be restarted with the actual compose Redis secret because `.env.local` expands an unescaped `$`; EventBus readiness was restored. Historical console errors corresponded to those restarts; after the final checkpoint there were no new console errors or failed network requests. Unrelated Temporal worker startup warnings remain in the dev environment. The directly inserted fixture `SMOKE-RR-20260820-2341` remains in the shared dev database. No repository files were changed during smoke testing.

**Evidence:** `/tmp/alga-smoke-evidence/fix-sent-quote-resend-reminder-20260820-232644`

## Related

Closes the reported issue: Resend and Send Reminder on sent quotes failing with "Only draft or approved quotes can be sent."
