### PR TITLE
Fix intermittent auto-return from ticket detail

### DIFF
--- a/packages/tickets/src/components/TicketingDashboard.tsx
+++ b/packages/tickets/src/components/TicketingDashboard.tsx
@@ -136,6 +136,13 @@ interface TicketingDashboardProps {
   initialTicketTags?: Record<string, ITag[]>;
   initialTeams?: ITeam[];
   canUpdateTickets?: boolean;
+  /**
+   * Called immediately before any route change out of the list, so the container
+   * can stop mirroring filter state into the URL. A write that lands while the
+   * push is in flight replaces the entry the router just made and bounces the
+   * user back to the list.
+   */
+  onNavigateAway?: () => void;
   allowSlaStatusFilter?: boolean;
   useAlgaDeskQuickAddForm?: boolean;
   /**
@@ -280,6 +287,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
   initialTicketTags = {},
   initialTeams = [],
   canUpdateTickets = true,
+  onNavigateAway,
   allowSlaStatusFilter = true,
   useAlgaDeskQuickAddForm = false,
   viewPresentation,
@@ -408,12 +416,21 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
   const [clientFilterState, setClientFilterState] = useState<'active' | 'inactive' | 'all'>('active');
   const [clientTypeFilter, setClientTypeFilter] = useState<'all' | 'company' | 'individual'>('all');
 
+  // The only way out of this route. Announcing the departure *before* the push
+  // is the point: the container mirrors filter state into the URL, and a write
+  // that lands while the push is still in flight replaces the entry the router
+  // just made — which is what made a freshly-opened ticket snap back to the list.
+  const navigateAwayTo = useCallback((href: string) => {
+    onNavigateAway?.();
+    router.push(href);
+  }, [onNavigateAway, router]);
+
   // Create-ticket is a routed modal now (keeps the rich-text editor out of this route's
   // bundle). Navigate instead of rendering QuickAddTicket inline; the route renders the
   // dialog (intercepted as an overlay over the list) and refreshes the list on success.
   const openQuickAddTicket = useCallback(
-    () => router.push(buildCreateTicketHref({ isAlgaDeskMode: useAlgaDeskQuickAddForm })),
-    [router, useAlgaDeskQuickAddForm],
+    () => navigateAwayTo(buildCreateTicketHref({ isAlgaDeskMode: useAlgaDeskQuickAddForm })),
+    [navigateAwayTo, useAlgaDeskQuickAddForm],
   );
   usePageCreateShortcut(openQuickAddTicket);
 
@@ -822,11 +839,11 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
   // Custom function for clicking on tickets with filter preservation
   const handleTicketClick = useCallback((ticketId: string) => {
     const filterQuery = getCurrentFiltersQuery();
-    const href = filterQuery 
+    const href = filterQuery
       ? `/msp/tickets/${ticketId}?returnFilters=${encodeURIComponent(filterQuery)}`
       : `/msp/tickets/${ticketId}`;
-    router.push(href);
-  }, [getCurrentFiltersQuery, router]);
+    navigateAwayTo(href);
+  }, [getCurrentFiltersQuery, navigateAwayTo]);
 
 
   // Handle saving time entries created from intervals
@@ -2123,7 +2140,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
                       defaultValue: 'Export selected ({{count}})',
                     })
                   : t('dashboard.exportAction', { defaultValue: 'Export CSV' }),
-                onSelect: () => router.push('/msp/tickets/export'),
+                onSelect: () => navigateAwayTo('/msp/tickets/export'),
                 disabled: !hasSelection,
                 separator: true,
               },
@@ -2131,7 +2148,7 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
                 id: `${id}-share-import`,
                 icon: Upload,
                 label: t('dashboard.importAction', { defaultValue: 'Import CSV' }),
-                onSelect: () => router.push('/msp/tickets/import'),
+                onSelect: () => navigateAwayTo('/msp/tickets/import'),
               },
             ] satisfies ShareAction[]}
           />
@@ -2962,19 +2979,19 @@ const TicketingDashboard: React.FC<TicketingDashboardProps> = ({
           setIsBundleDialogOpen(true);
         }}
         onAssign={() => {
-          router.push('/msp/tickets/bulk-assign');
+          navigateAwayTo('/msp/tickets/bulk-assign');
         }}
         onStatus={() => {
-          router.push('/msp/tickets/bulk-status');
+          navigateAwayTo('/msp/tickets/bulk-status');
         }}
         onPriority={() => {
-          router.push('/msp/tickets/bulk-priority');
+          navigateAwayTo('/msp/tickets/bulk-priority');
         }}
         onTags={() => {
-          router.push('/msp/tickets/bulk-tags');
+          navigateAwayTo('/msp/tickets/bulk-tags');
         }}
         onDueDate={() => {
-          router.push('/msp/tickets/bulk-due-date');
+          navigateAwayTo('/msp/tickets/bulk-due-date');
         }}
         onDelete={() => {
           setBulkDeleteErrors([]);

--- a/packages/tickets/src/components/TicketingDashboardContainer.tsx
+++ b/packages/tickets/src/components/TicketingDashboardContainer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
+import { usePathname } from 'next/navigation';
 import TicketingDashboard from './TicketingDashboard';
 import { fetchTicketsWithPagination } from '../actions/optimizedTicketActions';
 import { toast } from 'react-hot-toast';
@@ -23,14 +24,12 @@ import {
   TICKET_STATUS_FILTER_OPEN,
 } from '../lib/ticketStatusFilter';
 import {
-  buildBoardSelectionFilterUpdate,
-  hasBoardFilterParam,
   hasTicketViewFilterParams,
-  resolveInitialBoardTab,
   shouldApplyBoardDefaultView,
   type BoardArrivalTrigger,
   TICKETS_LAST_ACTIVE_BOARD_SETTING,
 } from '../lib/boardTabs';
+import { shouldWriteTicketListUrl, TICKET_LIST_PATHNAME } from '../lib/ticketListUrlSync';
 import {
   buildBoardArrivalFilters,
   resolveTicketViewSettings,
@@ -194,6 +193,7 @@ export default function TicketingDashboardContainer({
   const filterFetchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastAppliedSearchRef = useRef<string>('');
   const isSyncingFromHistoryRef = useRef(false);
+  const navigatingAwayRef = useRef(false);
 
   const defaultSortBy = initialFilters?.sortBy ?? 'entered_at';
   const defaultSortDirection = initialFilters?.sortDirection ?? 'desc';
@@ -264,11 +264,11 @@ export default function TicketingDashboardContainer({
     }
   );
 
-  const {
-    value: storedActiveBoard,
-    setValue: setStoredActiveBoard,
-    isLoading: isActiveBoardPreferenceLoading,
-  } = useUserPreference<string>(
+  // Write-only here: the remembered tab is *restored* on the server, before the
+  // first paint (server/src/app/msp/tickets/page.tsx), so this screen never has
+  // to re-write the URL a beat after rendering. This hook only records where the
+  // user went next.
+  const { setValue: setStoredActiveBoard } = useUserPreference<string>(
     TICKETS_LAST_ACTIVE_BOARD_SETTING,
     {
       // '' means the "All tickets" tab — a distinct, storable choice rather than
@@ -279,6 +279,31 @@ export default function TicketingDashboardContainer({
     }
   );
 
+  /**
+   * The user has asked to leave the list. Everything that would still write to
+   * history from here on is stale by definition, so the flag is set before the
+   * router.push rather than after it — the whole window that has to be closed
+   * is the one where the push is in flight and window.location has not moved.
+   */
+  const markNavigatingAway = useCallback(() => {
+    navigatingAwayRef.current = true;
+    if (filterFetchTimeoutRef.current) {
+      clearTimeout(filterFetchTimeoutRef.current);
+      filterFetchTimeoutRef.current = null;
+    }
+  }, []);
+
+  // …and lifts again on the way back. Export, Import and every bulk action are
+  // *intercepted* routes: the list stays mounted underneath them, so a flag that
+  // only ever went one way would leave the address bar ignoring filter changes
+  // for the rest of the session once the user had opened one dialog.
+  const pathname = usePathname();
+  useEffect(() => {
+    if (pathname === TICKET_LIST_PATHNAME) {
+      navigatingAwayRef.current = false;
+    }
+  }, [pathname]);
+
   // Function to sync filter state and pagination to URL
   const updateURLWithFilters = useCallback((
     filters: Partial<ITicketListFilters>,
@@ -286,6 +311,18 @@ export default function TicketingDashboardContainer({
     pageSize?: number,
     historyMode: 'replace' | 'push' = 'replace',
   ) => {
+    // The list is no longer the page being described: writing here would replace
+    // the history entry the router just pushed for the ticket detail and bounce
+    // the user straight back to the list. lastAppliedSearchRef is deliberately
+    // left untouched — nothing was applied, so a later popstate must still be
+    // able to tell that the URL differs from what this screen last rendered.
+    if (!shouldWriteTicketListUrl({
+      pathname: typeof window === 'undefined' ? null : window.location.pathname,
+      hasNavigatedAway: navigatingAwayRef.current,
+    })) {
+      return;
+    }
+
     const params = new URLSearchParams();
 
     // Add pagination params
@@ -721,62 +758,12 @@ export default function TicketingDashboardContainer({
     updateURLWithFilters,
   ]);
 
-  // Restore the last-active board tab on a bare /msp/tickets. Applied at most
-  // once per mount (appliedInitialBoardRef) and only once the preference has
-  // actually resolved from the server, so a shared link is never stomped by a
-  // preference that arrives a tick later. A URL that names a board wins outright.
-  const availableBoardIds = useMemo(
-    () => effectiveOptions.boardOptions.map(board => board.board_id).filter((id): id is string => Boolean(id)),
-    [effectiveOptions.boardOptions]
-  );
-  const appliedInitialBoardRef = useRef(false);
-  useEffect(() => {
-    if (appliedInitialBoardRef.current || isActiveBoardPreferenceLoading || typeof window === 'undefined') {
-      return;
-    }
-    appliedInitialBoardRef.current = true;
-
-    const decision = resolveInitialBoardTab({
-      urlHasBoardFilter: hasBoardFilterParam(window.location.search),
-      storedBoardId: storedActiveBoard,
-      availableBoardIds,
-    });
-    if (!decision.apply) {
-      return;
-    }
-
-    const boardSelection = buildBoardSelectionFilterUpdate({
-      selectedBoards: [decision.boardId],
-      excludedBoards: [],
-      statusOptions: effectiveOptions.statusOptions,
-      currentStatusId: activeFiltersRef.current.statusId,
-    });
-    // Restoring the remembered tab is an arrival too, so the board's stored view
-    // applies here exactly as it does on a click — layered into this effect's
-    // existing single fetch rather than chasing it with another.
-    applyBoardViewPresentation(decision.boardId);
-    const arrival = boardArrivalFilters(decision.boardId, boardSelection, 'initial');
-    const mergedFilters: Partial<ITicketListFilters> =
-      arrival ?? { ...activeFiltersRef.current, ...boardSelection };
-    if (arrival?.sortBy) setSortBy(arrival.sortBy);
-    if (arrival?.sortDirection) setSortDirection(arrival.sortDirection);
-    setActiveFilters(mergedFilters);
-    activeFiltersRef.current = mergedFilters;
-    setCurrentPage(1);
-    // Replace (not push): restoring a remembered tab is where the user landed,
-    // so "back" should leave the page rather than fall through to All tickets.
-    updateURLWithFilters(mergedFilters, 1, pageSize);
-    void fetchTicketsRef.current(mergedFilters, 1, pageSize);
-  }, [
-    isActiveBoardPreferenceLoading,
-    storedActiveBoard,
-    availableBoardIds,
-    effectiveOptions.statusOptions,
-    pageSize,
-    updateURLWithFilters,
-    applyBoardViewPresentation,
-    boardArrivalFilters,
-  ]);
+  // The last-active board tab used to be restored here, by an effect that fired
+  // once the preference resolved — a second fetch, a visible board jump a beat
+  // after first paint, and a history write that could land after the user had
+  // already clicked into a ticket and bounce them back to the list. It is now
+  // resolved on the server (server/src/app/msp/tickets/page.tsx), so the board
+  // arrives in initialFilters and nothing here re-writes the URL on arrival.
 
   const handlePageChange = useCallback(async (newPage: number) => {
     setCurrentPage(newPage);
@@ -985,6 +972,7 @@ export default function TicketingDashboardContainer({
       initialTicketTags={ticketMetadata.ticketTags}
       initialTeams={initialTeams}
       canUpdateTickets={canUpdateTickets}
+      onNavigateAway={markNavigatingAway}
         allowSlaStatusFilter={allowSlaStatusFilter}
         useAlgaDeskQuickAddForm={useAlgaDeskQuickAddForm}
         viewPresentation={viewPresentation}

--- a/packages/tickets/src/components/TicketingDashboardContainer.urlSync.contract.test.tsx
+++ b/packages/tickets/src/components/TicketingDashboardContainer.urlSync.contract.test.tsx
@@ -1,0 +1,198 @@
+/* @vitest-environment jsdom */
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ITicketListFilters, IUser } from '@alga-psa/types';
+import type { TicketFilterChangeOptions } from '../lib/ticketFilterChange';
+
+/**
+ * The regression guard for "click the first ticket, it opens for a beat and
+ * snaps back to the list on a different board".
+ *
+ * The list mirrors its filter state into the address bar with
+ * `history.replaceState`. `router.push` is asynchronous, so the dashboard is
+ * still mounted — and its debounced writers still armed — while the detail route
+ * resolves. Any write that lands in that window replaces the entry the router
+ * just pushed, and Next reconciles back to the list URL it finds.
+ *
+ * So: once the dashboard reports a navigation, the container must not touch
+ * history again, and the pending filter fetch must not fire either.
+ */
+
+const fetchTicketsWithPagination = vi.fn(async () => ({ tickets: [], totalCount: 0 }));
+
+let currentPathname = '/msp/tickets';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => currentPathname,
+}));
+
+type DashboardProps = {
+  onFilterChange: (update: Partial<ITicketListFilters>, options?: TicketFilterChangeOptions) => void;
+  onNavigateAway?: () => void;
+};
+
+let dashboardProps: DashboardProps | null = null;
+
+vi.mock('./TicketingDashboard', () => ({
+  default: (props: DashboardProps) => {
+    dashboardProps = props;
+    return null;
+  },
+}));
+
+vi.mock('../actions/optimizedTicketActions', () => ({
+  fetchTicketsWithPagination: (...args: unknown[]) => fetchTicketsWithPagination(...(args as [])),
+}));
+
+vi.mock('react-hot-toast', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => (typeof fallback === 'string' ? fallback : _key),
+  }),
+}));
+
+vi.mock('@alga-psa/user-composition/hooks', () => ({
+  useUserPreference: () => ({
+    value: null,
+    setValue: vi.fn(),
+    isLoading: false,
+    hasLoadedInitial: true,
+  }),
+}));
+
+vi.mock('../hooks/useTicketFormOptions', () => ({
+  useTicketFormOptions: () => ({ options: null }),
+}));
+
+const { default: TicketingDashboardContainer } = await import('./TicketingDashboardContainer');
+
+const consolidatedData = {
+  tickets: [],
+  totalCount: 0,
+  options: {
+    boardOptions: [],
+    statusOptions: [],
+    priorityOptions: [],
+    categories: [],
+    clients: [],
+    users: [],
+    tags: [],
+  },
+} as unknown as React.ComponentProps<typeof TicketingDashboardContainer>['consolidatedData'];
+
+const currentUser = { user_id: 'user-1', tenant: 'tenant-1' } as IUser;
+
+function renderContainer() {
+  const view = render(
+    <TicketingDashboardContainer
+      consolidatedData={consolidatedData}
+      currentUser={currentUser}
+    />,
+  );
+  if (!dashboardProps) {
+    throw new Error('TicketingDashboard was not rendered');
+  }
+  return { props: dashboardProps, view };
+}
+
+describe('ticket list URL sync after navigating away', () => {
+  beforeEach(() => {
+    dashboardProps = null;
+    currentPathname = '/msp/tickets';
+    fetchTicketsWithPagination.mockClear();
+    window.history.replaceState(null, '', '/msp/tickets');
+  });
+
+  it('mirrors a filter change into the URL while the list is still the page', () => {
+    const { props } = renderContainer();
+    const replaceState = vi.spyOn(window.history, 'replaceState').mockImplementation(() => {});
+    const pushState = vi.spyOn(window.history, 'pushState').mockImplementation(() => {});
+
+    act(() => {
+      props.onFilterChange({ priorityId: 'priority-1' });
+    });
+
+    expect(replaceState).toHaveBeenCalledTimes(1);
+    expect(pushState).not.toHaveBeenCalled();
+
+    replaceState.mockRestore();
+    pushState.mockRestore();
+  });
+
+  it('writes no history entry once the dashboard reports a navigation', () => {
+    const { props } = renderContainer();
+    const replaceState = vi.spyOn(window.history, 'replaceState').mockImplementation(() => {});
+    const pushState = vi.spyOn(window.history, 'pushState').mockImplementation(() => {});
+
+    act(() => {
+      props.onNavigateAway?.();
+    });
+
+    // Everything that can still reach updateURLWithFilters: a filter edit, a
+    // board tab move (which normally pushes), a page change, a page-size change.
+    act(() => {
+      props.onFilterChange({ priorityId: 'priority-2' });
+      props.onFilterChange({ boardIds: ['board-1'] }, { activeBoardTab: 'board-1', pushHistory: true });
+    });
+
+    expect(replaceState).not.toHaveBeenCalled();
+    expect(pushState).not.toHaveBeenCalled();
+
+    replaceState.mockRestore();
+    pushState.mockRestore();
+  });
+
+  it('resumes writing once an intercepted modal route closes', () => {
+    // Export, Import and the bulk actions render *over* the list, so the
+    // container is never unmounted. A one-way flag would leave the address bar
+    // ignoring filter changes for the rest of the session after one dialog.
+    const { props, view } = renderContainer();
+
+    act(() => {
+      props.onNavigateAway?.();
+    });
+
+    currentPathname = '/msp/tickets/export';
+    view.rerender(
+      <TicketingDashboardContainer consolidatedData={consolidatedData} currentUser={currentUser} />,
+    );
+
+    currentPathname = '/msp/tickets';
+    view.rerender(
+      <TicketingDashboardContainer consolidatedData={consolidatedData} currentUser={currentUser} />,
+    );
+
+    const replaceState = vi.spyOn(window.history, 'replaceState').mockImplementation(() => {});
+    act(() => {
+      props.onFilterChange({ priorityId: 'priority-4' });
+    });
+
+    expect(replaceState).toHaveBeenCalledTimes(1);
+    replaceState.mockRestore();
+  });
+
+  it('exposes the navigation hook to the dashboard', () => {
+    // Without this wiring every router.push out of the list is still a race.
+    const { props } = renderContainer();
+    expect(typeof props.onNavigateAway).toBe('function');
+  });
+
+  it('cancels the debounced filter fetch on the way out', async () => {
+    const { props } = renderContainer();
+
+    act(() => {
+      props.onFilterChange({ priorityId: 'priority-3' });
+      props.onNavigateAway?.();
+    });
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 400));
+    });
+
+    expect(fetchTicketsWithPagination).not.toHaveBeenCalled();
+  });
+});

--- a/packages/tickets/src/components/boardArrival.contract.test.ts
+++ b/packages/tickets/src/components/boardArrival.contract.test.ts
@@ -18,7 +18,9 @@ import { describe, expect, it } from 'vitest';
  */
 
 const COMPONENTS = __dirname;
+const REPO_ROOT = join(COMPONENTS, '..', '..', '..', '..');
 const read = (file: string) => readFileSync(join(COMPONENTS, file), 'utf8');
+const readRepo = (file: string) => readFileSync(join(REPO_ROOT, file), 'utf8');
 
 function sliceCallback(source: string, name: string): string {
   const start = source.indexOf(`const ${name} = useCallback(`);
@@ -66,5 +68,98 @@ describe('board arrival wiring', () => {
     expect(body).not.toContain('window.location.search');
     // The entry-URL probe is a ref captured once, not a per-call read.
     expect(container).toContain('const entryUrlHasFilterOpinion = useRef(');
+  });
+});
+
+/**
+ * The remembered board tab is an *arrival* too, and it used to be applied by a
+ * client effect that ran once the preference resolved — after first paint, with
+ * its own fetch and its own history write. That write could land after the user
+ * had already clicked into a ticket, replacing the entry the router had just
+ * pushed and bouncing them back to the list on the restored board. It is
+ * resolved on the server now, and the wiring that keeps it honest — same shared
+ * resolvers, same precedence — is a cross-file property no unit test sees.
+ */
+describe('initial board resolution moved to the server', () => {
+  const container = read('TicketingDashboardContainer.tsx');
+  const page = readRepo('server/src/app/msp/tickets/page.tsx');
+
+  it('leaves no client-side restore effect behind', () => {
+    expect(container).not.toContain('resolveInitialBoardTab({');
+    expect(container).not.toContain('hasBoardFilterParam(');
+    expect(container).not.toContain("boardArrivalFilters(decision.boardId");
+  });
+
+  it('still records the tab the user moves to', () => {
+    // Only the *restore* moved; remembering is still a client concern, because
+    // only the client knows a tab was clicked.
+    expect(container).toContain('setStoredActiveBoard(');
+    expect(container).toContain('TICKETS_LAST_ACTIVE_BOARD_SETTING');
+  });
+
+  it('resolves the remembered board on the server before the list fetch', () => {
+    expect(page).toContain('TICKETS_LAST_ACTIVE_BOARD_SETTING');
+    // A stored board that no longer exists must be dropped, not rendered.
+    expect(page).toContain('findBoardById');
+    // A URL that names a board still wins outright.
+    expect(page).toContain('hasBoardFilterParam');
+  });
+
+  it('applies the board default view through the same shared resolvers', () => {
+    // Not a second, server-flavoured copy of the arrival rules: the board's
+    // stored document is sanitized, layered over the tenant document, validated
+    // on read, and folded in by buildBoardArrivalFilters — exactly as a tab
+    // click does on the client.
+    for (const resolver of [
+      'sanitizeStoredTicketView',
+      'resolveTicketViewSettings',
+      'validateCapturedFilters',
+      'buildBoardArrivalFilters',
+    ]) {
+      expect(page).toContain(resolver);
+    }
+    // …and only when the entry URL expressed no filter opinion of its own.
+    expect(page).toContain('hasTicketViewFilterParams');
+  });
+});
+
+/**
+ * The reported bug in one line: the list writes its own state into the address
+ * bar, and `router.push` is asynchronous, so a write that lands while the push
+ * is in flight replaces the entry the router just made. Every route change out
+ * of this screen therefore has to announce itself first.
+ */
+describe('navigating away stops the URL sync', () => {
+  const dashboard = read('TicketingDashboard.tsx');
+  const container = read('TicketingDashboardContainer.tsx');
+
+  it('routes every navigation out of the list through the announcing helper', () => {
+    const pushes = dashboard.match(/router\.push\(/g) ?? [];
+    // Exactly one: the one inside navigateAwayTo.
+    expect(pushes).toHaveLength(1);
+    expect(dashboard).toMatch(/const navigateAwayTo = useCallback\(\(href: string\) => \{\s*onNavigateAway\?\.\(\);\s*router\.push\(href\);/);
+  });
+
+  it('wires the departure signal from the dashboard to the container', () => {
+    expect(container).toContain('onNavigateAway={markNavigatingAway}');
+    expect(container).toContain('navigatingAwayRef.current = true');
+  });
+
+  it('lifts the flag again when the list is back on top', () => {
+    // Export/Import/bulk are intercepted routes — the list is never unmounted —
+    // so a one-way flag would silently retire the URL sync for the session.
+    expect(container).toContain('usePathname()');
+    expect(container).toContain('navigatingAwayRef.current = false');
+  });
+
+  it('guards the URL write itself rather than each call site', () => {
+    const start = container.indexOf('const updateURLWithFilters = useCallback(');
+    expect(start).toBeGreaterThan(-1);
+    const guard = container.slice(start, container.indexOf('const params = new URLSearchParams()', start));
+    expect(guard).toContain('shouldWriteTicketListUrl');
+    // The write is abandoned, not recorded: the "last applied search" must
+    // still describe what this screen last rendered, so a later popstate can
+    // tell that the URL has moved.
+    expect(guard).not.toContain('lastAppliedSearchRef.current =');
   });
 });

--- a/packages/tickets/src/lib/boardTabs.test.ts
+++ b/packages/tickets/src/lib/boardTabs.test.ts
@@ -290,6 +290,47 @@ describe('hasBoardFilterParam', () => {
   });
 });
 
+describe('URL probes on a server-built search string', () => {
+  /**
+   * The remembered board tab is resolved on the server now (see
+   * server/src/app/msp/tickets/page.tsx), where there is no `window.location`
+   * to read — the search string is rebuilt from Next's searchParams object via
+   * `URLSearchParams.toString()`, which yields no leading `?` and re-encodes
+   * repeated params. Both probes have to answer identically in that shape, or
+   * the server would silently stop honouring a shared link.
+   */
+  const searchStringFrom = (params: Record<string, string | string[]>) =>
+    new URLSearchParams(
+      Object.entries(params).flatMap(([key, value]): [string, string][] =>
+        Array.isArray(value) ? value.map(item => [key, item]) : [[key, value]]
+      )
+    ).toString();
+
+  it('sees a board opinion with no leading question mark', () => {
+    const search = searchStringFrom({ boardId: BOARD_A });
+    expect(search.startsWith('?')).toBe(false);
+    expect(hasBoardFilterParam(search)).toBe(true);
+    expect(hasTicketViewFilterParams(search)).toBe(false);
+  });
+
+  it('sees no board opinion on a bare entry, so the preference gets its turn', () => {
+    expect(hasBoardFilterParam(searchStringFrom({}))).toBe(false);
+    expect(hasBoardFilterParam(searchStringFrom({ page: '2', pageSize: '50' }))).toBe(false);
+  });
+
+  it('sees a filter opinion in a repeated param', () => {
+    // Next hands a repeated query param through as an array; flattened back to
+    // `tags=a&tags=b` it still has to read as "this link means these tickets".
+    expect(hasTicketViewFilterParams(searchStringFrom({ tags: ['urgent', 'vip'] }))).toBe(true);
+  });
+
+  it('survives values that need re-encoding', () => {
+    const search = searchStringFrom({ searchQuery: 'disk full & failing' });
+    expect(search).toContain('%26');
+    expect(hasTicketViewFilterParams(search)).toBe(true);
+  });
+});
+
 describe('resolveInitialBoardTab (URL beats preference)', () => {
   it('does not apply the preference when the URL names a board', () => {
     expect(resolveInitialBoardTab({

--- a/packages/tickets/src/lib/ticketListUrlSync.test.ts
+++ b/packages/tickets/src/lib/ticketListUrlSync.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment node
+
+import { describe, expect, it } from 'vitest';
+import { shouldWriteTicketListUrl, TICKET_LIST_PATHNAME } from './ticketListUrlSync';
+
+describe('shouldWriteTicketListUrl', () => {
+  it('writes while the list is still the page', () => {
+    expect(shouldWriteTicketListUrl({
+      pathname: TICKET_LIST_PATHNAME,
+      hasNavigatedAway: false,
+    })).toBe(true);
+  });
+
+  it('tolerates a trailing slash on the list route', () => {
+    expect(shouldWriteTicketListUrl({
+      pathname: '/msp/tickets/',
+      hasNavigatedAway: false,
+    })).toBe(true);
+  });
+
+  it('does not write once the route has moved to a ticket detail', () => {
+    // The late writer this guard exists for: a debounced search or a preference
+    // landing after the detail route has already committed.
+    expect(shouldWriteTicketListUrl({
+      pathname: '/msp/tickets/8f1c7a3e-0000-4000-8000-000000000000',
+      hasNavigatedAway: false,
+    })).toBe(false);
+  });
+
+  it('does not write on the routed modals that live under the list', () => {
+    for (const pathname of ['/msp/tickets/export', '/msp/tickets/import', '/msp/tickets/bulk-assign']) {
+      expect(shouldWriteTicketListUrl({ pathname, hasNavigatedAway: false })).toBe(false);
+    }
+  });
+
+  it('does not write once a navigation away has been requested', () => {
+    // The likelier half of the race: router.push is still in flight, so
+    // window.location has not moved yet and the pathname alone still says
+    // "list". Without the flag this is exactly the write that replaces the
+    // history entry the router just pushed.
+    expect(shouldWriteTicketListUrl({
+      pathname: TICKET_LIST_PATHNAME,
+      hasNavigatedAway: true,
+    })).toBe(false);
+  });
+
+  it('does not write without a window (SSR / prerender)', () => {
+    expect(shouldWriteTicketListUrl({ pathname: null, hasNavigatedAway: false })).toBe(false);
+    expect(shouldWriteTicketListUrl({ pathname: undefined, hasNavigatedAway: false })).toBe(false);
+  });
+
+  it('does not treat a different route that merely shares a prefix as the list', () => {
+    expect(shouldWriteTicketListUrl({
+      pathname: '/msp/tickets-archive',
+      hasNavigatedAway: false,
+    })).toBe(false);
+  });
+});

--- a/packages/tickets/src/lib/ticketListUrlSync.ts
+++ b/packages/tickets/src/lib/ticketListUrlSync.ts
@@ -1,0 +1,39 @@
+/**
+ * When the ticket list is still allowed to write its own state into the URL.
+ *
+ * The list mirrors its filter state into the address bar with
+ * `history.replaceState`, which is correct while the list is the page you are
+ * on — and a bug the moment it is not. `router.push('/msp/tickets/<id>')` is
+ * asynchronous: the dashboard stays mounted while the detail route resolves, so
+ * a debounced search, a page-size preference landing late, or any other
+ * deferred writer can still fire inside that window and overwrite the history
+ * entry the router just pushed. The router then reconciles to the URL it finds
+ * and the ticket that was open for a beat snaps back to the list — on whatever
+ * board the late writer happened to be describing.
+ *
+ * Two independent signals, because neither alone closes the window. The
+ * pathname catches a write that lands after the route has already committed;
+ * the navigation flag catches the much likelier case of a write that lands
+ * while `router.push` is still in flight and `window.location` has not moved
+ * yet.
+ *
+ * Pure, so the rule is testable without mounting the dashboard — same shape as
+ * boardTabs.ts and ticketViewSettings.ts.
+ */
+
+/** The one route whose state the ticket-list URL sync may describe. */
+export const TICKET_LIST_PATHNAME = '/msp/tickets';
+
+export function shouldWriteTicketListUrl(params: {
+  /** `window.location.pathname` at write time; null when there is no window. */
+  pathname: string | null | undefined;
+  /** True once a route change away from the list has been requested. */
+  hasNavigatedAway: boolean;
+}): boolean {
+  if (params.hasNavigatedAway) {
+    return false;
+  }
+  const pathname = (params.pathname ?? '').trim();
+  const normalized = pathname.length > 1 ? pathname.replace(/\/+$/, '') : pathname;
+  return normalized === TICKET_LIST_PATHNAME;
+}

--- a/server/src/app/msp/tickets/page.tsx
+++ b/server/src/app/msp/tickets/page.tsx
@@ -4,10 +4,22 @@ import { getTicketingDisplaySettings } from '@alga-psa/tickets/actions/ticketDis
 import { getTeams, isTeamActionError } from '@alga-psa/teams/actions';
 import type { ITicketListFilters } from '@alga-psa/types';
 import MspTicketsPageClient from '@alga-psa/msp-composition/tickets/MspTicketsPageClient';
+import { findBoardById } from '@alga-psa/tickets/actions/board-actions/boardActions';
 import {
   isTicketStatusOpenFilter,
   TICKET_STATUS_FILTER_OPEN,
 } from '@alga-psa/tickets/lib';
+import {
+  hasBoardFilterParam,
+  hasTicketViewFilterParams,
+  TICKETS_LAST_ACTIVE_BOARD_SETTING,
+} from '@alga-psa/tickets/lib/boardTabs';
+import {
+  buildBoardArrivalFilters,
+  resolveTicketViewSettings,
+  sanitizeStoredTicketView,
+  validateCapturedFilters,
+} from '@alga-psa/tickets/lib/ticketViewSettings';
 import { getServerTranslation } from '@alga-psa/ui/lib/i18n/serverOnly';
 import { getCurrentTenantProduct } from '@/lib/productAccess';
 import type { Metadata } from 'next';
@@ -204,6 +216,80 @@ export default async function TicketsPage({ searchParams }: TicketsPageProps) {
       }
     }
 
+    // ── Board memory, resolved before first paint ──────────────────────────
+    //
+    // The remembered board tab used to be restored by a client effect that fired
+    // once the preference resolved — a second list fetch, a board that visibly
+    // jumped a beat after the list had already rendered, and a
+    // history.replaceState late enough to land *after* a ticket click and bounce
+    // the user back to the list. Resolving it here means first paint is already
+    // the remembered board and nothing re-writes history on arrival.
+    //
+    // A URL that names a board still wins outright, and a URL carrying filter
+    // intent still outranks the board's stored view: a shared link is about
+    // *these tickets*, not about the board's usual way of looking at them.
+    const searchString = new URLSearchParams(
+      Object.entries(params ?? {}).flatMap(([key, value]): [string, string][] => {
+        if (value === undefined) return [];
+        return Array.isArray(value) ? value.map(item => [key, item]) : [[key, value]];
+      })
+    ).toString();
+
+    // Hoisted out of the list fetch below: the board's stored view resolves
+    // through the tenant layer, so both must be in hand before the filters the
+    // list is fetched with are decided.
+    const [displaySettings, rememberedBoardId] = await Promise.all([
+      getTicketingDisplaySettings(),
+      hasBoardFilterParam(searchString)
+        ? Promise.resolve(null)
+        : getUserPreference(user!.user_id, TICKETS_LAST_ACTIVE_BOARD_SETTING).catch(() => null),
+    ]);
+
+    const storedBoardId = typeof rememberedBoardId === 'string' ? rememberedBoardId.trim() : '';
+    if (storedBoardId) {
+      // A stored board that no longer exists (or is no longer readable) is
+      // ignored rather than rendering a tab that cannot be there — the same
+      // 'board-unavailable' rule the client resolver applied.
+      const board = await findBoardById(storedBoardId).catch(() => undefined);
+      if (board && !isReturnedActionError(board) && board.board_id) {
+        filtersFromURL.boardIds = [board.board_id];
+
+        if (!hasTicketViewFilterParams(searchString)) {
+          const resolvedView = resolveTicketViewSettings({
+            board: sanitizeStoredTicketView(board.list_view_settings),
+            tenant: sanitizeStoredTicketView(displaySettings?.list),
+          });
+          const arrivalFilters = buildBoardArrivalFilters({
+            baseline: {
+              statusId: TICKET_STATUS_FILTER_OPEN,
+              priorityId: 'all',
+              showOpenOnly: true,
+              boardFilterState: 'active',
+              bundleView: 'bundled',
+              searchQuery: '',
+              sortBy: 'entered_at',
+              sortDirection: 'desc',
+            },
+            boardSelection: {
+              boardIds: [board.board_id],
+              statusId: TICKET_STATUS_FILTER_OPEN,
+              showOpenOnly: true,
+            },
+            viewFilters: validateCapturedFilters(
+              resolvedView.filters,
+              {},
+              // Pseudo-filters, not ids: they must survive validation untouched.
+              [TICKET_STATUS_FILTER_OPEN, 'all'],
+            ),
+          });
+          if (!allowSlaStatusFilter) {
+            delete arrivalFilters.slaStatusFilter;
+          }
+          Object.assign(filtersFromURL, arrivalFilters);
+        }
+      }
+    }
+
     // Apply defaults for missing parameters
     const initialFilters: Partial<ITicketListFilters> = {
       boardFilterState: 'active',
@@ -244,9 +330,8 @@ export default async function TicketsPage({ searchParams }: TicketsPageProps) {
     };
 
     // Fetch consolidated data for the ticket list with initial filters and pagination
-    const [consolidatedData, displaySettings, teams, userPermissions] = await Promise.all([
+    const [consolidatedData, teams, userPermissions] = await Promise.all([
       getConsolidatedTicketListData(fetchFilters, page, pageSize),
-      getTicketingDisplaySettings(),
       getTeams().catch(() => []),
       getCurrentUserPermissions().catch(() => [] as string[])
     ]);

--- a/server/src/app/msp/tickets/ticketsModalRoutes.contract.test.ts
+++ b/server/src/app/msp/tickets/ticketsModalRoutes.contract.test.ts
@@ -46,7 +46,7 @@ describe('tickets modal route infrastructure', () => {
     expect(routeClient).toContain('TicketImportDialog');
     expect(routeClient).toContain('router.back()');
     expect(routeClient).toContain("router.replace('/msp/tickets')");
-    expect(dashboard).toContain("router.push('/msp/tickets/import')");
+    expect(dashboard).toContain("navigateAwayTo('/msp/tickets/import')");
     expect(dashboard).not.toContain("import TicketImportDialog from './TicketImportDialog'");
     expect(dashboard).not.toContain('<TicketImportDialog');
   });
@@ -63,7 +63,7 @@ describe('tickets modal route infrastructure', () => {
     expect(routeClient).toContain('useTicketsRouteState');
     expect(routeClient).toContain('filters={filters}');
     expect(routeClient).toContain('selectedTicketIds={selectedTicketIdsArray}');
-    expect(dashboard).toContain("router.push('/msp/tickets/export')");
+    expect(dashboard).toContain("navigateAwayTo('/msp/tickets/export')");
     expect(dashboard).not.toContain("import TicketExportDialog from './TicketExportDialog'");
     expect(dashboard).not.toContain('<TicketExportDialog');
   });
@@ -129,12 +129,15 @@ describe('tickets modal route infrastructure', () => {
   it('keeps the bulk action bar in the list while navigating to bulk modal routes', () => {
     const dashboard = read('packages/tickets/src/components/TicketingDashboard.tsx');
 
+    // navigateAwayTo, not router.push directly: leaving the list has to tell the
+    // container to stop mirroring filter state into the URL first, or the write
+    // races the push and lands on top of it.
     expect(dashboard).toContain('<BulkTicketActionBar');
-    expect(dashboard).toContain("router.push('/msp/tickets/bulk-assign')");
-    expect(dashboard).toContain("router.push('/msp/tickets/bulk-tags')");
-    expect(dashboard).toContain("router.push('/msp/tickets/bulk-due-date')");
-    expect(dashboard).toContain("router.push('/msp/tickets/bulk-status')");
-    expect(dashboard).toContain("router.push('/msp/tickets/bulk-priority')");
+    expect(dashboard).toContain("navigateAwayTo('/msp/tickets/bulk-assign')");
+    expect(dashboard).toContain("navigateAwayTo('/msp/tickets/bulk-tags')");
+    expect(dashboard).toContain("navigateAwayTo('/msp/tickets/bulk-due-date')");
+    expect(dashboard).toContain("navigateAwayTo('/msp/tickets/bulk-status')");
+    expect(dashboard).toContain("navigateAwayTo('/msp/tickets/bulk-priority')");
   });
 
   it('threads optional notification suppression through eligible bulk dialogs and excludes tag writes', () => {

--- a/server/src/test/unit/app/msp/tickets/page.initialBoard.test.tsx
+++ b/server/src/test/unit/app/msp/tickets/page.initialBoard.test.tsx
@@ -1,0 +1,223 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+(globalThis as unknown as { React?: typeof React }).React = React;
+
+/**
+ * The remembered board tab is resolved here, on the server, before first paint.
+ *
+ * It used to be a client effect that fired once the preference resolved: a
+ * second list fetch, a board that visibly jumped a beat after the list had
+ * rendered, and — the reported bug — a history.replaceState late enough to land
+ * after a ticket click and bounce the user back to the list on a different
+ * board. The precedence rules it carried have to survive the move:
+ *
+ *   URL board  >  remembered board  >  All tickets
+ *   URL filter intent  >  the board's stored default view
+ *
+ * plus "a stored board that no longer exists is ignored", which is what stops a
+ * deleted board rendering a tab that cannot be there.
+ */
+
+const BOARD_ID = 'b1111111-1111-4111-8111-111111111111';
+
+const getCurrentUserMock = vi.fn();
+const getCurrentUserPermissionsMock = vi.fn();
+const getUserPreferenceMock = vi.fn();
+const getCurrentTenantProductMock = vi.fn();
+const getConsolidatedTicketListDataMock = vi.fn();
+const getTicketingDisplaySettingsMock = vi.fn();
+const getTeamsMock = vi.fn();
+const findBoardByIdMock = vi.fn();
+
+function MspTicketsPageClientMock() {
+  return null;
+}
+
+vi.mock('@alga-psa/user-composition/actions', () => ({
+  getCurrentUser: getCurrentUserMock,
+  getCurrentUserPermissions: getCurrentUserPermissionsMock,
+  getUserPreference: getUserPreferenceMock,
+}));
+
+vi.mock('@/lib/productAccess', () => ({
+  getCurrentTenantProduct: getCurrentTenantProductMock,
+}));
+
+vi.mock('@alga-psa/tickets/actions/optimizedTicketActions', () => ({
+  getConsolidatedTicketListData: getConsolidatedTicketListDataMock,
+}));
+
+vi.mock('@alga-psa/tickets/actions/ticketDisplaySettings', () => ({
+  getTicketingDisplaySettings: getTicketingDisplaySettingsMock,
+}));
+
+vi.mock('@alga-psa/tickets/actions/board-actions/boardActions', () => ({
+  findBoardById: findBoardByIdMock,
+}));
+
+vi.mock('@alga-psa/teams/actions', () => ({
+  getTeams: getTeamsMock,
+  isTeamActionError: (value: unknown) => Boolean(value && typeof value === 'object' && 'error' in value),
+}));
+
+vi.mock('@alga-psa/msp-composition/tickets/MspTicketsPageClient', () => ({
+  default: MspTicketsPageClientMock,
+}));
+
+const { default: TicketsPage } = await import('server/src/app/msp/tickets/page');
+
+const renderProps = async (search: Record<string, string>) => {
+  const result = await TicketsPage({ searchParams: Promise.resolve(search) });
+  const pageContainer = result as React.ReactElement<{ children: React.ReactElement }>;
+  return pageContainer.props.children.props as Record<string, unknown>;
+};
+
+const initialFiltersOf = (props: Record<string, unknown>) =>
+  props.initialFilters as Record<string, unknown>;
+
+describe('MSP tickets page initial board resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    getCurrentUserMock.mockResolvedValue({ user_id: 'user-1', tenant: 'tenant-1' });
+    getCurrentUserPermissionsMock.mockResolvedValue(['ticket:update']);
+    getCurrentTenantProductMock.mockResolvedValue('psa');
+    getUserPreferenceMock.mockImplementation(async (_userId: string, setting: string) =>
+      setting === 'tickets_last_active_board' ? BOARD_ID : null,
+    );
+    findBoardByIdMock.mockResolvedValue({ board_id: BOARD_ID, board_name: 'Support' });
+    getConsolidatedTicketListDataMock.mockResolvedValue({
+      tickets: [],
+      totalCount: 0,
+      options: {
+        boardOptions: [],
+        statusOptions: [],
+        priorityOptions: [],
+        categories: [],
+        clients: [],
+        users: [],
+        tags: [],
+      },
+      metadata: { agentAvatarUrls: {}, teamAvatarUrls: {}, ticketTags: {} },
+    });
+    getTicketingDisplaySettingsMock.mockResolvedValue({ responseStateTrackingEnabled: true });
+    getTeamsMock.mockResolvedValue([]);
+  });
+
+  it('seeds the remembered board into the first paint and the first fetch', async () => {
+    const props = await renderProps({});
+
+    expect(findBoardByIdMock).toHaveBeenCalledWith(BOARD_ID);
+    expect(initialFiltersOf(props).boardIds).toEqual([BOARD_ID]);
+    // The one list fetch this page makes is already scoped to the board: there
+    // is no second, client-side fetch chasing it any more.
+    expect(getConsolidatedTicketListDataMock.mock.calls[0][0]).toMatchObject({ boardIds: [BOARD_ID] });
+  });
+
+  it('lets a URL that names a board win outright', async () => {
+    const props = await renderProps({ boardId: 'c2222222-2222-4222-8222-222222222222' });
+
+    expect(getUserPreferenceMock).not.toHaveBeenCalledWith(expect.anything(), 'tickets_last_active_board');
+    expect(findBoardByIdMock).not.toHaveBeenCalled();
+    expect(initialFiltersOf(props).boardId).toBe('c2222222-2222-4222-8222-222222222222');
+    expect(initialFiltersOf(props).boardIds).toBeUndefined();
+  });
+
+  it('ignores a remembered board that no longer exists', async () => {
+    findBoardByIdMock.mockResolvedValue(undefined);
+
+    const props = await renderProps({});
+
+    expect(initialFiltersOf(props).boardIds).toBeUndefined();
+  });
+
+  it('ignores a remembered board the action refuses to return', async () => {
+    findBoardByIdMock.mockResolvedValue({ permissionError: 'Permission denied' });
+
+    const props = await renderProps({});
+
+    expect(initialFiltersOf(props).boardIds).toBeUndefined();
+  });
+
+  it('ignores an empty preference without looking up a board', async () => {
+    getUserPreferenceMock.mockResolvedValue('   ');
+
+    const props = await renderProps({});
+
+    expect(findBoardByIdMock).not.toHaveBeenCalled();
+    expect(initialFiltersOf(props).boardIds).toBeUndefined();
+  });
+
+  it('applies the board default view when the URL has no filter opinion', async () => {
+    findBoardByIdMock.mockResolvedValue({
+      board_id: BOARD_ID,
+      board_name: 'Support',
+      list_view_settings: {
+        filters: { priorityId: 'priority-high', sortBy: 'due_date', sortDirection: 'asc' },
+      },
+    });
+
+    const props = await renderProps({});
+    const filters = initialFiltersOf(props);
+
+    expect(filters.boardIds).toEqual([BOARD_ID]);
+    expect(filters.priorityId).toBe('priority-high');
+    expect(filters.sortBy).toBe('due_date');
+    expect(filters.sortDirection).toBe('asc');
+  });
+
+  it('falls through to the tenant view when the board stores none', async () => {
+    getTicketingDisplaySettingsMock.mockResolvedValue({
+      responseStateTrackingEnabled: true,
+      list: { filters: { priorityId: 'tenant-priority' } },
+    });
+
+    const props = await renderProps({});
+
+    expect(initialFiltersOf(props).priorityId).toBe('tenant-priority');
+  });
+
+  it('lets URL filter intent outrank the board default view', async () => {
+    findBoardByIdMock.mockResolvedValue({
+      board_id: BOARD_ID,
+      board_name: 'Support',
+      list_view_settings: { filters: { priorityId: 'priority-high' } },
+    });
+
+    const props = await renderProps({ priorityId: 'priority-from-link' });
+    const filters = initialFiltersOf(props);
+
+    // The board still selects the tab — `?boardId=` says which board, not what
+    // to show on it — but the link's filters are the ones that apply.
+    expect(filters.boardIds).toEqual([BOARD_ID]);
+    expect(filters.priorityId).toBe('priority-from-link');
+  });
+
+  it('never lets a stored view scope the board somewhere else', async () => {
+    findBoardByIdMock.mockResolvedValue({
+      board_id: BOARD_ID,
+      board_name: 'Support',
+      list_view_settings: {
+        filters: { boardIds: ['d3333333-3333-4333-8333-333333333333'], priorityId: 'priority-high' },
+      },
+    });
+
+    const props = await renderProps({});
+
+    expect(initialFiltersOf(props).boardIds).toEqual([BOARD_ID]);
+  });
+
+  it('drops an SLA filter from a stored view on tenants without SLA', async () => {
+    getCurrentTenantProductMock.mockResolvedValue('algadesk');
+    findBoardByIdMock.mockResolvedValue({
+      board_id: BOARD_ID,
+      board_name: 'Support',
+      list_view_settings: { filters: { slaStatusFilter: 'breached' } },
+    });
+
+    const props = await renderProps({});
+
+    expect(initialFiltersOf(props).slaStatusFilter).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Opening a ticket from the list occasionally bounced the user straight back to `/msp/tickets`. `router.push` is asynchronous, and the ticket list mirrors its filter state into the URL via `history.replaceState`. If a debounced search, a late page-size preference, or any other deferred writer fired while the push to the ticket detail route was still in flight, it overwrote the history entry the router had just created — the router then reconciled to that stale list URL and the ticket snapped shut. This also interacted with a second issue: the remembered board tab was restored by a client effect after the initial preference fetch resolved, causing a visible board jump and an extra history write shortly after first paint, widening the race window. This PR closes the URL-write race and moves board-tab restoration to the server so it lands in the initial render instead.

## Changes

- **URL-write guarding (`packages/tickets`)**
  - Added `shouldWriteTicketListUrl` (`lib/ticketListUrlSync.ts`) — a pure predicate that blocks writes once navigation away from `/msp/tickets` has started, using both a "navigated away" flag and the current pathname as independent signals.
  - `TicketingDashboardContainer` now tracks a `navigatingAwayRef`, sets it before any `router.push` off the list, clears it via a `usePathname` effect when back on `/msp/tickets` (needed because export/import/bulk actions are intercepted routes that keep the list mounted underneath), and gates `updateURLWithFilters` on `shouldWriteTicketListUrl`.
  - `TicketingDashboard` routes every ticket-list navigation (ticket click, create, export, import, bulk actions) through a new `navigateAwayTo` helper that calls `onNavigateAway` before `router.push`, instead of calling `router.push` directly.
- **Board-tab restoration moved server-side**
  - `server/src/app/msp/tickets/page.tsx` now resolves the remembered board (`TICKETS_LAST_ACTIVE_BOARD_SETTING`) before render: it looks up the board via `findBoardById`, falls back gracefully if the board is missing/unreadable, and applies the board's stored view settings via `resolveTicketViewSettings`/`buildBoardArrivalFilters` — but only when the URL doesn't already name a board or carry filter intent (a shared link still wins).
  - Removed the corresponding client-side effect and its `useUserPreference`-driven `useEffect` in `TicketingDashboardContainer` (no more second fetch, no board jump after first paint, no post-arrival history write); the preference hook there is now write-only, recording the board the user navigates to.
  - `getTicketingDisplaySettings()` is fetched once, ahead of the consolidated ticket-list data fetch, and reused for both board-view resolution and the existing initial filters.

## Testing

- `npm test` (vitest) for the new/updated suites:
  - `packages/tickets/src/lib/ticketListUrlSync.test.ts` (new)
  - `packages/tickets/src/lib/boardTabs.test.ts` (updated — server-built search-string cases)
  - `packages/tickets/src/components/TicketingDashboardContainer.urlSync.contract.test.tsx` (new)
  - `packages/tickets/src/components/boardArrival.contract.test.ts` (new)
  - `server/src/app/msp/tickets/page.initialBoard.test.tsx` (new)
  - `server/src/app/msp/tickets/ticketsModalRoutes.contract.test.ts` (updated for `navigateAwayTo`)
