### PR TITLE
Add visual confirmation when creating a task from a ticket

### DIFF
--- a/docs/plans/2026-08-22-visual-confirmation-when-creating-task-from-ticket-plan.md
+++ b/docs/plans/2026-08-22-visual-confirmation-when-creating-task-from-ticket-plan.md
@@ -1,0 +1,60 @@
+# Visual confirmation when creating a task from a ticket — implementation plan
+
+## Goal
+
+After a user creates a new task from a ticket (via the "Create Task" flow on a
+ticket), show a clear success toast so the user knows the task was created
+successfully. Scope: v1.5.0, web app only.
+
+## Current behavior and constraints
+
+- `packages/projects/src/components/CreateTaskFromTicketDialog.tsx` is the entry
+  point. Its "Create Task" button opens a project/phase/status picker dialog; on
+  confirm it calls `openDrawer(...)` with a `<TaskQuickAdd>` drawer, passing
+  `onTaskAdded={() => null}` — the success callback is a **no-op**.
+- `packages/projects/src/components/TaskQuickAdd.tsx` calls `onTaskAdded(resultTask)`
+  from `handleSubmit` in create mode (line 58) once `TaskForm` submits. The drawer
+  is closed by `TaskForm`'s `onClose`; creation success today gives no feedback.
+- The app-wide toast is `react-hot-toast` (root `<ThemedToaster/>` in
+  `packages/ui/src/components/ThemedToaster.tsx`; `import { toast } from
+  'react-hot-toast'` + `toast.success(...)` is the established pattern, e.g.
+  `project-templates/TemplateDetail.tsx`, `TemplateStatusManager.tsx`).
+- `onTaskAdded` is called with `IProjectTask | null`. It is only non-null on a
+  successful create, so the toast must fire only when `resultTask` is truthy.
+- The dialog's i18n uses namespace `features/projects` with keys under
+  `dialogs.createTaskFromTicket.*`. New copy should follow that namespace.
+
+## Design
+
+### 1. Wire a real `onTaskAdded` in `CreateTaskFromTicketDialog.tsx`
+
+Replace the no-op `onTaskAdded={() => null}` (line 169) with a handler that:
+
+1. Calls `closeDrawer()` (already wired via `onClose={closeDrawer}`) so the
+   drawer closes exactly as it does today.
+2. If `resultTask` is truthy, fires
+   `toast.success(t('dialogs.createTaskFromTicket.createdSuccess', 'Task created successfully'))`.
+   Do not fire anything on `null` (cancelled/aborted submit).
+
+### 2. i18n copy
+
+Add one key to the `features/projects` locale file (en):
+`dialogs.createTaskFromTicket.createdSuccess` → `"Task created successfully"`.
+Keep the fallback string inline in the call for other locales.
+
+### 3. Deliberately NOT doing
+
+- No changes to `TaskQuickAdd`, `TaskForm`, or the ticket integration layer —
+  the toast is a consumer-side concern.
+- No success state beyond the toast (no inline banner, no navigation change).
+- No change to the existing error toasts/`handleError` paths in this dialog.
+- No mobile app changes.
+- No confirmation dialog changes.
+
+## Verification
+
+- Existing unit test `packages/projects/src/components/__tests__/CreateTaskFromTicketDialog.test.tsx`
+  should still pass (it asserts prefill mapping; add a case that a truthy
+  `resultTask` produces a success toast and a `null` result does not).
+- Manual smoke on the ticket detail view: Create Task → pick project/phase/status →
+  Create → drawer closes and a success toast appears; canceling the drawer shows no toast.

--- a/packages/projects/src/components/CreateTaskFromTicketDialog.tsx
+++ b/packages/projects/src/components/CreateTaskFromTicketDialog.tsx
@@ -21,6 +21,7 @@ import {
   isActionPermissionError,
 } from '@alga-psa/ui/lib/errorHandling';
 import { useTranslation } from 'react-i18next';
+import { toast } from 'react-hot-toast';
 
 interface CreateTaskFromTicketDialogProps {
   ticket: {
@@ -166,7 +167,14 @@ export default function CreateTaskFromTicketDialog({
           inDrawer
           phase={selectedPhase}
           onClose={closeDrawer}
-          onTaskAdded={() => null}
+          onTaskAdded={(resultTask) => {
+            closeDrawer();
+            if (resultTask) {
+              toast.success(
+                t('dialogs.createTaskFromTicket.createdSuccess', 'Task created successfully')
+              );
+            }
+          }}
           onTaskUpdated={async () => undefined}
           projectStatuses={statuses}
           defaultStatus={defaultStatus}

--- a/packages/projects/src/components/__tests__/CreateTaskFromTicketDialog.test.tsx
+++ b/packages/projects/src/components/__tests__/CreateTaskFromTicketDialog.test.tsx
@@ -5,12 +5,14 @@ import '@testing-library/jest-dom/vitest';
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { toast } from 'react-hot-toast';
 import CreateTaskFromTicketDialog from '../CreateTaskFromTicketDialog';
 import { TicketIntegrationProvider, type TicketIntegrationContextType } from '../../context/TicketIntegrationContext';
 
 const getProjectsMock = vi.fn();
 const getProjectDetailsMock = vi.fn();
 const openDrawerMock = vi.fn();
+const closeDrawerMock = vi.fn();
 
 vi.mock('../../actions/projectActions', () => ({
   getProjects: (...args: unknown[]) => getProjectsMock(...args),
@@ -18,7 +20,11 @@ vi.mock('../../actions/projectActions', () => ({
 }));
 
 vi.mock('@alga-psa/ui', () => ({
-  useDrawer: () => ({ openDrawer: openDrawerMock, closeDrawer: vi.fn() })
+  useDrawer: () => ({ openDrawer: openDrawerMock, closeDrawer: closeDrawerMock })
+}));
+
+vi.mock('react-hot-toast', () => ({
+  toast: { success: vi.fn() }
 }));
 
 vi.mock('../TaskQuickAdd', () => ({
@@ -253,6 +259,30 @@ describe('CreateTaskFromTicketDialog', () => {
 
     expect(openDrawerMock).toHaveBeenCalled();
     expect(getDrawerTaskQuickAddProps().prefillData.task_name).toBe('Printer issue');
+  });
+
+  it('closes the drawer and shows a success toast only when a task is created', async () => {
+    renderDialog();
+    fireEvent.click(screen.getByRole('button', { name: 'Create Task' }));
+
+    await waitFor(() => expect(screen.getByTestId('create-task-project').querySelectorAll('option').length).toBeGreaterThan(1));
+    fireEvent.change(screen.getByTestId('create-task-project'), { target: { value: 'project-1' } });
+    await waitFor(() => expect(screen.getByTestId('create-task-phase').querySelectorAll('option').length).toBeGreaterThan(1));
+
+    fireEvent.change(screen.getByTestId('create-task-phase'), { target: { value: 'phase-1' } });
+    fireEvent.change(screen.getByTestId('create-task-status'), { target: { value: 'status-1' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    const { onTaskAdded } = getDrawerTaskQuickAddProps();
+    onTaskAdded({ task_id: 'task-1' } as any);
+
+    expect(closeDrawerMock).toHaveBeenCalledTimes(1);
+    expect(toast.success).toHaveBeenCalledWith('Task created successfully');
+
+    onTaskAdded(null);
+
+    expect(closeDrawerMock).toHaveBeenCalledTimes(2);
+    expect(toast.success).toHaveBeenCalledTimes(1);
   });
 
   it('includes pendingTicketLink when auto-link is on', async () => {

--- a/server/public/locales/de/features/projects.json
+++ b/server/public/locales/de/features/projects.json
@@ -761,7 +761,8 @@
       "phasePlaceholder": "Phase auswählen",
       "statusLabel": "Status",
       "statusPlaceholder": "Status auswählen",
-      "linkTicketLabel": "Ticket mit der erstellten Aufgabe verknüpfen"
+      "linkTicketLabel": "Ticket mit der erstellten Aufgabe verknüpfen",
+      "createdSuccess": "Aufgabe wurde erfolgreich erstellt"
     },
     "linkTicketToTask": {
       "title": "Ticket mit Aufgabe verknüpfen",

--- a/server/public/locales/en/features/projects.json
+++ b/server/public/locales/en/features/projects.json
@@ -761,7 +761,8 @@
       "phasePlaceholder": "Select a phase",
       "statusLabel": "Status",
       "statusPlaceholder": "Select a status",
-      "linkTicketLabel": "Link ticket to the created task"
+      "linkTicketLabel": "Link ticket to the created task",
+      "createdSuccess": "Task created successfully"
     },
     "linkTicketToTask": {
       "title": "Link Ticket to Task",

--- a/server/public/locales/es/features/projects.json
+++ b/server/public/locales/es/features/projects.json
@@ -761,7 +761,8 @@
       "phasePlaceholder": "Seleccionar una fase",
       "statusLabel": "Estado",
       "statusPlaceholder": "Seleccionar un estado",
-      "linkTicketLabel": "Vincular el ticket a la tarea creada"
+      "linkTicketLabel": "Vincular el ticket a la tarea creada",
+      "createdSuccess": "La tarea se creó correctamente"
     },
     "linkTicketToTask": {
       "title": "Vincular ticket a tarea",

--- a/server/public/locales/fr/features/projects.json
+++ b/server/public/locales/fr/features/projects.json
@@ -761,7 +761,8 @@
       "phasePlaceholder": "Sélectionner une phase",
       "statusLabel": "Statut",
       "statusPlaceholder": "Sélectionner un statut",
-      "linkTicketLabel": "Lier le ticket à la tâche créée"
+      "linkTicketLabel": "Lier le ticket à la tâche créée",
+      "createdSuccess": "La tâche a été créée avec succès"
     },
     "linkTicketToTask": {
       "title": "Lier le ticket à la tâche",

--- a/server/public/locales/it/features/projects.json
+++ b/server/public/locales/it/features/projects.json
@@ -761,7 +761,8 @@
       "phasePlaceholder": "Seleziona una fase",
       "statusLabel": "Stato",
       "statusPlaceholder": "Seleziona uno stato",
-      "linkTicketLabel": "Collega il ticket all’attività creata"
+      "linkTicketLabel": "Collega il ticket all’attività creata",
+      "createdSuccess": "L’attività è stata creata correttamente"
     },
     "linkTicketToTask": {
       "title": "Collega ticket ad attività",

--- a/server/public/locales/nl/features/projects.json
+++ b/server/public/locales/nl/features/projects.json
@@ -761,7 +761,8 @@
       "phasePlaceholder": "Selecteer een fase",
       "statusLabel": "Status",
       "statusPlaceholder": "Selecteer een status",
-      "linkTicketLabel": "Koppel ticket aan de gemaakte taak"
+      "linkTicketLabel": "Koppel ticket aan de gemaakte taak",
+      "createdSuccess": "Taak is succesvol aangemaakt"
     },
     "linkTicketToTask": {
       "title": "Ticket aan taak koppelen",

--- a/server/public/locales/pl/features/projects.json
+++ b/server/public/locales/pl/features/projects.json
@@ -781,7 +781,8 @@
       "phasePlaceholder": "Wybierz fazę",
       "statusLabel": "Status",
       "statusPlaceholder": "Wybierz stan",
-      "linkTicketLabel": "Połącz zgłoszenie z utworzonym zadaniem"
+      "linkTicketLabel": "Połącz zgłoszenie z utworzonym zadaniem",
+      "createdSuccess": "Zadanie zostało utworzone pomyślnie"
     },
     "linkTicketToTask": {
       "title": "Połącz zgłoszenie z zadaniem",

--- a/server/public/locales/pt/features/projects.json
+++ b/server/public/locales/pt/features/projects.json
@@ -761,7 +761,8 @@
       "phasePlaceholder": "Selecione uma fase",
       "statusLabel": "Status",
       "statusPlaceholder": "Selecione um status",
-      "linkTicketLabel": "Vincular ticket à tarefa criada"
+      "linkTicketLabel": "Vincular ticket à tarefa criada",
+      "createdSuccess": "A tarefa foi criada com sucesso"
     },
     "linkTicketToTask": {
       "title": "Vincular ticket à tarefa",

--- a/server/public/locales/xx/features/projects.json
+++ b/server/public/locales/xx/features/projects.json
@@ -761,7 +761,8 @@
       "phasePlaceholder": "11111",
       "statusLabel": "11111",
       "statusPlaceholder": "11111",
-      "linkTicketLabel": "11111"
+      "linkTicketLabel": "11111",
+      "createdSuccess": "11111"
     },
     "linkTicketToTask": {
       "title": "11111",

--- a/server/public/locales/yy/features/projects.json
+++ b/server/public/locales/yy/features/projects.json
@@ -761,7 +761,8 @@
       "phasePlaceholder": "55555",
       "statusLabel": "55555",
       "statusPlaceholder": "55555",
-      "linkTicketLabel": "55555"
+      "linkTicketLabel": "55555",
+      "createdSuccess": "55555"
     },
     "linkTicketToTask": {
       "title": "55555",


### PR DESCRIPTION
## Summary

- Close the Create Task drawer after its creation callback completes, and show a success toast only when the callback returns a created task.
- Add a focused regression test covering a successful result versus a null result.
- Add the `createdSuccess` translation for all supported and pseudo locales, keeping locale-key consistency intact.
- Include the implementation plan for the task-from-ticket confirmation.

## Smoke test

PASS. Verified the real worktree Next.js server on port 3276 with the running `alga-psa-local-test` infrastructure.

- Happy path: From ticket `TIC1003`, created linked task `SMOKE task toast 20260822-141422`. The drawer closed and the visible toast read `Task created successfully`. Database verification found exactly one `project_tasks` row and one `project_ticket_links` row. Reloading the ticket changed its summary from `1 Task` to `2 Tasks`.
- Regression path: Reopened Create Task and canceled. No success toast appeared and the database count remained unchanged, catching false confirmation/duplicate creation.
- Fidelity compromise: alga-dev created the card-scoped browser tab, but rejected it as belonging to another host; its auto-targeting found no browser pane. The desktop-control fallback recursively stalled and was stopped. Testing therefore used installed system Chrome via Playwright against the real app and database. Screenshots came from Chrome rather than alga-dev. No simulator or mock was used.
- Not exercised: a forced backend failure returning null, because inducing it would require tampering with the real service; non-English locale rendering was also not tested.
- Concerns: multiple worktree servers share the database and rotate Glinda's password globally, making individual boot banners stale. The ticket page also logged non-blocking Hocuspocus `ws://localhost:1234` connection refusals and one transient sidebar-permissions fetch failure; no HTTP 5xx occurred. The smoke task remains intentionally persisted. No repository files were changed by this run.

Evidence: `/tmp/alga-smoke-evidence/task-from-ticket-success-toast-20260822-141422`
