### PR TITLE
Bind template designer field picker to real render paths per document kind

### DIFF
--- a/ee/docs/plans/2026-08-22-template-binding-path-integrity/PRD.md
+++ b/ee/docs/plans/2026-08-22-template-binding-path-integrity/PRD.md
@@ -1,0 +1,187 @@
+# PRD — Template Designer Binding Path Integrity
+
+- Slug: `template-binding-path-integrity`
+- Date: `2026-08-22`
+- Status: Draft
+- Ticket: `alga0002294`
+- Related: `alga0002295` (invoice discount — separate effort, may run in parallel)
+
+## Summary
+
+Make the template designer's Fields catalog **derive its options from the per-type
+binding catalogs**, so a field the picker offers is always a field the render model
+actually has. Today the picker menu and the path-translation table are two
+hand-maintained lists that were never checked against the binding catalogs that
+define the real render models, and they have drifted: 23 of 28 quote picker fields
+and all 10 sales-order-family fields produce bindings that resolve to nothing.
+
+## Problem
+
+Binding a Data Field via the Fields catalog — or inserting a field token into a
+Text Block — produces a binding whose path does not exist in the target render
+model. The label renders, the value is blank, and Preview reports
+`Shape: SUCCESS / Render: SUCCESS` because nothing is malformed: the binding is
+well-formed and simply names a field the data does not have.
+
+### Mechanism
+
+1. The picker menu is hand-declared in
+   `shared/workflow/expression-authoring/adapters/invoiceContextAdapter.ts`
+   (`createQuoteRootSchema`, `createQuoteTotalsSchema`, `createSalesOrderRootSchema`).
+   It describes *the menu*, and is not derived from or checked against any model.
+2. On export, `normalizeInvoiceBindingPath`
+   (`packages/billing/src/components/invoice-designer/ast/workspaceAst.ts:152-206`)
+   translates the picked path into a data path via a hand-written alias table. That
+   table was written for the invoice model, which genuinely is camelCase
+   (`invoiceNumber`). Quote and sales-order models are snake_case (`quote_number`,
+   `so_number`).
+3. `registerValueBinding` (`workspaceAst.ts:1425`) reuses an existing binding by
+   matching on **path**. `quoteNumber` misses `quote_number`, so rather than reusing
+   the correct built-in binding sitting right there, it mints a new one pointing at a
+   nonexistent path.
+4. The evaluator does `getPathValue(data, 'quoteNumber')` → `undefined` → empty string.
+
+### Measured scope
+
+Every picker option, bound and evaluated against each type's real sample model:
+
+| Document type | Picker fields resolving |
+|---|---|
+| Invoice | 15 / 16 |
+| Quote | 5 / 28 |
+| Sales Order | 0 / 10 root fields |
+| Packing Slip | 0 / 10 root fields |
+| Pick List | 0 / 10 root fields |
+
+The five quote fields that work do so **by coincidence** — `status`, `title`,
+`subtotal`, `tax`, `version` are spelled identically in both conventions. So are
+`client.*` and `contact.*`. That coincidence is why spot checks pass.
+
+`salesOrder.*` has no alias entries at all, so those paths export verbatim.
+Packing slip and pick list reuse the sales-order bindings and sample wholesale
+(`registry.ts`), inheriting the defect intact.
+
+Also broken for quotes: `tenant.name` / `tenant.address`, which line 200 maps to
+`tenantClient.*` — correct for invoices, wrong for `QuoteViewModel`, which exposes
+`tenant.{name,address}`.
+
+### Text Block variant has no workaround
+
+`{{quote.quoteNumber}}` exports `{"type":"path","path":"quoteNumber"}` — a raw path
+expression that bypasses the binding catalog entirely, so the "use custom path"
+workaround cannot rescue it. `{{quote_number}}` is rejected as a token outright:
+`isLikelyBindingTokenPath` requires a dot or membership in `SIMPLE_BINDING_ALIASES`,
+which is invoice-only. Quote scalar fields in text blocks are currently unfixable
+from the UI.
+
+### Not a regression
+
+`a6b481694f` (2026-03-13) added the quote bindings with snake_case paths.
+`9277f30bca` (2026-04-01) added the picker schema and the alias table in camelCase,
+in one commit, without cross-checking the bindings file from three weeks earlier.
+Neither line has been modified since. The two i18n commits touching this file
+(`00a43d572b`, `2d67191f45`, 2026-08-13) have all their hunks elsewhere.
+
+## Production state (verified 2026-08-22)
+
+**No template anywhere is currently rendering blank from this bug.**
+
+| | Found |
+|---|---|
+| Custom quote templates | 16 across 10 tenants |
+| Custom invoice templates | 55 across 28 tenants |
+| Sales-order / packing-slip / pick-list | 0 — `document_templates` is empty |
+| Templates with dangling bindings | 2, both in tenant `30d77d59` |
+| Templates actually rendering blank | 0 |
+
+The two affected templates ("NVTS Standard Quote Template" and its Copy) each carry
+`value.quoteDate` and `value.validUntil` alongside the correct built-ins. Each
+appears exactly twice in the AST — as the catalog key and as its own `id` — so **no
+node references them**. Every field node points at the correct built-in id. Someone
+hit this bug around 2026-07-13, worked around it, and left the dead bindings behind.
+
+Consequence: **no repair migration is required.** Fix-forward is correct, with an
+optional trivial sweep of those two orphaned bindings.
+
+## Goals
+
+- Every option the Fields catalog offers resolves against the document type's render
+  model, for all five document types.
+- The picker menu is **generated from the binding catalogs**, so menu and data cannot
+  drift apart again.
+- Text-block field tokens resolve on the same terms as Data Field bindings.
+- A guard test binds every picker option for every document type and asserts it
+  resolves, so this class of defect fails CI rather than shipping.
+
+## Non-goals
+
+- Exposing a real invoice discount — split to `alga0002295`.
+- Any repair migration for saved templates (production data shows none is needed).
+- Reworking the designer UI, the inspector, or the preview pipeline beyond what the
+  above requires.
+- Changing the render models themselves, or the binding catalogs, except to remove
+  `invoice.discount`.
+- Monitoring, metrics, or feature-flagging this change.
+
+## Users and Primary Flows
+
+**MSP admin building a quote template**: inserts a Data Field, picks
+Quote → Quote Number, previews, and sees `QT-2026-0001`. Same for every field the
+menu offers, on every document type.
+
+**MSP admin writing a Text Block**: types or inserts `{{quote.quoteNumber}}` and
+sees the value render.
+
+## Functional Requirements
+
+- **FR1** — Picker options for each document type are generated from that type's
+  binding catalog (`QUOTE_TEMPLATE_VALUE_BINDINGS`, `SALES_ORDER_*`, invoice
+  `buildSharedBindings`), not from a hand-declared schema.
+- **FR2** — Picking an option produces a binding that reuses the existing built-in
+  binding for that path, rather than minting a duplicate.
+- **FR3** — `normalizeInvoiceBindingPath` is either deleted or reduced to a
+  document-kind-aware shim that emits real render paths; `denormalizeBindingPath`
+  inverts it consistently so import → export round-trips stay stable.
+- **FR4** — Text-block tokens resolve through the same corrected mapping, and
+  `isLikelyBindingTokenPath` recognises tokens for all document types rather than
+  the invoice-only alias set.
+- **FR5** — `invoice.discount` is removed from `fieldCatalog.ts` and its computed
+  entry removed from `previewBindings.ts`.
+- **FR6** — Labels and descriptions in the Fields panel stay at least as good as
+  today (no regression to raw `humanizeBindingToken` output for fields that
+  currently have curated labels).
+- **FR7** — A guard test enumerates every picker option for every document type,
+  binds it, exports, evaluates against that type's sample model, and asserts a
+  resolved value.
+
+## Risks and Migration Notes
+
+- **Round-trip stability is the main risk.** The standard templates round-trip today
+  with `pathsChanged=0`. Any change to the alias layer must preserve that for all
+  four quote templates, both sales-order templates, packing slip, pick list, and the
+  invoice standards. This is already covered by
+  `workspaceAst.roundtrip.templates.test.ts` — keep it green.
+- **Two orphaned bindings** in tenant `30d77d59` are dead weight. Optional cleanup;
+  no user impact either way.
+- **Transform pipeline** (`TransformsWorkspace.tsx`) also calls
+  `normalizeInvoiceBindingPath` via `transforms.outputBindingId` — must be updated in
+  step with FR3.
+- **`INVOICE_TEMPLATE_BINDING_ALIASES`** is applied at render time by invoice and
+  document-template previews but *not* by `quoteTemplatePreview.ts`. Leave that
+  asymmetry alone; it is currently what makes quote `tenant.name` resolve.
+
+## Acceptance Criteria
+
+- For every document type, every option in the Fields catalog binds to a path that
+  resolves against that type's sample model. Verified by test, not by inspection.
+- `{{quote.quoteNumber}}` in a Text Block renders the quote number.
+- All standard templates still round-trip with zero path changes.
+- `invoice.discount` no longer appears in the picker, and no longer appears in
+  `previewBindings.ts`.
+- Adding a binding to a type's catalog surfaces it in the picker with no other edit.
+
+## Open Questions
+
+- Do we clean up the two orphaned bindings in tenant `30d77d59`, or leave them?
+- `fulfillment_type` is rendered by the standard packing slip but is absent from the
+  sales-order item schema. Add it while we are in there, or track separately?

--- a/ee/docs/plans/2026-08-22-template-binding-path-integrity/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-08-22-template-binding-path-integrity/SCRATCHPAD.md
@@ -1,0 +1,152 @@
+# SCRATCHPAD — Template Binding Path Integrity
+
+## Decisions
+
+- **2026-08-22 — Derive the picker from the binding catalogs** (chosen over patching
+  the alias tables). The alias table and the picker schema are two hand-maintained
+  lists that already drifted apart; correcting them leaves the same failure mode
+  available next time. Generating from the catalogs removes the second source of
+  truth. Cost: touches `shared/workflow/expression-authoring`.
+- **2026-08-22 — Fix forward, no repair migration.** Production evidence (below)
+  shows zero templates currently rendering blank.
+- **2026-08-22 — Remove `invoice.discount`; split real discount support to
+  `alga0002295`.** The derived value is structurally always zero, not merely
+  canvas-only. See below.
+- **2026-08-22 — Text-block tokens in scope** (assumed, not explicitly confirmed).
+  They share the normalizer being replaced, and unlike Data Fields they have no UI
+  workaround at all. Reverse this if the change gets too wide.
+
+## Production findings (2026-08-22)
+
+Read-only queries via `pgvector-coord-1` (see the prod-db-access memory; **the
+coordinator ordinal moves — look it up, do not hardcode**).
+
+```
+kubectl --context default get pods -n stackgres-pgvector -l role=master --no-headers
+kubectl --context default exec -n stackgres-pgvector <coord-pod> -c postgres-util -- \
+  psql -U postgres -d server -X -P pager=off -c "SELECT ..."
+```
+
+| | Found |
+|---|---|
+| Custom quote templates | 16 across 10 tenants |
+| Custom invoice templates | 55 across 28 tenants |
+| Sales-order / packing-slip / pick-list | 0 — `document_templates` empty |
+| Templates with dangling bindings | 2, tenant `30d77d59` |
+| Templates actually rendering blank | **0** |
+
+The two affected templates are "NVTS Standard Quote Template" (2026-07-13) and its
+Copy (2026-08-02). Each carries both the correct and the broken binding:
+
+```
+quoteDate        => {"id":"quoteDate",       "path":"quote_date"}   correct, built-in
+value.quoteDate  => {"id":"value.quoteDate", "path":"quoteDate"}    broken, picker-minted
+```
+
+`value.quoteDate` occurs exactly twice in each AST — as the catalog key and as its
+own `id` field — so **nothing references it**. Every field node points at a correct
+built-in id (`quoteDate`, `validUntil`, `total`, …). Someone hit the bug, worked
+around it, and left the dead binding behind.
+
+Useful query shape for finding dangling bindings:
+
+```sql
+WITH b AS (
+  SELECT t.tenant, t.template_id, t.name, v.value->>'path' AS path
+  FROM quote_document_templates t, jsonb_each(t."templateAst"->'bindings'->'values') v
+)
+SELECT tenant, name, count(*), string_agg(path, ', ')
+FROM b WHERE path IN ('quoteNumber','quoteDate','validUntil', ...)
+GROUP BY 1,2;
+```
+
+## Why `invoice.discount` is always zero
+
+Discounts are line items (`is_discount` on `invoice_charges`, stored negative) and
+the persisted subtotal is already net of them:
+
+```
+invoiceGeneration.ts:3232  const subtotal = calculatedSubtotal + discountSubtotalAdjustment  // negative
+invoiceGeneration.ts:3245  const totalAmount = finalSubtotal + finalTax
+```
+
+So `total === subtotal + tax`, making `previewBindings.ts`'s
+`Math.max(0, subtotal + tax - total)` identically `0`. Confirmed on all three
+production invoices carrying discount lines: `derived_discount_is_zero=3, nonzero=0`.
+
+The render model also cannot *see* discounts — `mapDbInvoiceToWasmViewModel`
+(`invoiceAdapters.ts:344-373`) drops `is_discount`, and `WasmInvoiceLineItem` has no
+such field. Exposing a real discount needs a gross-vs-net subtotal decision, which is
+why it is `alga0002295` and not this plan.
+
+## Measured picker health (before the fix)
+
+Harness: import a standard template, set `metadata.bindingKey` on a field node,
+`exportWorkspaceToTemplateAst`, then `evaluateTemplateAst` against the type's sample.
+
+```
+Invoice       15/16   (only invoice.discount blank)
+Quote          5/28
+Sales Order    0/10   root fields
+Packing Slip   0/10   root fields
+Pick List      0/10   root fields
+```
+
+Quote fields that work do so **by coincidence** (identical in both conventions):
+`status`, `title`, `subtotal`, `tax`, `version`, plus `client.*` and `contact.*`.
+
+## Gotchas
+
+- **`registerValueBinding` matches on PATH, not id** (`workspaceAst.ts:1425`). This is
+  why a correct built-in binding sitting right there gets ignored and a duplicate
+  minted. If the resolved path is right, the reuse works for free.
+- **`INVOICE_TEMPLATE_BINDING_ALIASES` is render-time, and asymmetric.** Invoice and
+  document-template previews pass it; `quoteTemplatePreview.ts:122` does not. That
+  asymmetry is load-bearing — it is why quote `tenant.name` (path `tenant.name`)
+  resolves today. Do not "tidy" it.
+- **`TransformsWorkspace.tsx:435`** also calls `normalizeInvoiceBindingPath` through
+  `transforms.outputBindingId`. Easy to miss.
+- **`resolveDesignerDocumentKind`** sniffs the binding catalog first and falls back to
+  substring-matching `metadata.templateName`. Changing catalog ids could shift kind
+  detection — `T046` guards this.
+- **Packing slip / pick list are not separate binding catalogs.** They reuse the
+  sales-order catalog and sample via `registry.ts`, so fixing sales order fixes all
+  three at once.
+- **`fulfillment_type`** is rendered by the standard packing slip table but is absent
+  from the sales-order item schema, so it cannot be re-added through the picker.
+- The custom-path input commits on `onChange` AND `onBlur`
+  (`DesignerSchemaInspector.tsx:289-291`); the `commit` flag only controls
+  undo-history batching (`designerStore.ts:1270`). The original report's
+  "only commits on Enter" claim did not reproduce.
+
+## History — this shipped broken, it is not a regression
+
+```
+a6b481694f  2026-03-13  quote bindings, snake_case paths
+9277f30bca  2026-04-01  picker schema + alias table, camelCase (same commit)
+```
+
+Neither line modified since. The i18n commits that touch `workspaceAst.ts`
+(`00a43d572b`, `2d67191f45`, 2026-08-13) have all their hunks elsewhere. Labels
+surviving while values vanish is by design: `react-renderer.tsx:492` resolves label
+from the i18n key and value from `evaluation.bindings` independently.
+
+## Links
+
+- Ticket: `alga0002294`
+- Split-out discount ticket: `alga0002295`
+- Key files:
+  - `shared/workflow/expression-authoring/adapters/invoiceContextAdapter.ts`
+  - `packages/billing/src/components/invoice-designer/ast/workspaceAst.ts` (152-206, 1425, 1524)
+  - `packages/billing/src/components/invoice-designer/fields/fieldCatalog.ts`
+  - `packages/billing/src/components/invoice-designer/preview/previewBindings.ts`
+  - `packages/billing/src/lib/quote-template-ast/bindings.ts`
+  - `packages/billing/src/lib/sales-order-template-ast/bindings.ts`
+  - `packages/billing/src/lib/document-templates/registry.ts`
+
+## Commands
+
+```bash
+cd packages/billing && npx vitest run tests/quote/
+npx vitest run src/components/invoice-designer/ast/workspaceAst.roundtrip.templates.test.ts
+```

--- a/ee/docs/plans/2026-08-22-template-binding-path-integrity/features.json
+++ b/ee/docs/plans/2026-08-22-template-binding-path-integrity/features.json
@@ -1,0 +1,170 @@
+[
+  {
+    "id": "F001",
+    "description": "Sales-order binding catalog exposes a stable exported map (id -> {path, fallback}) suitable for driving picker generation, matching the shape quote and invoice catalogs already have.",
+    "implemented": false,
+    "prdRefs": ["FR1"]
+  },
+  {
+    "id": "F002",
+    "description": "A shared buildPickerOptionsFromBindings(catalog, documentKind) helper turns a binding catalog into SharedExpressionPathOption[], deriving the option path from the binding id and the resolved data path from binding.path.",
+    "implemented": false,
+    "prdRefs": ["FR1"]
+  },
+  {
+    "id": "F003",
+    "description": "buildInvoiceExpressionContextRoots for documentKind 'quote' is generated from QUOTE_TEMPLATE_VALUE_BINDINGS / QUOTE_TEMPLATE_COLLECTION_BINDINGS instead of createQuoteRootSchema and createQuoteTotalsSchema.",
+    "implemented": false,
+    "prdRefs": ["FR1"]
+  },
+  {
+    "id": "F004",
+    "description": "buildInvoiceExpressionContextRoots for documentKind 'sales-order' is generated from the sales-order binding catalog instead of createSalesOrderRootSchema.",
+    "implemented": false,
+    "prdRefs": ["FR1"]
+  },
+  {
+    "id": "F005",
+    "description": "buildInvoiceExpressionContextRoots for documentKind 'invoice' is generated from buildSharedBindings instead of createInvoiceRootSchema, with no change to the resulting option set except the removal of invoice.discount.",
+    "implemented": false,
+    "prdRefs": ["FR1", "FR5"]
+  },
+  {
+    "id": "F006",
+    "description": "The hand-declared quote/quoteTotals/salesOrder schema literals are deleted from invoiceContextAdapter.ts once generation replaces them.",
+    "implemented": false,
+    "prdRefs": ["FR1"]
+  },
+  {
+    "id": "F007",
+    "description": "Line-item (item.*) picker options are generated from each type's line-item shape rather than hand-declared, preserving the currently-correct sales-order snake_case item fields.",
+    "implemented": false,
+    "prdRefs": ["FR1"]
+  },
+  {
+    "id": "F008",
+    "description": "Picker options carry the resolved data path alongside the display path, so the exporter no longer has to re-derive it from an alias table.",
+    "implemented": false,
+    "prdRefs": ["FR1", "FR3"]
+  },
+  {
+    "id": "F009",
+    "description": "normalizeInvoiceBindingPath becomes document-kind aware, or is removed entirely in favour of the resolved path carried on the option; invoice behaviour is unchanged.",
+    "implemented": false,
+    "prdRefs": ["FR3"]
+  },
+  {
+    "id": "F010",
+    "description": "denormalizeBindingPath inverts the corrected mapping per document kind, so importTemplateAstToWorkspace produces a bindingKey that re-normalizes to the same path.",
+    "implemented": false,
+    "prdRefs": ["FR3"]
+  },
+  {
+    "id": "F011",
+    "description": "registerValueBinding reuses an existing binding when the resolved path matches, so picking a field that already has a built-in binding never mints a duplicate value.* binding.",
+    "implemented": false,
+    "prdRefs": ["FR2"]
+  },
+  {
+    "id": "F012",
+    "description": "Quote picker fields quoteNumber, quoteDate, validUntil, scope, poNumber, discountTotal, total, termsAndConditions, clientNotes, acceptedByName and acceptedAt bind to their snake_case render paths.",
+    "implemented": false,
+    "prdRefs": ["FR1", "FR2"]
+  },
+  {
+    "id": "F013",
+    "description": "All twelve quoteTotals.* picker fields bind to their snake_case render paths.",
+    "implemented": false,
+    "prdRefs": ["FR1", "FR2"]
+  },
+  {
+    "id": "F014",
+    "description": "Quote tenant.name and tenant.address bind to tenant.name / tenant.address rather than tenantClient.*, matching QuoteViewModel.",
+    "implemented": false,
+    "prdRefs": ["FR1", "FR2"]
+  },
+  {
+    "id": "F015",
+    "description": "All ten salesOrder.* picker fields bind to their real render paths (so_number, order_date, expected_ship_date, client_po_number, currency_code, status, notes, subtotal, tax, total).",
+    "implemented": false,
+    "prdRefs": ["FR1", "FR2"]
+  },
+  {
+    "id": "F016",
+    "description": "Packing slip and pick list, which reuse the sales-order catalog, get the corrected picker options with no per-type work.",
+    "implemented": false,
+    "prdRefs": ["FR1"]
+  },
+  {
+    "id": "F017",
+    "description": "Text-block tokens resolve through the corrected mapping: {{quote.quoteNumber}} exports a path expression naming the real render path.",
+    "implemented": false,
+    "prdRefs": ["FR4"]
+  },
+  {
+    "id": "F018",
+    "description": "isLikelyBindingTokenPath recognises single-segment tokens for every document type, replacing the invoice-only SIMPLE_BINDING_ALIASES set.",
+    "implemented": false,
+    "prdRefs": ["FR4"]
+  },
+  {
+    "id": "F019",
+    "description": "TransformsWorkspace outputBindingId normalization is updated in step with the alias change so transform pipelines keep resolving.",
+    "implemented": false,
+    "prdRefs": ["FR3", "Risks"]
+  },
+  {
+    "id": "F020",
+    "description": "invoice.discount is removed from FIELD_DEFINITIONS in fieldCatalog.ts.",
+    "implemented": false,
+    "prdRefs": ["FR5"]
+  },
+  {
+    "id": "F021",
+    "description": "The computed 'invoice.discount' entry is removed from flattenInvoiceBindingMap in previewBindings.ts so the canvas no longer shows an always-zero value.",
+    "implemented": false,
+    "prdRefs": ["FR5"]
+  },
+  {
+    "id": "F022",
+    "description": "Curated labels and descriptions from fieldCatalog.ts are preserved for generated options, so the Fields panel does not regress to raw humanized ids.",
+    "implemented": false,
+    "prdRefs": ["FR6"]
+  },
+  {
+    "id": "F023",
+    "description": "Quote picker labels no longer read 'Quote Quote Number' — category prefix and field label do not double up.",
+    "implemented": false,
+    "prdRefs": ["FR6"]
+  },
+  {
+    "id": "F024",
+    "description": "A guard test enumerates every picker option for every document type, binds it to a field node, exports the workspace, evaluates against that type's sample model, and asserts a resolved value.",
+    "implemented": false,
+    "prdRefs": ["FR7"]
+  },
+  {
+    "id": "F025",
+    "description": "The guard test fails loudly with the offending path and document type named, so a future drift is diagnosable from CI output alone.",
+    "implemented": false,
+    "prdRefs": ["FR7"]
+  },
+  {
+    "id": "F026",
+    "description": "Adding a binding to a type's catalog surfaces it in the picker with no other edit, demonstrated by a test that adds a temporary binding and asserts the option appears.",
+    "implemented": false,
+    "prdRefs": ["FR1", "Acceptance Criteria"]
+  },
+  {
+    "id": "F027",
+    "description": "ComponentPalette.quoteFields.integration.test.tsx is extended past the onInsertTemplateVariable assertion so it also verifies the inserted token resolves.",
+    "implemented": false,
+    "prdRefs": ["FR7"]
+  },
+  {
+    "id": "F028",
+    "description": "Optional: a one-off sweep removes the two orphaned value.quoteDate / value.validUntil bindings from the NVTS templates in tenant 30d77d59.",
+    "implemented": false,
+    "prdRefs": ["Production state", "Open Questions"]
+  }
+]

--- a/ee/docs/plans/2026-08-22-template-binding-path-integrity/tests.json
+++ b/ee/docs/plans/2026-08-22-template-binding-path-integrity/tests.json
@@ -1,0 +1,284 @@
+[
+  {
+    "id": "T001",
+    "description": "buildPickerOptionsFromBindings maps a binding catalog entry {id:'quoteNumber', path:'quote_number'} to an option whose display path is quote.quoteNumber and whose resolved path is quote_number.",
+    "implemented": false,
+    "featureIds": ["F002"]
+  },
+  {
+    "id": "T002",
+    "description": "buildPickerOptionsFromBindings groups options under the correct category root for quote, quoteTotals, client, contact, tenant and item.",
+    "implemented": false,
+    "featureIds": ["F002", "F003"]
+  },
+  {
+    "id": "T003",
+    "description": "Quote context roots generated from the catalog contain exactly the value bindings in QUOTE_TEMPLATE_VALUE_BINDINGS, with no extra or missing ids.",
+    "implemented": false,
+    "featureIds": ["F003"]
+  },
+  {
+    "id": "T004",
+    "description": "Sales-order context roots contain exactly the sales-order catalog bindings, including the previously absent salesOrder.* set.",
+    "implemented": false,
+    "featureIds": ["F001", "F004"]
+  },
+  {
+    "id": "T005",
+    "description": "Invoice context roots after generation match the pre-change option set exactly, minus invoice.discount (regression guard for the one healthy document type).",
+    "implemented": false,
+    "featureIds": ["F005", "F020"]
+  },
+  {
+    "id": "T006",
+    "description": "createQuoteRootSchema, createQuoteTotalsSchema and createSalesOrderRootSchema no longer exist in invoiceContextAdapter.ts.",
+    "implemented": false,
+    "featureIds": ["F006"]
+  },
+  {
+    "id": "T007",
+    "description": "item.* options for sales order remain snake_case (service_sku, quantity_ordered, quantity_fulfilled, unit_price, amount) and still resolve against a sample line item.",
+    "implemented": false,
+    "featureIds": ["F007"]
+  },
+  {
+    "id": "T008",
+    "description": "item.* options for invoice remain camelCase (unitPrice, servicePeriodStart, billingTiming) and still resolve against a sample WasmInvoiceLineItem.",
+    "implemented": false,
+    "featureIds": ["F007"]
+  },
+  {
+    "id": "T009",
+    "description": "Binding quote.quoteNumber on a Data Field exports bindingId 'quoteNumber' (the existing built-in) and NOT a new value.quoteNumber binding.",
+    "implemented": false,
+    "featureIds": ["F011", "F012"]
+  },
+  {
+    "id": "T010",
+    "description": "Evaluating a template with quote.quoteNumber bound returns the sample quote number rather than undefined.",
+    "implemented": false,
+    "featureIds": ["F012"]
+  },
+  {
+    "id": "T011",
+    "description": "quote.quoteDate and quote.validUntil resolve to quote_date and valid_until values.",
+    "implemented": false,
+    "featureIds": ["F012"]
+  },
+  {
+    "id": "T012",
+    "description": "quote.total resolves to total_amount, not to a nonexistent 'total' path.",
+    "implemented": false,
+    "featureIds": ["F012"]
+  },
+  {
+    "id": "T013",
+    "description": "quote.scope resolves to scope_of_work and honours the binding's empty-string fallback.",
+    "implemented": false,
+    "featureIds": ["F012"]
+  },
+  {
+    "id": "T014",
+    "description": "All twelve quoteTotals.* options resolve to non-undefined values against a sample enriched with service and product groupings.",
+    "implemented": false,
+    "featureIds": ["F013"]
+  },
+  {
+    "id": "T015",
+    "description": "Quote tenant.name resolves to the sample tenant name and does not silently fall back to the 'Your Company' fallback.",
+    "implemented": false,
+    "featureIds": ["F014"]
+  },
+  {
+    "id": "T016",
+    "description": "Quote tenant.address resolves to the sample tenant address.",
+    "implemented": false,
+    "featureIds": ["F014"]
+  },
+  {
+    "id": "T017",
+    "description": "Quote client.name and contact.name still resolve after the change (guard against regressing the fields that already worked).",
+    "implemented": false,
+    "featureIds": ["F012", "F014"]
+  },
+  {
+    "id": "T018",
+    "description": "Quote status, title, subtotal, tax and version still resolve (the coincidental passes must not break).",
+    "implemented": false,
+    "featureIds": ["F012"]
+  },
+  {
+    "id": "T019",
+    "description": "salesOrder.orderNumber binds to so_number and resolves to the sample order number.",
+    "implemented": false,
+    "featureIds": ["F015"]
+  },
+  {
+    "id": "T020",
+    "description": "salesOrder.expectedShipDate, salesOrder.orderDate and salesOrder.poNumber resolve to expected_ship_date, order_date and client_po_number.",
+    "implemented": false,
+    "featureIds": ["F015"]
+  },
+  {
+    "id": "T021",
+    "description": "salesOrder.currencyCode, status, notes, subtotal, tax and total all resolve against the sales-order sample.",
+    "implemented": false,
+    "featureIds": ["F015"]
+  },
+  {
+    "id": "T022",
+    "description": "Packing slip picker options resolve against the sales-order sample without any packing-slip-specific code.",
+    "implemented": false,
+    "featureIds": ["F016"]
+  },
+  {
+    "id": "T023",
+    "description": "Pick list picker options resolve against the sales-order sample.",
+    "implemented": false,
+    "featureIds": ["F016"]
+  },
+  {
+    "id": "T024",
+    "description": "A Text Block containing {{quote.quoteNumber}} exports a path expression naming quote_number and evaluates to the sample quote number.",
+    "implemented": false,
+    "featureIds": ["F017"]
+  },
+  {
+    "id": "T025",
+    "description": "A Text Block mixing literal text and {{quote.validUntil}} exports a template expression whose arg resolves to valid_until.",
+    "implemented": false,
+    "featureIds": ["F017"]
+  },
+  {
+    "id": "T026",
+    "description": "{{salesOrder.orderNumber}} in a Text Block resolves against the sales-order sample.",
+    "implemented": false,
+    "featureIds": ["F017", "F018"]
+  },
+  {
+    "id": "T027",
+    "description": "{{client.name}} and {{invoice.number}} still resolve after the isLikelyBindingTokenPath change (no regression to previously working tokens).",
+    "implemented": false,
+    "featureIds": ["F018"]
+  },
+  {
+    "id": "T028",
+    "description": "A token naming a path that exists in no catalog is still treated as literal text rather than becoming a dangling binding.",
+    "implemented": false,
+    "featureIds": ["F018"]
+  },
+  {
+    "id": "T029",
+    "description": "A transform pipeline whose outputBindingId refers to a quote binding still evaluates after the normalization change.",
+    "implemented": false,
+    "featureIds": ["F019"]
+  },
+  {
+    "id": "T030",
+    "description": "invoice.discount is absent from getTemplateFieldDefinition and from the generated invoice picker options.",
+    "implemented": false,
+    "featureIds": ["F020"]
+  },
+  {
+    "id": "T031",
+    "description": "flattenInvoiceBindingMap no longer contains an 'invoice.discount' key, and resolveInvoiceBindingRawValue('invoice.discount') returns null.",
+    "implemented": false,
+    "featureIds": ["F021"]
+  },
+  {
+    "id": "T032",
+    "description": "Curated labels survive generation: customer.address still reports label 'Customer Address' and its multiline/single-line/raw display formats.",
+    "implemented": false,
+    "featureIds": ["F022"]
+  },
+  {
+    "id": "T033",
+    "description": "Quote picker label for quote.quoteNumber reads 'Quote Number', not 'Quote Quote Number'.",
+    "implemented": false,
+    "featureIds": ["F023"]
+  },
+  {
+    "id": "T034",
+    "description": "GUARD: for every document type (invoice, quote, sales-order, packing-slip, pick-list), every generated picker option binds, exports, and evaluates to a defined value against that type's sample model.",
+    "implemented": false,
+    "featureIds": ["F024"]
+  },
+  {
+    "id": "T035",
+    "description": "The guard test failure message names the document type, the option path, and the resolved path when an option fails to resolve.",
+    "implemented": false,
+    "featureIds": ["F025"]
+  },
+  {
+    "id": "T036",
+    "description": "Adding a temporary binding to the quote catalog makes a corresponding picker option appear, with no edit to any adapter or alias file.",
+    "implemented": false,
+    "featureIds": ["F026"]
+  },
+  {
+    "id": "T037",
+    "description": "ROUND TRIP: all four standard quote templates import then export with zero binding path changes.",
+    "implemented": false,
+    "featureIds": ["F009", "F010"]
+  },
+  {
+    "id": "T038",
+    "description": "ROUND TRIP: both standard sales-order templates, the packing slip and the pick list import then export with zero binding path changes.",
+    "implemented": false,
+    "featureIds": ["F009", "F010"]
+  },
+  {
+    "id": "T039",
+    "description": "ROUND TRIP: all standard invoice templates import then export with zero binding path changes.",
+    "implemented": false,
+    "featureIds": ["F009", "F010"]
+  },
+  {
+    "id": "T040",
+    "description": "ROUND TRIP: a template whose field was bound via the picker survives import -> export -> import with a stable bindingKey and binding id.",
+    "implemented": false,
+    "featureIds": ["F010", "F011"]
+  },
+  {
+    "id": "T041",
+    "description": "A template already containing an orphaned value.quoteDate binding still imports, exports and renders without error (back-compat for the NVTS templates).",
+    "implemented": false,
+    "featureIds": ["F011", "F028"]
+  },
+  {
+    "id": "T042",
+    "description": "Re-binding a field that currently points at an orphaned value.* binding relinks it to the correct built-in binding.",
+    "implemented": false,
+    "featureIds": ["F011"]
+  },
+  {
+    "id": "T043",
+    "description": "ComponentPalette quote fields test asserts the inserted token resolves against the quote sample, not merely that onInsertTemplateVariable was called.",
+    "implemented": false,
+    "featureIds": ["F027"]
+  },
+  {
+    "id": "T044",
+    "description": "Custom path entry still works: typing a raw snake_case path binds to the matching built-in binding.",
+    "implemented": false,
+    "featureIds": ["F011"]
+  },
+  {
+    "id": "T045",
+    "description": "Table column bindings (item.* inside a repeater) resolve for quote, sales-order and invoice line items after the change.",
+    "implemented": false,
+    "featureIds": ["F007"]
+  },
+  {
+    "id": "T046",
+    "description": "resolveDesignerDocumentKind still classifies all five standard template families correctly after any binding catalog changes.",
+    "implemented": false,
+    "featureIds": ["F001", "F004"]
+  },
+  {
+    "id": "T047",
+    "description": "Every generated picker option exposes both a display path and a resolved data path, and the resolved path equals the binding catalog's path for that id.",
+    "implemented": false,
+    "featureIds": ["F008"]
+  }
+]

--- a/packages/billing/src/components/invoice-designer/DesignerShell.tsx
+++ b/packages/billing/src/components/invoice-designer/DesignerShell.tsx
@@ -39,7 +39,6 @@ import { Button } from '@alga-psa/ui/components/Button';
 import { Input } from '@alga-psa/ui/components/Input';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import {
-  buildInvoiceExpressionPathOptions,
   insertTextIntoDomControl,
   insertTextIntoValue,
   validateSourcePaths,
@@ -84,10 +83,10 @@ import {
 } from './utils/sizeModes';
 import { resolveDesignerDocumentKind } from './utils/documentKind';
 import {
-  getTemplateFieldDefinition,
-  getTemplateFieldDisplayFormats,
-  resolveTemplateFieldLabel,
-} from './fields/fieldCatalog';
+  buildDocumentExpressionPathOptions,
+  resolveDocumentFieldLabel,
+} from './fields/documentBindingCatalog';
+import { getTemplateFieldDefinition, getTemplateFieldDisplayFormats } from './fields/fieldCatalog';
 
 const DROPPABLE_CANVAS_ID = 'designer-canvas';
 
@@ -492,7 +491,7 @@ const resolveFieldTypeLabel = (bindingKey: string): string => {
   if (!normalized) {
     return 'Unbound';
   }
-  return resolveTemplateFieldLabel(normalized);
+  return resolveDocumentFieldLabel(normalized);
 };
 
 const resolveSelectedFieldType = (selectedNode: DesignerNode | null): { label: string; bindingKey: string } | null => {
@@ -602,7 +601,7 @@ export const DesignerShell: React.FC = () => {
   const documentKind = useMemo(() => resolveDesignerDocumentKind(nodes), [nodes]);
   const invoicePathOptions = useMemo(
     () =>
-      buildInvoiceExpressionPathOptions({
+      buildDocumentExpressionPathOptions({
         includeRootPaths: false,
         documentKind,
       }),

--- a/packages/billing/src/components/invoice-designer/ast/workspaceAst.bindingPaths.test.ts
+++ b/packages/billing/src/components/invoice-designer/ast/workspaceAst.bindingPaths.test.ts
@@ -1,0 +1,361 @@
+import type { QuoteViewModel, QuoteViewModelLineItem, TemplateAst, TemplateNode } from '@alga-psa/types';
+import { TEMPLATE_AST_VERSION } from '@alga-psa/types';
+import { describe, expect, it } from 'vitest';
+
+import { DOCUMENT_TYPE_REGISTRY } from '../../../lib/document-templates/registry';
+import { evaluateTemplateAst } from '../../../lib/invoice-template-ast/evaluator';
+import { buildInvoiceTemplateBindings } from '../../../lib/invoice-template-ast/standardTemplates';
+import { buildQuoteTemplateBindings } from '../../../lib/quote-template-ast/bindings';
+import { getStandardQuoteTemplateAstByCode } from '../../../lib/quote-template-ast/standardTemplates';
+import {
+  buildDocumentExpressionPathOptions,
+  getDocumentItemFields,
+} from '../fields/documentBindingCatalog';
+import { INVOICE_PREVIEW_SAMPLE_SCENARIOS } from '../preview/sampleScenarios';
+import { QUOTE_PREVIEW_SAMPLE_SCENARIOS } from '../preview/quoteSampleScenarios';
+import type { DesignerDocumentKind } from '../utils/documentKind';
+import { resolveDesignerDocumentKind } from '../utils/documentKind';
+import { exportWorkspaceToTemplateAst, importTemplateAstToWorkspace } from './workspaceAst';
+import { cloneAst } from './workspaceAst.roundtrip.helpers';
+
+type UnknownRecord = Record<string, unknown>;
+
+type DocumentTypeFixture = {
+  label: string;
+  documentKind: DesignerDocumentKind;
+  bindings: NonNullable<TemplateAst['bindings']>;
+  sample: UnknownRecord;
+  lineItems: UnknownRecord[];
+};
+
+/**
+ * The shipped quote preview sample only carries the recurring / one-time groupings, so the
+ * service and product totals have nothing to resolve against. The guard fills them in — every
+ * field the picker offers must resolve, and QuoteViewModel documents all four groupings.
+ */
+const buildQuoteSample = (): UnknownRecord => {
+  const base = { ...QUOTE_PREVIEW_SAMPLE_SCENARIOS[0]!.data } as QuoteViewModel;
+  const lineItems = base.line_items as QuoteViewModelLineItem[];
+  const sumOf = (field: 'total_price' | 'tax_amount') =>
+    lineItems.reduce((total, item) => total + (item[field] ?? 0), 0);
+
+  base.service_items = lineItems;
+  base.product_items = [];
+  base.service_subtotal = sumOf('total_price');
+  base.service_tax = sumOf('tax_amount');
+  base.service_total = base.service_subtotal + base.service_tax;
+  base.product_subtotal = 0;
+  base.product_tax = 0;
+  base.product_total = 0;
+
+  return base as unknown as UnknownRecord;
+};
+
+const buildFixtures = (): DocumentTypeFixture[] => {
+  const invoiceSample = INVOICE_PREVIEW_SAMPLE_SCENARIOS[0]!.data as unknown as UnknownRecord;
+  const quoteSample = buildQuoteSample();
+
+  const salesOrderFamily = (['sales-order', 'packing-slip', 'pick-list'] as const).map((documentType) => {
+    const entry = DOCUMENT_TYPE_REGISTRY[documentType];
+    const sample = entry.buildSampleViewModel();
+    return {
+      label: documentType,
+      documentKind: 'sales-order' as DesignerDocumentKind,
+      bindings: entry.buildBindings(),
+      sample,
+      lineItems: (sample.line_items as UnknownRecord[]) ?? [],
+    };
+  });
+
+  return [
+    {
+      label: 'invoice',
+      documentKind: 'invoice',
+      bindings: buildInvoiceTemplateBindings(),
+      sample: invoiceSample,
+      lineItems: (invoiceSample.items as UnknownRecord[]) ?? [],
+    },
+    {
+      label: 'quote',
+      documentKind: 'quote',
+      bindings: buildQuoteTemplateBindings(),
+      sample: quoteSample,
+      lineItems: (quoteSample.line_items as UnknownRecord[]) ?? [],
+    },
+    ...salesOrderFamily,
+  ];
+};
+
+const firstValueBindingId = (bindings: NonNullable<TemplateAst['bindings']>): string =>
+  Object.keys(bindings.values ?? {})[0]!;
+
+const createProbeAst = (bindings: NonNullable<TemplateAst['bindings']>): TemplateAst => ({
+  kind: 'invoice-template-ast',
+  version: TEMPLATE_AST_VERSION,
+  metadata: { templateName: 'Binding probe' },
+  bindings: cloneAst(bindings),
+  layout: {
+    id: 'root',
+    type: 'document',
+    children: [
+      {
+        id: 'probe-field',
+        type: 'field',
+        label: 'Probe',
+        binding: { bindingId: firstValueBindingId(bindings) },
+      },
+      { id: 'probe-text', type: 'text', content: { type: 'literal', value: 'Probe text' } },
+    ],
+  },
+});
+
+const setProbeMetadata = (
+  ast: TemplateAst,
+  nodeType: 'field' | 'text',
+  patch: UnknownRecord
+): TemplateAst => {
+  const workspace = importTemplateAstToWorkspace(cloneAst(ast));
+  const node = Object.values(workspace.nodesById).find((candidate) => candidate.type === nodeType);
+  if (!node) {
+    throw new Error(`Probe workspace is missing a ${nodeType} node`);
+  }
+  const props = node.props as UnknownRecord;
+  props.metadata = { ...(props.metadata as UnknownRecord), ...patch };
+  return exportWorkspaceToTemplateAst(workspace);
+};
+
+const findNodeOfType = (node: TemplateNode, type: string): TemplateNode | null => {
+  if (node.type === type) {
+    return node;
+  }
+  const children = Array.isArray((node as { children?: TemplateNode[] }).children)
+    ? ((node as { children?: TemplateNode[] }).children as TemplateNode[])
+    : [];
+  for (const child of children) {
+    const found = findNodeOfType(child, type);
+    if (found) return found;
+  }
+  return null;
+};
+
+const exportedFieldBinding = (ast: TemplateAst): { bindingId: string; path: string } => {
+  const fieldNode = findNodeOfType(ast.layout, 'field');
+  if (!fieldNode || fieldNode.type !== 'field') {
+    throw new Error('Exported AST is missing its field node');
+  }
+  const bindingId = fieldNode.binding.bindingId;
+  const path = ast.bindings?.values?.[bindingId]?.path;
+  if (typeof path !== 'string') {
+    throw new Error(`Exported binding "${bindingId}" has no path`);
+  }
+  return { bindingId, path };
+};
+
+const getPathValue = (model: unknown, path: string): unknown =>
+  path.split('.').reduce<unknown>((cursor, segment) => {
+    if (cursor === null || cursor === undefined || typeof cursor !== 'object') {
+      return undefined;
+    }
+    return (cursor as UnknownRecord)[segment];
+  }, model);
+
+const fixtures = buildFixtures();
+
+describe('field picker binding paths resolve for every document type', () => {
+  it.each(fixtures.map((fixture) => [fixture.label, fixture] as const))(
+    'binds, exports and resolves every %s picker option',
+    (_label, fixture) => {
+      const probe = createProbeAst(fixture.bindings);
+      const options = buildDocumentExpressionPathOptions({
+        mode: 'template',
+        includeRootPaths: false,
+        documentKind: fixture.documentKind,
+      }).filter((option) => option.isLeaf && !option.path.startsWith('item.'));
+
+      expect(options.length).toBeGreaterThan(0);
+
+      const failures: string[] = [];
+      for (const option of options) {
+        const exported = setProbeMetadata(probe, 'field', { bindingKey: option.path });
+        const { bindingId, path } = exportedFieldBinding(exported);
+        const evaluation = evaluateTemplateAst(exported, fixture.sample);
+        if (evaluation.bindings[bindingId] === undefined) {
+          failures.push(`${fixture.label}: option "${option.path}" -> path "${path}" resolved to nothing`);
+        }
+      }
+
+      expect(failures).toEqual([]);
+    }
+  );
+
+  it.each(fixtures.map((fixture) => [fixture.label, fixture] as const))(
+    'resolves every %s line-item option against the sample line items',
+    (_label, fixture) => {
+      const itemFields = getDocumentItemFields(fixture.documentKind);
+      expect(itemFields.length).toBeGreaterThan(0);
+      expect(fixture.lineItems.length).toBeGreaterThan(0);
+
+      const failures = itemFields
+        .filter((itemField) =>
+          fixture.lineItems.every((lineItem) => getPathValue(lineItem, itemField.name) === undefined)
+        )
+        .map((itemField) => `${fixture.label}: option "item.${itemField.name}" resolved to nothing`);
+
+      expect(failures).toEqual([]);
+    }
+  );
+
+  it('classifies the sales-order family from its shared binding catalog', () => {
+    for (const documentType of ['sales-order', 'packing-slip', 'pick-list'] as const) {
+      const entry = DOCUMENT_TYPE_REGISTRY[documentType];
+      const workspace = importTemplateAstToWorkspace(
+        entry.getStandardTemplateAstByCode(entry.defaultStandardCode)!
+      );
+      const nodes = Object.values(workspace.nodesById).map((node) => ({
+        ...node,
+        parentId: null,
+      })) as never;
+      expect(resolveDesignerDocumentKind(nodes)).toBe('sales-order');
+    }
+  });
+});
+
+describe('picked bindings reuse the document catalog', () => {
+  const quoteProbe = () => createProbeAst(buildQuoteTemplateBindings());
+
+  it('reuses the built-in quote binding instead of minting a duplicate', () => {
+    const exported = setProbeMetadata(quoteProbe(), 'field', { bindingKey: 'quote.quoteNumber' });
+
+    expect(exportedFieldBinding(exported)).toEqual({ bindingId: 'quoteNumber', path: 'quote_number' });
+    expect(Object.keys(exported.bindings?.values ?? {}).filter((id) => id.startsWith('value.'))).toEqual([]);
+  });
+
+  it('resolves quote fields whose render path differs from the picker path', () => {
+    const sample = buildQuoteSample();
+
+    for (const [bindingKey, expectedPath] of [
+      ['quote.quoteDate', 'quote_date'],
+      ['quote.validUntil', 'valid_until'],
+      ['quote.total', 'total_amount'],
+      ['quote.scope', 'scope_of_work'],
+      ['tenant.name', 'tenant.name'],
+      ['tenant.address', 'tenant.address'],
+      ['client.name', 'client.name'],
+      ['contact.name', 'contact.name'],
+      ['quote.status', 'status'],
+      ['quote.title', 'title'],
+      ['quote.subtotal', 'subtotal'],
+      ['quote.version', 'version'],
+    ] as const) {
+      const exported = setProbeMetadata(quoteProbe(), 'field', { bindingKey });
+      const { bindingId, path } = exportedFieldBinding(exported);
+      expect(`${bindingKey} -> ${path}`).toBe(`${bindingKey} -> ${expectedPath}`);
+      expect(evaluateTemplateAst(exported, sample).bindings[bindingId]).toBe(
+        getPathValue(sample, expectedPath)
+      );
+    }
+  });
+
+  it('binds a raw render path typed into the custom path input to the built-in binding', () => {
+    const exported = setProbeMetadata(quoteProbe(), 'field', { bindingKey: 'quote_number' });
+
+    expect(exportedFieldBinding(exported)).toEqual({ bindingId: 'quoteNumber', path: 'quote_number' });
+  });
+
+  it('relinks a field that pointed at an orphaned picker-minted binding', () => {
+    // The shape two production quote templates carry: a dangling `value.quoteDate` binding
+    // alongside the correct built-in one.
+    const withOrphan = cloneAst(quoteProbe());
+    withOrphan.bindings!.values!['value.quoteDate'] = {
+      id: 'value.quoteDate',
+      kind: 'value',
+      path: 'quoteDate',
+    };
+    const fieldNode = findNodeOfType(withOrphan.layout, 'field');
+    if (!fieldNode || fieldNode.type !== 'field') throw new Error('probe field missing');
+    fieldNode.binding = { bindingId: 'value.quoteDate' };
+
+    const reexported = setProbeMetadata(withOrphan, 'field', { bindingKey: 'quote.quoteDate' });
+
+    expect(exportedFieldBinding(reexported)).toEqual({ bindingId: 'quoteDate', path: 'quote_date' });
+  });
+
+  it('keeps a picker-bound field stable across repeated import/export cycles', () => {
+    const once = setProbeMetadata(quoteProbe(), 'field', { bindingKey: 'quote.total' });
+    const twice = exportWorkspaceToTemplateAst(importTemplateAstToWorkspace(cloneAst(once)));
+
+    expect(twice).toEqual(once);
+    expect(exportedFieldBinding(twice)).toEqual({ bindingId: 'total', path: 'total_amount' });
+  });
+
+  it('re-binds an imported standard quote template field without changing its path', () => {
+    const source = getStandardQuoteTemplateAstByCode('standard-quote-default')!;
+    const workspace = importTemplateAstToWorkspace(cloneAst(source));
+    const fieldNodes = Object.values(workspace.nodesById).filter((node) => node.type === 'field');
+    const quoteNumberField = fieldNodes.find(
+      (node) => ((node.props as UnknownRecord).metadata as UnknownRecord)?.bindingKey === 'quote.quoteNumber'
+    );
+
+    expect(quoteNumberField).toBeTruthy();
+    expect(exportWorkspaceToTemplateAst(workspace).bindings?.values?.quoteNumber?.path).toBe('quote_number');
+  });
+});
+
+describe('text block tokens resolve per document type', () => {
+  it('compiles {{quote.quoteNumber}} into the quote render path', () => {
+    const exported = setProbeMetadata(createProbeAst(buildQuoteTemplateBindings()), 'text', {
+      text: '{{quote.quoteNumber}}',
+    });
+    const textNode = findNodeOfType(exported.layout, 'text');
+
+    expect(textNode?.type === 'text' ? textNode.content : null).toEqual({
+      type: 'path',
+      path: 'quote_number',
+    });
+  });
+
+  it('compiles mixed literal text and a quote token into a template expression', () => {
+    const exported = setProbeMetadata(createProbeAst(buildQuoteTemplateBindings()), 'text', {
+      text: 'Valid until {{quote.validUntil}}',
+    });
+    const textNode = findNodeOfType(exported.layout, 'text');
+    const content = textNode?.type === 'text' ? textNode.content : null;
+
+    expect(content?.type).toBe('template');
+    const args = content?.type === 'template' ? content.args ?? {} : {};
+    expect(Object.values(args).map((arg) => (arg.type === 'path' ? arg.path : null))).toEqual([
+      'valid_until',
+    ]);
+  });
+
+  it('compiles {{salesOrder.orderNumber}} into the sales-order render path', () => {
+    const entry = DOCUMENT_TYPE_REGISTRY['sales-order'];
+    const exported = setProbeMetadata(createProbeAst(entry.buildBindings()), 'text', {
+      text: '{{salesOrder.orderNumber}}',
+    });
+    const textNode = findNodeOfType(exported.layout, 'text');
+
+    expect(textNode?.type === 'text' ? textNode.content : null).toEqual({
+      type: 'path',
+      path: 'so_number',
+    });
+  });
+
+  it('keeps invoice tokens working and leaves unknown tokens as literal text', () => {
+    const invoiceProbe = createProbeAst(buildInvoiceTemplateBindings());
+
+    const invoiceToken = setProbeMetadata(invoiceProbe, 'text', { text: '{{invoice.number}}' });
+    const invoiceTextNode = findNodeOfType(invoiceToken.layout, 'text');
+    expect(invoiceTextNode?.type === 'text' ? invoiceTextNode.content : null).toEqual({
+      type: 'path',
+      path: 'invoiceNumber',
+    });
+
+    const unknownToken = setProbeMetadata(invoiceProbe, 'text', { text: '{{notAFieldAnywhere}}' });
+    const unknownTextNode = findNodeOfType(unknownToken.layout, 'text');
+    expect(unknownTextNode?.type === 'text' ? unknownTextNode.content : null).toEqual({
+      type: 'literal',
+      value: '{{notAFieldAnywhere}}',
+    });
+  });
+});

--- a/packages/billing/src/components/invoice-designer/ast/workspaceAst.ts
+++ b/packages/billing/src/components/invoice-designer/ast/workspaceAst.ts
@@ -30,6 +30,12 @@ import type {
   DesignerWorkspaceSnapshot,
 } from '../state/designerStore';
 import { createEmptyDesignerTransformWorkspace, DOCUMENT_NODE_ID } from '../state/designerStore';
+import {
+  getDocumentTokenPaths,
+  resolveDocumentDisplayPath,
+  resolveDocumentRenderPath,
+} from '../fields/documentBindingCatalog';
+import { resolveDocumentKindFromBindingCatalog, type DesignerDocumentKind } from '../utils/documentKind';
 import { getDefinition } from '../constants/componentCatalog';
 import { DESIGNER_CANVAS_BOUNDS } from '../constants/layout';
 import { resolveMediaFrameSize } from '../utils/mediaSizing';
@@ -119,7 +125,8 @@ const exportI18nText = (text: string, ref: unknown): TemplateI18nText | undefine
 
 const resolveExpressionPreviewText = (
   expression: TemplateValueExpression,
-  astInput: TemplateAst
+  astInput: TemplateAst,
+  documentKind: DesignerDocumentKind
 ): string => {
   if (expression.type === 'literal') {
     return String(expression.value ?? '');
@@ -129,11 +136,11 @@ const resolveExpressionPreviewText = (
       astInput.bindings?.values?.[expression.bindingId]?.path ??
       astInput.bindings?.collections?.[expression.bindingId]?.path ??
       expression.bindingId;
-    return `{{${denormalizeBindingPath(bindingPath)}}}`;
+    return `{{${denormalizeBindingPath(bindingPath, documentKind)}}}`;
   }
   if (expression.type === 'path') {
     const parsed = decodeTemplatePathExpression(expression.path);
-    const denormalizedPath = denormalizeBindingPath(parsed.path);
+    const denormalizedPath = denormalizeBindingPath(parsed.path, documentKind);
     if (parsed.filter) {
       return `{{${denormalizedPath} | ${parsed.filter}}}`;
     }
@@ -149,84 +156,34 @@ const resolveExpressionPreviewText = (
 const sanitizeId = (value: string): string =>
   value.replace(/[^a-zA-Z0-9_.-]+/g, '_').replace(/^_+|_+$/g, '');
 
-const normalizeInvoiceBindingPath = (bindingKey: string): string => {
+/**
+ * Designer binding key (the picker's display path, e.g. `quote.quoteNumber`) -> the path the
+ * document's render model actually exposes (`quote_number`). Generated per document kind from the
+ * binding catalogs, so the menu and the data cannot drift apart.
+ */
+const normalizeInvoiceBindingPath = (
+  bindingKey: string,
+  documentKind: DesignerDocumentKind
+): string => {
   const normalized = bindingKey.trim();
-  const aliases: Record<string, string> = {
-    'invoice.number': 'invoiceNumber',
-    'invoice.issueDate': 'issueDate',
-    'invoice.dueDate': 'dueDate',
-    'invoice.subtotal': 'subtotal',
-    'invoice.tax': 'tax',
-    'invoice.total': 'total',
-    'invoice.discount': 'discount',
-    'invoice.currencyCode': 'currencyCode',
-    'invoice.poNumber': 'poNumber',
-    'invoice.recurringServicePeriodStart': 'recurringServicePeriodStart',
-    'invoice.recurringServicePeriodEnd': 'recurringServicePeriodEnd',
-    'invoice.recurringServicePeriodLabel': 'recurringServicePeriodLabel',
-    'quote.quoteNumber': 'quoteNumber',
-    'quote.quoteDate': 'quoteDate',
-    'quote.validUntil': 'validUntil',
-    'quote.status': 'status',
-    'quote.title': 'title',
-    'quote.scope': 'scope',
-    'quote.poNumber': 'poNumber',
-    'quote.subtotal': 'subtotal',
-    'quote.discountTotal': 'discountTotal',
-    'quote.tax': 'tax',
-    'quote.total': 'total',
-    'quote.termsAndConditions': 'termsAndConditions',
-    'quote.clientNotes': 'clientNotes',
-    'quote.version': 'version',
-    'quote.acceptedByName': 'acceptedByName',
-    'quote.acceptedAt': 'acceptedAt',
-    'quoteTotals.recurringSubtotal': 'recurringSubtotal',
-    'quoteTotals.recurringTax': 'recurringTax',
-    'quoteTotals.recurringTotal': 'recurringTotal',
-    'quoteTotals.onetimeSubtotal': 'onetimeSubtotal',
-    'quoteTotals.onetimeTax': 'onetimeTax',
-    'quoteTotals.onetimeTotal': 'onetimeTotal',
-    'quoteTotals.serviceSubtotal': 'serviceSubtotal',
-    'quoteTotals.serviceTax': 'serviceTax',
-    'quoteTotals.serviceTotal': 'serviceTotal',
-    'quoteTotals.productSubtotal': 'productSubtotal',
-    'quoteTotals.productTax': 'productTax',
-    'quoteTotals.productTotal': 'productTotal',
-    'client.name': 'client.name',
-    'client.address': 'client.address',
-    'contact.name': 'contact.name',
-    'customer.name': 'customer.name',
-    'customer.address': 'customer.address',
-    'tenant.name': 'tenantClient.name',
-    'tenant.address': 'tenantClient.address',
-  };
 
   if (normalized.startsWith('item.')) {
     return normalized.slice('item.'.length);
   }
-  return aliases[normalized] ?? normalized;
+  return resolveDocumentRenderPath(documentKind, normalized) ?? normalized;
 };
 
 const supportsFieldDisplayFormat = (bindingPath: string): boolean => bindingPath.trim().endsWith('.address');
 
 const TEMPLATE_TOKEN_PATTERN = /\{\{\s*([^{}]+?)\s*\}\}/g;
-const SIMPLE_BINDING_ALIASES = new Set([
-  'invoiceNumber',
-  'issueDate',
-  'dueDate',
-  'subtotal',
-  'tax',
-  'total',
-  'discount',
-  'currencyCode',
-  'poNumber',
-]);
 
-const isLikelyBindingTokenPath = (token: string): boolean => {
+const isLikelyBindingTokenPath = (token: string, documentKind: DesignerDocumentKind): boolean => {
   if (token.includes('.')) {
     return true;
   }
-  return SIMPLE_BINDING_ALIASES.has(token);
+  // Single-segment tokens are only bindings when the document type's catalog names them,
+  // e.g. `{{quote_number}}` on a quote — anything else stays literal text.
+  return getDocumentTokenPaths(documentKind).has(token);
 };
 
 const sanitizeTemplateArgName = (input: string, fallbackIndex: number): string => {
@@ -239,7 +196,10 @@ const sanitizeTemplateArgName = (input: string, fallbackIndex: number): string =
   return /^[a-zA-Z_]/.test(candidate) ? candidate : `value_${candidate}`;
 };
 
-const parseTemplateInterpolationExpression = (text: string): TemplateValueExpression | null => {
+const parseTemplateInterpolationExpression = (
+  text: string,
+  documentKind: DesignerDocumentKind
+): TemplateValueExpression | null => {
   if (!text.includes('{{')) {
     return null;
   }
@@ -252,10 +212,10 @@ const parseTemplateInterpolationExpression = (text: string): TemplateValueExpres
   const parsedMatches = matches.map((match, index) => {
     const rawToken = asTrimmedString(match[1]);
     const parsedToken = parseTemplateToken(rawToken);
-    if (!parsedToken || !isLikelyBindingTokenPath(parsedToken.path)) {
+    if (!parsedToken || !isLikelyBindingTokenPath(parsedToken.path, documentKind)) {
       return null;
     }
-    const normalizedPath = normalizeInvoiceBindingPath(parsedToken.path);
+    const normalizedPath = normalizeInvoiceBindingPath(parsedToken.path, documentKind);
     if (!normalizedPath) {
       return null;
     }
@@ -349,7 +309,7 @@ const hasInlineLayoutKeys = (inline: Record<string, unknown> | undefined): boole
   );
 };
 
-const resolveFieldBindingPath = (node: WorkspaceNode): string => {
+const resolveFieldBindingPath = (node: WorkspaceNode, documentKind: DesignerDocumentKind): string => {
   const metadata = getWorkspaceNodeMetadata(node);
   const fromMetadata =
     asTrimmedString(metadata.bindingKey) ||
@@ -357,7 +317,7 @@ const resolveFieldBindingPath = (node: WorkspaceNode): string => {
     asTrimmedString(metadata.path);
 
   if (fromMetadata.length > 0) {
-    return normalizeInvoiceBindingPath(fromMetadata);
+    return normalizeInvoiceBindingPath(fromMetadata, documentKind);
   }
 
   switch (node.type as DesignerComponentType) {
@@ -374,14 +334,14 @@ const resolveFieldBindingPath = (node: WorkspaceNode): string => {
   }
 };
 
-const resolveCollectionPath = (node: WorkspaceNode): string => {
+const resolveCollectionPath = (node: WorkspaceNode, documentKind: DesignerDocumentKind): string => {
   const metadata = getWorkspaceNodeMetadata(node);
   const rawPath =
     asTrimmedString(metadata.collectionBindingKey) ||
     asTrimmedString(metadata.collectionPath) ||
     asTrimmedString(metadata.bindingKey) ||
     asTrimmedString(metadata.path);
-  const normalized = normalizeInvoiceBindingPath(rawPath);
+  const normalized = normalizeInvoiceBindingPath(rawPath, documentKind);
   return normalized.length > 0 && normalized !== 'invoiceNumber' ? normalized : 'items';
 };
 
@@ -399,10 +359,13 @@ const resolveNodeTextContent = (node: WorkspaceNode): string => {
   );
 };
 
-const resolveTextNodeContentExpression = (node: WorkspaceNode): TemplateValueExpression => {
+const resolveTextNodeContentExpression = (
+  node: WorkspaceNode,
+  documentKind: DesignerDocumentKind
+): TemplateValueExpression => {
   const metadata = getWorkspaceNodeMetadata(node);
   const currentText = resolveNodeTextContent(node);
-  const parsedExpression = parseTemplateInterpolationExpression(currentText);
+  const parsedExpression = parseTemplateInterpolationExpression(currentText, documentKind);
   const preservedExpression = isTemplateValueExpression(metadata.astContentExpression)
     ? metadata.astContentExpression
     : null;
@@ -860,7 +823,7 @@ const coerceNodeStyleFromInlineStyle = (inline: Record<string, unknown> | undefi
   return Object.keys(style).length > 0 ? style : undefined;
 };
 
-const mapTableColumns = (node: WorkspaceNode): TemplateTableColumn[] => {
+const mapTableColumns = (node: WorkspaceNode, documentKind: DesignerDocumentKind): TemplateTableColumn[] => {
   const metadata = getWorkspaceNodeMetadata(node);
   const columns = Array.isArray(metadata.columns) ? metadata.columns : [];
 
@@ -872,7 +835,8 @@ const mapTableColumns = (node: WorkspaceNode): TemplateTableColumn[] => {
       const id = asTrimmedString(column.id) || `col-${index + 1}`;
       const header = asTrimmedString(column.header);
       const key = normalizeInvoiceBindingPath(
-        asTrimmedString(column.key) || asTrimmedString(column.path) || asTrimmedString(column.bindingKey)
+        asTrimmedString(column.key) || asTrimmedString(column.path) || asTrimmedString(column.bindingKey),
+        documentKind
       );
       const preservedExpression = isTemplateValueExpression(column.valueExpression)
         ? column.valueExpression
@@ -958,9 +922,13 @@ const getWorkspaceRootPrintSettings = (
 const resolveCollectionSourceBindingId = (
   collectionPath: string,
   registerCollectionBinding: (path: string) => string,
+  documentKind: DesignerDocumentKind,
   transformOutputBindingId?: string
 ): string => {
-  const normalizedTransformOutputBindingId = normalizeInvoiceBindingPath(transformOutputBindingId ?? '');
+  const normalizedTransformOutputBindingId = normalizeInvoiceBindingPath(
+    transformOutputBindingId ?? '',
+    documentKind
+  );
   return collectionPath === normalizedTransformOutputBindingId && normalizedTransformOutputBindingId.length > 0
     ? normalizedTransformOutputBindingId
     : registerCollectionBinding(collectionPath);
@@ -971,6 +939,7 @@ const mapDesignerNodeToAstNode = (
   nodesById: Map<string, WorkspaceNode>,
   registerValueBinding: (path: string) => string,
   registerCollectionBinding: (path: string) => string,
+  documentKind: DesignerDocumentKind,
   transformOutputBindingId?: string
 ): TemplateNode | null => {
   const children = node.children
@@ -982,6 +951,7 @@ const mapDesignerNodeToAstNode = (
         nodesById,
         registerValueBinding,
         registerCollectionBinding,
+        documentKind,
         transformOutputBindingId
       )
     )
@@ -998,6 +968,7 @@ const mapDesignerNodeToAstNode = (
           nodesById,
           registerValueBinding,
           registerCollectionBinding,
+          documentKind,
           transformOutputBindingId
         );
         if (!mappedChild) continue;
@@ -1087,7 +1058,7 @@ const mapDesignerNodeToAstNode = (
       return {
         ...createBaseNode(node),
         type: 'text',
-        content: resolveTextNodeContentExpression(node),
+        content: resolveTextNodeContentExpression(node, documentKind),
       };
     }
     case 'field':
@@ -1096,7 +1067,7 @@ const mapDesignerNodeToAstNode = (
     case 'discount':
     case 'custom-total': {
       const metadata = getWorkspaceNodeMetadata(node);
-      const bindingPath = resolveFieldBindingPath(node);
+      const bindingPath = resolveFieldBindingPath(node, documentKind);
       const bindingId = registerValueBinding(bindingPath);
       const explicitLabel = asTrimmedString(metadata.label);
       const format = parseTemplateValueFormat(metadata.format);
@@ -1158,8 +1129,9 @@ const mapDesignerNodeToAstNode = (
       const sourceBindingId = preservedSourceBindingId.length > 0
         ? preservedSourceBindingId
         : resolveCollectionSourceBindingId(
-            resolveCollectionPath(node),
+            resolveCollectionPath(node, documentKind),
             registerCollectionBinding,
+            documentKind,
             transformOutputBindingId
           );
       const headerBg = asTrimmedString(metadata.headerBackgroundColor);
@@ -1180,7 +1152,7 @@ const mapDesignerNodeToAstNode = (
           sourceBinding: { bindingId: sourceBindingId },
           itemBinding: 'item',
         },
-        columns: mapTableColumns(node),
+        columns: mapTableColumns(node, documentKind),
         headerStyle,
         emptyStateText:
           typeof metadata.emptyStateText === 'string'
@@ -1191,7 +1163,7 @@ const mapDesignerNodeToAstNode = (
     case 'totals':
       {
         const metadata = getWorkspaceNodeMetadata(node);
-        const sourceBindingPath = resolveCollectionPath(node);
+        const sourceBindingPath = resolveCollectionPath(node, documentKind);
         const rowsSource = Array.isArray(metadata.totalsRows) ? metadata.totalsRows : [];
         const rows: TemplateTotalsRow[] =
           rowsSource
@@ -1205,7 +1177,7 @@ const mapDesignerNodeToAstNode = (
               const preservedValue = isTemplateValueExpression(row.valueExpression)
                 ? row.valueExpression
                 : null;
-              const valuePath = normalizeInvoiceBindingPath(asTrimmedString(row.valuePath));
+              const valuePath = normalizeInvoiceBindingPath(asTrimmedString(row.valuePath), documentKind);
               const format = parseTemplateValueFormat(row.format ?? row.type);
               const mappedRow: TemplateTotalsRow = {
                 id: sanitizeId(id),
@@ -1237,6 +1209,7 @@ const mapDesignerNodeToAstNode = (
             bindingId: resolveCollectionSourceBindingId(
               sourceBindingPath,
               registerCollectionBinding,
+              documentKind,
               transformOutputBindingId
             ),
           },
@@ -1354,6 +1327,10 @@ export const exportWorkspaceToTemplateAst = (
     documentHeightPx: rootSize.height,
     pagePaddingPx: parsePxLength(pageLayout?.padding),
   });
+  const documentKind = resolveDocumentKindFromBindingCatalog(
+    rootMetadata.__astBindingCatalog,
+    rootMetadata.__astTemplateMetadata
+  );
   const importedBindings = isRecord(rootMetadata.__astBindingCatalog)
     ? (rootMetadata.__astBindingCatalog as UnknownRecord)
     : null;
@@ -1423,7 +1400,7 @@ export const exportWorkspaceToTemplateAst = (
   };
 
   const registerValueBinding = (path: string): string => {
-    const normalizedPath = normalizeInvoiceBindingPath(path);
+    const normalizedPath = normalizeInvoiceBindingPath(path, documentKind);
     const existingBindingId = valueBindingPathToId.get(normalizedPath);
     if (existingBindingId) {
       return existingBindingId;
@@ -1442,7 +1419,7 @@ export const exportWorkspaceToTemplateAst = (
   };
 
   const registerCollectionBinding = (path: string): string => {
-    const normalizedPath = normalizeInvoiceBindingPath(path);
+    const normalizedPath = normalizeInvoiceBindingPath(path, documentKind);
     const existingBindingId = collectionBindingPathToId.get(normalizedPath);
     if (existingBindingId) {
       return existingBindingId;
@@ -1478,6 +1455,7 @@ export const exportWorkspaceToTemplateAst = (
         nodesById,
         registerValueBinding,
         registerCollectionBinding,
+        documentKind,
         workspaceTransforms.outputBindingId
       )
     : null;
@@ -1521,58 +1499,17 @@ export const exportWorkspaceToTemplateAstJson = (
   workspace: DesignerWorkspaceSnapshot
 ): string => JSON.stringify(exportWorkspaceToTemplateAst(workspace), null, 2);
 
-const denormalizeBindingPath = (path: string): string => {
-  const aliases: Record<string, string> = {
-    invoiceNumber: 'invoice.number',
-    issueDate: 'invoice.issueDate',
-    dueDate: 'invoice.dueDate',
-    subtotal: 'invoice.subtotal',
-    tax: 'invoice.tax',
-    total: 'invoice.total',
-    discount: 'invoice.discount',
-    currencyCode: 'invoice.currencyCode',
-    poNumber: 'invoice.poNumber',
-    recurringServicePeriodStart: 'invoice.recurringServicePeriodStart',
-    recurringServicePeriodEnd: 'invoice.recurringServicePeriodEnd',
-    recurringServicePeriodLabel: 'invoice.recurringServicePeriodLabel',
-    quoteNumber: 'quote.quoteNumber',
-    quoteDate: 'quote.quoteDate',
-    validUntil: 'quote.validUntil',
-    status: 'quote.status',
-    title: 'quote.title',
-    scope: 'quote.scope',
-    discountTotal: 'quote.discountTotal',
-    termsAndConditions: 'quote.termsAndConditions',
-    clientNotes: 'quote.clientNotes',
-    version: 'quote.version',
-    acceptedByName: 'quote.acceptedByName',
-    acceptedAt: 'quote.acceptedAt',
-    recurringSubtotal: 'quoteTotals.recurringSubtotal',
-    recurringTax: 'quoteTotals.recurringTax',
-    recurringTotal: 'quoteTotals.recurringTotal',
-    onetimeSubtotal: 'quoteTotals.onetimeSubtotal',
-    onetimeTax: 'quoteTotals.onetimeTax',
-    onetimeTotal: 'quoteTotals.onetimeTotal',
-    serviceSubtotal: 'quoteTotals.serviceSubtotal',
-    serviceTax: 'quoteTotals.serviceTax',
-    serviceTotal: 'quoteTotals.serviceTotal',
-    productSubtotal: 'quoteTotals.productSubtotal',
-    productTax: 'quoteTotals.productTax',
-    productTotal: 'quoteTotals.productTotal',
-    'client.name': 'client.name',
-    'client.address': 'client.address',
-    'contact.name': 'contact.name',
-    'customer.name': 'customer.name',
-    'customer.address': 'customer.address',
-    'tenantClient.name': 'tenant.name',
-    'tenantClient.address': 'tenant.address',
-  };
-  return aliases[path] ?? path;
-};
+/**
+ * Render-model path -> designer binding key. The inverse of `normalizeInvoiceBindingPath`, so an
+ * imported template exports again with byte-identical binding paths.
+ */
+const denormalizeBindingPath = (path: string, documentKind: DesignerDocumentKind): string =>
+  resolveDocumentDisplayPath(documentKind, path) ?? path;
 
 const resolveImportedCollectionBindingPath = (
   astInput: TemplateAst,
   bindingId: string,
+  documentKind: DesignerDocumentKind,
   fallbackPath = 'items'
 ): string => {
   const trimmedBindingId = asTrimmedString(bindingId);
@@ -1586,9 +1523,13 @@ const resolveImportedCollectionBindingPath = (
   }
 
   const transformOutputBindingId = normalizeInvoiceBindingPath(
-    asTrimmedString(astInput.transforms?.outputBindingId)
+    asTrimmedString(astInput.transforms?.outputBindingId),
+    documentKind
   );
-  if (transformOutputBindingId.length > 0 && normalizeInvoiceBindingPath(trimmedBindingId) === transformOutputBindingId) {
+  if (
+    transformOutputBindingId.length > 0 &&
+    normalizeInvoiceBindingPath(trimmedBindingId, documentKind) === transformOutputBindingId
+  ) {
     return transformOutputBindingId;
   }
 
@@ -1611,6 +1552,7 @@ const parseSizeFromStyle = (node: TemplateNode): { width?: number; height?: numb
 export const importTemplateAstToWorkspace = (
   ast: TemplateAst
 ): DesignerWorkspaceSnapshot => {
+  const documentKind = resolveDocumentKindFromBindingCatalog(ast.bindings, ast.metadata);
   const astDocument = ast.layout.type === 'document' ? ast.layout : null;
   const documentInline = astDocument && isRecord(astDocument.style?.inline)
     ? (astDocument.style?.inline as Record<string, unknown>)
@@ -1880,7 +1822,7 @@ export const importTemplateAstToWorkspace = (
 
         if (inputNode.type === 'text') {
           metadata.astContentExpression = inputNode.content;
-          const resolvedText = resolveExpressionPreviewText(inputNode.content, astInput);
+          const resolvedText = resolveExpressionPreviewText(inputNode.content, astInput, documentKind);
           metadata.text = resolvedText;
           metadata.__astContentPreviewText = resolvedText;
         } else if (inputNode.type === 'field') {
@@ -1888,7 +1830,7 @@ export const importTemplateAstToWorkspace = (
             astInput.bindings?.values?.[inputNode.binding.bindingId]?.path ??
             astInput.bindings?.collections?.[inputNode.binding.bindingId]?.path ??
             inputNode.binding.bindingId;
-          metadata.bindingKey = denormalizeBindingPath(bindingPath);
+          metadata.bindingKey = denormalizeBindingPath(bindingPath, documentKind);
           metadata.__astFieldHadFormat = Object.prototype.hasOwnProperty.call(inputNode, 'format');
           metadata.__astFieldHadEmptyValue = Object.prototype.hasOwnProperty.call(inputNode, 'emptyValue');
           metadata.__astFieldHadPlaceholder = Object.prototype.hasOwnProperty.call(inputNode, 'placeholder');
@@ -1930,13 +1872,13 @@ export const importTemplateAstToWorkspace = (
           // without being replaced by a synthesized `collection.*` id.
           const isResolvableGlobalBinding =
             Boolean(astInput.bindings?.collections?.[rawBindingId]) ||
-            normalizeInvoiceBindingPath(asTrimmedString(astInput.transforms?.outputBindingId)) ===
-              normalizeInvoiceBindingPath(rawBindingId);
+            normalizeInvoiceBindingPath(asTrimmedString(astInput.transforms?.outputBindingId), documentKind) ===
+              normalizeInvoiceBindingPath(rawBindingId, documentKind);
           if (!isResolvableGlobalBinding) {
             metadata.__astTableSourceBindingId = rawBindingId;
           }
-          const collectionPath = resolveImportedCollectionBindingPath(astInput, rawBindingId);
-          metadata.collectionBindingKey = denormalizeBindingPath(collectionPath);
+          const collectionPath = resolveImportedCollectionBindingPath(astInput, rawBindingId, documentKind);
+          metadata.collectionBindingKey = denormalizeBindingPath(collectionPath, documentKind);
           metadata.columns = inputNode.columns.map((column) => {
             const importedHeader = importI18nText(column.header);
             const mappedColumn: Record<string, unknown> = {
@@ -1973,9 +1915,10 @@ export const importTemplateAstToWorkspace = (
           const sourcePath = resolveImportedCollectionBindingPath(
             astInput,
             inputNode.sourceBinding.bindingId,
+            documentKind,
             inputNode.sourceBinding.bindingId
           );
-          metadata.collectionBindingKey = denormalizeBindingPath(sourcePath);
+          metadata.collectionBindingKey = denormalizeBindingPath(sourcePath, documentKind);
           metadata.totalsRows = inputNode.rows.map((row) => {
             const importedRowLabel = importI18nText(row.label);
             return {

--- a/packages/billing/src/components/invoice-designer/fields/documentBindingCatalog.test.ts
+++ b/packages/billing/src/components/invoice-designer/fields/documentBindingCatalog.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildInvoiceTemplateBindings } from '../../../lib/invoice-template-ast/standardTemplates';
+import { QUOTE_TEMPLATE_VALUE_BINDINGS } from '../../../lib/quote-template-ast/bindings';
+import { SALES_ORDER_TEMPLATE_VALUE_BINDINGS } from '../../../lib/sales-order-template-ast/bindings';
+import type { DesignerDocumentKind } from '../utils/documentKind';
+import { getTemplateFieldDefinition } from './fieldCatalog';
+import {
+  buildDocumentExpressionPathOptions,
+  describeBindingOption,
+  getDocumentBindingFields,
+  getDocumentTokenPaths,
+  resolveCandidateRenderPaths,
+  resolveDocumentDisplayPath,
+  resolveDocumentFieldLabel,
+  resolveDocumentRenderPath,
+} from './documentBindingCatalog';
+
+const optionPaths = (documentKind: DesignerDocumentKind): string[] =>
+  buildDocumentExpressionPathOptions({ mode: 'template', includeRootPaths: false, documentKind })
+    .map((option) => option.path)
+    .sort();
+
+const renderPathOf = (documentKind: DesignerDocumentKind, displayPath: string): string | undefined =>
+  getDocumentBindingFields(documentKind).find((field) => field.path === displayPath)?.renderPath;
+
+describe('document binding catalog generation', () => {
+  it('derives quote options from the quote binding catalog, keeping snake_case render paths', () => {
+    expect(renderPathOf('quote', 'quote.quoteNumber')).toBe('quote_number');
+    expect(renderPathOf('quote', 'quote.quoteDate')).toBe('quote_date');
+    expect(renderPathOf('quote', 'quote.validUntil')).toBe('valid_until');
+    expect(renderPathOf('quote', 'quote.total')).toBe('total_amount');
+    expect(renderPathOf('quote', 'quote.scope')).toBe('scope_of_work');
+    expect(renderPathOf('quote', 'quote.poNumber')).toBe('po_number');
+    expect(renderPathOf('quote', 'quote.discountTotal')).toBe('discount_total');
+    expect(renderPathOf('quote', 'quote.termsAndConditions')).toBe('terms_and_conditions');
+    expect(renderPathOf('quote', 'quote.clientNotes')).toBe('client_notes');
+    expect(renderPathOf('quote', 'quote.acceptedByName')).toBe('accepted_by_name');
+    expect(renderPathOf('quote', 'quote.acceptedAt')).toBe('accepted_at');
+  });
+
+  it('groups the quote recurring/onetime/service/product totals under quoteTotals', () => {
+    const totalsOptions = optionPaths('quote').filter((path) => path.startsWith('quoteTotals.'));
+
+    expect(totalsOptions).toEqual([
+      'quoteTotals.onetimeSubtotal',
+      'quoteTotals.onetimeTax',
+      'quoteTotals.onetimeTotal',
+      'quoteTotals.productSubtotal',
+      'quoteTotals.productTax',
+      'quoteTotals.productTotal',
+      'quoteTotals.recurringSubtotal',
+      'quoteTotals.recurringTax',
+      'quoteTotals.recurringTotal',
+      'quoteTotals.serviceSubtotal',
+      'quoteTotals.serviceTax',
+      'quoteTotals.serviceTotal',
+    ]);
+    expect(renderPathOf('quote', 'quoteTotals.serviceSubtotal')).toBe('service_subtotal');
+  });
+
+  it('keeps the quote issuer party on tenant.*, matching QuoteViewModel', () => {
+    expect(renderPathOf('quote', 'tenant.name')).toBe('tenant.name');
+    expect(renderPathOf('quote', 'tenant.address')).toBe('tenant.address');
+    expect(renderPathOf('quote', 'client.name')).toBe('client.name');
+    expect(renderPathOf('quote', 'contact.name')).toBe('contact.name');
+  });
+
+  it('derives sales-order options, including the previously absent salesOrder.* set', () => {
+    expect(renderPathOf('sales-order', 'salesOrder.orderNumber')).toBe('so_number');
+    expect(renderPathOf('sales-order', 'salesOrder.orderDate')).toBe('order_date');
+    expect(renderPathOf('sales-order', 'salesOrder.expectedShipDate')).toBe('expected_ship_date');
+    expect(renderPathOf('sales-order', 'salesOrder.poNumber')).toBe('client_po_number');
+    expect(renderPathOf('sales-order', 'salesOrder.currencyCode')).toBe('currency_code');
+    expect(renderPathOf('sales-order', 'salesOrder.status')).toBe('status');
+    expect(renderPathOf('sales-order', 'salesOrder.notes')).toBe('notes');
+    expect(renderPathOf('sales-order', 'salesOrder.subtotal')).toBe('subtotal');
+    expect(renderPathOf('sales-order', 'salesOrder.tax')).toBe('tax');
+    expect(renderPathOf('sales-order', 'salesOrder.total')).toBe('total');
+    // The sales-order model keeps the issuer under tenantClient, unlike the quote model.
+    expect(renderPathOf('sales-order', 'tenant.name')).toBe('tenantClient.name');
+  });
+
+  it('keeps every invoice option that shipped before, minus invoice.discount', () => {
+    const invoiceOptions = new Set(optionPaths('invoice'));
+
+    for (const shipped of [
+      'invoice.number',
+      'invoice.issueDate',
+      'invoice.dueDate',
+      'invoice.poNumber',
+      'invoice.subtotal',
+      'invoice.tax',
+      'invoice.total',
+      'invoice.currencyCode',
+      'invoice.recurringServicePeriodStart',
+      'invoice.recurringServicePeriodEnd',
+      'invoice.recurringServicePeriodLabel',
+      'customer.name',
+      'customer.address',
+      'tenant.name',
+      'tenant.address',
+      'item.description',
+      'item.quantity',
+      'item.unitPrice',
+      'item.total',
+      'item.servicePeriodStart',
+      'item.servicePeriodEnd',
+      'item.billingTiming',
+    ]) {
+      expect(invoiceOptions.has(shipped)).toBe(true);
+    }
+
+    expect(invoiceOptions.has('invoice.discount')).toBe(false);
+    expect(getTemplateFieldDefinition('invoice.discount')).toBeNull();
+  });
+
+  it('offers a picker option for every value binding a document type publishes', () => {
+    const catalogs: Array<[DesignerDocumentKind, Record<string, { id: string; path: string }>]> = [
+      ['invoice', buildInvoiceTemplateBindings().values as Record<string, { id: string; path: string }>],
+      ['quote', QUOTE_TEMPLATE_VALUE_BINDINGS as Record<string, { id: string; path: string }>],
+      ['sales-order', SALES_ORDER_TEMPLATE_VALUE_BINDINGS as Record<string, { id: string; path: string }>],
+    ];
+
+    for (const [documentKind, catalog] of catalogs) {
+      const optionRenderPaths = new Set(
+        getDocumentBindingFields(documentKind).map((field) => field.renderPath)
+      );
+      const missing = Object.values(catalog)
+        // Logo bindings feed image nodes, not the field picker.
+        .filter((binding) => !/logo/i.test(binding.id))
+        .filter((binding) => !optionRenderPaths.has(binding.path))
+        .map((binding) => `${documentKind}: ${binding.id} -> ${binding.path}`);
+
+      expect(missing).toEqual([]);
+    }
+  });
+
+  it('round-trips display paths back to the picker path they came from', () => {
+    for (const documentKind of ['invoice', 'quote', 'sales-order'] as DesignerDocumentKind[]) {
+      for (const field of getDocumentBindingFields(documentKind)) {
+        expect(resolveDocumentRenderPath(documentKind, field.path)).toBe(field.renderPath);
+        expect(resolveDocumentDisplayPath(documentKind, field.renderPath)).toBe(field.path);
+      }
+    }
+  });
+
+  it('recognises single-segment text tokens per document type', () => {
+    expect(getDocumentTokenPaths('quote').has('quote_number')).toBe(true);
+    expect(getDocumentTokenPaths('quote').has('invoiceNumber')).toBe(false);
+    expect(getDocumentTokenPaths('invoice').has('invoiceNumber')).toBe(true);
+    expect(getDocumentTokenPaths('sales-order').has('so_number')).toBe(true);
+  });
+
+  it('resolves the render paths a binding key can mean across document types', () => {
+    expect(resolveCandidateRenderPaths('tenant.name')).toEqual(['tenantClient.name', 'tenant.name']);
+    expect(resolveCandidateRenderPaths('quote.total')).toEqual(['total_amount']);
+    expect(resolveCandidateRenderPaths('nothing.here')).toEqual([]);
+  });
+
+  it('labels generated options without repeating the category', () => {
+    const quoteNumberOption = buildDocumentExpressionPathOptions({
+      mode: 'template',
+      includeRootPaths: false,
+      documentKind: 'quote',
+    }).find((option) => option.path === 'quote.quoteNumber');
+
+    expect(quoteNumberOption).toBeTruthy();
+    expect(describeBindingOption(quoteNumberOption!)?.label).toBe('Quote Number');
+    expect(resolveDocumentFieldLabel('quote.quoteNumber')).toBe('Quote Number');
+    expect(resolveDocumentFieldLabel('salesOrder.expectedShipDate')).toBe('Expected Ship Date');
+  });
+
+  it('keeps curated field-catalog labels and display formats over generated ones', () => {
+    const addressOption = buildDocumentExpressionPathOptions({
+      mode: 'template',
+      includeRootPaths: false,
+      documentKind: 'invoice',
+    }).find((option) => option.path === 'customer.address');
+
+    expect(addressOption).toBeTruthy();
+    const described = describeBindingOption(addressOption!);
+    expect(described?.label).toBe('Customer Address');
+    expect(described?.description).toBe('The customer billing address.');
+    expect(getTemplateFieldDefinition('customer.address')?.supportedDisplayFormats).toEqual([
+      'single-line',
+      'multiline',
+      'raw',
+    ]);
+  });
+});

--- a/packages/billing/src/components/invoice-designer/fields/documentBindingCatalog.ts
+++ b/packages/billing/src/components/invoice-designer/fields/documentBindingCatalog.ts
@@ -1,0 +1,420 @@
+/* eslint-disable custom-rules/no-feature-to-feature-imports -- Designer field picker builds its options with the shared expression-authoring path builder */
+import type { TemplateAst } from '@alga-psa/types';
+import type {
+  ExpressionMode,
+  SharedExpressionContextRoot,
+  SharedExpressionPathOption,
+  SharedExpressionSchemaNode,
+} from '@alga-psa/workflows/expression-authoring';
+import { buildInvoiceExpressionPathOptions } from '@alga-psa/workflows/expression-authoring';
+
+import { buildInvoiceTemplateBindings } from '../../../lib/invoice-template-ast/standardTemplates';
+import { QUOTE_TEMPLATE_VALUE_BINDINGS } from '../../../lib/quote-template-ast/bindings';
+import { SALES_ORDER_TEMPLATE_VALUE_BINDINGS } from '../../../lib/sales-order-template-ast/bindings';
+import type { DesignerDocumentKind } from '../utils/documentKind';
+import {
+  getTemplateFieldDefinition,
+  humanizeBindingToken,
+  type InvoiceFieldCategory,
+} from './fieldCatalog';
+
+/**
+ * The field picker is generated from each document type's binding catalog, so the menu can only
+ * offer fields the render model actually has. `path` is the display path the designer stores as
+ * `metadata.bindingKey`; `renderPath` is what the exported AST binds against.
+ */
+export type DocumentBindingField = {
+  path: string;
+  renderPath: string;
+  bindingId?: string;
+  valueType: 'string' | 'number' | 'boolean';
+  description: string;
+};
+
+type CatalogValueBindings = NonNullable<NonNullable<TemplateAst['bindings']>['values']>;
+
+type DocumentItemField = {
+  name: string;
+  valueType: 'string' | 'number' | 'boolean';
+  description: string;
+};
+
+const ROOT_METADATA: Record<string, { label: string; description: string }> = {
+  invoice: { label: 'Invoice', description: 'Invoice-level fields' },
+  quote: { label: 'Quote', description: 'Quote-level fields' },
+  quoteTotals: { label: 'Quote Totals', description: 'Recurring, one-time, service, and product totals.' },
+  salesOrder: { label: 'Sales Order', description: 'Sales order-level fields' },
+  client: { label: 'Client', description: 'Client fields' },
+  contact: { label: 'Contact', description: 'Contact fields' },
+  customer: { label: 'Customer', description: 'Customer fields' },
+  tenant: { label: 'Tenant', description: 'Tenant fields' },
+  item: { label: 'Line Item', description: 'Line item fields for repeating/table contexts' },
+};
+
+// The issuer party is `tenantClient` on the invoice and sales-order models and `tenant` on the
+// quote model. The picker speaks one language — `tenant.*` — and the render path stays per-model.
+const DISPLAY_ROOT_BY_RENDER_ROOT: Record<string, string> = {
+  tenantClient: 'tenant',
+};
+
+const QUOTE_TOTALS_BINDING_ID = /^(recurring|onetime|service|product)(Subtotal|Tax|Total)$/;
+
+// Logo bindings drive image sources, not text fields, so they stay out of the field picker.
+const IMAGE_BINDING_ID = /logo/i;
+
+const NUMERIC_RENDER_PATH = /(^|[._])(subtotal|tax|total|amount|version|quantity|price|rate|count)([._]|$)/i;
+
+const ITEM_FIELDS: Record<DesignerDocumentKind, DocumentItemField[]> = {
+  invoice: [
+    { name: 'description', valueType: 'string', description: 'Line item description.' },
+    { name: 'quantity', valueType: 'number', description: 'Line item quantity.' },
+    { name: 'unitPrice', valueType: 'number', description: 'Line item unit price.' },
+    { name: 'total', valueType: 'number', description: 'Line item total.' },
+    {
+      name: 'servicePeriodStart',
+      valueType: 'string',
+      description: 'Line item recurring service period start date when available.',
+    },
+    {
+      name: 'servicePeriodEnd',
+      valueType: 'string',
+      description: 'Line item recurring service period end date when available.',
+    },
+    { name: 'billingTiming', valueType: 'string', description: 'Line item billing timing when available.' },
+  ],
+  quote: [
+    { name: 'description', valueType: 'string', description: 'Quote line item description.' },
+    { name: 'quantity', valueType: 'number', description: 'Quote line item quantity.' },
+    { name: 'unit_price', valueType: 'number', description: 'Quote line item unit price.' },
+    { name: 'total_price', valueType: 'number', description: 'Quote line item total.' },
+    { name: 'tax_amount', valueType: 'number', description: 'Quote line item tax amount.' },
+    { name: 'net_amount', valueType: 'number', description: 'Quote line item total including tax.' },
+    { name: 'billing_frequency', valueType: 'string', description: 'Recurring billing frequency.' },
+    { name: 'is_recurring', valueType: 'boolean', description: 'Whether the line item is recurring.' },
+  ],
+  'sales-order': [
+    { name: 'description', valueType: 'string', description: 'Line description (product name).' },
+    { name: 'service_name', valueType: 'string', description: 'Product / service name.' },
+    { name: 'service_sku', valueType: 'string', description: 'Product SKU.' },
+    { name: 'quantity_ordered', valueType: 'number', description: 'Quantity ordered.' },
+    { name: 'quantity_fulfilled', valueType: 'number', description: 'Quantity fulfilled so far.' },
+    { name: 'unit_price', valueType: 'number', description: 'Unit price.' },
+    { name: 'amount', valueType: 'number', description: 'Line amount (qty × unit price).' },
+  ],
+};
+
+const resolveValueType = (renderPath: string): DocumentBindingField['valueType'] =>
+  NUMERIC_RENDER_PATH.test(renderPath) ? 'number' : 'string';
+
+const toDisplayPath = (
+  binding: { id: string; path: string },
+  spec: { scalarRoot: string; totalsRoot?: string; leafOverrides?: Record<string, string> }
+): string => {
+  if (binding.path.includes('.')) {
+    const [renderRoot, ...rest] = binding.path.split('.');
+    return [DISPLAY_ROOT_BY_RENDER_ROOT[renderRoot] ?? renderRoot, ...rest].join('.');
+  }
+  const root =
+    spec.totalsRoot && QUOTE_TOTALS_BINDING_ID.test(binding.id) ? spec.totalsRoot : spec.scalarRoot;
+  return `${root}.${spec.leafOverrides?.[binding.id] ?? binding.id}`;
+};
+
+const buildCatalogFields = (
+  values: CatalogValueBindings,
+  spec: { scalarRoot: string; totalsRoot?: string; leafOverrides?: Record<string, string> }
+): DocumentBindingField[] =>
+  Object.values(values)
+    .filter((binding) => !IMAGE_BINDING_ID.test(binding.id))
+    .map((binding) => ({
+      path: toDisplayPath(binding, spec),
+      renderPath: binding.path,
+      bindingId: binding.id,
+      valueType: resolveValueType(binding.path),
+      description: `Data path: ${binding.path}`,
+    }));
+
+const buildDocumentBindingFields = (documentKind: DesignerDocumentKind): DocumentBindingField[] => {
+  if (documentKind === 'quote') {
+    return buildCatalogFields(QUOTE_TEMPLATE_VALUE_BINDINGS, {
+      scalarRoot: 'quote',
+      totalsRoot: 'quoteTotals',
+    });
+  }
+  if (documentKind === 'sales-order') {
+    return buildCatalogFields(SALES_ORDER_TEMPLATE_VALUE_BINDINGS, { scalarRoot: 'salesOrder' });
+  }
+  return [
+    ...buildCatalogFields(buildInvoiceTemplateBindings().values ?? {}, {
+      scalarRoot: 'invoice',
+      // `invoice.number` is the path shipped templates and the field catalog already use.
+      leafOverrides: { invoiceNumber: 'number' },
+    }),
+    // On every invoice render model, but with no built-in binding to generate from.
+    {
+      path: 'invoice.currencyCode',
+      renderPath: 'currencyCode',
+      valueType: 'string',
+      description: 'Data path: currencyCode',
+    },
+  ];
+};
+
+type DocumentCatalog = {
+  fields: DocumentBindingField[];
+  renderPathByDisplayPath: Map<string, string>;
+  displayPathByRenderPath: Map<string, string>;
+  tokenPaths: Set<string>;
+  contextRoots: SharedExpressionContextRoot[];
+};
+
+const buildContextRoots = (
+  documentKind: DesignerDocumentKind,
+  fields: DocumentBindingField[]
+): SharedExpressionContextRoot[] => {
+  const schemaByRoot = new Map<string, SharedExpressionSchemaNode>();
+
+  const propertyFor = (root: string, segments: string[]): Record<string, SharedExpressionSchemaNode> => {
+    let schema = schemaByRoot.get(root);
+    if (!schema) {
+      schema = { type: 'object', properties: {} };
+      schemaByRoot.set(root, schema);
+    }
+    let properties = schema.properties as Record<string, SharedExpressionSchemaNode>;
+    for (const segment of segments) {
+      const next = properties[segment] ?? { type: 'object', properties: {} };
+      properties[segment] = next;
+      next.properties = next.properties ?? {};
+      properties = next.properties;
+    }
+    return properties;
+  };
+
+  for (const field of fields) {
+    const [root, ...rest] = field.path.split('.');
+    const leaf = rest.pop();
+    if (!root || !leaf) continue;
+    propertyFor(root, rest)[leaf] = { type: field.valueType, description: field.description };
+  }
+
+  for (const itemField of ITEM_FIELDS[documentKind]) {
+    propertyFor('item', [])[itemField.name] = {
+      type: itemField.valueType,
+      description: itemField.description,
+    };
+  }
+
+  return Array.from(schemaByRoot.entries()).map(([root, schema]) => ({
+    key: root,
+    label: ROOT_METADATA[root]?.label ?? root,
+    description: ROOT_METADATA[root]?.description,
+    schema,
+    allowInModes: ['path-only', 'template'],
+  }));
+};
+
+const buildDocumentCatalog = (documentKind: DesignerDocumentKind): DocumentCatalog => {
+  const fields = buildDocumentBindingFields(documentKind);
+  const renderPathByDisplayPath = new Map<string, string>();
+  const displayPathByRenderPath = new Map<string, string>();
+  const tokenPaths = new Set<string>();
+
+  for (const field of fields) {
+    if (!renderPathByDisplayPath.has(field.path)) {
+      renderPathByDisplayPath.set(field.path, field.renderPath);
+    }
+    if (!displayPathByRenderPath.has(field.renderPath)) {
+      displayPathByRenderPath.set(field.renderPath, field.path);
+    }
+    if (!field.renderPath.includes('.')) {
+      tokenPaths.add(field.renderPath);
+    }
+  }
+
+  return {
+    fields,
+    renderPathByDisplayPath,
+    displayPathByRenderPath,
+    tokenPaths,
+    contextRoots: buildContextRoots(documentKind, fields),
+  };
+};
+
+const catalogCache = new Map<DesignerDocumentKind, DocumentCatalog>();
+
+const getDocumentCatalog = (documentKind: DesignerDocumentKind): DocumentCatalog => {
+  const cached = catalogCache.get(documentKind);
+  if (cached) {
+    return cached;
+  }
+  const catalog = buildDocumentCatalog(documentKind);
+  catalogCache.set(documentKind, catalog);
+  return catalog;
+};
+
+export const getDocumentBindingFields = (documentKind: DesignerDocumentKind): DocumentBindingField[] =>
+  getDocumentCatalog(documentKind).fields;
+
+export const getDocumentItemFields = (documentKind: DesignerDocumentKind): DocumentItemField[] =>
+  ITEM_FIELDS[documentKind];
+
+/** Picker display path -> render-model path. */
+export const resolveDocumentRenderPath = (
+  documentKind: DesignerDocumentKind,
+  displayPath: string
+): string | undefined => getDocumentCatalog(documentKind).renderPathByDisplayPath.get(displayPath);
+
+/** Render-model path -> picker display path. */
+export const resolveDocumentDisplayPath = (
+  documentKind: DesignerDocumentKind,
+  renderPath: string
+): string | undefined => getDocumentCatalog(documentKind).displayPathByRenderPath.get(renderPath);
+
+/** Single-segment text-block tokens this document type recognises, e.g. `{{quote_number}}`. */
+export const getDocumentTokenPaths = (documentKind: DesignerDocumentKind): ReadonlySet<string> =>
+  getDocumentCatalog(documentKind).tokenPaths;
+
+export const buildDocumentExpressionContextRoots = (
+  documentKind: DesignerDocumentKind
+): SharedExpressionContextRoot[] => getDocumentCatalog(documentKind).contextRoots;
+
+export const buildDocumentExpressionPathOptions = (params: {
+  mode?: ExpressionMode;
+  includeRootPaths?: boolean;
+  documentKind: DesignerDocumentKind;
+}): SharedExpressionPathOption[] =>
+  buildInvoiceExpressionPathOptions({
+    mode: params.mode,
+    includeRootPaths: params.includeRootPaths,
+    contextRoots: buildDocumentExpressionContextRoots(params.documentKind),
+  });
+
+const DOCUMENT_KINDS: DesignerDocumentKind[] = ['invoice', 'quote', 'sales-order'];
+
+/**
+ * Every render path a binding key could mean, across document types. The editor canvas resolves a
+ * binding key against whichever sample model it was handed, so it tries each and takes the first
+ * that exists — `tenant.name` is `tenantClient.name` on an invoice and `tenant.name` on a quote.
+ */
+export const resolveCandidateRenderPaths = (bindingKey: string): string[] => {
+  const key = bindingKey.trim();
+  if (key.length === 0) {
+    return [];
+  }
+  const candidates = new Set<string>();
+  for (const documentKind of DOCUMENT_KINDS) {
+    const renderPath = resolveDocumentRenderPath(documentKind, key);
+    if (renderPath) {
+      candidates.add(renderPath);
+    }
+  }
+  return Array.from(candidates);
+};
+
+const FIELD_CATEGORY_BY_ROOT: Record<string, InvoiceFieldCategory> = {
+  invoice: 'Invoice',
+  customer: 'Customer',
+  quote: 'Quote',
+  quoteTotals: 'Quote Totals',
+  salesOrder: 'Sales Order',
+  client: 'Client',
+  contact: 'Contact',
+  tenant: 'Tenant',
+  item: 'Line Item',
+};
+
+// The picker already groups options under the category heading, so document-root fields do not
+// repeat it ("Quote Number", never "Quote Quote Number"). Party and line-item fields keep the
+// prefix, because "Name" or "Address" on its own is ambiguous.
+const UNPREFIXED_CATEGORIES: ReadonlySet<InvoiceFieldCategory> = new Set<InvoiceFieldCategory>([
+  'Invoice',
+  'Quote',
+  'Sales Order',
+]);
+
+const toTitleCase = (value: string): string =>
+  value
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+
+const applyCategoryPrefix = (category: InvoiceFieldCategory, fieldLabel: string): string => {
+  if (UNPREFIXED_CATEGORIES.has(category)) {
+    return fieldLabel;
+  }
+  const prefix = category === 'Line Item' ? 'Item' : category;
+  return fieldLabel.toLowerCase().startsWith(`${prefix.toLowerCase()} `)
+    ? fieldLabel
+    : `${prefix} ${fieldLabel}`;
+};
+
+export type DocumentFieldOptionDescription = {
+  category: InvoiceFieldCategory;
+  label: string;
+  description: string;
+};
+
+/** Curated field-catalog labels first, generated labels second — the Fields panel's label layer. */
+export const describeBindingOption = (
+  option: SharedExpressionPathOption
+): DocumentFieldOptionDescription | null => {
+  const curated = getTemplateFieldDefinition(option.path);
+  if (curated) {
+    return { category: curated.category, label: curated.label, description: curated.description };
+  }
+
+  const category = FIELD_CATEGORY_BY_ROOT[option.root];
+  if (!category) {
+    return null;
+  }
+  const segments = option.path.split('.');
+  if (segments.length < 2 || !option.isLeaf) {
+    return null;
+  }
+  const fieldName = segments[segments.length - 1]?.replace(/\[\]/g, '') ?? option.path;
+  return {
+    category,
+    label: applyCategoryPrefix(category, toTitleCase(fieldName)),
+    description: option.description ?? option.path,
+  };
+};
+
+let labelCache: Map<string, string> | null = null;
+
+const generatedLabelByPath = (): Map<string, string> => {
+  if (labelCache) {
+    return labelCache;
+  }
+  labelCache = new Map<string, string>();
+  for (const documentKind of DOCUMENT_KINDS) {
+    for (const field of getDocumentBindingFields(documentKind)) {
+      if (labelCache.has(field.path)) continue;
+      const category = FIELD_CATEGORY_BY_ROOT[field.path.split('.')[0] ?? ''];
+      if (!category) continue;
+      const leaf = field.path.split('.').slice(-1)[0] ?? field.path;
+      labelCache.set(field.path, applyCategoryPrefix(category, toTitleCase(leaf)));
+    }
+  }
+  return labelCache;
+};
+
+/** True when the binding key is one the field picker offers for some document type. */
+export const isDocumentFieldPath = (bindingKey: string): boolean => {
+  const normalized = bindingKey.trim();
+  return normalized.length > 0 &&
+    (Boolean(getTemplateFieldDefinition(normalized)) || generatedLabelByPath().has(normalized));
+};
+
+/** Human label for a stored binding key, e.g. `quote.quoteNumber` -> "Quote Number". */
+export const resolveDocumentFieldLabel = (bindingKey: string): string => {
+  const normalized = bindingKey.trim();
+  if (!normalized) {
+    return 'Unbound';
+  }
+  return (
+    getTemplateFieldDefinition(normalized)?.label ??
+    generatedLabelByPath().get(normalized) ??
+    humanizeBindingToken(normalized)
+  );
+};

--- a/packages/billing/src/components/invoice-designer/fields/fieldCatalog.ts
+++ b/packages/billing/src/components/invoice-designer/fields/fieldCatalog.ts
@@ -7,6 +7,7 @@ export type InvoiceFieldCategory =
   | 'Line Item'
   | 'Quote'
   | 'Quote Totals'
+  | 'Sales Order'
   | 'Client'
   | 'Contact';
 
@@ -63,12 +64,6 @@ const FIELD_DEFINITIONS: Record<string, TemplateFieldDefinition> = {
     label: 'Tax',
     category: 'Invoice',
     description: 'The tax amount for the invoice.',
-  },
-  'invoice.discount': {
-    path: 'invoice.discount',
-    label: 'Discount',
-    category: 'Invoice',
-    description: 'The invoice discount amount.',
   },
   'invoice.total': {
     path: 'invoice.total',
@@ -191,14 +186,6 @@ export const humanizeBindingToken = (input: string): string =>
 export const getTemplateFieldDefinition = (bindingKey: string): TemplateFieldDefinition | null => {
   const normalized = bindingKey.trim();
   return FIELD_DEFINITIONS[normalized] ?? null;
-};
-
-export const resolveTemplateFieldLabel = (bindingKey: string): string => {
-  const normalized = bindingKey.trim();
-  if (!normalized) {
-    return 'Unbound';
-  }
-  return getTemplateFieldDefinition(normalized)?.label ?? humanizeBindingToken(normalized);
 };
 
 export const getTemplateFieldDisplayFormats = (bindingKey: string): TemplateFieldDisplayFormat[] =>

--- a/packages/billing/src/components/invoice-designer/inspector/DesignerSchemaInspector.tsx
+++ b/packages/billing/src/components/invoice-designer/inspector/DesignerSchemaInspector.tsx
@@ -4,10 +4,7 @@ import { Input } from '@alga-psa/ui/components/Input';
 import ColorPicker from '@alga-psa/ui/components/ColorPicker';
 import CustomSelect from '@alga-psa/ui/components/CustomSelect';
 import { Tooltip } from '@alga-psa/ui/components/Tooltip';
-import {
-  buildInvoiceExpressionPathOptions,
-  type SharedExpressionPathOption,
-} from '@alga-psa/workflows/expression-authoring';
+import { type SharedExpressionPathOption } from '@alga-psa/workflows/expression-authoring';
 import { getComponentSchema } from '../schema/componentSchema';
 import type { DesignerNode } from '../state/designerStore';
 import { useInvoiceDesignerStore } from '../state/designerStore';
@@ -18,13 +15,14 @@ import type {
 } from '../schema/inspectorSchema';
 import { TableEditorWidget } from './widgets/TableEditorWidget';
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
-import {
-  getTemplateFieldDefinition,
-  humanizeBindingToken,
-  resolveTemplateFieldLabel,
-  type InvoiceFieldCategory,
-} from '../fields/fieldCatalog';
+import { type InvoiceFieldCategory } from '../fields/fieldCatalog';
 import { resolveDesignerDocumentKind } from '../utils/documentKind';
+import {
+  buildDocumentExpressionPathOptions,
+  describeBindingOption,
+  isDocumentFieldPath,
+  resolveDocumentFieldLabel,
+} from '../fields/documentBindingCatalog';
 import {
   normalizeCssColor,
   normalizeCssLength,
@@ -95,50 +93,13 @@ type BindingOption = {
   searchText: string;
 };
 
-const categoryLabelByRoot: Record<string, InvoiceFieldCategory> = {
-  invoice: 'Invoice',
-  customer: 'Customer',
-  quote: 'Quote',
-  quoteTotals: 'Quote Totals',
-  client: 'Client',
-  contact: 'Contact',
-  tenant: 'Tenant',
-  item: 'Line Item',
-};
-
-const toTitleCase = (value: string) =>
-  value
-    .replace(/([a-z])([A-Z])/g, '$1 $2')
-    .replace(/[_-]+/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim()
-    .replace(/\b\w/g, (char) => char.toUpperCase());
-
 const toBindingOption = (option: SharedExpressionPathOption): BindingOption | null => {
-  const knownField = getTemplateFieldDefinition(option.path);
-  if (knownField) {
-    return {
-      path: knownField.path,
-      label: knownField.label,
-      category: knownField.category,
-      description: knownField.description,
-      searchText: `${knownField.label} ${knownField.path} ${knownField.description} ${knownField.category}`.toLowerCase(),
-    };
-  }
-  const category = categoryLabelByRoot[option.root];
-  if (!category) return null;
-  const pathSegments = option.path.split('.');
-  if (pathSegments.length < 2 || !option.isLeaf) return null;
-  const fieldName = pathSegments[pathSegments.length - 1]?.replace(/\[\]/g, '') ?? option.path;
-  const categoryPrefix = category === 'Line Item' ? 'Item' : category;
-  const label = category === 'Invoice' ? toTitleCase(fieldName) : `${categoryPrefix} ${toTitleCase(fieldName)}`;
-  const description = option.description ?? option.path;
+  const described = describeBindingOption(option);
+  if (!described) return null;
   return {
     path: option.path,
-    label,
-    category,
-    description,
-    searchText: `${label} ${option.path} ${description} ${category}`.toLowerCase(),
+    ...described,
+    searchText: `${described.label} ${option.path} ${described.description} ${described.category}`.toLowerCase(),
   };
 };
 
@@ -162,10 +123,10 @@ const FieldBindingPicker: React.FC<FieldBindingPickerProps> = ({
   const nodes = useInvoiceDesignerStore((state) => state.nodes);
   const documentKind = useMemo(() => resolveDesignerDocumentKind(nodes), [nodes]);
   const normalizedBinding = value.trim();
-  const selectedDefinition = getTemplateFieldDefinition(normalizedBinding);
+
   const currentNode = useInvoiceDesignerStore((state) => state.nodesById[nodeId] as DesignerNode | undefined);
   const [query, setQuery] = useState('');
-  const [customMode, setCustomMode] = useState(() => normalizedBinding.length > 0 && !selectedDefinition);
+  const [customMode, setCustomMode] = useState(() => normalizedBinding.length > 0 && !isDocumentFieldPath(normalizedBinding));
   const currentPlaceholder = useMemo(() => {
     if (!currentNode || !isPlainObject(currentNode.props)) {
       return '';
@@ -173,16 +134,16 @@ const FieldBindingPicker: React.FC<FieldBindingPickerProps> = ({
     const metadata = isPlainObject(currentNode.props.metadata) ? currentNode.props.metadata : null;
     return typeof metadata?.placeholder === 'string' ? metadata.placeholder.trim() : '';
   }, [currentNode]);
-  const autoPlaceholderLabel = useMemo(() => resolveTemplateFieldLabel(normalizedBinding), [normalizedBinding]);
+  const autoPlaceholderLabel = useMemo(() => resolveDocumentFieldLabel(normalizedBinding), [normalizedBinding]);
 
   React.useEffect(() => {
-    setCustomMode(normalizedBinding.length > 0 && !getTemplateFieldDefinition(normalizedBinding));
+    setCustomMode(normalizedBinding.length > 0 && !isDocumentFieldPath(normalizedBinding));
     setQuery('');
   }, [nodeId, normalizedBinding]);
 
   const options = useMemo(() => {
     const seen = new Set<string>();
-    return buildInvoiceExpressionPathOptions({
+    return buildDocumentExpressionPathOptions({
       mode: 'template',
       includeRootPaths: false,
       documentKind,
@@ -224,8 +185,7 @@ const FieldBindingPicker: React.FC<FieldBindingPickerProps> = ({
     [filteredOptions]
   );
 
-  const currentLabel =
-    selectedDefinition?.label ?? (normalizedBinding ? humanizeBindingToken(normalizedBinding) : 'No field selected');
+  const currentLabel = normalizedBinding ? resolveDocumentFieldLabel(normalizedBinding) : 'No field selected';
 
   if (customMode) {
     return (

--- a/packages/billing/src/components/invoice-designer/palette/ComponentPalette.tsx
+++ b/packages/billing/src/components/invoice-designer/palette/ComponentPalette.tsx
@@ -1,10 +1,7 @@
 /* eslint-disable custom-rules/no-feature-to-feature-imports -- Invoice designer palette uses shared expression-authoring utilities to enumerate available template fields */
 import React, { useMemo, useState } from 'react';
 import { useDraggable } from '@dnd-kit/core';
-import {
-  buildInvoiceExpressionPathOptions,
-  type SharedExpressionPathOption,
-} from '@alga-psa/workflows/expression-authoring';
+import { type SharedExpressionPathOption } from '@alga-psa/workflows/expression-authoring';
 import { COMPONENT_CATALOG, ComponentDefinition } from '../constants/componentCatalog';
 import { LAYOUT_PRESETS } from '../constants/presets';
 import { OutlineView } from './OutlineView';
@@ -12,7 +9,8 @@ import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import clsx from 'clsx';
 import { useInvoiceDesignerStore } from '../state/designerStore';
 import { resolveDesignerDocumentKind } from '../utils/documentKind';
-import { getTemplateFieldDefinition, type InvoiceFieldCategory } from '../fields/fieldCatalog';
+import { type InvoiceFieldCategory } from '../fields/fieldCatalog';
+import { buildDocumentExpressionPathOptions, describeBindingOption } from '../fields/documentBindingCatalog';
 
 interface PaletteProps {
   onSearch?: (query: string) => void;
@@ -40,48 +38,10 @@ type TemplateVariableOption = {
   description: string;
 };
 
-const categoryLabelByRoot: Record<string, InvoiceFieldCategory> = {
-  invoice: 'Invoice',
-  customer: 'Customer',
-  quote: 'Quote',
-  quoteTotals: 'Quote Totals',
-  client: 'Client',
-  contact: 'Contact',
-  tenant: 'Tenant',
-  item: 'Line Item',
-};
-
-const toTitleCase = (value: string) =>
-  value
-    .replace(/([a-z])([A-Z])/g, '$1 $2')
-    .replace(/[_-]+/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim()
-    .replace(/\b\w/g, (char) => char.toUpperCase());
-
 const toTemplateVariableOption = (option: SharedExpressionPathOption): TemplateVariableOption | null => {
-  const knownField = getTemplateFieldDefinition(option.path);
-  if (knownField) {
-    return {
-      path: knownField.path,
-      label: knownField.label,
-      category: knownField.category,
-      description: knownField.description,
-    };
-  }
-  const category = categoryLabelByRoot[option.root];
-  if (!category) return null;
-  const pathSegments = option.path.split('.');
-  if (pathSegments.length < 2 || !option.isLeaf) return null;
-  const fieldName = pathSegments[pathSegments.length - 1]?.replace(/\[\]/g, '') ?? option.path;
-  const categoryPrefix = category === 'Line Item' ? 'Item' : category;
-  const fieldLabel = toTitleCase(fieldName);
-  return {
-    path: option.path,
-    label: category === 'Invoice' ? fieldLabel : `${categoryPrefix} ${fieldLabel}`,
-    category,
-    description: option.description ?? option.path,
-  };
+  const described = describeBindingOption(option);
+  if (!described) return null;
+  return { path: option.path, ...described };
 };
 
 const groupTemplateVariablesByCategory = (variables: TemplateVariableOption[]) =>
@@ -249,7 +209,7 @@ export const ComponentPalette: React.FC<PaletteProps> = ({
   }, [normalizedQuery]);
 
   const templateVariableGroups = useMemo(() => {
-    const pathOptions = buildInvoiceExpressionPathOptions({
+    const pathOptions = buildDocumentExpressionPathOptions({
       mode: 'template',
       includeRootPaths: false,
       documentKind,

--- a/packages/billing/src/components/invoice-designer/preview/previewBindings.test.ts
+++ b/packages/billing/src/components/invoice-designer/preview/previewBindings.test.ts
@@ -85,7 +85,9 @@ describe('previewBindings', () => {
     expect(labelValue.text).toBe('Jan 1, 2026 - Feb 1, 2026');
   });
 
-  it('derives invoice.discount from subtotal + tax - total', () => {
+  // The persisted subtotal is already net of discount lines, so the old derived value was
+  // structurally always zero. Real discount exposure is tracked separately (alga0002295).
+  it('no longer exposes a derived invoice.discount value', () => {
     const value = resolveFieldPreviewValue({
       invoice: {
         ...previewInvoice,
@@ -97,7 +99,7 @@ describe('previewBindings', () => {
       format: 'currency',
     });
 
-    expect(value.text).toBe('$2.00');
+    expect(value.text).toBeNull();
   });
 
   it('returns null recurring service period header bindings when canonical summary is missing', () => {

--- a/packages/billing/src/components/invoice-designer/preview/previewBindings.test.ts
+++ b/packages/billing/src/components/invoice-designer/preview/previewBindings.test.ts
@@ -85,6 +85,27 @@ describe('previewBindings', () => {
     expect(labelValue.text).toBe('Jan 1, 2026 - Feb 1, 2026');
   });
 
+  // The editor canvas is handed a quote render model but the designer speaks picker paths, so a
+  // quote binding key has to resolve through the quote catalog's snake_case path.
+  it('resolves quote picker paths against a quote render model', () => {
+    const quoteModel = {
+      quote_number: 'QT-2026-0042',
+      total_amount: 94830,
+      currencyCode: 'USD',
+      tenant: { name: 'Northwind MSP', address: '400 SW Main St' },
+    } as unknown as WasmInvoiceViewModel;
+
+    expect(
+      resolveFieldPreviewValue({ invoice: quoteModel, bindingKey: 'quote.quoteNumber', format: 'text' }).text
+    ).toBe('QT-2026-0042');
+    expect(
+      resolveFieldPreviewValue({ invoice: quoteModel, bindingKey: 'quote.total', format: 'currency' }).text
+    ).toBe('$948.30');
+    expect(
+      resolveFieldPreviewValue({ invoice: quoteModel, bindingKey: 'tenant.name', format: 'text' }).text
+    ).toBe('Northwind MSP');
+  });
+
   // The persisted subtotal is already net of discount lines, so the old derived value was
   // structurally always zero. Real discount exposure is tracked separately (alga0002295).
   it('no longer exposes a derived invoice.discount value', () => {

--- a/packages/billing/src/components/invoice-designer/preview/previewBindings.ts
+++ b/packages/billing/src/components/invoice-designer/preview/previewBindings.ts
@@ -4,6 +4,7 @@ import {
   normalizeFieldFormat as normalizeTemplateFieldFormat,
 } from '../../../lib/invoice-template-ast/fieldFormatting';
 import { resolveInvoiceTemplateBindingAlias } from '../../../lib/invoice-template-ast/bindingAliases';
+import { resolveCandidateRenderPaths } from '../fields/documentBindingCatalog';
 
 const asTrimmedString = (value: unknown): string => (typeof value === 'string' ? value.trim() : '');
 
@@ -11,7 +12,6 @@ const isNullish = (value: unknown): value is null | undefined => value === null 
 const supportsAddressDisplayFormat = (bindingKey: string): boolean => asTrimmedString(bindingKey).endsWith('.address');
 
 const flattenInvoiceBindingMap = (invoice: WasmInvoiceViewModel): Record<string, unknown> => ({
-  'invoice.discount': Math.max(0, (invoice.subtotal ?? 0) + (invoice.tax ?? 0) - (invoice.total ?? 0)),
   'invoice.number': invoice.invoiceNumber,
   'invoice.invoiceNumber': invoice.invoiceNumber,
   'invoice.issueDate': invoice.issueDate,
@@ -29,6 +29,17 @@ const flattenInvoiceBindingMap = (invoice: WasmInvoiceViewModel): Record<string,
   'tenant.name': invoice.tenantClient?.name,
   'tenant.address': invoice.tenantClient?.address,
 });
+
+const getModelPathValue = (model: unknown, path: string): unknown => {
+  let cursor: unknown = model;
+  for (const segment of path.split('.').filter(Boolean)) {
+    if (isNullish(cursor) || typeof cursor !== 'object') {
+      return undefined;
+    }
+    cursor = (cursor as Record<string, unknown>)[segment];
+  }
+  return cursor;
+};
 
 export const resolveInvoiceBindingRawValue = (
   invoice: WasmInvoiceViewModel | null,
@@ -56,16 +67,15 @@ export const resolveInvoiceBindingRawValue = (
     }
   }
 
-  // Last-chance resolver for direct dotted paths in the model shape.
-  const pathSegments = aliasedKey.split('.').filter(Boolean);
-  let cursor: unknown = invoice;
-  for (const segment of pathSegments) {
-    if (isNullish(cursor) || typeof cursor !== 'object') {
-      return null;
+  // Last-chance resolver: the key as written, then each document type's render path for it —
+  // the canvas is handed whichever sample model the editor is previewing.
+  for (const candidate of [aliasedKey, ...resolveCandidateRenderPaths(normalizedKey)]) {
+    const resolved = getModelPathValue(invoice, candidate);
+    if (!isNullish(resolved)) {
+      return resolved;
     }
-    cursor = (cursor as Record<string, unknown>)[segment];
   }
-  return cursor;
+  return null;
 };
 
 export const normalizeFieldFormat = normalizeTemplateFieldFormat;

--- a/packages/billing/src/components/invoice-designer/utils/documentKind.ts
+++ b/packages/billing/src/components/invoice-designer/utils/documentKind.ts
@@ -51,25 +51,24 @@ const hasQuoteBindingCatalog = (bindings: unknown): boolean => {
   return hasQuoteSpecificValueBinding || hasQuoteSpecificCollectionBinding;
 };
 
-export const resolveDesignerDocumentKind = (nodes: DesignerNode[]): DesignerDocumentKind => {
-  const documentNode =
-    nodes.find((node) => node.type === 'document' && node.parentId === null) ??
-    nodes.find((node) => node.type === 'document');
-  if (!documentNode) {
-    return 'invoice';
-  }
-
-  const metadata = getNodeMetadata(documentNode) as Record<string, unknown>;
+/**
+ * Classifies a template from its binding catalog — usable from both the designer store (via
+ * `resolveDesignerDocumentKind`) and the AST import/export, which only has the raw AST.
+ * Packing slips and pick lists reuse the sales-order catalog, so they classify as 'sales-order'.
+ */
+export const resolveDocumentKindFromBindingCatalog = (
+  bindings: unknown,
+  templateMetadata?: unknown
+): DesignerDocumentKind => {
   // Sales order is checked before quote — both expose tenant/customer bindings, so the
   // sales-order-specific bindings must win.
-  if (hasSalesOrderBindingCatalog(metadata.__astBindingCatalog)) {
+  if (hasSalesOrderBindingCatalog(bindings)) {
     return 'sales-order';
   }
-  if (hasQuoteBindingCatalog(metadata.__astBindingCatalog)) {
+  if (hasQuoteBindingCatalog(bindings)) {
     return 'quote';
   }
 
-  const templateMetadata = metadata.__astTemplateMetadata;
   if (templateMetadata && typeof templateMetadata === 'object') {
     const templateName = String((templateMetadata as { templateName?: unknown }).templateName ?? '').toLowerCase();
     if (templateName.includes('sales order') || templateName.includes('order confirmation')) {
@@ -81,4 +80,16 @@ export const resolveDesignerDocumentKind = (nodes: DesignerNode[]): DesignerDocu
   }
 
   return 'invoice';
+};
+
+export const resolveDesignerDocumentKind = (nodes: DesignerNode[]): DesignerDocumentKind => {
+  const documentNode =
+    nodes.find((node) => node.type === 'document' && node.parentId === null) ??
+    nodes.find((node) => node.type === 'document');
+  if (!documentNode) {
+    return 'invoice';
+  }
+
+  const metadata = getNodeMetadata(documentNode) as Record<string, unknown>;
+  return resolveDocumentKindFromBindingCatalog(metadata.__astBindingCatalog, metadata.__astTemplateMetadata);
 };

--- a/packages/billing/src/lib/invoice-template-ast/standardTemplates.ts
+++ b/packages/billing/src/lib/invoice-template-ast/standardTemplates.ts
@@ -4,7 +4,8 @@ import { DEFAULT_INVOICE_PRINT_SETTINGS, TEMPLATE_AST_VERSION } from '@alga-psa/
 const cloneAst = (ast: TemplateAst): TemplateAst =>
   JSON.parse(JSON.stringify(ast)) as TemplateAst;
 
-const buildSharedBindings = (): NonNullable<TemplateAst['bindings']> => ({
+/** The invoice document's binding catalog — also what the designer's field picker generates from. */
+export const buildInvoiceTemplateBindings = (): NonNullable<TemplateAst['bindings']> => ({
   values: {
     invoiceNumber: { id: 'invoiceNumber', kind: 'value', path: 'invoiceNumber' },
     issueDate: { id: 'issueDate', kind: 'value', path: 'issueDate' },
@@ -67,7 +68,7 @@ const buildStandardDefaultAst = (templateName: string): TemplateAst => ({
     templateName,
     printSettings: DEFAULT_INVOICE_PRINT_SETTINGS,
   },
-  bindings: buildSharedBindings(),
+  bindings: buildInvoiceTemplateBindings(),
   layout: {
     id: 'root',
     type: 'document',
@@ -156,7 +157,7 @@ const buildStandardDetailedAst = (): TemplateAst => ({
     templateName: 'Detailed Template',
     printSettings: DEFAULT_INVOICE_PRINT_SETTINGS,
   },
-  bindings: buildSharedBindings(),
+  bindings: buildInvoiceTemplateBindings(),
   layout: {
     id: 'root',
     type: 'document',
@@ -498,7 +499,7 @@ const buildStandardGroupedAst = (): TemplateAst => ({
     templateName: 'Grouped Template',
     printSettings: DEFAULT_INVOICE_PRINT_SETTINGS,
   },
-  bindings: buildSharedBindings(),
+  bindings: buildInvoiceTemplateBindings(),
   layout: {
     id: 'root',
     type: 'document',
@@ -672,7 +673,7 @@ const buildStandardByLocationAst = (): TemplateAst => ({
     templateName: 'Standard Invoice By Location',
     printSettings: DEFAULT_INVOICE_PRINT_SETTINGS,
   },
-  bindings: buildSharedBindings(),
+  bindings: buildInvoiceTemplateBindings(),
   layout: {
     id: 'root',
     type: 'document',

--- a/server/src/test/unit/docs/servicePeriodFirstBillingPlan.contract.test.ts
+++ b/server/src/test/unit/docs/servicePeriodFirstBillingPlan.contract.test.ts
@@ -183,6 +183,12 @@ const servicePeriodPostInventoryRefs = new Set([
   'packages/billing/src/components/billing-dashboard/AutomaticInvoices.tsx',
   'packages/billing/src/components/invoice-designer/inspector/TableEditorWidget.integration.test.tsx',
   'packages/billing/src/components/invoice-designer/inspector/widgets/TableEditorWidget.tsx',
+  // The designer field picker now generates its per-document-kind options from
+  // the binding catalogs, so the invoice line-item options — including the
+  // persisted service-period boundaries — are declared here; it landed after
+  // the pass-0 snapshot.
+  'packages/billing/src/components/invoice-designer/fields/documentBindingCatalog.ts',
+  'packages/billing/src/components/invoice-designer/fields/documentBindingCatalog.test.ts',
   'shared/billingClients/bucketUsageService.ts',
   'packages/billing/tests/accounting/accountingExportInvoiceSelector.preview.test.ts',
   'packages/billing/tests/accounting/accountingExportValidation.rules.test.ts',

--- a/shared/workflow/expression-authoring/adapters/invoiceContextAdapter.ts
+++ b/shared/workflow/expression-authoring/adapters/invoiceContextAdapter.ts
@@ -23,7 +23,6 @@ const createInvoiceRootSchema = (): SharedExpressionSchemaNode => ({
     poNumber: { type: 'string', description: 'Purchase order number.' },
     subtotal: { type: 'number', description: 'Subtotal before tax and discounts.' },
     tax: { type: 'number', description: 'Tax amount.' },
-    discount: { type: 'number', description: 'Discount amount.' },
     total: { type: 'number', description: 'Final invoice total.' },
     currencyCode: { type: 'string', description: 'Invoice currency code.' },
   },
@@ -51,171 +50,17 @@ const createItemSchema = (): SharedExpressionSchemaNode => ({
   },
 });
 
-const createQuoteRootSchema = (): SharedExpressionSchemaNode => ({
-  type: 'object',
-  properties: {
-    quoteNumber: { type: 'string', description: 'Primary quote identifier.' },
-    quoteDate: { type: 'string', description: 'Date the quote was issued.' },
-    validUntil: { type: 'string', description: 'Quote expiration date.' },
-    status: { type: 'string', description: 'Current quote status.' },
-    title: { type: 'string', description: 'Quote title.' },
-    scope: { type: 'string', description: 'Scope of work.' },
-    poNumber: { type: 'string', description: 'Purchase order number.' },
-    subtotal: { type: 'number', description: 'Quote subtotal before tax.' },
-    discountTotal: { type: 'number', description: 'Discount amount.' },
-    tax: { type: 'number', description: 'Quote tax amount.' },
-    total: { type: 'number', description: 'Final quote total.' },
-    termsAndConditions: { type: 'string', description: 'Terms and conditions.' },
-    clientNotes: { type: 'string', description: 'Client-facing notes.' },
-    version: { type: 'number', description: 'Quote revision number.' },
-    acceptedByName: { type: 'string', description: 'Name of the accepting contact or user.' },
-    acceptedAt: { type: 'string', description: 'Acceptance timestamp.' },
-  },
-  required: ['quoteNumber', 'title', 'total'],
-});
-
-const createQuoteTotalsSchema = (): SharedExpressionSchemaNode => ({
-  type: 'object',
-  properties: {
-    recurringSubtotal: { type: 'number', description: 'Subtotal for recurring line items.' },
-    recurringTax: { type: 'number', description: 'Tax for recurring line items.' },
-    recurringTotal: { type: 'number', description: 'Total for recurring line items.' },
-    onetimeSubtotal: { type: 'number', description: 'Subtotal for one-time line items.' },
-    onetimeTax: { type: 'number', description: 'Tax for one-time line items.' },
-    onetimeTotal: { type: 'number', description: 'Total for one-time line items.' },
-    serviceSubtotal: { type: 'number', description: 'Subtotal for service line items.' },
-    serviceTax: { type: 'number', description: 'Tax for service line items.' },
-    serviceTotal: { type: 'number', description: 'Total for service line items.' },
-    productSubtotal: { type: 'number', description: 'Subtotal for product line items.' },
-    productTax: { type: 'number', description: 'Tax for product line items.' },
-    productTotal: { type: 'number', description: 'Total for product line items.' },
-  },
-});
-
-const createQuoteItemSchema = (): SharedExpressionSchemaNode => ({
-  type: 'object',
-  properties: {
-    description: { type: 'string', description: 'Quote line item description.' },
-    quantity: { type: 'number', description: 'Quote line item quantity.' },
-    unitPrice: { type: 'number', description: 'Quote line item unit price.' },
-    total: { type: 'number', description: 'Quote line item total.' },
-    billingFrequency: { type: 'string', description: 'Recurring billing frequency.' },
-    recurring: { type: 'boolean', description: 'Whether the line item is recurring.' },
-    serviceKind: { type: 'string', description: 'Whether the line item is a service or product.' },
-  },
-});
-
-const createSalesOrderRootSchema = (): SharedExpressionSchemaNode => ({
-  type: 'object',
-  properties: {
-    orderNumber: { type: 'string', description: 'Primary sales order identifier.' },
-    orderDate: { type: 'string', description: 'Date the order was placed.' },
-    expectedShipDate: { type: 'string', description: 'Expected ship date.' },
-    status: { type: 'string', description: 'Current sales order status.' },
-    poNumber: { type: 'string', description: "Customer's purchase order number." },
-    currencyCode: { type: 'string', description: 'Order currency code.' },
-    notes: { type: 'string', description: 'Order notes.' },
-    subtotal: { type: 'number', description: 'Order subtotal before tax.' },
-    tax: { type: 'number', description: 'Order tax amount.' },
-    total: { type: 'number', description: 'Order total.' },
-  },
-  required: ['orderNumber', 'total'],
-});
-
-const createSalesOrderItemSchema = (): SharedExpressionSchemaNode => ({
-  type: 'object',
-  properties: {
-    description: { type: 'string', description: 'Line description (product name).' },
-    service_name: { type: 'string', description: 'Product / service name.' },
-    service_sku: { type: 'string', description: 'Product SKU.' },
-    quantity_ordered: { type: 'number', description: 'Quantity ordered.' },
-    quantity_fulfilled: { type: 'number', description: 'Quantity fulfilled so far.' },
-    unit_price: { type: 'number', description: 'Unit price.' },
-    amount: { type: 'number', description: 'Line amount (qty × unit price).' },
-  },
-});
-
+/**
+ * The invoice roots below are the default menu. Document types whose fields live in a binding
+ * catalog (quote, sales order, and the packing slip / pick list that reuse it) inject generated
+ * roots through `contextRoots` — those catalogs live in packages/billing, and the dependency only
+ * ever runs billing -> shared.
+ */
 export const buildInvoiceExpressionContextRoots = (params: {
-  documentKind?: 'invoice' | 'quote' | 'sales-order';
+  contextRoots?: SharedExpressionContextRoot[];
 } = {}): SharedExpressionContextRoot[] => {
-  if (params.documentKind === 'sales-order') {
-    return [
-      {
-        key: 'salesOrder',
-        label: 'Sales Order',
-        description: 'Sales order-level fields',
-        schema: createSalesOrderRootSchema(),
-        allowInModes: ['path-only', 'template'],
-      },
-      {
-        key: 'customer',
-        label: 'Customer',
-        description: 'Customer fields',
-        schema: createPartySchema('Customer'),
-        allowInModes: ['path-only', 'template'],
-      },
-      {
-        key: 'tenant',
-        label: 'Tenant',
-        description: 'Tenant fields',
-        schema: createPartySchema('Tenant'),
-        allowInModes: ['path-only', 'template'],
-      },
-      {
-        key: 'item',
-        label: 'Line Item',
-        description: 'Sales order line item fields for repeating/table contexts',
-        schema: createSalesOrderItemSchema(),
-        allowInModes: ['path-only', 'template'],
-      },
-    ];
-  }
-
-  if (params.documentKind === 'quote') {
-    return [
-      {
-        key: 'quote',
-        label: 'Quote',
-        description: 'Quote-level fields',
-        schema: createQuoteRootSchema(),
-        allowInModes: ['path-only', 'template'],
-      },
-      {
-        key: 'quoteTotals',
-        label: 'Quote Totals',
-        description: 'Recurring, one-time, service, and product totals.',
-        schema: createQuoteTotalsSchema(),
-        allowInModes: ['path-only', 'template'],
-      },
-      {
-        key: 'client',
-        label: 'Client',
-        description: 'Client fields',
-        schema: createPartySchema('Client'),
-        allowInModes: ['path-only', 'template'],
-      },
-      {
-        key: 'contact',
-        label: 'Contact',
-        description: 'Contact fields',
-        schema: createPartySchema('Contact'),
-        allowInModes: ['path-only', 'template'],
-      },
-      {
-        key: 'tenant',
-        label: 'Tenant',
-        description: 'Tenant fields',
-        schema: createPartySchema('Tenant'),
-        allowInModes: ['path-only', 'template'],
-      },
-      {
-        key: 'item',
-        label: 'Line Item',
-        description: 'Quote line item fields for repeating/table contexts',
-        schema: createQuoteItemSchema(),
-        allowInModes: ['path-only', 'template'],
-      },
-    ];
+  if (params.contextRoots && params.contextRoots.length > 0) {
+    return params.contextRoots;
   }
 
   return [
@@ -253,9 +98,9 @@ export const buildInvoiceExpressionContextRoots = (params: {
 export const buildInvoiceExpressionPathOptions = (params: {
   mode?: ExpressionMode;
   includeRootPaths?: boolean;
-  documentKind?: 'invoice' | 'quote' | 'sales-order';
+  contextRoots?: SharedExpressionContextRoot[];
 } = {}): SharedExpressionPathOption[] =>
   buildPathOptionsFromContextRoots(
-    buildInvoiceExpressionContextRoots({ documentKind: params.documentKind }),
+    buildInvoiceExpressionContextRoots({ contextRoots: params.contextRoots }),
     params
   );


### PR DESCRIPTION
## Summary

The invoice/quote/sales-order template designer's field picker offered binding paths that didn't match what the underlying render model actually exposes for each document kind. Selecting a field like `quote.subtotal` or a sales-order field could bind to a path the AST importer/exporter and canvas preview couldn't resolve, silently breaking the rendered output. This change introduces a single source of truth — a per-document-kind binding catalog — that generates the picker's options, the AST import/export path normalization, and the canvas preview's data lookup, so all three can no longer drift apart. It also removes the `invoice.discount` field, which was never backed by a real render-model value.

## Changes

- **New binding catalog** (`fields/documentBindingCatalog.ts`): derives the designer's field-picker options, display labels, and display-path ↔ render-path mapping per document kind (invoice, quote, sales-order) from the same value bindings used to build each template's AST (`buildInvoiceTemplateBindings`, `QUOTE_TEMPLATE_VALUE_BINDINGS`, `SALES_ORDER_TEMPLATE_VALUE_BINDINGS`), instead of hand-maintained alias tables.
- **`utils/documentKind.ts`**: extracted `resolveDocumentKindFromBindingCatalog` so document-kind classification works from a raw binding catalog (used by AST import) as well as from the live designer node tree.
- **`ast/workspaceAst.ts`**: binding-path normalization (`normalizeInvoiceBindingPath`) and template-token detection (`isLikelyBindingTokenPath`) are now driven by the new catalog per resolved document kind, replacing static alias/allow-list maps that only covered invoice/quote paths.
- **`preview/previewBindings.ts`**: canvas preview lookup now falls back through each document kind's candidate render paths (`resolveCandidateRenderPaths`) instead of a single last-chance dotted-path walk, and drops the synthetic `invoice.discount` computed field.
- **`palette/ComponentPalette.tsx` / `inspector/DesignerSchemaInspector.tsx` / `DesignerShell.tsx`**: switched from the ad-hoc `categoryLabelByRoot`/title-casing logic and `buildInvoiceExpressionPathOptions` calls to the shared `buildDocumentExpressionPathOptions` / `describeBindingOption` / `resolveDocumentFieldLabel` / `isDocumentFieldPath` helpers from the new catalog.
- **`fields/fieldCatalog.ts`**: removed the unbacked `invoice.discount` field definition and `resolveTemplateFieldLabel` (superseded by the catalog's label resolver).
- **`lib/invoice-template-ast/standardTemplates.ts`**: exported `buildInvoiceTemplateBindings` (was private `buildSharedBindings`) so the new catalog can consume it as its invoice source of truth.
- **`shared/workflow/expression-authoring/adapters/invoiceContextAdapter.ts`**: removed the hardcoded quote/sales-order schema definitions and `documentKind` branching from `buildInvoiceExpressionContextRoots`/`buildInvoiceExpressionPathOptions`; they now accept caller-supplied `contextRoots` (generated by the billing-side catalog) instead of owning quote/sales-order knowledge in the shared package, and drop the `discount` field from the invoice schema.

## Testing

- Added `ast/workspaceAst.bindingPaths.test.ts` covering binding-path normalization and round-tripping across invoice, quote, and sales-order document kinds.
- Added `fields/documentBindingCatalog.test.ts` asserting every field-picker option resolves to a path the corresponding render model actually exposes.
- Updated `preview/previewBindings.test.ts` for the new candidate-path fallback resolution and removal of `invoice.discount`.
- Ran the affected unit suites (`workspaceAst`, `documentBindingCatalog`, `previewBindings`) locally.
