### PR TITLE
fix(tests): repair the infrastructure suite and split it into its own CI job

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -162,6 +162,7 @@ jobs:
           chmod 600 secrets/*
 
       - name: Run Tier-1 integration subset
+        id: tier1
         if: github.event_name != 'schedule' && github.event.inputs.suite != 'full'
         working-directory: ./server
         run: npm run test:integration:tier1 -- --reporter=default --reporter=json --outputFile.json=./test-results-integration.json
@@ -169,37 +170,10 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=8192'
 
       - name: Run full integration suite
+        id: full
         if: github.event_name == 'schedule' || github.event.inputs.suite == 'full'
         working-directory: ./server
         run: npm run test:integration:ci -- --reporter=default --reporter=json --outputFile.json=./test-results-integration.json
-        env:
-          NODE_OPTIONS: '--max-old-space-size=8192'
-
-      # src/test/infrastructure is the original DB-backed billing-engine suite
-      # (invoice generation, tax, credits). It shares this job's Postgres rather
-      # than running a parallel workflow. Non-blocking until it has a green
-      # baseline; flip continue-on-error off once stable.
-      # `always()` lets the infra suite build its baseline even when the
-      # integration step above fails — without it a red nightly leaves the
-      # infra suite with no data at all.
-      # timeout-minutes bounds a hang: continue-on-error ignores a failure but NOT
-      # a hung process, so without this a stuck infra run would consume the whole
-      # job timeout and cancel the (passing) integration step above.
-      - name: Run Tier-1 infrastructure subset (non-blocking)
-        if: always() && github.event_name != 'schedule' && github.event.inputs.suite != 'full'
-        continue-on-error: true
-        timeout-minutes: 15
-        working-directory: ./server
-        run: npm run test:infrastructure:tier1
-        env:
-          NODE_OPTIONS: '--max-old-space-size=8192'
-
-      - name: Run full infrastructure suite (non-blocking)
-        if: always() && (github.event_name == 'schedule' || github.event.inputs.suite == 'full')
-        continue-on-error: true
-        timeout-minutes: 60
-        working-directory: ./server
-        run: npm run test:infrastructure:ci -- --reporter=default --reporter=json --outputFile.json=./test-results-infrastructure.json
         env:
           NODE_OPTIONS: '--max-old-space-size=8192'
 
@@ -207,8 +181,11 @@ jobs:
       # (docs/reference/test-metrics.md). No-op until the Google secrets exist.
       # Tier-1 rows are recorded on push to main only — PR runs would be noisy
       # and fork PRs don't get secrets anyway.
+      # Recording is gated on the suite step's *outcome* rather than always():
+      # a run the job timeout cancelled reports whatever fraction of the suite
+      # had finished, which lands in the sheet as a vacuous green.
       - name: Record Tier-1 metrics to Google Sheet
-        if: always() && github.event_name == 'push'
+        if: always() && github.event_name == 'push' && (steps.tier1.outcome == 'success' || steps.tier1.outcome == 'failure')
         continue-on-error: true
         run: node scripts/record-test-metrics.mjs
         env:
@@ -218,7 +195,7 @@ jobs:
           TEST_METRICS_SHEET_ID: ${{ vars.TEST_METRICS_SHEET_ID }}
 
       - name: Record full-suite metrics to Google Sheet
-        if: always() && (github.event_name == 'schedule' || github.event.inputs.suite == 'full')
+        if: always() && (steps.full.outcome == 'success' || steps.full.outcome == 'failure')
         continue-on-error: true
         run: node scripts/record-test-metrics.mjs
         env:
@@ -227,8 +204,127 @@ jobs:
           GOOGLE_SA_KEY: ${{ secrets.TEST_METRICS_GOOGLE_SA_KEY }}
           TEST_METRICS_SHEET_ID: ${{ vars.TEST_METRICS_SHEET_ID }}
 
+  # src/test/infrastructure is the original DB-backed billing-engine suite
+  # (invoice generation, tax, credits). It ran as two extra steps inside the
+  # integration job until the pair outgrew the 90-minute budget and the job
+  # timeout cancelled the integration suite mid-run (2026-08-21). Its own job
+  # gives each suite independent duration headroom and keeps infra's pool
+  # problems out of the integration run.
+  # Non-blocking until it has a green baseline; drop continue-on-error once
+  # stable — that is the whole point of collecting the baseline.
+  infrastructure-tests:
+    name: ${{ (github.event_name == 'schedule' || github.event.inputs.suite == 'full') && 'Full infrastructure suite' || 'Tier-1 infrastructure subset' }}
+    needs: check-changes
+    if: always() && (github.event_name == 'schedule' || needs.check-changes.outputs.should_run == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    continue-on-error: true
+
+    services:
+      postgres:
+        image: ankane/pgvector:latest
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: test_password
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DB_HOST: localhost
+      DB_PORT: '5432'
+      DB_USER_ADMIN: postgres
+      DB_PASSWORD_ADMIN: test_password
+      DB_USER_SERVER: app_user
+      DB_PASSWORD_SERVER: test_password
+      APP_ENV: test
+      NODE_ENV: test
+      REQUIRE_DB: '1'
+      VITEST_SEED: '20260610'
+      REAL_REDIS: '1'
+      REDIS_HOST: localhost
+      REDIS_PORT: '6379'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Cache Nx computation cache
+        uses: actions/cache@v4
+        with:
+          path: .nx/cache
+          key: nx-cache-${{ runner.os }}-${{ hashFiles('package-lock.json', 'nx.json', 'tsconfig.base.json', '**/project.json') }}
+          restore-keys: |
+            nx-cache-${{ runner.os }}-
+
+      - name: Upgrade npm to version 11
+        run: npm install -g npm@11
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build shared libraries
+        run: npx nx run-many -t build --projects=@alga-psa/db,@alga-psa/core,@alga-psa/shared,@alga-psa/types,@alga-psa/event-bus,@alga-psa/event-schemas,@alga-psa/validation,@alga-psa/formatting,@alga-psa/search --parallel=3
+        env:
+          NX_DAEMON: 'false'
+          NODE_OPTIONS: '--max-old-space-size=8192'
+
+      - name: Wait for Postgres to be ready
+        run: |
+          until pg_isready -h localhost -p 5432 -U postgres; do
+            echo "Waiting for postgres..."
+            sleep 2
+          done
+
+      - name: Create secrets files
+        run: |
+          mkdir -p secrets
+          echo -n "test_password" > secrets/postgres_password
+          echo -n "test_password" > secrets/db_password_server
+          chmod 600 secrets/*
+
+      # timeout-minutes bounds a hang below the job budget so the recording
+      # step still gets to run.
+      - name: Run Tier-1 infrastructure subset
+        id: tier1
+        if: github.event_name != 'schedule' && github.event.inputs.suite != 'full'
+        timeout-minutes: 15
+        working-directory: ./server
+        run: npm run test:infrastructure:tier1
+        env:
+          NODE_OPTIONS: '--max-old-space-size=8192'
+
+      - name: Run full infrastructure suite
+        id: full
+        if: github.event_name == 'schedule' || github.event.inputs.suite == 'full'
+        timeout-minutes: 35
+        working-directory: ./server
+        run: npm run test:infrastructure:ci -- --reporter=default --reporter=json --outputFile.json=./test-results-infrastructure.json
+        env:
+          NODE_OPTIONS: '--max-old-space-size=8192'
+
       - name: Record infrastructure metrics to Google Sheet
-        if: always() && (github.event_name == 'schedule' || github.event.inputs.suite == 'full')
+        if: always() && (steps.full.outcome == 'success' || steps.full.outcome == 'failure')
         continue-on-error: true
         run: node scripts/record-test-metrics.mjs
         env:

--- a/docs/reference/test-metrics.md
+++ b/docs/reference/test-metrics.md
@@ -19,8 +19,15 @@ Google credentials are not configured.
 PR runs are not recorded. They would flood the sheet, and fork PRs cannot read
 the secret anyway.
 
-Red runs still record. The metrics steps use `if: always()`, because a drop in
-pass rate is the signal the sheet exists to show.
+Red runs still record — a drop in pass rate is the signal the sheet exists to
+show. Cancelled runs do not: each recording step is gated on the suite step's
+`outcome` being `success` or `failure`, so a run the job timeout killed leaves
+no row instead of a row covering the fraction of the suite that finished.
+
+The integration and infrastructure suites run in separate jobs. They shared one
+job until 2026-08-21, when their combined runtime hit the 90-minute job timeout
+and the cancellation of the integration suite produced the fake green described
+below.
 
 ## Column schema
 
@@ -32,17 +39,55 @@ Rows land on the `metrics` tab. The script writes the header row on first use.
 | `suite` | label from the table above |
 | `branch`, `commit` | ref name and short SHA of the tested commit |
 | `passed`, `failed`, `skipped`, `todo`, `total` | test counts from the vitest JSON report |
-| `pass_pct` | `passed / (passed + failed)` × 100; skipped tests do not count against it |
+| `pass_pct` | `passed / (passed + failed)` × 100; skipped tests do not count against it. Blank on partial runs |
 | `lines_pct`, `statements_pct`, `branches_pct`, `functions_pct` | coverage totals; blank for suites that run without coverage |
 | `duration_s` | wall-clock test time |
 | `run_url` | link back to the Actions run |
+| `executed` | `passed + failed` — how many tests actually ran |
+| `run_status` | `complete` or `partial` (see below); blank when the run recorded coverage only |
+| `files_measured`, `files_total` | source files in the coverage report vs. on disk; blank without coverage |
 
-For charts, add a second tab with `=QUERY(metrics!A:P, "select A, J where B = 'unit-coverage'")`
+For charts, add a second tab with `=QUERY(metrics!A:T, "select A, J where B = 'unit-coverage'")`
 style pulls and chart those ranges. Native Sheets charts update as rows arrive.
+Columns are appended at the end as the schema grows, so existing ranges keep
+their meaning — widen the range, don't reorder.
 
 Coverage percentages are only comparable while `coverage.include` in
 `server/vitest.config.ts` stays the same; widening or narrowing it changes
 the denominator and steps the totals on that day.
+
+### Partial runs
+
+`pass_pct` over a run that never reached most of its tests is arithmetic, not
+information: on 2026-08-21 `infrastructure-full` executed 5 of its 354 tests and
+recorded **100%**. The recorder marks a run `partial` when either
+signal shows in the vitest JSON report:
+
+- an assertion left in `pending` — vitest maps a test still in `run`/`queued`
+  state there when the process is cut short, while an intentional `describe.skip`
+  maps to `skipped` and `it.todo` to `todo`;
+- fewer than half the collected tests executed (`MIN_EXECUTED_RATIO` in the
+  recorder), which is what a dead bootstrap looks like.
+
+Partial rows keep their raw counts but leave `pass_pct` blank, so no average or
+trendline silently absorbs them. Three rows predate the check and still carry a
+pass rate: 2026-08-12 and 2026-08-13 `integration-full` (377/1,587 and
+111/1,564 executed) and 2026-08-21 `infrastructure-full` (5/354).
+
+### Coverage methodology break, 2026-07-31
+
+Coverage rows before and after **2026-07-31 17:46 UTC** are not comparable, and
+nothing in the sheet marks the seam:
+
+- `experimentalAstAwareRemapping: true` (commit `67b268ca55`) moved the line
+  denominator from ~679k to ~216k, a 3.15x change with no code change behind it.
+  Jul 30–31 interleave both regimes as branches rebased through.
+- The `**/*.generated.ts` coverage exclusion (commit `0c46063429`) dropped the
+  generated MCP registry — `server/src/lib/mcp` falls 58,903 lines to 13. That
+  file had been inflating headline coverage by roughly 7 points; its removal is
+  a correction, not a regression.
+
+Any trendline crossing that date is wrong. Compare within one regime.
 
 ## Per-directory coverage
 
@@ -67,6 +112,11 @@ with two caveats:
   completely.
 - Directory percentages come from the server unit suite alone. A directory
   covered mainly by integration tests will read low here.
+
+The same two counts roll up onto the `metrics` row as `files_measured` /
+`files_total` (about 4,100 of 5,600 files at the time of writing), so the
+headline percentage cannot be read as covering the whole tree without opening
+the detail tab.
 
 ## One-time setup
 

--- a/ee/docs/plans/2026-08-22-ci-test-metrics-health/findings-p1.md
+++ b/ee/docs/plans/2026-08-22-ci-test-metrics-health/findings-p1.md
@@ -1,0 +1,147 @@
+# P1 — infrastructure-full cluster work: what was fixed and what it exposed
+
+Companion to `plan.md`. Records the root causes found while working the
+failure clusters, and the product defects the repairs uncovered (P1 says to
+raise those as their own tickets rather than paper over them).
+
+Local repro used throughout: one file at a time against a scratch database
+(`TEST_DB_NAME=test_mc8 … npx vitest run src/test/infrastructure/<file>`).
+
+Verified locally, file by file:
+
+| File | Before | After |
+|---|---|---|
+| `invoices/invoiceNumberGeneration_part2` | 0/9 | **9/9** |
+| `invoices/billingInvoiceGeneration_tax` | 0/9 | **9/9** |
+| `time-periods/timePeriodsActions` | 0/1 | **1/1** |
+| `time-periods/timePeriods` | 0/8 | 5/8 (rest: open defects below) |
+| `projects/projectPermissions` + `tickets/ticketPermissions` | 0/12 | 5/12 |
+| `projects/projectManagement` | 0/11 | 0/11, but ~16 min of rebuild time gone |
+
+The time-periods pair also dropped from 180s for one file to 35s for both.
+
+## Cluster A — connection cascade (~35 failures, most of the timeouts)
+
+`resetDatabase(db)` destroys the pool of the handle it is given, then drops and
+recreates the database. Five infrastructure files called it from `beforeEach`:
+
+| File | Effect |
+|---|---|
+| timePeriods, timePeriodsActions, ticketPermissions, projectPermissions | called it with `context.db`, which is the TestContext *transaction* — the drop killed the connection, so every later query failed "Client has encountered a connection error and is not queryable" |
+| projectManagement | called it with its own root connection in `beforeAll` *and* `beforeEach` — "Unable to acquire a connection" from the first query onward |
+
+Fixed by using `TestContext.reset()` (transaction rollback) in the four
+context-based files, and a one-time bootstrap plus table cleanup in
+projectManagement. `resetDatabase` now rejects a transaction handle outright.
+
+Side effect worth noting: each `resetDatabase` call re-migrated and re-seeded
+the database, roughly 90s per test. The time-periods pair went from 180s for
+one file to 35s for both.
+
+projectManagement also mocked the default tenant id
+(`11111111-1111-1111-1111-111111111111`), which has no rows in the seeded
+database; it now reads the seeded tenant.
+
+## Cluster B — `clients.credit_balance` (schema drift)
+
+The column was dropped by
+`20260728120000_derive_credit_balance_drop_cache_and_reconciliation.cjs`.
+Forty of the 46 references were inert (`createClient` never forwarded the
+option), but the expiration suites updated and asserted the cache. Balance now
+comes from `credit_tracking` through `getAvailableCredit` / `getClientCredit`,
+which is where the product reads it.
+
+## Cluster C — "invoice_id undefined" (~10 failures)
+
+Not an undefined binding at all: `generateInvoice` was returning an action
+error, and `expect(invoice!.invoice_number)` reported the symptom.
+
+The real error is `Recurring service periods were not materialized for this
+client billing schedule window`, and it has three causes in the fixtures:
+
+1. **Arrears window shift.** A billing cycle's `period_start_date` /
+   `period_end_date` is the *invoice* window; an arrears schedule invoices the
+   service period **before** it. Fixtures materialized from the cycle start, so
+   the window had no row. Assignments must start one cycle earlier.
+2. **Every active line needs a row.** `generateInvoice` fails the whole run if
+   any active recurring contract line lacks a period for the window, so fixture
+   helpers that create a second line must materialize it too
+   (`materializeServicePeriods: true`).
+3. **Re-assignment retires periods.** Calling `assignContractLineToClient`
+   again for a later cycle re-anchors the schedule and retires the period the
+   next cycle bills. The follow-up assignments were redundant and are gone.
+
+`invoiceNumberGeneration_part2` went from 0/9 to 9/9 with those three changes.
+The same shape applies to the other invoice-generating families.
+
+## Cluster E — fixture drift found while unblocking A and C
+
+Once the connection cascade was gone, these suites failed on their own
+staleness:
+
+- **Fresh-tenant fixtures.** `createTestEnvironment` mints a *new* tenant, which
+  has none of the seeded statuses or priorities. `projectPermissions` and
+  `ticketPermissions` looked up the seeded "Initiating Spell" status in it and
+  threw. They use the context's seeded tenant now.
+- **TRUNCATE CASCADE inside the test transaction.** The same two suites listed
+  `clients`/`users` in `cleanupTables`; `TRUNCATE ... CASCADE` took the seeded
+  statuses and priorities with them for the rest of the file. The per-test
+  transaction rollback already provides the isolation, so the lists are gone.
+- **Schema drift in fixture rows.** `projects.project_number` is NOT NULL and
+  unique per tenant; `tickets.estimated_hours` no longer exists.
+- **Roleless admin.** `createMockUser` leaves `roles: []` and the default RBAC
+  mock reads them, so the "admin" fixture was denied every action.
+
+Still open: `projectManagement` mocks `ProjectModel` / `ProjectTaskModel` to
+return fabricated rows, and the actions now insert and reload from the
+database — "Created project could not be reloaded after insert". That file
+wants its model mocks dropped so it exercises the real DB path, which is what
+its place in `src/test/infrastructure` implies. Its 11 failures are unchanged
+in count, but it no longer rebuilds the schema once per test.
+
+## Cluster D — FK cleanup order (~3 failures)
+
+`cleanupTables` deletes in reverse array order, and every client gets an eager
+default billing profile (`testContext.ts` provisions it the way production
+does), so deleting `clients` first trips
+`client_billing_profiles_client_id_fkey`. The two permissions suites list
+`client_billing_profiles` after `clients` now.
+
+## Product defects exposed (tickets, not test edits)
+
+### 1. `generateTimePeriods` never terminated on a fixed end day — FIXED HERE
+
+With `frequency_unit: 'month'` and `end_day: 15`, `getEndOfPeriod` returns the
+15th of the current month, and the loop assigned that back to `currentDate`;
+the next iteration computed the same date and pushed a zero-length period
+forever. Any tenant with a semi-monthly settings row hangs the server action
+and grows the heap without bound — the infrastructure suite died at 8 GB.
+
+Fixed in this branch (`packages/scheduling/src/actions/timePeriodsActions.ts`)
+because an OOM takes the whole CI worker with it: a fixed end day advances to
+the next occurrence of `start_day`, which is what the dead `if` branch it
+replaces was written to do, with a no-progress guard behind it.
+
+### 2. `timePeriodSettingsSchema` rejects the NULLs the table allows — OPEN
+
+`start_month`, `start_day_of_month`, `end_month`, `end_day_of_month` are
+`.optional()`, which zod fails on `null`. `getActiveTimePeriodSettings`
+coalesces the NULLs before validating; the three call sites in
+`timePeriodsActions.ts` (lines 134, 166, 641) validate raw rows and throw
+`ZodError` on any row holding a NULL.
+
+Rows written through `createTimePeriodSettings` always carry defaults, so the
+app path is safe today — the exposure is any row inserted by another path
+(imports, fixtures, hand-written SQL). Suggested fix: `.nullish()` on those
+four fields, in `packages/scheduling/src/schemas/timeSheet.schemas.ts` **and**
+the stale copy at `server/src/lib/schemas/timeSheet.schemas.ts`. The fixtures
+in this branch fill the columns instead, matching what the app writes.
+
+### 3. `revalidatePath` invariant in `generateAndSaveTimePeriods` — OPEN
+
+Two time-period tests fail with `Invariant: static generation store missing in
+revalidatePath /msp/time-entry`: the action calls `revalidatePath` outside a
+request context and `next/cache` is only mocked for callers that route through
+`setupCommonMocks`. `createNextTimePeriod` already guards its own call with a
+comment that revalidation "only works in request context"; the same guard
+belongs on the generate path.

--- a/ee/docs/plans/2026-08-22-ci-test-metrics-health/findings-p1.md
+++ b/ee/docs/plans/2026-08-22-ci-test-metrics-health/findings-p1.md
@@ -69,8 +69,19 @@ tripped over at least one:
 
 | File | Failing | Shape |
 |---|---|---|
-| `invoices/clientBillingCycleAnchors` | 4/7 | anchor changes no longer regenerate/supersede recurring service periods the way the test expects — behavioural, needs a product decision rather than a fixture edit |
+| `invoices/clientBillingCycleAnchors` | 3/7 (was 4) | changing a client's anchor deactivates future billing cycles and does not supersede/regenerate the client-cadence periods the T083/T086 cases expect. Behavioural: either the product regressed or the requirement moved, and neither is a fixture edit. The fourth failure was a mocking fault and is fixed — see below. |
 | `invoices/usageBucketAndFinalization` | 1/3 | see defect 6 below |
+
+### A mock that does not reach across package boundaries
+
+`testMocks.ts` declares `vi.mock('@alga-psa/auth/rbac', …)` at module scope, and
+suites rely on importing it to get permission mocking for free. That works for
+some files and not others: in `clientBillingCycleAnchors` the same
+`hasPermission` returned `true` when the *test* called it and denied when
+`billingCycleActions` called it — two module instances, one mocked and one not.
+The fix is to declare `vi.mock('@alga-psa/auth/rbac', …)` in the test file
+itself, which is what the unit suites already do. Treat the shared declaration
+as a convenience, never as a guarantee.
 
 ## Cluster A — connection cascade (~35 failures, most of the timeouts)
 

--- a/ee/docs/plans/2026-08-22-ci-test-metrics-health/findings-p1.md
+++ b/ee/docs/plans/2026-08-22-ci-test-metrics-health/findings-p1.md
@@ -14,9 +14,14 @@ Verified locally, file by file:
 | `invoices/invoiceNumberGeneration_part2` | 0/9 | **9/9** |
 | `invoices/billingInvoiceGeneration_tax` | 0/9 | **9/9** |
 | `time-periods/timePeriodsActions` | 0/1 | **1/1** |
-| `time-periods/timePeriods` | 0/8 | 5/8 (rest: open defects below) |
-| `projects/projectPermissions` + `tickets/ticketPermissions` | 0/12 | 5/12 |
-| `projects/projectManagement` | 0/11 | 0/11, but ~16 min of rebuild time gone |
+| `time-periods/timePeriods` | 0/8 | **8/8** |
+| `projects/projectPermissions` | 0/7 | **7/7** |
+| `tickets/ticketPermissions` | 0/5 | **5/5** |
+| `projects/projectManagement` | 0/11 | **11/11** |
+| `credits/creditExpirationEffects` | 0/4 | **4/4** |
+| `credits/creditExpirationIntegration` | 1/2 | **2/2** |
+| `credits/creditExpirationPriority` | 2/3 | **3/3** |
+| `credits/creditServiceTypeRestrictionModeMigration` | 5/7 | **7/7** |
 
 The time-periods pair also dropped from 180s for one file to 35s for both.
 
@@ -92,12 +97,20 @@ staleness:
 - **Roleless admin.** `createMockUser` leaves `roles: []` and the default RBAC
   mock reads them, so the "admin" fixture was denied every action.
 
-Still open: `projectManagement` mocks `ProjectModel` / `ProjectTaskModel` to
-return fabricated rows, and the actions now insert and reload from the
-database — "Created project could not be reloaded after insert". That file
-wants its model mocks dropped so it exercises the real DB path, which is what
-its place in `src/test/infrastructure` implies. Its 11 failures are unchanged
-in count, but it no longer rebuilds the schema once per test.
+`projectManagement`'s model mocks are gone (round 2). It mocked `ProjectModel`
+/ `ProjectTaskModel` to return fabricated rows while the actions insert and
+reload from the database — "Created project could not be reloaded after
+insert". It now runs the real DB path, which is what its place in
+`src/test/infrastructure` implies, and asserts on persisted rows instead of
+`toHaveBeenCalledWith`. Three further fixture facts came out of that:
+
+- The acting user must be a **real row**. The authorization kernel narrows on
+  `team_members.user_id`, and the default mock id `'mock-user-id'` is not a
+  uuid; that query errored *inside the action's transaction*, so the next
+  statement failed with the unhelpful "current transaction is aborted".
+- `addProjectPhase` validates against the full phase schema, so `wbs_code` must
+  be present even though the action immediately replaces it.
+- `project_tasks.estimated_hours` is `numeric`, which pg returns as a string.
 
 ## Cluster D — FK cleanup order (~3 failures)
 
@@ -106,6 +119,73 @@ default billing profile (`testContext.ts` provisions it the way production
 does), so deleting `clients` first trips
 `client_billing_profiles_client_id_fkey`. The two permissions suites list
 `client_billing_profiles` after `clients` now.
+
+Round 2 removed those hand-written cleanup hooks from the two permissions
+suites outright. `permissions` cannot be deleted while `role_permissions`
+references it, and that error **aborts the surrounding transaction**, so every
+later statement in the hook failed with "current transaction is aborted". The
+per-test rollback already discards the fixture rows.
+
+## Cluster F — who the action thinks it is (round 2)
+
+Three separate seams decide the acting identity, and the suites were wired to
+the wrong one in each case.
+
+- **`withAuth` establishes tenant context; the mock did not.** The real wrapper
+  runs the action inside `runWithTenant`, and code below the action reads the
+  tenant straight off that AsyncLocalStorage store (`requireTenantId` in tag
+  cleanup, `getTenantContext` in scheduling). `createAuthModuleMock`'s
+  `withAuth` called the action bare, so deleting a project died on "tenant
+  context not found". `TestContext` had the mirror problem: its `runWithTenant`
+  spy was `(_tenant, fn) => fn()`, an empty store, so a suite that *explicitly*
+  wrapped a call in `runWithTenant` still got "Tenant context is required".
+  Both now delegate to the real implementation, pinned to the suite tenant.
+- **Two specifiers for one `hasPermission`.** `testMocks` mocks
+  `@alga-psa/auth/rbac`, `server/src/lib/auth/rbac` and `@/lib/auth/rbac`, all
+  routed through `permissionCheckRef`. `projectPermissions` instead patched
+  `@alga-psa/auth`'s export, which `projectActions` does not import — the rbac
+  mock stayed on its default ("no roles ⇒ allow everything", because DB user
+  rows carry no `roles` array), and the *regular* user was allowed to update,
+  create and delete. Reprogram the predicate through `setupCommonMocks` /
+  `mockRBAC`, never a single specifier.
+- **Trailing user arguments are ignored.** `getTickets`, `updateTicket` and
+  `addTicket` are `withAuth`-wrapped and take their user from the session;
+  `ticketPermissions` still passed `adminUser` / `regularUser` as a trailing
+  argument, which landed in `options` (or nowhere). Every call ran as the
+  session stub, so the admin was denied and the "denied" assertions passed for
+  the wrong reason.
+
+Also fixture drift, found once the identity was right: a ticket's status must
+belong to its board (`TicketModel.validateStatusBelongsToBoard`), so a
+boardless status can never create a ticket.
+
+## Cluster G — derived credit balance and job connections (round 2)
+
+- **Available credit excludes credits whose date has passed.**
+  `getAvailableCredit` filters `is_expired = false` **and**
+  `expiration_date > now()`. The expiration suites asserted a pre-job balance
+  that still counted a credit issued with a past expiration date — true of the
+  old cached `clients.credit_balance`, false of the derived one. The
+  "not processed yet" state lives in `credit_tracking`, and the assertions read
+  it there now.
+- **Invoice totals are immutable after finalization.**
+  `applyCreditToInvoiceInternal` never writes `total_amount`; balance due is
+  `total_amount - credit_applied` (`creditApplication.test.ts` already encodes
+  this). Three suites still expected a rewritten total, and their manual
+  fallback helpers wrote one, so the two paths disagreed. Both now leave totals
+  gross.
+- **Job handlers open their own connection.** `expiredCreditsHandler` calls
+  `getConnection(tenantId)` rather than `createTenantKnex()`, so `TestContext`'s
+  spy does not reach it. That second connection cannot see rows written inside
+  the suite transaction and blocks on their locks — a 120-second timeout, not a
+  failure. Mock `getConnection` to hand back `context.db`, as
+  `billing/quotes/expireQuotesHandler.test.ts` already does.
+- **Constraints that a later migration dropped.** Two
+  `creditServiceTypeRestrictionModeMigration` tests asserted CHECK arms that
+  `20260817130000` deliberately removed (the tenant-side NOT NULL could not be
+  installed on the hosted Citus cluster). They now pin the arrangement that
+  replaced them: no database constraint, and the mode/ids pairing normalized on
+  the write path by `updateClientBillingSettings`.
 
 ## Product defects exposed (tickets, not test edits)
 
@@ -137,11 +217,48 @@ four fields, in `packages/scheduling/src/schemas/timeSheet.schemas.ts` **and**
 the stale copy at `server/src/lib/schemas/timeSheet.schemas.ts`. The fixtures
 in this branch fill the columns instead, matching what the app writes.
 
-### 3. `revalidatePath` invariant in `generateAndSaveTimePeriods` — OPEN
+### 3. `revalidatePath` invariant in `timePeriodsActions` — FIXED HERE
 
-Two time-period tests fail with `Invariant: static generation store missing in
-revalidatePath /msp/time-entry`: the action calls `revalidatePath` outside a
-request context and `next/cache` is only mocked for callers that route through
-`setupCommonMocks`. `createNextTimePeriod` already guards its own call with a
-comment that revalidation "only works in request context"; the same guard
-belongs on the generate path.
+Time-period tests failed with `Invariant: static generation store missing in
+revalidatePath /msp/time-entry`. `createTimePeriod` carried a hand-rolled
+try/catch; the other four call sites did not, and two of them sit inside a
+`catch` that inspects `error.message` for "belongs to different tenant", so a
+failed revalidation surfaced as a bogus tenant error. These actions also run
+from background jobs and the billing bootstrap, where there is never a request
+context, so this was a live defect and not only a test artefact. All five now
+go through one module-local `safeRevalidate`, matching the helper
+`packages/billing/src/actions/serviceActions.ts` and
+`packages/inventory/src/actions/kitActions.ts` already use.
+
+### 4. Daily time periods were a day short — FIXED HERE
+
+Time periods are half-open intervals `[start, end)` —
+`TimePeriod.findOverlapping` says so in as many words, and `generateTimePeriods`
+plus the `week` / `year` arms of `TimePeriodSuggester.suggestNewTimePeriod` all
+add the whole frequency. The `day` arm added `frequency - 1`, so the
+create-next-period path produced 6-day periods from a 7-day setting while the
+bulk generator produced 7-day ones for the same settings row. Fixed in
+`packages/scheduling/src/lib/timePeriodSuggester.ts`.
+
+Two neighbours left alone deliberately:
+
+- `TimePeriodSuggester.calculateEndDate` (used by `TimePeriodForm` to prefill
+  the end date) uses an inclusive convention throughout — `months - 1 day`,
+  `years - 1 day`. Whether the form should agree with the generator is a UI
+  question, not a test-repair one.
+- `server/src/lib/timePeriodSuggester.ts` is a stale copy no product code
+  imports — but `server/src/test/unit/timePeriodSuggester.test.ts` imports *it*
+  rather than the package, so that unit test covers dead code. It also has no
+  `day`-unit case, which is why the bug above survived. Worth folding into the
+  package copy.
+
+### 5. `updateTaskSchema` undid its own `.partial()` — FIXED HERE
+
+`updateTaskSchema` is `projectTaskSchema.partial().omit({…}).extend({…})`, and
+`.extend` replaces a key outright rather than merging into it. `service_id`
+restated `.optional()`; `assigned_to` did not. Every partial task update that
+omitted `assigned_to` — which is what a partial update means — was rejected
+with `Please fix the task details: assigned_to: Invalid input`. Fixed in
+`packages/projects/src/schemas/project.schemas.ts`; the stale copy at
+`server/src/lib/schemas/project.schemas.ts` has the same shape and the same
+bug, and is a candidate for the same deletion as the suggester copy above.

--- a/ee/docs/plans/2026-08-22-ci-test-metrics-health/findings-p1.md
+++ b/ee/docs/plans/2026-08-22-ci-test-metrics-health/findings-p1.md
@@ -22,8 +22,55 @@ Verified locally, file by file:
 | `credits/creditExpirationIntegration` | 1/2 | **2/2** |
 | `credits/creditExpirationPriority` | 2/3 | **3/3** |
 | `credits/creditServiceTypeRestrictionModeMigration` | 5/7 | **7/7** |
+| `credits/creditExpirationCore` | 0/4 | **4/4** |
+| `invoices/billingInvoiceGeneration_subtotal` | 1/5 | **5/5** |
+| `invoices/negativeInvoiceCredit` | 0/6 | **6/6** |
+| `invoices/contractInvoiceManualCredit` | 0/2 | **2/2** |
+| `invoices/prepaymentInvoice` | 4/11 | **11/11** |
+| `quotes/quoteInfrastructure` | 76/83 | **83/83** |
+| `pricingSchedules/pricingScheduleRateOverrides` | 0/5 | **5/5** |
+| `invoices/multiCurrency` | 0/3 | **3/3** |
+| `invoices/billingInvoiceGeneration_consistency` | 0/1 | **1/1** |
+| `invoices/billingInvoiceGeneration_edgeCases` | 0/2 | **2/2** |
+| `invoices/fixedPriceAndTimeBasedPlans` | 0/3 | **3/3** |
 
 The time-periods pair also dropped from 180s for one file to 35s for both.
+
+A whole-suite baseline taken partway through this round: **13 files / 49 tests
+failing out of 354**. Everything above is now green file-by-file.
+
+### The four fixture faults behind almost all of it
+
+Worth knowing before touching any billing fixture, because every suite above
+tripped over at least one:
+
+1. **Contracts need `owner_client_id`.** Invoice generation resolves a
+   window's recurring service periods through
+   `recurring_service_periods -> contract_lines -> contracts -> clients` on
+   that column. An ownerless contract yields no periods and the run comes back
+   as `Recurring service periods were not materialized`, which the tests then
+   report as "expected undefined to be …".
+2. **Arrears shifts the window by a cycle.** A billing cycle's period is the
+   *invoice* window; an arrears line bills the service period before it. Both
+   `contract_lines.billing_timing` and `createFixedPlanAssignment` default to
+   arrears, so assignments have to start a cycle earlier than the cycle under
+   test — and the window has to be a whole period, since it is matched on the
+   exact `invoice_window_start`/`invoice_window_end` pair.
+3. **Materialize last, and only when asked.** `createFixedPlanAssignment`
+   materializes only with `materializeServicePeriods: true`, and the sync reads
+   the line's service configuration, so it has to run after the extra services
+   are attached and after the line is on its final contract.
+4. **Hand-built lines are incomplete.** `contract_lines.is_template` defaults
+   to `true`, and a Fixed line also needs its
+   `contract_line_service_fixed_config` and `contract_line_services` rows or it
+   produces no charges and `generateInvoice` returns null.
+
+### Still failing after this round
+
+| File | Failing | Shape |
+|---|---|---|
+| `invoices/clientBillingCycleAnchors` | 4/7 | anchor changes no longer regenerate/supersede recurring service periods the way the test expects — behavioural, needs a product decision rather than a fixture edit |
+| `invoices/usageBucketAndFinalization` | 1/3 | see defect 6 below |
 
 ## Cluster A — connection cascade (~35 failures, most of the timeouts)
 
@@ -262,3 +309,18 @@ with `Please fix the task details: assigned_to: Invalid input`. Fixed in
 `packages/projects/src/schemas/project.schemas.ts`; the stale copy at
 `server/src/lib/schemas/project.schemas.ts` has the same shape and the same
 bug, and is a candidate for the same deletion as the suggester copy above.
+
+### 6. Bucket overage is billed per minute at the hourly rate — OPEN
+
+`usageBucketAndFinalization`'s overage case records 45 hours against a 40-hour
+bucket (`minutesUsed: 45 * 60`, `overageMinutes: 5 * 60`) on a service whose
+`unit_of_measure` is `hour` and whose rate is 7500 (`$75.00/hour`). The
+expected charge is 5 × 7500 = 37500; the engine produces **2250000**, which is
+300 × 7500 — the overage *minutes* multiplied by the hourly rate.
+
+Either `computeBucketCharges` must convert to the service's unit of measure
+before applying the rate, or `bucket_usage.overage_minutes` is misnamed and
+the fixtures should store hours. That is a product decision, so the test is
+left failing rather than adjusted to whichever answer makes it pass. The same
+case also reports `tax: 0` where 3750 is expected, so overage charges appear
+not to be taxed at all — likely the same charge-construction path.

--- a/ee/docs/plans/2026-08-22-ci-test-metrics-health/findings-p1.md
+++ b/ee/docs/plans/2026-08-22-ci-test-metrics-health/findings-p1.md
@@ -36,8 +36,14 @@ Verified locally, file by file:
 
 The time-periods pair also dropped from 180s for one file to 35s for both.
 
-A whole-suite baseline taken partway through this round: **13 files / 49 tests
-failing out of 354**. Everything above is now green file-by-file.
+Whole-suite runs, start and end of this round:
+
+| | Files | Tests | Duration |
+|---|---|---|---|
+| Baseline (taken partway through) | 13 failed / 54 | 49 failed / 354 | 1317s |
+| After | **2 failed / 54** | **4 failed / 354** | 1047s |
+
+The four that remain are the two open product questions below, not fixtures.
 
 ### The four fixture faults behind almost all of it
 

--- a/ee/docs/plans/2026-08-22-ci-test-metrics-health/plan.md
+++ b/ee/docs/plans/2026-08-22-ci-test-metrics-health/plan.md
@@ -1,0 +1,185 @@
+# CI Test-Metrics Health: Findings & Improvement Plan
+
+**Date:** 2026-08-22
+**Scope:** The nightly/PR test pipeline and the shared metrics sheet
+(`docs/reference/test-metrics.md`, sheet id `1eKcgRVSwd3bDBSbbwyj-WYb8jhqSEDOG8FPO9--O21M`).
+**Sources:** All 5 sheet tabs (1,284 suite runs Jun 12 → Aug 22, 117k coverage rows),
+`.github/workflows/integration-tests.yml` / `unit-tests.yml` / `validate-translations.yml`,
+`scripts/record-test-metrics.mjs`, `server/vitest.config.ts`, git history, and the
+Aug 21/22 nightly run logs (runs 32447991048, 32552410001).
+
+---
+
+## Investigated findings
+
+### F1 — The nightly job is riding its 90-minute timeout (root cause of the fake-green day)
+
+Test execution alone in the shared nightly job (`integration-tests.yml`, one job runs
+integration-full then infrastructure-full):
+
+| Date | integ (s) | infra (s) | sum (min) |
+|---|---|---|---|
+| 08-19 | 3,237 | 1,451 | 78 |
+| 08-20 | 3,470 | 1,511 | **83** |
+| 08-21 | *cancelled* | 163 | — |
+| 08-22 | 3,341 | 1,413 | 79 |
+
+Add ~8–10 min of setup (npm ci, nx builds, migrations) and the job is at the
+`timeout-minutes: 90` ceiling. On Aug 21 the integration step was **cancelled by the
+timeout**; the infra step still ran under `if: always()`, was interrupted after 163s
+(5 executed, 349 "skipped"), and the recorder logged it as **100% pass**. integration-full
+got no row at all that day. Both suites grow ~1–2% per day — this recurs without a fix.
+
+### F2 — The recorder reports vacuous greens on partial runs
+
+`record-test-metrics.mjs` computes `pass_pct = passed / (passed + failed)`; skipped tests
+are invisible. Three partial runs in the history posted misleading rows:
+
+- 2026-08-21 infrastructure-full: 5/354 executed → recorded **100%**
+- 2026-08-13 integration-full: 111/1,564 executed (65s) → recorded 97.3%
+- 2026-08-12 integration-full: 377/1,587 executed (466s) → recorded 99.2%
+
+Nothing in the row or the summary tab distinguishes these from real runs.
+
+### F3 — infrastructure-full: 109 stable failures, non-blocking by design
+
+69.21% pass, failure count pinned at 107–109 for 19 straight days — a fixed broken set,
+not flakiness. The workflow comment says "non-blocking until it has a green baseline;
+flip continue-on-error off once stable." Aug 22 log failure clusters:
+
+| Cluster | ~Count | Signature | Likely fix locus |
+|---|---|---|---|
+| A. DB connection cascade | ~35 | `Client has encountered a connection error and is not queryable`, `Unable to acquire a connection` — whole files fail (timePeriods 8/8, projectManagement 11) | per-file bootstrap/pool teardown; one shared cause |
+| B. Schema drift: `clients.credit_balance` | ~5+ | `column "credit_balance" of relation "clients" does not exist` | tests/helpers not migrated to current schema |
+| C. Undefined `invoice_id` from shared helper | ~10 | `Undefined binding(s) … [invoice_id]`, `expected undefined to be 'INV-000001'` | one invoice-generation test helper |
+| D. FK cleanup order | ~3 | `delete from "clients" … violates client_billing_profiles FK` | cleanup ordering in teardown |
+| E. Assertion drift | ~15 | quote template lists, tax per-item amounts, `expected undefined to be 10000` | individual test updates |
+| F. Timeouts | ~5 | 20s/120s timeouts | likely downstream of A |
+
+Top files: projectManagement (11), invoiceNumberGeneration_part2 (9),
+billingInvoiceGeneration_tax (9), timePeriods (8), projectPermissions (7),
+quoteInfrastructure (7), prepaymentInvoice (7).
+
+### F4 — Coverage history has a deliberate methodology break at 2026-07-31
+
+`experimentalAstAwareRemapping: true` (commit `67b268ca55`, Jul 30) changed the line
+denominator ~679k → ~216k (3.15x). Jul 30–31 the sheet interleaves both regimes
+(37 runs, main vs. un-rebased branches); all runs after Jul 31 17:46 are the new regime.
+The `server/src/lib/mcp` line-count collapse (58,903 → 13) is the `**/*.generated.ts`
+exclusion (`0c46063429`, Jul 29) removing the generated MCP registry — intentional and
+correct (it had been inflating coverage ~7 points). **No regression here**, but nothing
+in the sheet marks the break, so any trendline crossing Jul 31 is wrong.
+
+### F5 — Coverage is 32.38% and overstated; debt is concentrated
+
+- 26% of source files (1,467 of 5,587) are never loaded by the suite, so they're absent
+  from the denominator (v8 untested-file crawl never leaves `server/` — documented in
+  the recorder). True coverage is lower than headline.
+- Trend within the comparable window: 30.49% → 32.38% over 20 days. Healthy direction.
+- Three directories hold ~35% of uncovered lines: `packages/billing` (28.2k),
+  `server/src/lib/api` (17.0k), `server/src/app` (9.3k). Worst core infra by %:
+  `server/src/services` 5.7%, `server/src/lib/eventBus` 8.4%.
+
+### F6 — Healthy subsystems (no action)
+
+- **unit-coverage**: 100% on main, 12,920 tests; sub-100 runs are PR branches — the
+  blocking gate works as intended.
+- **integration-tier1**: 100% across all 254 runs.
+- **i18n validation**: real blocking jobs (glossary audit, template parity); the
+  all-zeros record is legitimate post-merge state. 7 locales in lockstep at 29,238 keys.
+- **integration-full**: healthy since the Jul 3 repair, but failures crept 0→7 over
+  three weeks — watch, don't ignore.
+
+### F7 — Minor: summary tab mixes run vintages
+
+The summary tab pairs 06:04 rows (integration/infra) with 21:38 rows (unit/tier1)
+with no staleness indication, and duration growth of tier1 (300s → 1,284s for 731
+tests) is out of proportion to its test-count growth.
+
+---
+
+## Plan
+
+### P0 — Stop lying: honest metrics + timeout headroom (small diffs, do first)
+
+1. **Split the infra suite into its own job** in `integration-tests.yml` (own service
+   containers, own timeout ~45 min; integration-full keeps ~75 min). This removes the
+   shared-fate cancellation (F1) and gives each suite duration headroom independently.
+   Cheaper alternative if runner cost matters: keep one job, raise `timeout-minutes`
+   to 120 — but the split also isolates infra's pool problems (F3-A) from the
+   integration suite, so prefer the split.
+2. **Guard recording against partial runs** (`scripts/record-test-metrics.mjs` +
+   workflow steps):
+   - Give the run steps `id:`s and gate recording on
+     `steps.<id>.outcome == 'success' || steps.<id>.outcome == 'failure'`
+     (excludes `cancelled`).
+   - In the recorder, add an `executed` column (`passed+failed`) and a `run_status`
+     column: `complete` when the vitest JSON has no interrupted signal, else `partial`.
+     Leave `pass_pct` blank for partial rows so no formula averages them.
+   - Existing tabs: append columns at the end; the header-row check already tolerates
+     schema growth (new tab creation writes full header).
+3. **Add vacuous-green detection to the summary tab**: flag when `executed` <
+   80% of the trailing-7-run median for the suite, or duration < 50% of median.
+   These two checks would have caught all three bad days in the history.
+4. **Backfill honesty**: annotate the three known-partial rows (Aug 12, 13, 21) and
+   add a note row/named range marking the 2026-07-31 coverage methodology break (F4).
+   Document both in `docs/reference/test-metrics.md`.
+
+**Acceptance:** a cancelled or interrupted run can no longer produce a ≥-pass_pct row;
+nightly completes with ≥25 min headroom; summary tab shows staleness/partial flags.
+
+### P1 — Re-green infrastructure-full (the one real red)
+
+Work the clusters in leverage order; each cluster is one PR-sized unit:
+
+1. **Cluster A (connection cascade, ~35 fails + most of F):** reproduce one all-fail
+   file locally (`timePeriods.test.ts`) against the CI bootstrap; suspect pool
+   destruction in a shared teardown or a bootstrap that dies once and poisons the fork.
+   Fixing this alone should cut failures roughly in half.
+2. **Cluster C (undefined `invoice_id`, ~10):** trace the shared invoice-generation
+   helper; one fix un-fails invoiceNumberGeneration/billingInvoiceGeneration families.
+3. **Cluster B (`credit_balance` schema drift, ~5):** migrate tests/helpers to the
+   current credit schema (verify actual columns first — see client-terminology memory).
+4. **Cluster D (FK cleanup order, ~3):** delete `client_billing_profiles` before
+   `clients` in teardown helpers.
+5. **Cluster E (assertion drift, ~15):** update expectations file-by-file; treat any
+   that expose real product bugs as separate tickets.
+6. **Flip `continue-on-error` off** for the infra steps once the suite holds green for
+   5 consecutive nightlies — this is the workflow's own stated intent.
+
+**Acceptance:** infrastructure-full ≥99% for 5 consecutive nightlies, then blocking.
+
+### P2 — Coverage integrity and targets
+
+1. **Fix the 26%-unmeasured blind spot:** post-process the coverage summary to add
+   0%-line entries for on-disk source files absent from the report (the recorder
+   already walks the tree for `files_total` — extend that walk to emit denominator
+   lines), OR accept the blind spot but surface `files_measured/files_total` on the
+   summary tab so the headline can't be read as complete.
+2. **Ratchet, don't target:** add a PR check that fails if lines% drops >0.15pt vs.
+   main's latest row (the sheet already has the data; the unit gate is already
+   blocking). Avoid fixed % targets — the denominator will move again.
+3. **Directed debt paydown** (only if/when capacity exists, in this order):
+   `server/src/services` (5.7%, 3.7k lines — small and core),
+   `server/src/lib/eventBus` (8.4%), then `packages/billing` by module.
+
+### P3 — Watch items (no immediate work)
+
+- **integration-full drift** 0→7 failures over 3 weeks: if it crosses ~10, treat as P1.
+- **tier1 duration** (300s → 1,284s): profile once; likely test-count + bootstrap
+  growth, but 4.3x for 731 tests deserves one look.
+- **unit-coverage duration** (272s → 1,056s): proportional to 3.2x test growth; fine.
+
+### Sequencing & effort
+
+| Phase | Effort | Dependency |
+|---|---|---|
+| P0.1–0.2 (job split + recorder guard) | ~half day | none |
+| P0.3–0.4 (summary flags + annotations) | ~half day | P0.2 columns |
+| P1.1 (connection cascade) | 1–2 days investigation-heavy | P0.1 helps isolate |
+| P1.2–1.5 (remaining clusters) | ~2–3 days total | none |
+| P1.6 (make blocking) | trivial | 5 green nightlies |
+| P2 | 1–2 days | independent |
+
+The single highest-leverage item is **P0.1**: it fixes the fake-green mechanism, the
+recurring timeout, and unblocks clean P1 investigation at once.

--- a/packages/projects/src/schemas/project.schemas.ts
+++ b/packages/projects/src/schemas/project.schemas.ts
@@ -170,7 +170,10 @@ export const updateTaskSchema = projectTaskSchema.partial().omit({
   tenant: true,
   actual_hours: true,
 }).extend({
-  assigned_to: z.string().uuid().nullable().or(z.literal('')).transform(val => val === '' ? null : val),
+  // .extend replaces the key outright, so these have to restate .optional()
+  // themselves — without it the surrounding .partial() is undone and every
+  // partial task update is rejected with "assigned_to: Invalid input".
+  assigned_to: z.string().uuid().nullable().or(z.literal('')).transform(val => val === '' ? null : val).optional(),
   service_id: z.string().uuid().nullable().or(z.literal('')).transform(val => val === '' ? null : val).optional()
 });
 

--- a/packages/scheduling/src/actions/timePeriodsActions.ts
+++ b/packages/scheduling/src/actions/timePeriodsActions.ts
@@ -357,6 +357,33 @@ function getEndOfPeriod(startDate: string, setting: ITimePeriodSettings): Tempor
   }
 }
 
+// Start of the period that follows the one beginning at currentStart, for
+// settings whose end day is fixed rather than the end of the period.
+function getNextPeriodStart(
+  currentStart: Temporal.PlainDate,
+  setting: ITimePeriodSettings
+): Temporal.PlainDate {
+  const frequency = setting.frequency || 1;
+
+  switch (setting.frequency_unit) {
+    case 'week':
+      return currentStart.add({ days: 7 * frequency });
+
+    case 'month': {
+      const next = currentStart.add({ months: frequency });
+      return setting.start_day
+        ? next.with({ day: Math.min(setting.start_day, next.daysInMonth) })
+        : next;
+    }
+
+    case 'year':
+      return currentStart.add({ years: frequency });
+
+    default:
+      return currentStart.add({ days: frequency });
+  }
+}
+
 // Modify the generateTimePeriods function
 export async function generateTimePeriods(
   settings: ITimePeriodSettings[],
@@ -418,13 +445,18 @@ export async function generateTimePeriods(
       };
       periods.push(newPeriod);
 
-      if (setting.end_day !== END_OF_PERIOD) {
-        // if the end day is not END_OF_PERIOD, we need to adjust the current date to the end of the period
-        currentDate = periodEndDate;
-        continue;
+      // A period that ends on a fixed day of the month (the 15th, say) does not
+      // chain: the next one starts at the next occurrence of start_day. Walking
+      // to periodEndDate instead recomputed the same end date from the same
+      // date forever — an infinite loop that filled the heap.
+      const chainsToItsEnd = setting.end_day === undefined || setting.end_day === END_OF_PERIOD;
+      const nextDate = chainsToItsEnd ? periodEndDate : getNextPeriodStart(currentDate, setting);
+
+      if (Temporal.PlainDate.compare(nextDate, currentDate) <= 0) {
+        break;
       }
 
-      currentDate = periodEndDate;
+      currentDate = nextDate;
     }
   }
 

--- a/packages/scheduling/src/actions/timePeriodsActions.ts
+++ b/packages/scheduling/src/actions/timePeriodsActions.ts
@@ -37,6 +37,18 @@ import {
 // Special value to indicate end of period
 const END_OF_PERIOD = 0;
 
+// These actions are also driven from background jobs and from the billing
+// bootstrap, where there is no Next.js request context and revalidatePath
+// throws "Invariant: static generation store missing". Cache invalidation is
+// best-effort, so it must never fail the period write that just committed.
+function safeRevalidate(path: string): void {
+  try {
+    revalidatePath(path);
+  } catch (error) {
+    logger.warn(`[timePeriodsActions] Failed to revalidate path "${path}":`, error instanceof Error ? error.message : error);
+  }
+}
+
 // Input type for server actions - accepts string dates (Next.js can't serialize Temporal.PlainDate)
 interface TimePeriodInput {
   start_date: string;
@@ -174,12 +186,7 @@ export const createTimePeriod = withAuth(async (
       const timePeriod = await TimePeriod.create(trx, tenant, timePeriodData);
       const validatedPeriod = validateData(timePeriodSchema, timePeriod);
 
-      // revalidatePath only works in request context, not from background jobs
-      try {
-        revalidatePath('/msp/time-entry');
-      } catch {
-        // Ignore revalidation errors when called outside request context (e.g., from jobs)
-      }
+      safeRevalidate('/msp/time-entry');
 
       return toTimePeriodView(validatedPeriod);
     } catch (error) {
@@ -499,7 +506,7 @@ export const deleteTimePeriod = withAuth(async (_user, { tenant }, periodId: str
 
     try {
       await TimePeriod.delete(knex, tenant, periodId);
-      revalidatePath('/msp/time-entry');
+      safeRevalidate('/msp/time-entry');
     } catch (error: any) {
       if (error.message.includes('belongs to different tenant')) {
         throw new Error('Access denied: Cannot delete time period');
@@ -588,7 +595,7 @@ export const deleteTimePeriods = withAuth(async (
   }
 
   if (deletedIds.length > 0) {
-    revalidatePath('/msp/time-entry');
+    safeRevalidate('/msp/time-entry');
   }
 
   return { deletedIds, failed };
@@ -638,7 +645,7 @@ export const updateTimePeriod = withAuth(async (
         const updatedPeriod = await TimePeriod.update(trx, tenant, periodId, updates);
         const validatedPeriod = validateData(timePeriodSchema, updatedPeriod);
 
-        revalidatePath('/msp/time-entry');
+        safeRevalidate('/msp/time-entry');
         return toTimePeriodView(validatedPeriod);
       } catch (error: any) {
         if (error.message.includes('belongs to different tenant')) {
@@ -697,7 +704,7 @@ export const generateAndSaveTimePeriods = withAuth(async (_user, { tenant }, sta
       }));
       const validatedPeriods = validateArray(timePeriodSchema, savedPeriods);
 
-      revalidatePath('/msp/time-entry');
+      safeRevalidate('/msp/time-entry');
       return validatedPeriods.map((period): ITimePeriodView => toTimePeriodView(period));
     } catch (error) {
       const expected = timePeriodActionErrorFrom(error);

--- a/packages/scheduling/src/lib/timePeriodSuggester.ts
+++ b/packages/scheduling/src/lib/timePeriodSuggester.ts
@@ -78,7 +78,13 @@ export class TimePeriodSuggester {
 
     switch (setting.frequency_unit) {
       case 'day':
-        endDate = startDate.add({ days: setting.frequency - 1 });
+        // Time periods are half-open intervals [start, end) — TimePeriod
+        // .findOverlapping says so, and every other arm here (and
+        // generateTimePeriods) adds the whole frequency. Subtracting a day made
+        // daily periods one day short of their configured frequency, so a
+        // 7-day setting produced 6-day periods on the create-next-period path
+        // while the bulk generator produced 7-day ones.
+        endDate = startDate.add({ days: setting.frequency });
         break;
       case 'week':
         endDate = startDate.add({ weeks: setting.frequency });

--- a/scripts/record-test-metrics.mjs
+++ b/scripts/record-test-metrics.mjs
@@ -26,6 +26,7 @@ export const HEADER = [
   'passed', 'failed', 'skipped', 'todo', 'total', 'pass_pct',
   'lines_pct', 'statements_pct', 'branches_pct', 'functions_pct',
   'duration_s', 'run_url',
+  'executed', 'run_status', 'files_measured', 'files_total',
 ];
 
 export const DETAIL_HEADER = [
@@ -45,6 +46,28 @@ function readJson(path) {
   }
 }
 
+// A run that never reached most of its tests still writes a report, and
+// pass_pct over the handful that did run reads as a green day (2026-08-21
+// infrastructure-full: 5 of 354 executed, recorded 100%). Two signals say the
+// report is not a whole run:
+//   - an assertion left in "pending": vitest maps run/queued state there when
+//     the process is cut short, while an intentional skip maps to "skipped"
+//     and a todo to "todo";
+//   - a no-show majority: fewer than half the collected tests executed, which
+//     is what a dead bootstrap looks like.
+export const MIN_EXECUTED_RATIO = 0.5;
+
+export function runStatus(results) {
+  if (!results) return '';
+  const executed = (results.numPassedTests ?? 0) + (results.numFailedTests ?? 0);
+  const total = results.numTotalTests ?? 0;
+  const cutShort = (results.testResults ?? []).some(
+    (f) => (f.assertionResults ?? []).some((a) => a.status === 'pending'),
+  );
+  const noShow = total > 0 && executed < total * MIN_EXECUTED_RATIO;
+  return cutShort || noShow ? 'partial' : 'complete';
+}
+
 export function testCounts(results) {
   if (!results) return null;
   const passed = results.numPassedTests ?? 0;
@@ -52,8 +75,11 @@ export function testCounts(results) {
   const skipped = results.numPendingTests ?? 0;
   const todo = results.numTodoTests ?? 0;
   const total = results.numTotalTests ?? passed + failed + skipped + todo;
-  const passPct = passed + failed > 0
-    ? Math.round((passed / (passed + failed)) * 10000) / 100
+  const executed = passed + failed;
+  const status = runStatus(results);
+  // Blank on partial runs so sheet formulas cannot average a vacuous green.
+  const passPct = executed > 0 && status !== 'partial'
+    ? Math.round((passed / executed) * 10000) / 100
     : '';
   let durationS = '';
   const files = results.testResults ?? [];
@@ -62,7 +88,7 @@ export function testCounts(results) {
   if (starts.length && ends.length) {
     durationS = Math.round((Math.max(...ends) - Math.min(...starts)) / 1000);
   }
-  return { passed, failed, skipped, todo, total, passPct, durationS };
+  return { passed, failed, skipped, todo, total, executed, passPct, durationS, runStatus: status };
 }
 
 export function coveragePcts(summary) {
@@ -167,6 +193,17 @@ export function coverageByDirectory(summary, repoRoot = process.cwd()) {
   return rows.sort((a, b) => a.dir.localeCompare(b.dir));
 }
 
+// Headline coverage only describes the files the suite loaded. Carrying the
+// measured/on-disk file counts onto the summary row keeps a percentage over
+// three quarters of the tree from reading as a percentage over all of it.
+export function coverageFileCounts(summary, repoRoot = process.cwd()) {
+  if (!summary) return { measured: '', total: '' };
+  return coverageByDirectory(summary, repoRoot).reduce(
+    (acc, r) => ({ measured: acc.measured + (r.filesMeasured || 0), total: acc.total + (r.filesTotal || 0) }),
+    { measured: 0, total: 0 },
+  );
+}
+
 export function buildRow() {
   const suite = process.env.TEST_METRICS_SUITE;
   if (!suite) {
@@ -174,7 +211,9 @@ export function buildRow() {
     process.exit(1);
   }
   const counts = testCounts(readJson(process.env.TEST_METRICS_RESULTS));
-  const cov = coveragePcts(readJson(process.env.TEST_METRICS_COVERAGE));
+  const summary = readJson(process.env.TEST_METRICS_COVERAGE);
+  const cov = coveragePcts(summary);
+  const files = coverageFileCounts(summary);
   if (!counts && cov.lines === '') {
     console.warn('test-metrics: no results or coverage files found, nothing to record');
     process.exit(0);
@@ -192,6 +231,8 @@ export function buildRow() {
     cov.lines, cov.statements, cov.branches, cov.functions,
     counts?.durationS ?? '',
     runUrl,
+    counts?.executed ?? '', counts?.runStatus ?? '',
+    files.measured, files.total,
   ];
 }
 
@@ -278,11 +319,11 @@ function writeJobSummary(row) {
   appendFileSync(
     process.env.GITHUB_STEP_SUMMARY,
     [
-      `### Test metrics — ${row[1]}`,
+      `### Test metrics — ${row[1]}${row[17] === 'partial' ? ' (partial run)' : ''}`,
       '',
-      '| passed | failed | skipped | pass % | lines % | branches % | duration |',
-      '|---|---|---|---|---|---|---|',
-      `| ${cell(row[4])} | ${cell(row[5])} | ${cell(row[6])} | ${cell(row[9])} | ${cell(row[10])} | ${cell(row[12])} | ${row[14] !== '' ? `${row[14]}s` : '—'} |`,
+      '| passed | failed | skipped | executed | pass % | lines % | branches % | duration |',
+      '|---|---|---|---|---|---|---|---|',
+      `| ${cell(row[4])} | ${cell(row[5])} | ${cell(row[6])} | ${cell(row[16])} | ${cell(row[9])} | ${cell(row[10])} | ${cell(row[12])} | ${row[14] !== '' ? `${row[14]}s` : '—'} |`,
       '',
     ].join('\n'),
   );
@@ -325,7 +366,7 @@ async function main() {
   if (detailRows.length) {
     await appendRows(token, sheetId, 'coverage_by_dir', DETAIL_HEADER, detailRows);
   }
-  console.log(`test-metrics: recorded ${row[1]} run (${row[4]} passed / ${row[5]} failed)${detailRows.length ? ` + ${detailRows.length} directory rows` : ''} to sheet`);
+  console.log(`test-metrics: recorded ${row[1]} run (${row[4]} passed / ${row[5]} failed${row[17] === 'partial' ? ', partial run' : ''})${detailRows.length ? ` + ${detailRows.length} directory rows` : ''} to sheet`);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/server/src/test/infrastructure/billing/credits/creditApplication.test.ts
+++ b/server/src/test/infrastructure/billing/credits/creditApplication.test.ts
@@ -397,7 +397,6 @@ describe('Credit Application Tests', () => {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0
     });
 
     await setupDefaultTax(clientId);
@@ -466,7 +465,6 @@ describe('Credit Application Tests', () => {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0
     });
 
     await setupDefaultTax(clientId);
@@ -560,7 +558,6 @@ describe('Credit Application Tests', () => {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0
     });
 
     await setupDefaultTax(clientId);
@@ -650,7 +647,6 @@ describe('Credit Application Tests', () => {
         billing_cycle: 'monthly',
         region_code: 'US-NY',
         is_tax_exempt: false,
-        credit_balance: 0
       }
     );
 
@@ -751,7 +747,6 @@ describe('Credit Application Tests', () => {
         billing_cycle: 'monthly',
         region_code: 'US-NY',
         is_tax_exempt: false,
-        credit_balance: 0
       }
     );
 
@@ -846,7 +841,6 @@ describe('Credit Application Tests', () => {
         billing_cycle: 'monthly',
         region_code: 'US-NY',
         is_tax_exempt: false,
-        credit_balance: 0
       }
     );
 
@@ -920,7 +914,6 @@ describe('Credit Application Tests', () => {
         billing_cycle: 'monthly',
         region_code: 'US-NY',
         is_tax_exempt: false,
-        credit_balance: 0
       }
     );
 
@@ -1018,7 +1011,6 @@ describe('Credit Application Tests', () => {
         billing_cycle: 'monthly',
         region_code: 'US-NY',
         is_tax_exempt: false,
-        credit_balance: 0
       }
     );
 
@@ -1091,7 +1083,6 @@ describe('Credit Application Tests', () => {
         billing_cycle: 'monthly',
         region_code: 'US-NY',
         is_tax_exempt: false,
-        credit_balance: 0
       }
     );
 
@@ -1164,7 +1155,6 @@ describe('Credit Application Tests', () => {
         billing_cycle: 'monthly',
         region_code: 'US-NY',
         is_tax_exempt: false,
-        credit_balance: 0
       }
     );
 

--- a/server/src/test/infrastructure/billing/credits/creditDrawdownGoCustomSeeding.test.ts
+++ b/server/src/test/infrastructure/billing/credits/creditDrawdownGoCustomSeeding.test.ts
@@ -134,7 +134,6 @@ describe('Credit Draw-Down "Go Custom" Seeding Fix', () => {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0,
     });
 
     const tenantEligibleTypeId = uuidv4();

--- a/server/src/test/infrastructure/billing/credits/creditDrawdownPolicy.test.ts
+++ b/server/src/test/infrastructure/billing/credits/creditDrawdownPolicy.test.ts
@@ -323,7 +323,6 @@ describe('Credit Draw-Down Policy Controls', () => {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0,
     });
 
     const policy = await resolveCreditDrawdownPolicy(context.db, context.tenantId, clientId);
@@ -337,7 +336,6 @@ describe('Credit Draw-Down Policy Controls', () => {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0,
     });
 
     const laborTypeId = await createServiceType('Labor');
@@ -374,7 +372,6 @@ describe('Credit Draw-Down Policy Controls', () => {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0,
     });
 
     await setupDefaultTax(clientId);
@@ -429,7 +426,6 @@ describe('Credit Draw-Down Policy Controls', () => {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0,
     });
 
     await setupDefaultTax(clientId);
@@ -496,7 +492,6 @@ describe('Credit Draw-Down Policy Controls', () => {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0,
     });
 
     await setupDefaultTax(clientId);
@@ -580,7 +575,6 @@ describe('Credit Draw-Down Policy Controls', () => {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0,
     });
 
     await setupDefaultTax(clientId);
@@ -655,7 +649,6 @@ describe('Credit Draw-Down Policy Controls', () => {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0,
     });
 
     await setupDefaultTax(clientId);
@@ -712,7 +705,6 @@ describe('Credit Draw-Down Policy Controls', () => {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0,
     });
     await setupDefaultTax(oldestFirstClient);
     await ensureClientBillingSettings(oldestFirstClient, { credit_application_order: 'oldest_first' });
@@ -767,7 +759,6 @@ describe('Credit Draw-Down Policy Controls', () => {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0,
     });
     await setupDefaultTax(clientId);
     await ensureClientBillingSettings(clientId, { credit_application_order: 'expiration_first' });

--- a/server/src/test/infrastructure/billing/credits/creditDrawdownRbac.test.ts
+++ b/server/src/test/infrastructure/billing/credits/creditDrawdownRbac.test.ts
@@ -94,7 +94,6 @@ async function seedClientWithSettings(): Promise<string> {
     billing_cycle: 'monthly',
     region_code: 'US-NY',
     is_tax_exempt: false,
-    credit_balance: 0,
   });
 
   const now = new Date().toISOString();

--- a/server/src/test/infrastructure/billing/credits/creditDrawdownUseDefaultSettings.test.ts
+++ b/server/src/test/infrastructure/billing/credits/creditDrawdownUseDefaultSettings.test.ts
@@ -134,7 +134,6 @@ describe('Credit Draw-Down "Use Default Settings" Data-Loss Fix', () => {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0,
     });
 
     const tenantEligibleTypeId = uuidv4();

--- a/server/src/test/infrastructure/billing/credits/creditExpirationCore.test.ts
+++ b/server/src/test/infrastructure/billing/credits/creditExpirationCore.test.ts
@@ -34,12 +34,20 @@ vi.mock('server/src/lib/analytics/posthog', () => ({
   }
 }));
 
+// expiredCreditsHandler is a background job: it calls getConnection() for its
+// own pool instead of going through createTenantKnex. That second connection
+// cannot see the rows this suite writes inside its transaction, and it blocks
+// on their locks until the test times out. Hand it the suite transaction —
+// knex turns the handler's inner transaction into a savepoint on it.
+const handlerConnection = vi.hoisted(() => ({ db: null as any }));
+
 vi.mock('@alga-psa/db', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@alga-psa/db')>();
   return {
     ...actual,
     withTransaction: vi.fn(async (knex, callback) => callback(knex)),
-    withAdminTransaction: vi.fn(async (callback, existingConnection) => callback(existingConnection as any))
+    withAdminTransaction: vi.fn(async (callback, existingConnection) => callback(existingConnection as any)),
+    getConnection: vi.fn(async () => handlerConnection.db)
   };
 });
 
@@ -141,6 +149,7 @@ describe('Credit Expiration Core Tests', () => {
       userType: 'internal'
     });
 
+    handlerConnection.db = context.db;
     const mockContext = setupCommonMocks({
       tenantId: context.tenantId,
       userId: context.userId,
@@ -154,6 +163,7 @@ describe('Credit Expiration Core Tests', () => {
 
   beforeEach(async () => {
     context = await resetContext();
+    handlerConnection.db = context.db;
     const mockContext = setupCommonMocks({
       tenantId: context.tenantId,
       userId: context.userId,
@@ -330,10 +340,12 @@ describe('Credit Expiration Core Tests', () => {
     await finalizeInvoice(prepaymentInvoice.invoice_id);
     console.log('Test: Prepayment invoice finalized');
     
-    // Step 3: Verify initial credit balance and credit tracking entry
+    // Step 3: Verify initial credit balance and credit tracking entry.
+    // Available credit is derived from non-expired credit_tracking rows, so a
+    // credit issued with a past expiration date is already unspendable — the
+    // work the job has yet to do shows up in the tracking row, not here.
     const initialCredit = await ClientContractLine.getClientCredit(client_id);
-    expect(initialCredit).toBe(prepaymentAmount);
-    console.log('Test: Initial credit balance verified:', initialCredit);
+    expect(initialCredit).toBe(0);
     
     // Get the credit transaction
     const creditTransaction = await context.db('transactions')
@@ -465,9 +477,11 @@ describe('Credit Expiration Core Tests', () => {
     await finalizeInvoice(prepaymentInvoice1.invoice_id);
     await finalizeInvoice(prepaymentInvoice2.invoice_id);
     
-    // Step 4: Verify initial credit balance
+    // Step 4: Verify initial credit balance. Only the future-dated credit is
+    // spendable; the past-dated one stopped counting when its date passed,
+    // before the expiration job flagged it.
     const initialCredit = await ClientContractLine.getClientCredit(client_id);
-    expect(initialCredit).toBe(12000); // $120.00 total credit
+    expect(initialCredit).toBe(7000); // only the non-expired $70.00 credit
     
     // Get the credit transactions
     const creditTransaction1 = await context.db('transactions')

--- a/server/src/test/infrastructure/billing/credits/creditExpirationEffects.test.ts
+++ b/server/src/test/infrastructure/billing/credits/creditExpirationEffects.test.ts
@@ -26,12 +26,20 @@ vi.mock('server/src/lib/analytics/posthog', () => ({
   }
 }));
 
+// expiredCreditsHandler is a background job: it calls getConnection() for its
+// own pool instead of going through createTenantKnex. That second connection
+// cannot see the rows this suite writes inside its transaction, and it blocks
+// on their locks until the test times out. Hand it the suite transaction —
+// knex turns the handler's inner transaction into a savepoint on it.
+const handlerConnection = vi.hoisted(() => ({ db: null as any }));
+
 vi.mock('@alga-psa/db', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@alga-psa/db')>();
   return {
     ...actual,
     withTransaction: vi.fn(async (knex, callback) => callback(knex)),
-    withAdminTransaction: vi.fn(async (callback, existingConnection) => callback(existingConnection as any))
+    withAdminTransaction: vi.fn(async (callback, existingConnection) => callback(existingConnection as any)),
+    getConnection: vi.fn(async () => handlerConnection.db)
   };
 });
 
@@ -102,6 +110,7 @@ describe('Credit Expiration Effects Tests', () => {
       userType: 'internal'
     });
 
+    handlerConnection.db = context.db;
     setupCommonMocks({
       tenantId: context.tenantId,
       userId: context.userId,
@@ -113,6 +122,7 @@ describe('Credit Expiration Effects Tests', () => {
 
   beforeEach(async () => {
     context = await resetContext();
+    handlerConnection.db = context.db;
     setupCommonMocks({
       tenantId: context.tenantId,
       userId: context.userId,
@@ -286,12 +296,15 @@ describe('Credit Expiration Effects Tests', () => {
     
     expect(expirationTransaction2).toBeUndefined();
     
-    // Verify client credit balances
+    // Verify client credit balances. Both credits carry the same past
+    // expiration date, so neither is spendable — the derived balance stops
+    // counting a credit when its date passes, not when the job flags it. That
+    // the job skipped client2 is what the tracking rows above assert.
     const client1Credit = await ClientContractLine.getClientCredit(client1_id);
     const client2Credit = await ClientContractLine.getClientCredit(client2_id);
-    
-    expect(client1Credit).toBe(0); // Credit expired
-    expect(client2Credit).toBe(7000); // Credit still active
+
+    expect(client1Credit).toBe(0);
+    expect(client2Credit).toBe(0);
   }, 120000);
 
   it('should test that expired credits have their remaining amount set to zero', async () => {
@@ -400,10 +413,13 @@ describe('Credit Expiration Effects Tests', () => {
     expect(initialCreditTracking2.is_expired).toBe(false);
     expect(Number(initialCreditTracking2.remaining_amount)).toBe(prepaymentAmount2);
     
-    // Verify initial client credit balance
+    // Available credit is derived from non-expired credit_tracking rows, so a
+    // credit whose expiration date has already passed stops counting the moment
+    // the date passes — before the job flips is_expired. The un-run job is
+    // visible in the tracking rows asserted above, not in this balance.
     const initialCredit = await ClientContractLine.getClientCredit(client_id);
-    expect(initialCredit).toBe(prepaymentAmount1 + prepaymentAmount2);
-    
+    expect(initialCredit).toBe(prepaymentAmount2);
+
     // Run the expired credits handler
     await expiredCreditsHandler({ tenantId: context.tenantId });
     
@@ -512,13 +528,19 @@ describe('Credit Expiration Effects Tests', () => {
       })
       .first();
     
-    // Verify initial state
-    const initialCredit = await ClientContractLine.getClientCredit(client_id);
-    expect(initialCredit).toBe(prepaymentAmount);
-    
+    // Verify initial state. Available credit is derived from non-expired
+    // credit_tracking rows, so this credit — issued with a past expiration date
+    // — is already unspendable; what the job has yet to do is visible in the
+    // tracking row, not in the balance.
+    const initialTracking = await context.db('credit_tracking')
+      .where({ transaction_id: creditTransaction.transaction_id, tenant: context.tenantId })
+      .first();
+    expect(initialTracking.is_expired).toBe(false);
+    expect(Number(initialTracking.remaining_amount)).toBe(prepaymentAmount);
+
     // Run the expired credits handler to process expired credits
     await expiredCreditsHandler({ tenantId: context.tenantId });
-    
+
     // Verify the expiration transaction was created
     const expirationTransaction = await context.db('transactions')
       .where({
@@ -620,10 +642,6 @@ describe('Credit Expiration Effects Tests', () => {
     );
     await finalizeInvoice(prepaymentInvoice.invoice_id);
     
-    // Verify initial credit balance
-    const initialCredit = await ClientContractLine.getClientCredit(client_id);
-    expect(initialCredit).toBe(prepaymentAmount);
-    
     // Get the credit transaction
     const creditTransaction = await context.db('transactions')
       .where({
@@ -632,10 +650,19 @@ describe('Credit Expiration Effects Tests', () => {
         type: 'credit_issuance'
       })
       .first();
-    
+
+    // Verify the credit is still tracked as unexpired but already past its
+    // date: the derived balance drops when the date passes, the job only
+    // records that fact.
+    const initialTracking = await context.db('credit_tracking')
+      .where({ transaction_id: creditTransaction.transaction_id, tenant: context.tenantId })
+      .first();
+    expect(initialTracking.is_expired).toBe(false);
+    expect(Number(initialTracking.remaining_amount)).toBe(prepaymentAmount);
+
     // Run the expired credits handler
     await expiredCreditsHandler({ tenantId: context.tenantId });
-    
+
     // Verify client credit balance is reduced to zero
     const finalCredit = await ClientContractLine.getClientCredit(client_id);
     expect(finalCredit).toBe(0);

--- a/server/src/test/infrastructure/billing/credits/creditExpirationEffects.test.ts
+++ b/server/src/test/infrastructure/billing/credits/creditExpirationEffects.test.ts
@@ -145,14 +145,12 @@ describe('Credit Expiration Effects Tests', () => {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0
     });
 
     const client2_id = await createClient(context.db, context.tenantId, 'Client 2 Expiration Test', {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0
     });
 
     await setupClientTaxConfiguration(context, {
@@ -312,7 +310,6 @@ describe('Credit Expiration Effects Tests', () => {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0
     });
 
     await setupClientTaxConfiguration(context, {
@@ -467,7 +464,6 @@ describe('Credit Expiration Effects Tests', () => {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0
     });
 
     await setupClientTaxConfiguration(context, {
@@ -586,7 +582,6 @@ describe('Credit Expiration Effects Tests', () => {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0
     });
 
     await setupClientTaxConfiguration(context, {
@@ -668,15 +663,7 @@ describe('Credit Expiration Effects Tests', () => {
     
     expect(updatedCreditTracking.is_expired).toBe(true);
     expect(Number(updatedCreditTracking.remaining_amount)).toBe(0);
-    
-    // Verify the client record has been updated with the reduced credit balance
-    const updatedClient = await context.db('clients')
-      .where({
-        client_id: client_id,
-        tenant: context.tenantId
-      })
-      .first();
-    
-    expect(Number(updatedClient.credit_balance)).toBe(0);
+    // The balance itself is the getClientCredit assertion above: it is derived
+    // from these tracking rows, not cached on the client.
   }, 120000);
 });

--- a/server/src/test/infrastructure/billing/credits/creditExpirationIntegration.test.ts
+++ b/server/src/test/infrastructure/billing/credits/creditExpirationIntegration.test.ts
@@ -508,13 +508,8 @@ describe('Credit Expiration Integration Tests', () => {
       related_transaction_id: expiredCreditTransaction.transaction_id
     });
 
-    // Update client credit balance to reflect the expired credit
-    await context.db('clients')
-      .where({ client_id: clientId, tenant: context.tenantId })
-      .update({
-        credit_balance: activeCreditAmount, // Only the active credit remains
-        updated_at: new Date().toISOString()
-      });
+    // No cached balance to update: zeroing the expired tracking row above is
+    // what makes only the active credit count.
 
     // Step 6: Verify initial credit balance (should only include active credit)
     const initialCredit = await ClientContractLine.getClientCredit(clientId);
@@ -623,12 +618,8 @@ describe('Credit Expiration Integration Tests', () => {
           updated_at: nowIso
         });
 
-      await context.db('clients')
-        .where({ client_id: clientId, tenant: context.tenantId })
-        .update({
-          credit_balance: newBalance,
-          updated_at: nowIso
-        });
+      // The remaining balance follows from the credit_tracking update above —
+      // there is no cached column on the client to write it to.
     }
 
     // Step 9: Get the updated invoice to verify credit application

--- a/server/src/test/infrastructure/billing/credits/creditExpirationIntegration.test.ts
+++ b/server/src/test/infrastructure/billing/credits/creditExpirationIntegration.test.ts
@@ -610,11 +610,13 @@ describe('Credit Expiration Integration Tests', () => {
           updated_at: nowIso
         });
 
+      // Invoice totals are immutable after finalization: credit is recorded in
+      // credit_applied and the balance due is derived, so total_amount stays
+      // gross here exactly as the real finalize path leaves it.
       await context.db('invoices')
         .where({ invoice_id: positiveInvoiceId })
         .update({
           credit_applied: activeCreditAmount,
-          total_amount: totalBeforeCredit - expectedAppliedCredit,
           updated_at: nowIso
         });
 
@@ -633,7 +635,8 @@ describe('Credit Expiration Integration Tests', () => {
     expect(updatedInvoice.subtotal).toBe(subtotal);
     expect(updatedInvoice.tax).toBe(tax);
     expect(updatedInvoice.credit_applied).toBe(expectedAppliedCredit);
-    expect(parseInt(updatedInvoice.total_amount)).toBe(expectedRemainingTotal);
+    expect(parseInt(updatedInvoice.total_amount)).toBe(totalBeforeCredit);
+    expect(parseInt(updatedInvoice.total_amount) - Number(updatedInvoice.credit_applied)).toBe(expectedRemainingTotal);
 
     // Step 11: Verify credit application transaction
     const creditApplicationTx = await context.db('transactions')

--- a/server/src/test/infrastructure/billing/credits/creditExpirationPriority.test.ts
+++ b/server/src/test/infrastructure/billing/credits/creditExpirationPriority.test.ts
@@ -15,6 +15,7 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 import { Temporal } from '@js-temporal/polyfill';
 import { ClientContractLine } from '@alga-psa/billing/models';
+import { getAvailableCredit } from '@alga-psa/billing/lib/creditBalance';
 import { createTestDate, createTestDateISO } from '../../../test-utils/dateUtils';
 import { expiredCreditsHandler } from '@alga-psa/jobs/handlers/expiredCreditsHandler';
 import { toPlainDate } from 'server/src/lib/utils/dateTimeUtils';
@@ -193,12 +194,9 @@ async function applyCreditsManually(
 
   const totalApplied = appliedCredits.reduce((sum, entry) => sum + entry.amount, 0);
 
-  const clientRow = await tenantTable(context, 'clients')
-    .where({ client_id: clientId, tenant: context.tenantId })
-    .first();
-
-  const currentBalance = Number(clientRow?.credit_balance ?? 0);
-  const newBalance = currentBalance - totalApplied;
+  // Balance is derived from the credit_tracking remainders the loop above just
+  // drew down, so reading it here already nets out what was applied.
+  const newBalance = await getAvailableCredit(context.db, context.tenantId, clientId);
 
   const creditApplicationTransactionId = uuidv4();
 
@@ -235,13 +233,6 @@ async function applyCreditsManually(
     created_at: nowIso,
     tenant: context.tenantId
   });
-
-  await tenantTable(context, 'clients')
-    .where({ client_id: clientId, tenant: context.tenantId })
-    .update({
-      credit_balance: newBalance,
-      updated_at: nowIso
-    });
 
   await tenantTable(context, 'invoices')
     .where({ invoice_id: invoiceId })
@@ -349,7 +340,6 @@ describe('Credit Expiration Prioritization Tests', () => {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0
     });
 
     await setupClientTaxConfiguration(context, {
@@ -1066,14 +1056,9 @@ describe('Credit Expiration Prioritization Tests', () => {
       related_transaction_id: expiringCreditTx.transaction_id
     });
     
-    // Update client credit balance
-    await tenantTable(context, 'clients')
-      .where({ client_id: client_id, tenant: context.tenantId })
-      .update({
-        credit_balance: activeCreditAmount, // Only the active credit remains
-        updated_at: new Date().toISOString()
-      });
-    
+    // No cached balance to update: zeroing the expired tracking row above is
+    // what leaves only the active credit spendable.
+
     // Step 7: Verify credit balance after expiration
     const creditAfterExpiration = await ClientContractLine.getClientCredit(client_id);
     expect(creditAfterExpiration).toBe(activeCreditAmount);

--- a/server/src/test/infrastructure/billing/credits/creditExpirationPriority.test.ts
+++ b/server/src/test/infrastructure/billing/credits/creditExpirationPriority.test.ts
@@ -234,11 +234,13 @@ async function applyCreditsManually(
     tenant: context.tenantId
   });
 
+  // Invoice totals are immutable after finalization: applied credit lives in
+  // credit_applied and the balance due is derived, so total_amount stays gross
+  // here exactly as the real finalize path leaves it.
   await tenantTable(context, 'invoices')
     .where({ invoice_id: invoiceId })
     .update({
       credit_applied: totalApplied,
-      total_amount: totalBeforeCredit - totalApplied,
       updated_at: nowIso
     });
 
@@ -562,8 +564,9 @@ describe('Credit Expiration Prioritization Tests', () => {
     expect(Number(updatedInvoice.subtotal)).toBe(subtotal);
     expect(Number(updatedInvoice.tax)).toBe(tax);
     expect(Number(updatedInvoice.credit_applied)).toBe(expectedAppliedCredit);
-    expect(Number(updatedInvoice.total_amount)).toBe(expectedRemainingTotal);
-    
+    expect(Number(updatedInvoice.total_amount)).toBe(totalBeforeCredit);
+    expect(Number(updatedInvoice.total_amount) - Number(updatedInvoice.credit_applied)).toBe(expectedRemainingTotal);
+
     // Step 11: Verify credit application transaction
     const creditApplicationTx = await tenantTable(context, 'transactions')
       .where({
@@ -776,7 +779,8 @@ describe('Credit Expiration Prioritization Tests', () => {
     // Verify invoice values
     console.log(`First invoice - Subtotal: ${subtotal1}, Tax: ${tax1}, Total: ${totalBeforeCredit1}`);
     expect(Number(updatedInvoice1.credit_applied)).toBe(expectedAppliedCredit1);
-    expect(Number(updatedInvoice1.total_amount)).toBe(expectedRemainingTotal1);
+    expect(Number(updatedInvoice1.total_amount)).toBe(totalBeforeCredit1);
+    expect(Number(updatedInvoice1.total_amount) - Number(updatedInvoice1.credit_applied)).toBe(expectedRemainingTotal1);
     
     // Step 9: Verify credit application transaction for first invoice
     const creditApplicationTx1 = await tenantTable(context, 'transactions')
@@ -846,8 +850,9 @@ describe('Credit Expiration Prioritization Tests', () => {
     const expectedRemainingTotal2 = totalBeforeCredit2 - actualAppliedCredit2;
 
     // Verify second invoice values
-    // The remaining amount should be the difference between the total and the applied credit
-    expect(Number(updatedInvoice2.total_amount)).toBe(expectedRemainingTotal2);
+    // The remaining amount is derived: gross total minus applied credit.
+    expect(Number(updatedInvoice2.total_amount)).toBe(totalBeforeCredit2);
+    expect(Number(updatedInvoice2.total_amount) - actualAppliedCredit2).toBe(expectedRemainingTotal2);
     
     // Step 15: Verify credit application transaction for second invoice
     const creditApplicationTx2 = await tenantTable(context, 'transactions')
@@ -1090,8 +1095,9 @@ describe('Credit Expiration Prioritization Tests', () => {
     expect(Number(updatedInvoice.subtotal)).toBe(subtotal);
     expect(Number(updatedInvoice.tax)).toBe(tax);
     expect(Number(updatedInvoice.credit_applied)).toBe(expectedAppliedCredit);
-    expect(Number(updatedInvoice.total_amount)).toBe(expectedRemainingTotal);
-    
+    expect(Number(updatedInvoice.total_amount)).toBe(totalBeforeCredit);
+    expect(Number(updatedInvoice.total_amount) - Number(updatedInvoice.credit_applied)).toBe(expectedRemainingTotal);
+
     // Step 11: Verify credit application transaction
     const creditApplicationTx = await tenantTable(context, 'transactions')
       .where({

--- a/server/src/test/infrastructure/billing/credits/creditServiceTypeRestrictionMode.test.ts
+++ b/server/src/test/infrastructure/billing/credits/creditServiceTypeRestrictionMode.test.ts
@@ -329,7 +329,6 @@ describe('Credit Service-Type Restriction Mode (Option B)', () => {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0,
     });
     await seedClientRestriction(clientId, null, null);
 
@@ -345,7 +344,6 @@ describe('Credit Service-Type Restriction Mode (Option B)', () => {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0,
     });
     await seedClientRestriction(clientId, null, null);
 
@@ -363,7 +361,6 @@ describe('Credit Service-Type Restriction Mode (Option B)', () => {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0,
     });
     await seedClientRestriction(clientId, 'all', null);
 
@@ -382,7 +379,6 @@ describe('Credit Service-Type Restriction Mode (Option B)', () => {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0,
     });
     // Client picks a *different* list than the tenant.
     await seedClientRestriction(clientId, 'restricted', [hardwareTypeId]);
@@ -398,7 +394,6 @@ describe('Credit Service-Type Restriction Mode (Option B)', () => {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0,
     });
 
     await setupDefaultTax(clientId);
@@ -467,7 +462,6 @@ describe('Credit Service-Type Restriction Mode (Option B)', () => {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0,
     });
 
     await setupDefaultTax(clientId);

--- a/server/src/test/infrastructure/billing/credits/creditServiceTypeRestrictionModeMigration.test.ts
+++ b/server/src/test/infrastructure/billing/credits/creditServiceTypeRestrictionModeMigration.test.ts
@@ -5,6 +5,7 @@ import { tenantDb } from '@alga-psa/db';
 import { TestContext } from '../../../../../test-utils/testContext';
 import { v4 as uuidv4 } from 'uuid';
 import { createClient } from '../../../../../test-utils/testDataFactory';
+import { updateClientBillingSettings } from '@shared/billingClients/billingSettings';
 
 let mockedTenantId = '11111111-1111-1111-1111-111111111111';
 let mockedUserId = 'mock-user-id';
@@ -275,96 +276,95 @@ describe('credit service-type restriction mode migration', () => {
     expect(row.credit_eligible_service_type_ids).toBeNull();
   });
 
-  it('rejects tenant inserts violating each CHECK arm', async () => {
+  // 20260816120000 shipped a CHECK on each table pairing the mode with the ids.
+  // 20260817130000 drops both: the tenant-side NOT NULL that came with them
+  // could not be installed on the hosted Citus cluster, and neither constraint
+  // was load-bearing. The pairing now lives on the write path
+  // (updateClientBillingSettings) and NULL reads back as 'all'. These two tests
+  // pin that arrangement so the constraints cannot quietly come back.
+  async function checkConstraintNames(table: string): Promise<string[]> {
+    const result = await context.db.raw(
+      `SELECT conname
+         FROM pg_constraint
+        WHERE conrelid = ?::regclass
+          AND contype = 'c'
+          AND conname LIKE '%credit_service_type_restriction_mode%'`,
+      [table]
+    );
+    return result.rows.map((row: { conname: string }) => row.conname);
+  }
+
+  it('leaves the tenant mode/ids pairing unconstrained in the database', async () => {
+    expect(await checkConstraintNames('default_billing_settings')).toEqual([]);
+
     await deleteTenantRow();
 
-    // mode 'restricted' with null ids is rejected.
-    await expect(
-      tenantTable(context, 'default_billing_settings').insert({
-        tenant: context.tenantId,
-        zero_dollar_invoice_handling: 'normal',
-        suppress_zero_dollar_invoices: false,
-        credit_service_type_restriction_mode: 'restricted',
-        credit_eligible_service_type_ids: null,
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      })
-    ).rejects.toThrow();
+    // Rows the dropped CHECK used to reject now insert.
+    await tenantTable(context, 'default_billing_settings').insert({
+      tenant: context.tenantId,
+      zero_dollar_invoice_handling: 'normal',
+      suppress_zero_dollar_invoices: false,
+      credit_service_type_restriction_mode: 'restricted',
+      credit_eligible_service_type_ids: null,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
 
-    // mode 'all' with non-empty ids is rejected.
-    await expect(
-      tenantTable(context, 'default_billing_settings').insert({
-        tenant: context.tenantId,
-        zero_dollar_invoice_handling: 'normal',
-        suppress_zero_dollar_invoices: false,
-        credit_service_type_restriction_mode: 'all',
-        credit_eligible_service_type_ids: JSON.stringify([uuidv4()]),
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      })
-    ).rejects.toThrow();
-
-    // mode 'restricted' with an empty array is rejected.
-    await expect(
-      tenantTable(context, 'default_billing_settings').insert({
-        tenant: context.tenantId,
-        zero_dollar_invoice_handling: 'normal',
-        suppress_zero_dollar_invoices: false,
-        credit_service_type_restriction_mode: 'restricted',
-        credit_eligible_service_type_ids: JSON.stringify([]),
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      })
-    ).rejects.toThrow();
+    const row = await tenantTable(context, 'default_billing_settings')
+      .where({ tenant: context.tenantId })
+      .first();
+    expect(row.credit_service_type_restriction_mode).toBe('restricted');
+    expect(row.credit_eligible_service_type_ids).toBeNull();
   });
 
-  it('rejects client inserts violating each CHECK arm', async () => {
+  it('normalizes the client mode/ids pairing on the write path', async () => {
+    expect(await checkConstraintNames('client_billing_settings')).toEqual([]);
+
     const clientId = await createClient(context.db, context.tenantId, 'Constraint Client', {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
     });
 
-    // mode 'restricted' with null ids is rejected.
-    await expect(
-      tenantTable(context, 'client_billing_settings').insert({
-        tenant: context.tenantId,
-        client_id: clientId,
-        zero_dollar_invoice_handling: 'normal',
-        suppress_zero_dollar_invoices: false,
-        credit_service_type_restriction_mode: 'restricted',
-        credit_eligible_service_type_ids: null,
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      })
-    ).rejects.toThrow();
+    const readSettings = async () =>
+      tenantTable(context, 'client_billing_settings')
+        .where({ client_id: clientId, tenant: context.tenantId })
+        .first();
 
-    // mode 'all' with non-empty ids is rejected.
-    await expect(
-      tenantTable(context, 'client_billing_settings').insert({
-        tenant: context.tenantId,
-        client_id: clientId,
-        zero_dollar_invoice_handling: 'normal',
-        suppress_zero_dollar_invoices: false,
-        credit_service_type_restriction_mode: 'all',
-        credit_eligible_service_type_ids: JSON.stringify([uuidv4()]),
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      })
-    ).rejects.toThrow();
+    // 'restricted' keeps the ids it is given.
+    const restrictedId = uuidv4();
+    await updateClientBillingSettings(context.db, context.tenantId, clientId, {
+      creditServiceTypeRestrictionMode: 'restricted',
+      creditEligibleServiceTypeIds: [restrictedId],
+    });
+    let row = await readSettings();
+    expect(row.credit_service_type_restriction_mode).toBe('restricted');
+    expect(row.credit_eligible_service_type_ids).toEqual([restrictedId]);
 
-    // NULL mode with non-empty ids is rejected (a restricted list must declare its mode).
-    await expect(
-      tenantTable(context, 'client_billing_settings').insert({
-        tenant: context.tenantId,
-        client_id: clientId,
-        zero_dollar_invoice_handling: 'normal',
-        suppress_zero_dollar_invoices: false,
-        credit_service_type_restriction_mode: null,
-        credit_eligible_service_type_ids: JSON.stringify([uuidv4()]),
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      })
-    ).rejects.toThrow();
+    // 'all' clears them rather than storing a contradictory pair.
+    await updateClientBillingSettings(context.db, context.tenantId, clientId, {
+      creditServiceTypeRestrictionMode: 'all',
+      creditEligibleServiceTypeIds: [uuidv4()],
+    });
+    row = await readSettings();
+    expect(row.credit_service_type_restriction_mode).toBe('all');
+    expect(row.credit_eligible_service_type_ids).toBeNull();
+
+    // An ids-only write derives the mode instead of leaving it NULL.
+    const derivedId = uuidv4();
+    await updateClientBillingSettings(context.db, context.tenantId, clientId, {
+      creditEligibleServiceTypeIds: [derivedId],
+    });
+    row = await readSettings();
+    expect(row.credit_service_type_restriction_mode).toBe('restricted');
+    expect(row.credit_eligible_service_type_ids).toEqual([derivedId]);
+
+    // An empty list means "inherit": NULL mode and NULL ids.
+    await updateClientBillingSettings(context.db, context.tenantId, clientId, {
+      creditEligibleServiceTypeIds: [],
+    });
+    row = await readSettings();
+    expect(row.credit_service_type_restriction_mode).toBeNull();
+    expect(row.credit_eligible_service_type_ids).toBeNull();
   });
 });

--- a/server/src/test/infrastructure/billing/credits/creditServiceTypeRestrictionModeMigration.test.ts
+++ b/server/src/test/infrastructure/billing/credits/creditServiceTypeRestrictionModeMigration.test.ts
@@ -203,13 +203,11 @@ describe('credit service-type restriction mode migration', () => {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0,
     });
     const inheritClient = await createClient(context.db, context.tenantId, 'Inherit Migration Client', {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0,
     });
 
     const laborTypeId = uuidv4();
@@ -256,7 +254,6 @@ describe('credit service-type restriction mode migration', () => {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0,
     });
 
     await tenantTable(context, 'client_billing_settings').insert({
@@ -326,7 +323,6 @@ describe('credit service-type restriction mode migration', () => {
       billing_cycle: 'monthly',
       region_code: 'US-NY',
       is_tax_exempt: false,
-      credit_balance: 0,
     });
 
     // mode 'restricted' with null ids is rejected.

--- a/server/src/test/infrastructure/billing/credits/invoiceCreditReversalConcurrency.test.ts
+++ b/server/src/test/infrastructure/billing/credits/invoiceCreditReversalConcurrency.test.ts
@@ -91,7 +91,6 @@ async function newTestClient(name: string): Promise<string> {
   return createClient(db, tenant, name, {
     billing_cycle: 'monthly',
     is_tax_exempt: false,
-    credit_balance: 0,
   });
 }
 

--- a/server/src/test/infrastructure/billing/credits/invoiceCreditReversalLifecycle.test.ts
+++ b/server/src/test/infrastructure/billing/credits/invoiceCreditReversalLifecycle.test.ts
@@ -247,7 +247,6 @@ async function setupCreditedClientInvoice(options: {
     billing_cycle: 'monthly',
     region_code: 'US-NY',
     is_tax_exempt: false,
-    credit_balance: 0,
   });
 
   await setupDefaultTax(clientId);

--- a/server/src/test/infrastructure/billing/invoices/billingInvoiceGeneration_consistency.test.ts
+++ b/server/src/test/infrastructure/billing/invoices/billingInvoiceGeneration_consistency.test.ts
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { createInvoiceFromBillingResult } from '@alga-psa/billing/actions/invoiceGeneration';
 import { generateManualInvoice as generateManualInvoiceRaw } from '@alga-psa/billing/actions';
 import { setupClientTaxConfiguration, assignServiceTaxRate, createTestService, ensureClientPlanBundlesTable,
+  seedBillingChargeSources,
   unwrapManualInvoice
 } from '../../../../../test-utils/billingTestHelpers';
 import { TextEncoder as NodeTextEncoder } from 'util';
@@ -234,6 +235,10 @@ async function ensureDefaultBillingSettings() {
         adjustments: [],
         finalAmount: 1000
       };
+
+      // persistInvoiceCharges marks each usage charge's source usage_tracking
+      // row invoiced and throws when there is none behind a fabricated usageId.
+      await seedBillingChargeSources(context, [autoCharge as unknown as Record<string, unknown>]);
 
       const createdAutoInvoice = await createInvoiceFromBillingResult(
         billingResult,

--- a/server/src/test/infrastructure/billing/invoices/billingInvoiceGeneration_edgeCases.test.ts
+++ b/server/src/test/infrastructure/billing/invoices/billingInvoiceGeneration_edgeCases.test.ts
@@ -3,7 +3,7 @@ import '../../../../../test-utils/nextApiMock';
 import { setupCommonMocks } from '../../../../../test-utils/testMocks';
 import { TestContext } from '../../../../../test-utils/testContext';
 import { generateInvoice } from '@alga-psa/billing/actions/invoiceGeneration';
-import { createTestService, assignServiceTaxRate, setupClientTaxConfiguration, createFixedPlanAssignment, addServiceToFixedPlan, ensureClientPlanBundlesTable } from '../../../../../test-utils/billingTestHelpers';
+import { createTestService, assignServiceTaxRate, setupClientTaxConfiguration, createFixedPlanAssignment, addServiceToFixedPlan, ensureClientPlanBundlesTable, materializeRecurringServicePeriods } from '../../../../../test-utils/billingTestHelpers';
 import { TextEncoder as NodeTextEncoder } from 'util';
 import { v4 as uuidv4 } from 'uuid';
 import { seedBillingCycle } from '../../../../../test-utils/billingProfileTestHelpers';
@@ -180,6 +180,11 @@ describe('Billing Invoice Edge Cases', () => {
       detailBaseRateCents: 7500
     });
 
+    // generateInvoice refuses a window with no recurring service period, and
+    // the fixture only materializes on request. Run it after the extra service
+    // so the line is complete.
+    await materializeRecurringServicePeriods(context, creditContractLineId);
+
     const billingCycleId = uuidv4();
     await seedBillingCycle(context.db, context.tenantId, {
       billing_cycle_id: billingCycleId,
@@ -223,9 +228,27 @@ describe('Billing Invoice Edge Cases', () => {
       planName: 'Free Plan',
       baseRateCents: 0,
       detailBaseRateCents: 0,
-      startDate: '2025-02-01',
-      clientId: context.clientId
+      // Default billing timing is arrears, and an arrears cycle invoices the
+      // service period before its own window.
+      startDate: '2025-01-01',
+      clientId: context.clientId,
+      materializeServicePeriods: true
     });
+
+    // This test is about a zero-dollar invoice that is actually produced, so
+    // the client must not be on the suppressing default: with
+    // suppress_zero_dollar_invoices set, generateInvoice returns null.
+    await context.db('client_billing_settings')
+      .insert({
+        tenant: context.tenantId,
+        client_id: context.clientId,
+        zero_dollar_invoice_handling: 'normal',
+        suppress_zero_dollar_invoices: false,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString()
+      })
+      .onConflict(['tenant', 'client_id'])
+      .merge({ zero_dollar_invoice_handling: 'normal', suppress_zero_dollar_invoices: false });
 
     const billingCycleId = uuidv4();
     await seedBillingCycle(context.db, context.tenantId, {

--- a/server/src/test/infrastructure/billing/invoices/billingInvoiceGeneration_subtotal.test.ts
+++ b/server/src/test/infrastructure/billing/invoices/billingInvoiceGeneration_subtotal.test.ts
@@ -12,6 +12,7 @@ import {
   assignServiceTaxRate,
   ensureDefaultBillingSettings,
   ensureClientPlanBundlesTable,
+  materializeRecurringServicePeriods,
   unwrapManualInvoice
 } from '../../../../../test-utils/billingTestHelpers';
 import { TextEncoder as NodeTextEncoder } from 'util';
@@ -258,6 +259,11 @@ describe('Billing Invoice Subtotal Calculations', () => {
     await addServiceToFixedPlan(context, planId, serviceB, { detailBaseRateCents: 7500 });
     await addServiceToFixedPlan(context, planId, serviceC, { detailBaseRateCents: 10000 });
 
+    // generateInvoice refuses a window with no recurring service period, and
+    // the fixture only materializes on request. Run it after the extra services
+    // so the line is complete.
+    await materializeRecurringServicePeriods(context, planId);
+
     const billingCycleId = await context.createEntity('client_billing_cycles', {
       client_id: context.clientId,
       billing_cycle: 'monthly',
@@ -278,7 +284,11 @@ describe('Billing Invoice Subtotal Calculations', () => {
     expect(invoice!.subtotal).toBe(22500);
   });
 
-  it('returns zero subtotal when manual invoice line items have zero quantity', async () => {
+  // A zero-quantity line no longer reaches the invoice: buildManualInvoiceItem
+  // rejects it with ManualInvoiceError('INVALID_QUANTITY'). The old expectation
+  // — three zero-value lines and a zero subtotal — describes behaviour the
+  // product deliberately dropped.
+  it('rejects manual invoice line items with zero quantity', async () => {
     const serviceA = await createTestService(context, {
       service_name: 'Consulting',
       default_rate: 5000,
@@ -297,40 +307,37 @@ describe('Billing Invoice Subtotal Calculations', () => {
       tax_region: 'US-NY'
     });
 
-    const invoice = await generateManualInvoice({
-      clientId: context.clientId,
-      items: [
-        {
-          service_id: serviceA,
-          description: 'Consulting services',
-          unit_price: 5000,
-          quantity: 0,
-          rate: 5000
-        },
-        {
-          service_id: serviceB,
-          description: 'Development services',
-          unit_price: 7500,
-          quantity: 0,
-          rate: 7500
-        },
-        {
-          service_id: serviceC,
-          description: 'Training services',
-          unit_price: 10000,
-          quantity: 0,
-          rate: 10000
-        }
-      ]
-    });
+    await expect(
+      generateManualInvoice({
+        clientId: context.clientId,
+        items: [
+          {
+            service_id: serviceA,
+            description: 'Consulting services',
+            unit_price: 5000,
+            quantity: 0,
+            rate: 5000
+          },
+          {
+            service_id: serviceB,
+            description: 'Development services',
+            unit_price: 7500,
+            quantity: 0,
+            rate: 7500
+          },
+          {
+            service_id: serviceC,
+            description: 'Training services',
+            unit_price: 10000,
+            quantity: 0,
+            rate: 10000
+          }
+        ]
+      })
+    ).rejects.toThrow('Quantity must be greater than 0');
 
-    expect(invoice.subtotal).toBe(0);
-
-    const items = await getInvoiceItems(invoice.invoice_id);
-    expect(items).toHaveLength(3);
-    items.forEach(item => {
-      expect(Number(item.net_amount)).toBe(0);
-    });
+    const invoices = await context.db('invoices').where({ tenant: context.tenantId });
+    expect(invoices).toHaveLength(0);
   });
 
   it('calculates subtotal when contract line charges net to zero', async () => {
@@ -350,10 +357,15 @@ describe('Billing Invoice Subtotal Calculations', () => {
       planName: 'Zero Credit Plan',
       baseRateCents: 0,
       detailBaseRateCents: 5000,
-      startDate: '2025-02-01'
+      // Default billing timing is arrears, and an arrears cycle invoices the
+      // service period *before* its own window, so the line has to start a
+      // cycle earlier than the cycle below.
+      startDate: '2025-01-01'
     });
 
     await addServiceToFixedPlan(context, planId, creditServiceB, { detailBaseRateCents: -5000 });
+
+    await materializeRecurringServicePeriods(context, planId);
 
     const billingCycleId = await context.createEntity('client_billing_cycles', {
       client_id: context.clientId,
@@ -381,12 +393,13 @@ describe('Billing Invoice Subtotal Calculations', () => {
       tax_region: 'US-NY'
     });
 
-    const { planId } = await createFixedPlanAssignment(context, creditService, {
+    await createFixedPlanAssignment(context, creditService, {
       planName: 'Credit Plan',
       baseRateCents: -12500,
       detailBaseRateCents: -12500,
       startDate: '2025-02-01',
-      billingTiming: 'advance'
+      billingTiming: 'advance',
+      materializeServicePeriods: true
     });
 
     const billingCycleId = await context.createEntity('client_billing_cycles', {

--- a/server/src/test/infrastructure/billing/invoices/billingInvoiceGeneration_tax.test.ts
+++ b/server/src/test/infrastructure/billing/invoices/billingInvoiceGeneration_tax.test.ts
@@ -478,7 +478,7 @@ describe('Billing Invoice Tax Calculations', () => {
 
       // persistInvoiceCharges marks each usage charge's source row invoiced and
       // throws when there is none behind a fabricated usageId.
-      await seedBillingChargeSources(context, billingResult.charges, { clientId: clientId });
+      await seedBillingChargeSources(context, billingResult.charges as Array<Record<string, unknown>>, { clientId: clientId });
 
       const createdInvoice = await createInvoiceFromBillingResult(
         billingResult,
@@ -892,7 +892,7 @@ describe('Billing Invoice Tax Calculations', () => {
 
     // persistInvoiceCharges marks each usage charge's source row invoiced and
     // throws when there is none behind a fabricated usageId.
-    await seedBillingChargeSources(context, billingResult.charges, { clientId: client_id });
+    await seedBillingChargeSources(context, billingResult.charges as Array<Record<string, unknown>>, { clientId: client_id });
 
     const createdInvoice = await createInvoiceFromBillingResult(
       billingResult,
@@ -1306,7 +1306,7 @@ describe('Billing Invoice Tax Calculations', () => {
 
     // persistInvoiceCharges marks each usage charge's source row invoiced and
     // throws when there is none behind a fabricated usageId.
-    await seedBillingChargeSources(context, billingResult.charges, { clientId: context.clientId });
+    await seedBillingChargeSources(context, billingResult.charges as Array<Record<string, unknown>>, { clientId: context.clientId });
 
     const createdInvoice = await createInvoiceFromBillingResult(
       billingResult,

--- a/server/src/test/infrastructure/billing/invoices/billingInvoiceGeneration_tax.test.ts
+++ b/server/src/test/infrastructure/billing/invoices/billingInvoiceGeneration_tax.test.ts
@@ -9,6 +9,8 @@ import {
   assignServiceTaxRate,
   ensureDefaultBillingSettings,
   ensureClientPlanBundlesTable as ensureClientContractsTable,
+  ensureClientBillingEmail,
+  seedBillingChargeSources,
   unwrapManualInvoice
 } from '../../../../../test-utils/billingTestHelpers';
 import { generateInvoice, createInvoiceFromBillingResult } from '@alga-psa/billing/actions/invoiceGeneration';
@@ -208,6 +210,10 @@ describe('Billing Invoice Tax Calculations', () => {
         is_inactive: false
       }, 'client_id');
 
+      // Invoice generation refuses a client with no billing recipient; fixtures
+      // that insert the row directly have to seed one.
+      await ensureClientBillingEmail(context, client_id);
+
       // Ensure tax region exists
       await tenantTable(context, 'tax_regions').insert({
         tenant: context.tenantId,
@@ -319,6 +325,10 @@ describe('Billing Invoice Tax Calculations', () => {
         created_at: Temporal.Now.plainDateISO().toString(),
         updated_at: Temporal.Now.plainDateISO().toString()
       }, 'client_id');
+
+      // Invoice generation refuses a client with no billing recipient; fixtures
+      // that insert the row directly have to seed one.
+      await ensureClientBillingEmail(context, clientId);
 
       await tenantTable(context, 'tax_regions').insert([
         {
@@ -466,6 +476,10 @@ describe('Billing Invoice Tax Calculations', () => {
         finalAmount: 1500
       };
 
+      // persistInvoiceCharges marks each usage charge's source row invoiced and
+      // throws when there is none behind a fabricated usageId.
+      await seedBillingChargeSources(context, billingResult.charges, { clientId: clientId });
+
       const createdInvoice = await createInvoiceFromBillingResult(
         billingResult,
         clientId,
@@ -508,6 +522,10 @@ describe('Billing Invoice Tax Calculations', () => {
         url: '',
         is_inactive: false
       }, 'client_id');
+
+      // Invoice generation refuses a client with no billing recipient; fixtures
+      // that insert the row directly have to seed one.
+      await ensureClientBillingEmail(context, client_id);
 
       // Ensure tax region exists
       await tenantTable(context, 'tax_regions').insert({
@@ -648,6 +666,10 @@ describe('Billing Invoice Tax Calculations', () => {
         is_inactive: false
       }, 'client_id');
 
+      // Invoice generation refuses a client with no billing recipient; fixtures
+      // that insert the row directly have to seed one.
+      await ensureClientBillingEmail(context, client_id);
+
       // Ensure tax region exists
       await tenantTable(context, 'tax_regions').insert({
         tenant: context.tenantId,
@@ -771,6 +793,10 @@ describe('Billing Invoice Tax Calculations', () => {
       is_inactive: false
     }, 'client_id');
 
+    // Invoice generation refuses a client with no billing recipient; fixtures
+    // that insert the row directly have to seed one.
+    await ensureClientBillingEmail(context, client_id);
+
     // Ensure tax region exists
     await tenantTable(context, 'tax_regions').insert({
       tenant: context.tenantId,
@@ -864,6 +890,10 @@ describe('Billing Invoice Tax Calculations', () => {
       finalAmount: 10000
     };
 
+    // persistInvoiceCharges marks each usage charge's source row invoiced and
+    // throws when there is none behind a fabricated usageId.
+    await seedBillingChargeSources(context, billingResult.charges, { clientId: client_id });
+
     const createdInvoice = await createInvoiceFromBillingResult(
       billingResult,
       client_id,
@@ -904,6 +934,10 @@ describe('Billing Invoice Tax Calculations', () => {
       url: '',
       is_inactive: false
     }, 'client_id');
+
+    // Invoice generation refuses a client with no billing recipient; fixtures
+    // that insert the row directly have to seed one.
+    await ensureClientBillingEmail(context, client_id);
 
     // Ensure tax region exists
     await tenantTable(context, 'tax_regions').insert({
@@ -994,6 +1028,10 @@ describe('Billing Invoice Tax Calculations', () => {
       created_at: Temporal.Now.plainDateISO().toString(),
       updated_at: Temporal.Now.plainDateISO().toString()
     }, 'client_id');
+
+    // Invoice generation refuses a client with no billing recipient; fixtures
+    // that insert the row directly have to seed one.
+    await ensureClientBillingEmail(context, client_id);
 
     // Ensure tax regions exist
     await tenantTable(context, 'tax_regions').insert([
@@ -1266,6 +1304,10 @@ describe('Billing Invoice Tax Calculations', () => {
       finalAmount: 30000
     };
 
+    // persistInvoiceCharges marks each usage charge's source row invoiced and
+    // throws when there is none behind a fabricated usageId.
+    await seedBillingChargeSources(context, billingResult.charges, { clientId: context.clientId });
+
     const createdInvoice = await createInvoiceFromBillingResult(
       billingResult,
       context.clientId,
@@ -1318,6 +1360,10 @@ describe('Billing Invoice Tax Calculations', () => {
       created_at: Temporal.Now.plainDateISO().toString(),
       updated_at: Temporal.Now.plainDateISO().toString()
     }, 'client_id');
+
+    // Invoice generation refuses a client with no billing recipient; fixtures
+    // that insert the row directly have to seed one.
+    await ensureClientBillingEmail(context, clientId);
 
     // Ensure tax region exists with active tax rate
     await tenantTable(context, 'tax_regions').insert({

--- a/server/src/test/infrastructure/billing/invoices/clientBillingCycleAnchors.test.ts
+++ b/server/src/test/infrastructure/billing/invoices/clientBillingCycleAnchors.test.ts
@@ -14,6 +14,13 @@ import { createTenantKnex } from 'server/src/lib/db';
 import { seedBillingCycle } from '../../../../../test-utils/billingProfileTestHelpers';
 
 
+// billingCycleActions imports hasPermission from '@alga-psa/auth/rbac'. The
+// shared mock testMocks declares for that specifier does not reach this file's
+// module graph, so the real check ran and denied a roleless fixture user.
+vi.mock('@alga-psa/auth/rbac', () => ({
+  hasPermission: vi.fn(() => Promise.resolve(true)),
+}));
+
 vi.mock('@alga-psa/auth', async () => {
   const { createAuthModuleMock } = await import('../../../../../test-utils/authModuleMock');
   return createAuthModuleMock();

--- a/server/src/test/infrastructure/billing/invoices/contractInvoiceManualCredit.test.ts
+++ b/server/src/test/infrastructure/billing/invoices/contractInvoiceManualCredit.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
 import '../../../../../test-utils/nextApiMock';
 import { TestContext } from '../../../../../test-utils/testContext';
-import { createFixedPlanAssignment, createTestService, setupClientTaxConfiguration, assignServiceTaxRate, ensureClientPlanBundlesTable } from '../../../../../test-utils/billingTestHelpers';
+import { createFixedPlanAssignment, createTestService, setupClientTaxConfiguration, assignServiceTaxRate, ensureClientPlanBundlesTable, materializeRecurringServicePeriods } from '../../../../../test-utils/billingTestHelpers';
 import { createClient } from '../../../../../test-utils/testDataFactory';
 import { createTestDate, createTestDateISO } from '../../../test-utils/dateUtils';
 import { setupCommonMocks } from '../../../../../test-utils/testMocks';
@@ -194,10 +194,17 @@ describe('Contract Invoice Manual Credit', () => {
       billingTiming: 'advance'
     });
 
+    // owner_client_id is load-bearing: invoice generation resolves a window's
+    // recurring service periods through
+    // recurring_service_periods -> contract_lines -> contracts -> clients on
+    // contracts.owner_client_id, so an ownerless contract yields no periods
+    // and the run fails with "Recurring service periods were not materialized".
     const contractId = await context.createEntity('contracts', {
       contract_name: 'Support Agreement',
       billing_frequency: 'monthly',
-      is_active: true
+      is_active: true,
+      owner_client_id: clientId,
+      status: 'active'
     }, 'contract_id');
 
     const clientContractId = await context.createEntity('client_contracts', {
@@ -216,6 +223,12 @@ describe('Contract Invoice Manual Credit', () => {
     });
 
     await ensureClientBillingSettings(context.clientId);
+
+    // generateInvoice refuses a window with no recurring service period, and
+    // the fixture only materializes on request. Run it after the line is
+    // attached to its contract, so the schedule is anchored where it will be
+    // read from.
+    await materializeRecurringServicePeriods(context, contractLineId);
 
     const periodStart = startDate;
     const periodEnd = createTestDateISO({ year: 2025, month: 2, day: 1 });
@@ -446,6 +459,12 @@ describe('Contract Invoice Manual Credit', () => {
     await ensureClientBillingSettings(preservedClientId);
     await ensureClientBillingSettings(clonedClientId);
 
+    for (const line of [preservedBase, preservedAddOn, clonedBase, clonedAddOn]) {
+      // Every active line needs a period for the window, or generateInvoice
+      // fails the whole run.
+      await materializeRecurringServicePeriods(context, line.contractLineId);
+    }
+
     const preservedBillingCycleId = await context.createEntity('client_billing_cycles', {
       client_id: preservedClientId,
       billing_cycle: 'monthly',
@@ -471,21 +490,32 @@ describe('Contract Invoice Manual Credit', () => {
     expect(Number(clonedInvoice!.tax)).toBe(Number(preservedInvoice!.tax));
     expect(Number(clonedInvoice!.total_amount)).toBe(Number(preservedInvoice!.total_amount));
 
-    const preservedCharges = await context.db('invoice_charges')
-      .where({ tenant: context.tenantId, invoice_id: preservedInvoice!.invoice_id })
-      .whereNotNull('contract_line_id')
-      .orderBy('description', 'asc');
-    const clonedCharges = await context.db('invoice_charges')
-      .where({ tenant: context.tenantId, invoice_id: clonedInvoice!.invoice_id })
-      .whereNotNull('contract_line_id')
-      .orderBy('description', 'asc');
+    // invoice_charges no longer carries contract_line_id. A charge reaches its
+    // contract line through invoice_charge_details.config_id ->
+    // contract_line_service_configuration.contract_line_id, which is the
+    // linkage this test is really about.
+    const chargesWithContractLine = async (invoiceId: string) => {
+      const rows = await context.db('invoice_charges as ic')
+        .join('invoice_charge_details as icd', function joinDetails() {
+          this.on('icd.item_id', '=', 'ic.item_id').andOn('icd.tenant', '=', 'ic.tenant');
+        })
+        .join('contract_line_service_configuration as clsc', function joinConfig() {
+          this.on('clsc.config_id', '=', 'icd.config_id').andOn('clsc.tenant', '=', 'icd.tenant');
+        })
+        .where({ 'ic.tenant': context.tenantId, 'ic.invoice_id': invoiceId })
+        .orderBy('ic.description', 'asc')
+        .select('ic.description', 'ic.net_amount', 'clsc.contract_line_id');
+      return rows;
+    };
+
+    const preservedCharges = await chargesWithContractLine(preservedInvoice!.invoice_id);
+    const clonedCharges = await chargesWithContractLine(clonedInvoice!.invoice_id);
 
     expect(preservedCharges).toHaveLength(2);
     expect(clonedCharges).toHaveLength(2);
-    expect(clonedCharges.map((charge) => charge.contract_line_id)).toEqual([
-      clonedAddOn.contractLineId,
-      clonedBase.contractLineId,
-    ]);
+    expect(clonedCharges.map((charge) => charge.contract_line_id).sort()).toEqual(
+      [clonedAddOn.contractLineId, clonedBase.contractLineId].sort()
+    );
     expect(clonedCharges.some((charge) =>
       charge.contract_line_id === preservedBase.contractLineId ||
       charge.contract_line_id === preservedAddOn.contractLineId

--- a/server/src/test/infrastructure/billing/invoices/fixedPriceAndTimeBasedPlans.test.ts
+++ b/server/src/test/infrastructure/billing/invoices/fixedPriceAndTimeBasedPlans.test.ts
@@ -10,6 +10,7 @@ import {
   assignContractLineToClient,
   createTestService,
   createFixedPlanAssignment,
+  materializeRecurringServicePeriods,
   addServiceToFixedPlan,
   setupClientTaxConfiguration,
   assignServiceTaxRate,
@@ -215,6 +216,11 @@ describe('Billing Invoice Generation – Fixed Price and Time-Based Plans', () =
         detailBaseRateCents: 15000
       });
 
+      // generateInvoice refuses a window with no recurring service period, and
+      // the fixture only materializes on request. Run it after the extra
+      // service so the line is complete.
+      await materializeRecurringServicePeriods(context, planId);
+
       // Create billing cycle
       const billingCycleId = await context.createEntity('client_billing_cycles', {
         client_id: context.clientId,
@@ -251,14 +257,15 @@ describe('Billing Invoice Generation – Fixed Price and Time-Based Plans', () =
         tax_region: 'US-NY'
       });
 
-      const { planId } = await createFixedPlanAssignment(context, serviceId, {
+      await createFixedPlanAssignment(context, serviceId, {
         planName: 'Taxable Plan',
         billingFrequency: 'monthly',
         baseRateCents: 50000,
         detailBaseRateCents: 50000,
         quantity: 1,
         startDate: createTestDateISO({ year: 2023, month: 1, day: 1 }),
-        billingTiming: 'advance'
+        billingTiming: 'advance',
+        materializeServicePeriods: true
       });
 
       // Create billing cycle
@@ -324,17 +331,23 @@ describe('Billing Invoice Generation – Fixed Price and Time-Based Plans', () =
         tenant: context.tenantId
       });
 
-      // Create billing cycle
+      // Create billing cycle. The window has to be a whole monthly period —
+      // generateInvoice matches recurring_service_periods on the exact
+      // invoice_window pair, and a Jan 1 - Jan 31 window matches none of them.
+      // Arrears: the Feb window bills the January service period, which is
+      // where the time entry below sits.
       const billingCycleId = await context.createEntity('client_billing_cycles', {
         client_id: context.clientId,
         billing_cycle: 'monthly',
-        effective_date: createTestDateISO({ year: 2023, month: 1, day: 1 }),
-        period_start_date: createTestDateISO({ year: 2023, month: 1, day: 1 }),
-        period_end_date: createTestDateISO({ year: 2023, month: 1, day: 31 })
+        effective_date: createTestDateISO({ year: 2023, month: 2, day: 1 }),
+        period_start_date: createTestDateISO({ year: 2023, month: 2, day: 1 }),
+        period_end_date: createTestDateISO({ year: 2023, month: 3, day: 1 })
       }, 'billing_cycle_id');
 
+      // contract_lines.billing_timing defaults to arrears, so the assignment
+      // starts before the period this invoices.
       await assignContractLineToClient(context, planId, {
-        startDate: createTestDateISO({ year: 2023, month: 1, day: 1 })
+        startDate: createTestDateISO({ year: 2022, month: 12, day: 1 })
       });
 
       // Create test ticket

--- a/server/src/test/infrastructure/billing/invoices/invoiceNumberGeneration_part2.test.ts
+++ b/server/src/test/infrastructure/billing/invoices/invoiceNumberGeneration_part2.test.ts
@@ -241,7 +241,7 @@ describe('Billing Invoice Generation – Invoice Number Generation (Part 2)', ()
 
     // Assign plan to client for both periods
     await assignContractLineToClient(context, planId, {
-      startDate: createTestDateISO({ year: 2023, month: 1, day: 1 })
+      startDate: createTestDateISO({ year: 2022, month: 12, day: 1 })
     });
 
     // Generate invoices that will exceed padding length
@@ -299,7 +299,8 @@ describe('Billing Invoice Generation – Invoice Number Generation (Part 2)', ()
       planName: 'Basic Plan',
       billingFrequency: 'monthly',
       baseRateCents: 10000,
-      startDate: createTestDateISO({ year: 2023, month: 1, day: 1 })
+      startDate: createTestDateISO({ year: 2022, month: 12, day: 1 }),
+      materializeServicePeriods: true
     });
 
     // Create billing cycle
@@ -312,7 +313,7 @@ describe('Billing Invoice Generation – Invoice Number Generation (Part 2)', ()
     }, 'billing_cycle_id');
 
     await assignContractLineToClient(context, planId, {
-      startDate: createTestDateISO({ year: 2023, month: 1, day: 1 })
+      startDate: createTestDateISO({ year: 2022, month: 12, day: 1 })
     });
 
     // Generate invoice
@@ -431,7 +432,7 @@ describe('Billing Invoice Generation – Invoice Number Generation (Part 2)', ()
 
     // Assign plan to client for all periods
     await assignContractLineToClient(context, planId, {
-      startDate: createTestDateISO({ year: 2023, month: 1, day: 1 })
+      startDate: createTestDateISO({ year: 2022, month: 12, day: 1 })
     });
 
     // 1. Query for the minimum invoice number.
@@ -555,7 +556,7 @@ describe('Billing Invoice Generation – Invoice Number Generation (Part 2)', ()
 
     // Assign plan to client for all periods
     await assignContractLineToClient(context, planId, {
-      startDate: createTestDateISO({ year: 2023, month: 1, day: 1 })
+      startDate: createTestDateISO({ year: 2022, month: 12, day: 1 })
     });
 
     // Generate invoices in sequence
@@ -628,7 +629,8 @@ describe('Billing Invoice Generation – Invoice Number Generation (Part 2)', ()
       planName: 'Basic Plan',
       billingFrequency: 'monthly',
       baseRateCents: 10000,
-      startDate: createTestDateISO({ year: 2023, month: 1, day: 1 })
+      startDate: createTestDateISO({ year: 2022, month: 12, day: 1 }),
+      materializeServicePeriods: true
     });
 
     // Create billing cycle
@@ -641,7 +643,7 @@ describe('Billing Invoice Generation – Invoice Number Generation (Part 2)', ()
     }, 'billing_cycle_id');
 
     await assignContractLineToClient(context, planId, {
-      startDate: createTestDateISO({ year: 2023, month: 1, day: 1 })
+      startDate: createTestDateISO({ year: 2022, month: 12, day: 1 })
     });
 
     // Generate invoice
@@ -694,7 +696,8 @@ describe('Billing Invoice Generation – Invoice Number Generation (Part 2)', ()
       planName: 'Basic Plan',
       billingFrequency: 'monthly',
       baseRateCents: 10000,
-      startDate: createTestDateISO({ year: 2023, month: 1, day: 1 })
+      startDate: createTestDateISO({ year: 2022, month: 12, day: 1 }),
+      materializeServicePeriods: true
     });
 
     // Create billing cycle
@@ -707,7 +710,7 @@ describe('Billing Invoice Generation – Invoice Number Generation (Part 2)', ()
     }, 'billing_cycle_id');
 
     await assignContractLineToClient(context, planId, {
-      startDate: createTestDateISO({ year: 2023, month: 1, day: 1 })
+      startDate: createTestDateISO({ year: 2022, month: 12, day: 1 })
     });
 
     // Generate invoice
@@ -762,7 +765,8 @@ describe('Billing Invoice Generation – Invoice Number Generation (Part 2)', ()
       planName: 'Basic Plan',
       billingFrequency: 'monthly',
       baseRateCents: 10000,
-      startDate: createTestDateISO({ year: 2023, month: 1, day: 1 })
+      startDate: createTestDateISO({ year: 2022, month: 12, day: 1 }),
+      materializeServicePeriods: true
     });
 
     // Create billing cycle
@@ -775,7 +779,7 @@ describe('Billing Invoice Generation – Invoice Number Generation (Part 2)', ()
     }, 'billing_cycle_id');
 
     await assignContractLineToClient(context, planId, {
-      startDate: createTestDateISO({ year: 2023, month: 1, day: 1 })
+      startDate: createTestDateISO({ year: 2022, month: 12, day: 1 })
     });
 
     // Generate invoice
@@ -828,7 +832,8 @@ describe('Billing Invoice Generation – Invoice Number Generation (Part 2)', ()
       planName: 'Basic Plan',
       billingFrequency: 'monthly',
       baseRateCents: 10000,
-      startDate: createTestDateISO({ year: 2023, month: 1, day: 1 })
+      startDate: createTestDateISO({ year: 2022, month: 12, day: 1 }),
+      materializeServicePeriods: true
     });
 
     // Create billing cycle
@@ -841,7 +846,7 @@ describe('Billing Invoice Generation – Invoice Number Generation (Part 2)', ()
     }, 'billing_cycle_id');
 
     await assignContractLineToClient(context, planId, {
-      startDate: createTestDateISO({ year: 2023, month: 1, day: 1 })
+      startDate: createTestDateISO({ year: 2022, month: 12, day: 1 })
     });
 
     // Generate invoice with initial prefix
@@ -864,10 +869,9 @@ describe('Billing Invoice Generation – Invoice Number Generation (Part 2)', ()
         period_start_date: createTestDateISO({ year: 2023, month: 2, day: 1 }),
         period_end_date: createTestDateISO({ year: 2023, month: 3, day: 1 })
       }, 'billing_cycle_id');
-  
-      await assignContractLineToClient(context, planId, {
-        startDate: createTestDateISO({ year: 2023, month: 2, day: 1 })
-      });
+
+      // No second assignment: the line is already assigned, and re-anchoring it
+      // to February retires the January service period this cycle invoices.
 
     // Generate invoice with new prefix
     const invoice2 = await generateInvoice(billingCycle2);
@@ -919,7 +923,8 @@ describe('Billing Invoice Generation – Invoice Number Generation (Part 2)', ()
       planName: 'Basic Plan',
       billingFrequency: 'monthly',
       baseRateCents: 10000,
-      startDate: createTestDateISO({ year: 2023, month: 1, day: 1 })
+      startDate: createTestDateISO({ year: 2022, month: 12, day: 1 }),
+      materializeServicePeriods: true
     });
 
     // Create billing cycle
@@ -932,7 +937,7 @@ describe('Billing Invoice Generation – Invoice Number Generation (Part 2)', ()
     }, 'billing_cycle_id');
 
     await assignContractLineToClient(context, planId, {
-      startDate: createTestDateISO({ year: 2023, month: 1, day: 1 })
+      startDate: createTestDateISO({ year: 2022, month: 12, day: 1 })
     });
 
     // Generate invoice with initial prefix
@@ -955,10 +960,9 @@ describe('Billing Invoice Generation – Invoice Number Generation (Part 2)', ()
         period_start_date: createTestDateISO({ year: 2023, month: 2, day: 1 }),
         period_end_date: createTestDateISO({ year: 2023, month: 3, day: 1 })
       }, 'billing_cycle_id');
-  
-      await assignContractLineToClient(context, planId, {
-        startDate: createTestDateISO({ year: 2023, month: 2, day: 1 })
-      });      
+
+      // No second assignment: the line is already assigned, and re-anchoring it
+      // to February retires the January service period this cycle invoices.
 
     // Generate invoice with shorter prefix
     const invoice2 = await generateInvoice(billingCycle2);
@@ -981,9 +985,8 @@ describe('Billing Invoice Generation – Invoice Number Generation (Part 2)', ()
       period_end_date: createTestDateISO({ year: 2023, month: 4, day: 1 })
     }, 'billing_cycle_id');
 
-    await assignContractLineToClient(context, planId, {
-      startDate: createTestDateISO({ year: 2023, month: 3, day: 1 })
-    });
+    // No further assignment: re-anchoring the line to March would retire the
+    // February service period this cycle invoices.
 
     // Generate invoice with longer prefix
     const invoice3 = await generateInvoice(billingCycle3);

--- a/server/src/test/infrastructure/billing/invoices/multiCurrency.test.ts
+++ b/server/src/test/infrastructure/billing/invoices/multiCurrency.test.ts
@@ -195,6 +195,9 @@ describe('Multi-Currency Billing', () => {
     await tenantTable(context, 'contracts').insert({
       contract_id: contractId,
       contract_name: 'EUR Contract',
+      // Recurring service periods resolve through
+      // contract_lines -> contracts -> clients on owner_client_id.
+      owner_client_id: context.clientId,
       billing_frequency: 'monthly',
       currency_code: 'EUR',
       status: 'active',
@@ -213,6 +216,8 @@ describe('Multi-Currency Billing', () => {
       contract_line_type: 'Fixed',
       billing_frequency: 'monthly',
       is_custom: false,
+      // contract_lines.is_template defaults to true; these are live lines.
+      is_template: false,
       tenant: context.tenantId,
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString()
@@ -225,12 +230,12 @@ describe('Multi-Currency Billing', () => {
       client_contract_id: uuidv4(),
       client_id: context.clientId,
       contract_id: contractId,
-      start_date: createTestDateISO({ year: 2023, month: 1, day: 1 }),
+      // Lines bill in arrears, so the assignment has to start a cycle before
+      // the cycle under test or its invoice window has no period.
+      start_date: createTestDateISO({ year: 2022, month: 12, day: 1 }),
       is_active: true,
       status: 'pending'
     });
-
-    await materializeRecurringServicePeriods(context, contractLineId);
 
     // 6. Add service configuration to the contract line (Fixed)
     const configId = uuidv4();
@@ -243,6 +248,26 @@ describe('Multi-Currency Billing', () => {
       quantity: 1,
       tenant: context.tenantId
     });
+
+    // A Fixed line bills off its fixed config and its contract_line_services
+    // row; without them the run produces no charges and returns null.
+    await tenantTable(context, 'contract_line_service_fixed_config').insert({
+      config_id: configId,
+      tenant: context.tenantId,
+      base_rate: 10000
+    });
+    await tenantTable(context, 'contract_line_services').insert({
+      tenant: context.tenantId,
+      contract_line_id: contractLineId,
+      service_id: serviceId,
+      quantity: 1,
+      custom_rate: 10000
+    });
+
+    // Materialize last: the sync reads the line's service configuration, so a
+    // line with none yet produces no periods and generateInvoice then refuses
+    // the window.
+    await materializeRecurringServicePeriods(context, contractLineId);
 
     // 7. Create billing cycle
     const billingCycleId = await context.createEntity('client_billing_cycles', {
@@ -274,6 +299,9 @@ describe('Multi-Currency Billing', () => {
     await tenantTable(context, 'contracts').insert({
       contract_id: contractAId,
       contract_name: 'USD Contract',
+      // Recurring service periods resolve through
+      // contract_lines -> contracts -> clients on owner_client_id.
+      owner_client_id: context.clientId,
       billing_frequency: 'monthly',
       currency_code: 'USD',
       status: 'active',
@@ -288,6 +316,9 @@ describe('Multi-Currency Billing', () => {
     await tenantTable(context, 'contracts').insert({
       contract_id: contractBId,
       contract_name: 'EUR Contract',
+      // Recurring service periods resolve through
+      // contract_lines -> contracts -> clients on owner_client_id.
+      owner_client_id: context.clientId,
       billing_frequency: 'monthly',
       currency_code: 'EUR',
       status: 'active',
@@ -306,6 +337,8 @@ describe('Multi-Currency Billing', () => {
       contract_line_type: 'Fixed',
       billing_frequency: 'monthly',
       is_custom: false,
+      // contract_lines.is_template defaults to true; these are live lines.
+      is_template: false,
       tenant: context.tenantId
     });
 
@@ -317,6 +350,8 @@ describe('Multi-Currency Billing', () => {
       contract_line_type: 'Fixed',
       billing_frequency: 'monthly',
       is_custom: false,
+      // contract_lines.is_template defaults to true; these are live lines.
+      is_template: false,
       tenant: context.tenantId
     });
 
@@ -328,7 +363,7 @@ describe('Multi-Currency Billing', () => {
         client_contract_id: uuidv4(),
         client_id: context.clientId,
         contract_id: contractAId,
-        start_date: createTestDateISO({ year: 2023, month: 1, day: 1 }),
+        start_date: createTestDateISO({ year: 2022, month: 12, day: 1 }),
         is_active: true,
         status: 'pending'
       },
@@ -337,14 +372,11 @@ describe('Multi-Currency Billing', () => {
         client_contract_id: uuidv4(),
         client_id: context.clientId,
         contract_id: contractBId,
-        start_date: createTestDateISO({ year: 2023, month: 1, day: 1 }),
+        start_date: createTestDateISO({ year: 2022, month: 12, day: 1 }),
         is_active: true,
         status: 'pending'
       }
     ]);
-
-    await materializeRecurringServicePeriods(context, lineAId);
-    await materializeRecurringServicePeriods(context, lineBId);
 
     // 5. Add dummy service configs so they are billed
     const serviceId = await createTestService(context, { service_name: 'Generic Service' });
@@ -367,6 +399,10 @@ describe('Multi-Currency Billing', () => {
       }
     ]);
 
+    // Materialize last: the sync reads each line's service configuration.
+    await materializeRecurringServicePeriods(context, lineAId);
+    await materializeRecurringServicePeriods(context, lineBId);
+
     // 6. Create billing cycle
     const billingCycleId = await context.createEntity('client_billing_cycles', {
       client_id: context.clientId,
@@ -377,9 +413,10 @@ describe('Multi-Currency Billing', () => {
     }, 'billing_cycle_id');
 
     // Act & Assert
-    await expect(generateInvoice(billingCycleId))
-      .rejects
-      .toThrow(/Mixed currency billing is not supported/);
+    // generateInvoice reports expected failures by returning an action error
+    // (withInvoiceGenerationActionErrors) rather than throwing.
+    const mixedResult = await generateInvoice(billingCycleId) as unknown as { actionError?: string };
+    expect(mixedResult?.actionError).toMatch(/Mixed currency billing is not supported/);
   });
 
   // contracts.currency_code is NOT NULL DEFAULT 'USD', so the legacy
@@ -397,6 +434,9 @@ describe('Multi-Currency Billing', () => {
     await tenantTable(context, 'contracts').insert({
       contract_id: contractId,
       contract_name: 'Legacy Contract',
+      // Recurring service periods resolve through
+      // contract_lines -> contracts -> clients on owner_client_id.
+      owner_client_id: context.clientId,
       billing_frequency: 'monthly',
       status: 'active',
       tenant: context.tenantId,
@@ -414,6 +454,8 @@ describe('Multi-Currency Billing', () => {
       contract_line_type: 'Fixed',
       billing_frequency: 'monthly',
       is_custom: false,
+      // contract_lines.is_template defaults to true; these are live lines.
+      is_template: false,
       tenant: context.tenantId
     });
 
@@ -422,22 +464,38 @@ describe('Multi-Currency Billing', () => {
       client_contract_id: uuidv4(),
       client_id: context.clientId,
       contract_id: contractId,
-      start_date: createTestDateISO({ year: 2023, month: 1, day: 1 }),
+      // Lines bill in arrears, so the assignment has to start a cycle before
+      // the cycle under test or its invoice window has no period.
+      start_date: createTestDateISO({ year: 2022, month: 12, day: 1 }),
       is_active: true,
       status: 'pending'
     });
 
-    await materializeRecurringServicePeriods(context, lineId);
-
     const serviceId = await createTestService(context, { service_name: 'GBP Service' });
+    const legacyConfigId = uuidv4();
     await tenantTable(context, 'contract_line_service_configuration').insert({
-      config_id: uuidv4(),
+      config_id: legacyConfigId,
       contract_line_id: lineId,
       service_id: serviceId,
       configuration_type: 'Fixed',
       custom_rate: 5000, // 50.00 GBP
       tenant: context.tenantId
     });
+    await tenantTable(context, 'contract_line_service_fixed_config').insert({
+      config_id: legacyConfigId,
+      tenant: context.tenantId,
+      base_rate: 5000
+    });
+    await tenantTable(context, 'contract_line_services').insert({
+      tenant: context.tenantId,
+      contract_line_id: lineId,
+      service_id: serviceId,
+      quantity: 1,
+      custom_rate: 5000
+    });
+
+    // Materialize last: the sync reads the line's service configuration.
+    await materializeRecurringServicePeriods(context, lineId);
 
     // 4. Create billing cycle
     const billingCycleId = await context.createEntity('client_billing_cycles', {

--- a/server/src/test/infrastructure/billing/invoices/negativeInvoiceCredit.test.ts
+++ b/server/src/test/infrastructure/billing/invoices/negativeInvoiceCredit.test.ts
@@ -16,7 +16,8 @@ import {
   createTestService,
   setupClientTaxConfiguration,
   assignServiceTaxRate,
-  ensureClientPlanBundlesTable
+  ensureClientPlanBundlesTable,
+  seedBillingChargeSources
 } from '../../../../../test-utils/billingTestHelpers';
 import type { IBillingCharge, IBillingResult } from 'server/src/interfaces/billing.interfaces';
 
@@ -153,6 +154,10 @@ async function generateInvoiceFromCharges(
     totalAmount,
     finalAmount: totalAmount
   };
+
+  // persistInvoiceCharges marks each usage charge's source usage_tracking row
+  // invoiced and throws when there is none behind a fabricated usageId.
+  await seedBillingChargeSources(context, charges as Array<Record<string, unknown>>, { clientId });
 
   const createdInvoice = await createInvoiceFromBillingResult(
     billingResult,
@@ -352,6 +357,8 @@ describe('Negative Invoice Credit Tests', () => {
         finalAmount: -12500
       };
 
+      await seedBillingChargeSources(context, charges as Array<Record<string, unknown>>, { clientId: client_id });
+
       const createdInvoice = await createInvoiceFromBillingResult(
         billingResult,
         client_id,
@@ -426,28 +433,32 @@ describe('Negative Invoice Credit Tests', () => {
         effective_date: startDate,
       }, 'billing_cycle_id');
 
+      const recurringCreditCharges: IBillingCharge[] = [
+        {
+          tenant: context.tenantId,
+          type: 'usage',
+          serviceId,
+          serviceName: 'Recurring Credit Service',
+          quantity: 1,
+          rate: -4200,
+          total: -4200,
+          tax_amount: 0,
+          tax_rate: 0,
+          tax_region: 'US-NY',
+          is_taxable: false,
+          usageId: uuidv4(),
+          servicePeriodStart: startDate,
+          servicePeriodEnd: endDate,
+          billingTiming: 'arrears',
+        } as IBillingCharge,
+      ];
+
+      await seedBillingChargeSources(context, recurringCreditCharges as Array<Record<string, unknown>>, { clientId });
+
       const createdInvoice = await createInvoiceFromBillingResult(
         {
           tenant: context.tenantId,
-          charges: [
-            {
-              tenant: context.tenantId,
-              type: 'usage',
-              serviceId,
-              serviceName: 'Recurring Credit Service',
-              quantity: 1,
-              rate: -4200,
-              total: -4200,
-              tax_amount: 0,
-              tax_rate: 0,
-              tax_region: 'US-NY',
-              is_taxable: false,
-              usageId: uuidv4(),
-              servicePeriodStart: startDate,
-              servicePeriodEnd: endDate,
-              billingTiming: 'arrears',
-            },
-          ],
+          charges: recurringCreditCharges,
           discounts: [],
           adjustments: [],
           totalAmount: -4200,
@@ -472,32 +483,28 @@ describe('Negative Invoice Credit Tests', () => {
       const credits = await listClientCredits(clientId, false, 1, 20);
       const creditDetails = await getCreditDetails(creditRow.credit_id);
 
-      expect(credits.credits).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            credit_id: creditRow.credit_id,
-            invoice_id: createdInvoice.invoice_id,
-            invoice_date_basis: 'canonical_recurring_service_period',
-            invoice_service_period_start: startDate,
-            invoice_service_period_end: endDate,
-          }),
-        ])
+      // The service-period columns round-trip through the database, which
+      // renders milliseconds ("…T00:00:00.000Z") that Temporal's toString()
+      // omits ("…T00:00:00Z"). Compare the instants, not the strings.
+      const asInstant = (value: unknown) => new Date(String(value)).toISOString();
+
+      const listedCredit = credits.credits.find(
+        (credit: Record<string, unknown>) => credit.credit_id === creditRow.credit_id
       );
-      expect(creditDetails).toMatchObject({
-        invoice_date_basis: 'canonical_recurring_service_period',
-        invoice_service_period_start: startDate,
-        invoice_service_period_end: endDate,
-      });
-      expect(creditDetails.invoice).toMatchObject({
-        invoice_id: createdInvoice.invoice_id,
-        invoice_charges: [
-          expect.objectContaining({
-            service_period_start: startDate,
-            service_period_end: endDate,
-            billing_timing: 'arrears',
-          }),
-        ],
-      });
+      expect(listedCredit).toBeTruthy();
+      expect(listedCredit!.invoice_id).toBe(createdInvoice.invoice_id);
+      expect(listedCredit!.invoice_date_basis).toBe('canonical_recurring_service_period');
+      expect(asInstant(listedCredit!.invoice_service_period_start)).toBe(asInstant(startDate));
+      expect(asInstant(listedCredit!.invoice_service_period_end)).toBe(asInstant(endDate));
+      expect(creditDetails.invoice_date_basis).toBe('canonical_recurring_service_period');
+      expect(asInstant(creditDetails.invoice_service_period_start)).toBe(asInstant(startDate));
+      expect(asInstant(creditDetails.invoice_service_period_end)).toBe(asInstant(endDate));
+
+      expect(creditDetails.invoice!.invoice_id).toBe(createdInvoice.invoice_id);
+      const detailCharge = creditDetails.invoice!.invoice_charges![0] as Record<string, unknown>;
+      expect(asInstant(detailCharge.service_period_start)).toBe(asInstant(startDate));
+      expect(asInstant(detailCharge.service_period_end)).toBe(asInstant(endDate));
+      expect(detailCharge.billing_timing).toBe('arrears');
     });
   });
 
@@ -766,7 +773,11 @@ describe('Negative Invoice Credit Tests', () => {
       
       expect(creditTransaction).toBeTruthy();
       expect(parseInt(creditTransaction.amount)).toBe(12500);
-      expect(parseInt(creditTransaction.balance_after)).toBe(12500);
+      // balance_after is a running ledger across every transaction type, not a
+      // credit-only total: the invoice_generated row for this -$125.00 invoice
+      // already moved it to -12500, so issuing the credit brings it back to 0.
+      // The spendable figure is getClientCredit above.
+      expect(parseInt(creditTransaction.balance_after)).toBe(0);
 
       // Now create a positive invoice that will use the credit
 
@@ -831,7 +842,11 @@ describe('Negative Invoice Credit Tests', () => {
 
       // Credit should be fully applied
       expect(Number(finalPositiveInvoice.credit_applied)).toBe(11000); // $110.00 credit applied
-      expect(parseInt(finalPositiveInvoice.total_amount)).toBe(0); // $0.00 remaining total
+      // Invoice totals are immutable after finalization; the balance due is
+      // derived as total_amount - credit_applied.
+      expect(
+        parseInt(finalPositiveInvoice.total_amount) - Number(finalPositiveInvoice.credit_applied)
+      ).toBe(0);
 
       // 23. Verify the credit balance is reduced
       const finalCredit = await ClientContractLine.getClientCredit(client_id);
@@ -978,7 +993,9 @@ describe('Negative Invoice Credit Tests', () => {
 
       // Credit should be partially applied
       expect(Number(finalPositiveInvoice.credit_applied)).toBe(5000); // $50.00 credit applied (all available)
-      expect(parseInt(finalPositiveInvoice.total_amount)).toBe(14250); // $142.50 remaining total ($192.50 - $50.00)
+      expect(
+        parseInt(finalPositiveInvoice.total_amount) - Number(finalPositiveInvoice.credit_applied)
+      ).toBe(14250); // $142.50 remaining ($192.50 - $50.00)
 
       // 22. Verify the credit balance is now zero
       const finalCredit = await ClientContractLine.getClientCredit(client_id);
@@ -1125,7 +1142,9 @@ describe('Negative Invoice Credit Tests', () => {
 
       // Credit should fully cover the invoice
       expect(Number(finalPositiveInvoice.credit_applied)).toBe(5500); // $55.00 credit applied
-      expect(parseInt(finalPositiveInvoice.total_amount)).toBe(0); // $0.00 remaining total
+      expect(
+        parseInt(finalPositiveInvoice.total_amount) - Number(finalPositiveInvoice.credit_applied)
+      ).toBe(0);
 
       // 22. Verify the credit balance is reduced but still has remaining credit
       const finalCredit = await ClientContractLine.getClientCredit(client_id);

--- a/server/src/test/infrastructure/billing/invoices/prepaymentInvoice.test.ts
+++ b/server/src/test/infrastructure/billing/invoices/prepaymentInvoice.test.ts
@@ -19,7 +19,8 @@ import {
   setupClientTaxConfiguration,
   assignServiceTaxRate,
   ensureDefaultBillingSettings,
-  ensureClientPlanBundlesTable
+  ensureClientPlanBundlesTable,
+  seedBillingChargeSources
 } from '../../../../../test-utils/billingTestHelpers';
 import type { IBillingCharge, IBillingResult } from 'server/src/interfaces/billing.interfaces';
 import { seedBillingCycle } from '../../../../../test-utils/billingProfileTestHelpers';
@@ -129,17 +130,6 @@ vi.mock('server/src/lib/auth/rbac', () => ({
   hasPermission: vi.fn(() => Promise.resolve(true))
 }));
 
-let numberingSequence = 0;
-
-vi.mock('server/src/lib/services/numberingService', () => ({
-  NumberingService: class {
-    async getNextNumber(): Promise<string> {
-      numberingSequence += 1;
-      return `TIC${numberingSequence.toString().padStart(6, '0')}`;
-    }
-  }
-}));
-
 const originalCalculateBilling = BillingEngine.prototype.calculateBilling;
 vi.spyOn(BillingEngine.prototype, 'calculateBilling').mockImplementation(async function (...args) {
   const result = await originalCalculateBilling.apply(this, args as any);
@@ -172,7 +162,10 @@ function parseInvoiceTotals(invoice: Record<string, unknown>) {
     tax,
     creditApplied,
     totalAmount,
-    totalBeforeCredit: subtotal + tax
+    totalBeforeCredit: subtotal + tax,
+    // Invoice totals are immutable after finalization; balance due is derived
+    // (total - credit) rather than written back to total_amount.
+    amountDue: totalAmount - creditApplied
   };
 }
 
@@ -227,6 +220,10 @@ async function generateInvoiceForCycle(
     totalAmount: amountCents,
     finalAmount: amountCents
   };
+
+  // persistInvoiceCharges marks each usage charge's source usage_tracking row
+  // invoiced and throws when there is none behind a fabricated usageId.
+  await seedBillingChargeSources(context, [charge as unknown as Record<string, unknown>]);
 
   const createdInvoice = await createInvoiceFromBillingResult(
     billingResult,
@@ -341,7 +338,6 @@ describe('Prepayment Invoice System', () => {
   }, 120000);
 
   beforeEach(async () => {
-    numberingSequence = 0;
     context = await resetContext();
     context.db.on('query-error', (error, obj) => {
       console.error('[Test][MultiCredits] query-error', error?.message, obj?.sql);
@@ -374,8 +370,12 @@ describe('Prepayment Invoice System', () => {
         const prepaymentAmount = 100000;
       const result = await createPrepaymentInvoice(context.clientId, prepaymentAmount);
   
+        // Invoice numbers come from SharedNumberingService now; the local
+        // 'server/src/lib/services/numberingService' mock this file used to
+        // carry stopped intercepting anything when the actions moved to the
+        // shared service, so assert the seeded format rather than a fixture's.
         expect(result).toMatchObject({
-          invoice_number: expect.stringMatching(/^TIC\d{6}$/),
+          invoice_number: expect.stringMatching(/^[A-Z]+-\d{6}$/),
           subtotal: prepaymentAmount,
           total_amount: prepaymentAmount.toString(),
           status: 'draft'
@@ -641,6 +641,8 @@ describe('Prepayment Invoice System', () => {
       finalAmount: 1000
     };
 
+    await seedBillingChargeSources(context, [charge as unknown as Record<string, unknown>]);
+
     const createdInvoice = await createInvoiceFromBillingResult(
       billingResult,
       context.clientId,
@@ -661,7 +663,7 @@ describe('Prepayment Invoice System', () => {
       const totals = parseInvoiceTotals(updatedInvoice ?? {});
 
       // Verify credit application after finalization
-      expect(totals.totalAmount).toBeLessThan(totals.totalBeforeCredit);
+      expect(totals.amountDue).toBeLessThan(totals.totalBeforeCredit);
       expect(totals.creditApplied).toBeGreaterThan(0);
 
       // Verify credit balance update
@@ -692,28 +694,32 @@ describe('Prepayment Invoice System', () => {
       const cycleStart = cycleRecord.period_start_date ?? cycleRecord.effective_date;
       const cycleEnd = cycleRecord.period_end_date ?? cycleRecord.effective_date;
 
+      const canonicalCharges: IBillingCharge[] = [
+        {
+          tenant: context.tenantId,
+          type: 'usage',
+          serviceId,
+          serviceName: 'Test Service',
+          quantity: 1,
+          rate: 1000,
+          total: 1000,
+          tax_amount: 0,
+          tax_rate: 0,
+          tax_region: 'US-NY',
+          is_taxable: true,
+          usageId: uuidv4(),
+          servicePeriodStart: cycleStart,
+          servicePeriodEnd: cycleEnd,
+          billingTiming: 'arrears',
+        } as IBillingCharge,
+      ];
+
+      await seedBillingChargeSources(context, canonicalCharges as unknown as Array<Record<string, unknown>>);
+
       const createdInvoice = await createInvoiceFromBillingResult(
         {
           tenant: context.tenantId,
-          charges: [
-            {
-              tenant: context.tenantId,
-              type: 'usage',
-              serviceId,
-              serviceName: 'Test Service',
-              quantity: 1,
-              rate: 1000,
-              total: 1000,
-              tax_amount: 0,
-              tax_rate: 0,
-              tax_region: 'US-NY',
-              is_taxable: true,
-              usageId: uuidv4(),
-              servicePeriodStart: cycleStart,
-              servicePeriodEnd: cycleEnd,
-              billingTiming: 'arrears',
-            },
-          ],
+          charges: canonicalCharges,
           discounts: [],
           adjustments: [],
           totalAmount: 1000,
@@ -745,15 +751,14 @@ describe('Prepayment Invoice System', () => {
       const rereadInvoice = await Invoice.getById(context.db, context.tenantId, createdInvoice.invoice_id);
 
       expect(Number(rereadInvoice?.credit_applied ?? 0)).toBeGreaterThan(0);
-      expect(rereadInvoice?.invoice_charges).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            service_period_start: cycleStart,
-            service_period_end: cycleEnd,
-            billing_timing: 'arrears',
-          }),
-        ])
-      );
+      // The view model serializes the periods, so compare instants rather than
+      // a string against the Date the cycle fixture holds.
+      const asInstant = (value: unknown) => new Date(String(value)).toISOString();
+      const rereadCharge = (rereadInvoice?.invoice_charges ?? [])[0] as Record<string, unknown>;
+      expect(rereadCharge).toBeTruthy();
+      expect(asInstant(rereadCharge.service_period_start)).toBe(asInstant(cycleStart));
+      expect(asInstant(rereadCharge.service_period_end)).toBe(asInstant(cycleEnd));
+      expect(rereadCharge.billing_timing).toBe('arrears');
     });
   });
 });
@@ -801,7 +806,6 @@ describe('Multiple Credit Applications', () => {
   }, 120000);
 
   beforeEach(async () => {
-    numberingSequence = 0;
     context = await resetContext();
     setupCommonMocks({
       tenantId: context.tenantId,
@@ -904,7 +908,7 @@ describe('Multiple Credit Applications', () => {
     const totals = parseInvoiceTotals(updatedInvoice ?? {});
 
     // Verify credit application
-    expect(totals.totalAmount).toBeLessThan(totals.totalBeforeCredit);
+    expect(totals.amountDue).toBeLessThan(totals.totalBeforeCredit);
     expect(totals.creditApplied).toBeGreaterThan(0);
 
     // Verify credit balance update
@@ -960,9 +964,9 @@ describe('Multiple Credit Applications', () => {
     const totals2 = parseInvoiceTotals(updatedInvoice2 ?? {});
 
     // Verify credit application on both invoices
-    expect(totals1.totalAmount).toBeLessThan(totals1.totalBeforeCredit);
+    expect(totals1.amountDue).toBeLessThan(totals1.totalBeforeCredit);
     expect(totals1.creditApplied).toBeGreaterThan(0);
-    expect(totals2.totalAmount).toBeLessThan(totals2.totalBeforeCredit);
+    expect(totals2.amountDue).toBeLessThan(totals2.totalBeforeCredit);
     expect(totals2.creditApplied).toBeGreaterThan(0);
 
     // Verify total credit applied
@@ -1001,7 +1005,7 @@ describe('Multiple Credit Applications', () => {
     const totals = parseInvoiceTotals(updatedInvoice ?? {});
 
     // Verify credit application
-    expect(totals.totalAmount).toBe(0);
+    expect(totals.amountDue).toBe(0);
     const creditApplied = totals.creditApplied;
     expect(creditApplied).toBeLessThanOrEqual(totalPrepayment);
 
@@ -1045,10 +1049,10 @@ describe('Multiple Credit Applications', () => {
     const totals = parseInvoiceTotals(updatedInvoice ?? {});
 
     // Verify credit application
-    expect(totals.totalAmount).toBeLessThan(totals.totalBeforeCredit);
+    expect(totals.amountDue).toBeLessThan(totals.totalBeforeCredit);
     const creditApplied = Math.min(prepaymentAmount, totals.totalBeforeCredit);
     expect(totals.creditApplied).toBe(creditApplied);
-    expect(totals.totalAmount).toBe(totals.totalBeforeCredit - creditApplied);
+    expect(totals.amountDue).toBe(totals.totalBeforeCredit - creditApplied);
 
     // Verify final credit balance
     const finalCredit = await ClientContractLine.getClientCredit(context.clientId);

--- a/server/src/test/infrastructure/billing/pricingSchedules/pricingScheduleRateOverrides.test.ts
+++ b/server/src/test/infrastructure/billing/pricingSchedules/pricingScheduleRateOverrides.test.ts
@@ -9,6 +9,7 @@ import { createTestDateISO } from '../../../../../test-utils/dateUtils';
 import {
   createTestService,
   createFixedPlanAssignment,
+  materializeRecurringServicePeriods,
   setupClientTaxConfiguration,
   assignServiceTaxRate
 } from '../../../../../test-utils/billingTestHelpers';
@@ -258,7 +259,12 @@ describe('Billing Invoice Generation – Pricing Schedule Rate Overrides', () =>
       const contractId = await context.createEntity('contracts', {
         contract_name: 'Client Contract',
         billing_frequency: 'monthly',
-        is_active: true
+        is_active: true,
+        // Recurring service periods resolve through
+        // contract_lines -> contracts -> clients on owner_client_id, so an
+        // ownerless contract yields no periods for the invoice window.
+        owner_client_id: context.clientId,
+        status: 'active'
       }, 'contract_id');
 
       // Link the contract to the client
@@ -276,6 +282,10 @@ describe('Billing Invoice Generation – Pricing Schedule Rate Overrides', () =>
         contractLineId,
         clientContractLineId
       });
+
+      // The fixture only materializes on request, and the schedule has to be
+      // anchored on the contract the invoice will be read through.
+      await materializeRecurringServicePeriods(context, contractLineId);
 
       // Add pricing schedule with higher rate
       const scheduleId = uuidv4();
@@ -337,7 +347,9 @@ describe('Billing Invoice Generation – Pricing Schedule Rate Overrides', () =>
       const contractId = await context.createEntity('contracts', {
         contract_name: 'Default Contract',
         billing_frequency: 'monthly',
-        is_active: true
+        is_active: true,
+        owner_client_id: context.clientId,
+        status: 'active'
       }, 'contract_id');
 
       const clientContractId = await context.createEntity('client_contracts', {
@@ -354,6 +366,10 @@ describe('Billing Invoice Generation – Pricing Schedule Rate Overrides', () =>
         contractLineId,
         clientContractLineId
       });
+
+      // The fixture only materializes on request, and the schedule has to be
+      // anchored on the contract the invoice will be read through.
+      await materializeRecurringServicePeriods(context, contractLineId);
 
       // Create billing cycle (without pricing schedule)
       const billingCycleId = await context.createEntity('client_billing_cycles', {
@@ -402,7 +418,9 @@ describe('Billing Invoice Generation – Pricing Schedule Rate Overrides', () =>
       const contractId = await context.createEntity('contracts', {
         contract_name: 'Multi-Rate Contract',
         billing_frequency: 'monthly',
-        is_active: true
+        is_active: true,
+        owner_client_id: context.clientId,
+        status: 'active'
       }, 'contract_id');
 
       const clientContractId = await context.createEntity('client_contracts', {
@@ -419,6 +437,8 @@ describe('Billing Invoice Generation – Pricing Schedule Rate Overrides', () =>
         clientContractLineId,
         contractLineId
       });
+
+      await materializeRecurringServicePeriods(context, contractLineId);
 
       // Schedule 1: Jan-Feb @ $100/hour
       await context.db('contract_pricing_schedules').insert({
@@ -509,7 +529,9 @@ describe('Billing Invoice Generation – Pricing Schedule Rate Overrides', () =>
       const contractId = await context.createEntity('contracts', {
         contract_name: 'Null Rate Contract',
         billing_frequency: 'monthly',
-        is_active: true
+        is_active: true,
+        owner_client_id: context.clientId,
+        status: 'active'
       }, 'contract_id');
 
       const clientContractId = await context.createEntity('client_contracts', {
@@ -526,6 +548,8 @@ describe('Billing Invoice Generation – Pricing Schedule Rate Overrides', () =>
         clientContractLineId,
         contractLineId
       });
+
+      await materializeRecurringServicePeriods(context, contractLineId);
 
       // Add pricing schedule with null rate
       await context.db('contract_pricing_schedules').insert({
@@ -585,7 +609,9 @@ describe('Billing Invoice Generation – Pricing Schedule Rate Overrides', () =>
       const contractId = await context.createEntity('contracts', {
         contract_name: 'Expired Schedule Contract',
         billing_frequency: 'monthly',
-        is_active: true
+        is_active: true,
+        owner_client_id: context.clientId,
+        status: 'active'
       }, 'contract_id');
 
       const clientContractId = await context.createEntity('client_contracts', {
@@ -602,6 +628,8 @@ describe('Billing Invoice Generation – Pricing Schedule Rate Overrides', () =>
         clientContractLineId,
         contractLineId
       });
+
+      await materializeRecurringServicePeriods(context, contractLineId);
 
       // Add pricing schedule that expired before billing period
       await context.db('contract_pricing_schedules').insert({

--- a/server/src/test/infrastructure/billing/quotes/quoteInfrastructure.test.ts
+++ b/server/src/test/infrastructure/billing/quotes/quoteInfrastructure.test.ts
@@ -38,7 +38,6 @@ import { resolveQuoteTemplateAst } from '../../../../../../packages/billing/src/
 import { evaluateTemplateAst } from '../../../../../../packages/billing/src/lib/invoice-template-ast/evaluator';
 import { createPDFGenerationService } from '../../../../../../packages/billing/src/services/pdfGenerationService';
 import { browserPoolService } from '../../../../../../packages/billing/src/services/browserPoolService';
-import { TaxService } from '../../../../../../packages/billing/src/services/taxService';
 
 process.env.DB_PORT = process.env.DB_PORT === '6432' ? '5432' : process.env.DB_PORT;
 
@@ -342,9 +341,7 @@ describe('Quote infrastructure', () => {
       created_by: context.userId,
     });
 
-    const calculateTaxSpy = vi.spyOn(TaxService.prototype, 'calculateTax').mockResolvedValue({ taxAmount: 270, taxRate: 9 });
-
-    await QuoteItem.create(context.db, context.tenantId, {
+    const item = await QuoteItem.create(context.db, context.tenantId, {
       quote_id: quote.quote_id,
       service_id: serviceId,
       description: 'Managed Endpoint',
@@ -354,16 +351,17 @@ describe('Quote infrastructure', () => {
       created_by: context.userId,
     });
 
-    expect(calculateTaxSpy).toHaveBeenCalledWith(
-      context.clientId,
-      3000,
-      expect.any(String),
-      'US-NY',
-      true,
-      'USD'
-    );
+    // Quote tax is computed inside quoteCalculationService, not through
+    // TaxService.calculateTax, so there is no spy seam to assert on any more.
+    // The observable contract is the same: the taxable item is taxed on its own
+    // net amount at its region's combined rate, rounded up to the cent.
+    const stored = await context.db('quote_items')
+      .where({ tenant: context.tenantId, quote_item_id: item.quote_item_id })
+      .first();
 
-    calculateTaxSpy.mockRestore();
+    expect(Number(stored.net_amount)).toBe(3000);
+    expect(stored.tax_region).toBe('US-NY');
+    expect(Number(stored.tax_amount)).toBe(Math.ceil((3000 * 8.875) / 100));
   });
 
   it('T052: Tax: is_taxable=false items get zero tax_amount', async () => {
@@ -1126,15 +1124,19 @@ describe('Quote infrastructure', () => {
     expect(columns.templateAst.type).toBe('jsonb');
   });
 
+  // Later migrations add further standard templates (by-location, grouped), so
+  // this asserts the two this migration owns are seeded rather than pinning the
+  // full list and breaking every time one is added.
+  const MIGRATION_OWNED_TEMPLATE_CODES = ['standard-quote-default', 'standard-quote-detailed'];
+
   it('T076: Template migration: standard_quote_templates seeded with default and detailed templates', async () => {
     const rows = await context.db('standard_quote_document_templates')
       .select('standard_quote_document_template_code')
       .orderBy('standard_quote_document_template_code', 'asc');
 
-    expect(rows.map((row) => row.standard_quote_document_template_code)).toEqual([
-      'standard-quote-default',
-      'standard-quote-detailed',
-    ]);
+    const codes = rows.map((row) => row.standard_quote_document_template_code);
+    expect(codes).toEqual(expect.arrayContaining(MIGRATION_OWNED_TEMPLATE_CODES));
+    expect(new Set(codes).size).toBe(codes.length);
   });
 
   it('T076a: Template migration: standard quote template seed upsert succeeds on repeated runs', async () => {
@@ -1151,17 +1153,22 @@ describe('Quote infrastructure', () => {
 
     const migration = await import(path.join(migrationsDir, migrationFile!));
 
+    const codesNow = async () =>
+      (await context.db('standard_quote_document_templates')
+        .select('standard_quote_document_template_code')
+        .orderBy('standard_quote_document_template_code', 'asc'))
+        .map((row) => row.standard_quote_document_template_code);
+
+    const before = await codesNow();
+
     await migration.up(context.db);
     await migration.up(context.db);
 
-    const rows = await context.db('standard_quote_document_templates')
-      .select('standard_quote_document_template_code')
-      .orderBy('standard_quote_document_template_code', 'asc');
-
-    expect(rows.map((row) => row.standard_quote_document_template_code)).toEqual([
-      'standard-quote-default',
-      'standard-quote-detailed',
-    ]);
+    // Idempotent: repeated runs upsert rather than duplicate, and never remove
+    // the templates later migrations added.
+    const after = await codesNow();
+    expect(after).toEqual(before);
+    expect(after).toEqual(expect.arrayContaining(MIGRATION_OWNED_TEMPLATE_CODES));
   });
 
   it('T077: QuoteViewModel: correctly maps all quote fields including items with optional/recurring metadata', async () => {
@@ -1210,9 +1217,12 @@ describe('Quote infrastructure', () => {
     expect(ast).toBeTruthy();
 
     const evaluation = evaluateTemplateAst(ast!, viewModel as unknown as Record<string, unknown>);
+    // The bindings render dates as YYYY-MM-DD; the quote row holds Date
+    // objects. Compare the days (vitest pins TZ=UTC), not the two renderings.
+    const asDay = (value: unknown) => new Date(String(value)).toISOString().slice(0, 10);
     expect(evaluation.bindings.quoteNumber).toBe(quote.quote_number);
-    expect(String(evaluation.bindings.quoteDate)).toBe(String(quote.quote_date));
-    expect(String(evaluation.bindings.validUntil)).toBe(String(quote.valid_until));
+    expect(asDay(evaluation.bindings.quoteDate)).toBe(asDay(quote.quote_date));
+    expect(asDay(evaluation.bindings.validUntil)).toBe(asDay(quote.valid_until));
   });
 
   it('T079: AST bindings: lineItems collection includes is_optional and is_recurring flags per item', async () => {
@@ -1256,10 +1266,16 @@ describe('Quote infrastructure', () => {
       templateCode: 'standard-quote-default',
     });
 
-    expect(preview.html).toContain('Quote');
-    expect(preview.html).toContain('Scope of Work');
-    expect(preview.html).toContain('Validity');
+    // The redesigned template renders the scope and validity as bindings in
+    // the header/overview stacks rather than under "Scope of Work" and
+    // "Validity" headings, so assert the content those sections carry.
+    expect(preview.html).toContain('QUOTE');
+    expect(preview.html).toContain('Quote #');
+    expect(preview.html).toContain('Valid Until');
+    expect(preview.html).toContain('Prepared For');
+    expect(preview.html).toContain('Scope copy');
     expect(preview.html).toContain('Terms &amp; Conditions');
+    expect(preview.html).toContain('Standard terms');
     expect(preview.html).toContain('Rendered line');
   });
 
@@ -1284,7 +1300,10 @@ describe('Quote infrastructure', () => {
       templateCode: 'standard-quote-detailed',
     });
 
-    expect(preview.html).toContain('Overview');
+    // Same redesign: the overview is an unlabeled stack now, so assert the
+    // scope copy it renders instead of an "Overview" heading.
+    expect(preview.html).toContain('Detailed scope');
+    expect(preview.html).toContain('Project Phase');
     expect(preview.html).toContain('Phase');
     expect(preview.html).toContain('Optional');
     expect(preview.html).toContain('Recurring');
@@ -1317,19 +1336,25 @@ describe('Quote infrastructure', () => {
     await context.db('clients')
       .where({ tenant: context.tenantId, client_id: context.clientId })
       .update({ billing_email: 'client-billing@example.com' });
-    await createClientLocation(context.db, context.clientId, context.tenantId, {
+    const clientLocationId = await createClientLocation(context.db, context.clientId, context.tenantId, {
       address_line1: '100 Client Way',
       city: 'Albany',
       state_province: 'NY',
       postal_code: '12207',
       country_name: 'United States',
     });
+    // ux_client_locations_default_per_client allows exactly one default, and
+    // the context client is provisioned with one already — flag only the new
+    // row, after clearing the flag everywhere else for this client.
     await context.db('client_locations')
       .where({ tenant: context.tenantId, client_id: context.clientId })
+      .update({ is_default: false, is_billing_address: false });
+    await context.db('client_locations')
+      .where({ tenant: context.tenantId, location_id: clientLocationId })
       .update({ is_default: true, is_billing_address: true });
 
     const tenantClientId = await createClient(context.db, context.tenantId, 'Tenant HQ', { billing_email: 'hq@example.com' });
-    await createClientLocation(context.db, tenantClientId, context.tenantId, {
+    const tenantLocationId = await createClientLocation(context.db, tenantClientId, context.tenantId, {
       address_line1: '1 MSP Plaza',
       city: 'Buffalo',
       state_province: 'NY',
@@ -1338,6 +1363,9 @@ describe('Quote infrastructure', () => {
     });
     await context.db('client_locations')
       .where({ tenant: context.tenantId, client_id: tenantClientId })
+      .update({ is_default: false, is_billing_address: false });
+    await context.db('client_locations')
+      .where({ tenant: context.tenantId, location_id: tenantLocationId })
       .update({ is_default: true, is_billing_address: true });
     await context.db('tenant_companies').insert({
       tenant: context.tenantId,

--- a/server/src/test/infrastructure/projects/projectManagement.test.ts
+++ b/server/src/test/infrastructure/projects/projectManagement.test.ts
@@ -13,7 +13,7 @@ import {
 } from '../../../../test-utils/testMocks';
 import { createTestDbConnection } from '../../../../test-utils/dbConfig';
 import { createTestEnvironment, createClient } from '../../../../test-utils/testDataFactory';
-import { resetDatabase, cleanupTables, createCleanupHook } from '../../../../test-utils/dbReset';
+import { cleanupTables, createCleanupHook } from '../../../../test-utils/dbReset';
 import {
     createProject,
     addProjectPhase,
@@ -228,9 +228,16 @@ describe('Project Management', () => {
     let initialStatusId: string;
 
     beforeAll(async () => {
-        // Initialize database with tenant context
+        // createTestDbConnection already drops, recreates, migrates and seeds
+        // the suite database. The resetDatabase() that used to follow it
+        // destroys the handle it is given, so every query in this file failed
+        // with "Unable to acquire a connection".
         db = await createTestDbConnection();
-        await resetDatabase(db);
+        const seededTenant = await db('tenants').first('tenant');
+        if (!seededTenant?.tenant) {
+            throw new Error('Seeded tenant missing from test database');
+        }
+        tenantId = seededTenant.tenant;
     });
 
     afterAll(async () => {
@@ -238,13 +245,17 @@ describe('Project Management', () => {
     });
 
     beforeEach(async () => {
-        await resetDatabase(db);
-        
-        // Set up common mocks
-        const { tenantId: mockTenantId } = setupCommonMocks({
-            user: createMockUser('admin')
+        // Per-test isolation without rebuilding the schema: drop the rows this
+        // suite creates. The full drop/migrate/seed cycle used to run here,
+        // costing ~90s per test on top of taking the connection with it.
+        await cleanupTables(db, ['projects', 'project_phases', 'project_tasks'], { ignoreErrors: true });
+
+        // Mocks must speak for the seeded tenant — the default mock tenant id
+        // has no rows in this database.
+        setupCommonMocks({
+            tenantId,
+            user: createMockUser('admin', { tenant: tenantId })
         });
-        tenantId = mockTenantId;
 
         // Create test client
         clientId = await createClient(db, tenantId, 'Test Client');

--- a/server/src/test/infrastructure/projects/projectManagement.test.ts
+++ b/server/src/test/infrastructure/projects/projectManagement.test.ts
@@ -2,18 +2,13 @@ import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vites
 import { v4 as uuidv4 } from 'uuid';
 import { TextEncoder } from 'util';
 import { Knex } from 'knex';
-import { TestContext } from '../../../../test-utils/testContext';
 import {
     setupCommonMocks,
-    mockNextHeaders,
-    mockNextAuth,
-    mockRBAC,
-    mockGetCurrentUser,
     createMockUser
 } from '../../../../test-utils/testMocks';
 import { createTestDbConnection } from '../../../../test-utils/dbConfig';
-import { createTestEnvironment, createClient } from '../../../../test-utils/testDataFactory';
-import { cleanupTables, createCleanupHook } from '../../../../test-utils/dbReset';
+import { createClient } from '../../../../test-utils/testDataFactory';
+import { cleanupTables } from '../../../../test-utils/dbReset';
 import {
     createProject,
     addProjectPhase,
@@ -29,202 +24,33 @@ import {
     deleteTask
 } from '@alga-psa/projects/actions/projectTaskActions';
 import type { IProject, IProjectPhase, IProjectTask } from '@alga-psa/types';
-import { ProjectModel, ProjectTaskModel } from '@alga-psa/projects/models';
+import { ProjectModel } from '@alga-psa/projects/models';
 
 global.TextEncoder = TextEncoder;
+
+// The project and task models are NOT mocked here. This file lives in
+// src/test/infrastructure, so its job is to exercise the real database path:
+// the actions insert and then reload through the models, and stubbed models
+// made every action fail with "Created project could not be reloaded after
+// insert" while proving nothing about the schema.
+//
+// The actions are withAuth-wrapped, so the acting user comes from the session.
+// Mocking the auth module lets setupCommonMocks drive that user (and its
+// tenant) instead of the real session/DB lookup.
+vi.mock('@alga-psa/auth', async () => {
+    const { createAuthModuleMock } = await import('../../../../test-utils/authModuleMock');
+    return createAuthModuleMock();
+});
 
 // Type definitions for create operations
 type CreateProjectInput = Omit<IProject, 'project_id' | 'created_at' | 'updated_at'>;
 type CreatePhaseInput = Omit<IProjectPhase, 'phase_id' | 'created_at' | 'updated_at' | 'tenant'>;
 type CreateTaskInput = Omit<IProjectTask, 'task_id' | 'created_at' | 'updated_at' | 'tenant' | 'phase_id'>;
 
-// Mock ProjectModel
-vi.mock('@alga-psa/projects/models/project', () => {
-    return {
-        default: {
-            getAll: vi.fn(),
-            getById: vi.fn(),
-            create: vi.fn((_knex: any, _tenant: string, data: any) => ({
-                ...data,
-                project_id: uuidv4(),
-                created_at: new Date(),
-                updated_at: new Date()
-            })),
-            update: vi.fn((_knex: any, _tenant: string, id: string, data: any) => ({
-                project_id: id,
-                ...data,
-                updated_at: new Date()
-            })),
-            delete: vi.fn(),
-            getPhases: vi.fn(() => []),
-            getPhaseById: vi.fn((_knex: any, _tenant: string, id: string) => ({
-                phase_id: id,
-                project_id: 'test-project-id',
-                phase_name: 'Test Phase',
-                wbs_code: '1.1'
-            })),
-            addPhase: vi.fn((_knex: any, _tenant: string, data: any) => ({
-                ...data,
-                phase_id: uuidv4(),
-                created_at: new Date(),
-                updated_at: new Date()
-            })),
-            updatePhase: vi.fn((_knex: any, _tenant: string, id: string, data: any) => ({
-                phase_id: id,
-                ...data,
-                updated_at: new Date()
-            })),
-            deletePhase: vi.fn(),
-            getProjectStatusMappings: vi.fn((_knex: any, _tenant: string, projectId: string) => [{
-                project_status_mapping_id: 'test-status-mapping-id',
-                project_id: projectId,
-                standard_status_id: 'test-standard-status-id',
-                is_standard: true,
-                custom_name: null,
-                display_order: 1,
-                is_visible: true
-            }]),
-            getProjectStatusMapping: vi.fn((_knex: any, _tenant: string, id: string) => ({
-                project_status_mapping_id: id,
-                project_id: 'test-project-id',
-                standard_status_id: 'test-standard-status-id',
-                is_standard: true,
-                custom_name: null,
-                display_order: 1,
-                is_visible: true
-            })),
-            addProjectStatusMapping: vi.fn(),
-            // Awaited with .catch() by the action, so the mock must be a promise.
-            getStandardStatusesByType: vi.fn(() => Promise.resolve([
-                {
-                    standard_status_id: uuidv4(),
-                    name: 'To Do',
-                    item_type: 'project_task',
-                    display_order: 1,
-                    is_closed: false
-                },
-                {
-                    standard_status_id: uuidv4(),
-                    name: 'In Progress',
-                    item_type: 'project_task',
-                    display_order: 2,
-                    is_closed: false
-                },
-                {
-                    standard_status_id: uuidv4(),
-                    name: 'Done',
-                    item_type: 'project_task',
-                    display_order: 3,
-                    is_closed: true
-                }
-            ])),
-            getCustomStatus: vi.fn(),
-            getStandardStatus: vi.fn(),
-            getStatusesByType: vi.fn(() => Promise.resolve([
-                {
-                    status_id: uuidv4(),
-                    name: 'Active',
-                    status_type: 'project',
-                    is_closed: false,
-                    order_number: 1
-                },
-                {
-                    status_id: uuidv4(),
-                    name: 'Completed',
-                    status_type: 'project',
-                    is_closed: true,
-                    order_number: 2
-                }
-            ])),
-            generateNextWbsCode: vi.fn((_knex: any, _tenant: string, parentWbsCode: string) => {
-                const parts = parentWbsCode.split('.');
-                const lastPart = parseInt(parts[parts.length - 1]);
-                parts[parts.length - 1] = (lastPart + 1).toString();
-                return Promise.resolve(parts.join('.'));
-            }),
-        }
-    };
-});
-
-// Mock ProjectTaskModel
-vi.mock('@alga-psa/projects/models/projectTask', () => {
-    const taskStore = new Map();
-
-    return {
-        default: {
-            getTasks: vi.fn(() => []),
-            getTaskById: vi.fn((_knex: any, _tenant: string, id: string) => taskStore.get(id) || null),
-            addTask: vi.fn((_knex: any, _tenant: string, phaseId: string, data: any) => {
-                const task = {
-                    task_id: uuidv4(),
-                    phase_id: phaseId,
-                    task_name: data.task_name,
-                    description: data.description,
-                    estimated_hours: data.estimated_hours,
-                    actual_hours: data.actual_hours || 0,
-                    assigned_to: data.assigned_to,
-                    due_date: data.due_date,
-                    project_status_mapping_id: data.project_status_mapping_id,
-                    wbs_code: data.wbs_code,
-                    created_at: new Date(),
-                    updated_at: new Date(),
-                    checklist_items: []
-                };
-                taskStore.set(task.task_id, task);
-                return task;
-            }),
-            updateTask: vi.fn((_knex: any, _tenant: string, id: string, data: any) => {
-                const task = {
-                    task_id: id,
-                    ...data,
-                    updated_at: new Date()
-                };
-                taskStore.set(id, task);
-                return task;
-            }),
-            deleteTask: vi.fn((_knex: any, _tenant: string, id: string) => {
-                taskStore.delete(id);
-            }),
-            getTaskTicketLinks: vi.fn(() => []),
-            updateTaskTicketLink: vi.fn(),
-            deleteTaskTicketLink: vi.fn(),
-            addTaskTicketLink: vi.fn(),
-            getChecklistItems: vi.fn(() => []),
-            addChecklistItem: vi.fn(),
-            updateChecklistItem: vi.fn(),
-            deleteChecklistItems: vi.fn(),
-            deleteChecklistItem: vi.fn(),
-        }
-    };
-});
-
-async function getNextWbsCode(db: Knex, tenantId: string): Promise<string> {
-    const maxProject = await db('projects')
-        .where({ tenant: tenantId })
-        .max('wbs_code as max')
-        .first();
-    
-    const currentMax = maxProject?.max ? parseInt(maxProject.max) : 0;
-    return (currentMax + 1).toString();
-}
-
-async function getNextPhaseWbsCode(db: Knex, projectWbsCode: string): Promise<string> {
-    const maxPhase = await db('project_phases')
-        .where('wbs_code', 'like', `${projectWbsCode}.%`)
-        .max('wbs_code as max')
-        .first();
-    
-    if (!maxPhase?.max) {
-        return `${projectWbsCode}.1`;
-    }
-
-    const currentMax = parseInt(maxPhase.max.split('.').pop() || '0');
-    return `${projectWbsCode}.${currentMax + 1}`;
-}
-
 describe('Project Management', () => {
     let db: Knex;
     let tenantId: string;
+    let userId: string;
     let clientId: string;
     let initialStatusId: string;
 
@@ -239,6 +65,16 @@ describe('Project Management', () => {
             throw new Error('Seeded tenant missing from test database');
         }
         tenantId = seededTenant.tenant;
+
+        // The acting user must be a real row: the authorization kernel narrows
+        // on team_members.user_id, and the default mock id ('mock-user-id') is
+        // not a uuid — that query errored and aborted the action's transaction,
+        // so the next statement failed with "current transaction is aborted".
+        const seededUser = await db('users').where({ tenant: tenantId }).first('user_id');
+        if (!seededUser?.user_id) {
+            throw new Error('Seeded user missing from test database');
+        }
+        userId = seededUser.user_id;
     });
 
     afterAll(async () => {
@@ -259,9 +95,11 @@ describe('Project Management', () => {
         // has no rows in this database.
         setupCommonMocks({
             tenantId,
+            userId,
             // createMockUser leaves roles empty, and the default RBAC mock reads
             // them, so the admin fixture was denied everything.
             user: createMockUser('internal', {
+                user_id: userId,
                 tenant: tenantId,
                 roles: [{ role_id: 'mock-admin-role', role_name: 'Admin', description: 'Admin', tenant: tenantId }]
             })
@@ -279,22 +117,61 @@ describe('Project Management', () => {
         initialStatusId = status.status_id;
     });
 
+    // wbs_code and project_number are generated by the action, so fixtures only
+    // supply the fields a caller would.
+    function projectInput(overrides: Partial<CreateProjectInput> = {}): CreateProjectInput {
+        return {
+            client_id: clientId,
+            project_name: 'Test Project',
+            description: 'Test Project Description',
+            start_date: new Date(),
+            end_date: new Date(Date.now() + 86400000), // tomorrow
+            is_inactive: false,
+            tenant: tenantId,
+            status: initialStatusId,
+            ...overrides
+        } as CreateProjectInput;
+    }
+
+    // addProjectPhase validates against the full phase schema, so wbs_code has
+    // to be present even though the action immediately replaces it with one
+    // derived from the project's own code.
+    function phaseInput(projectId: string, overrides: Partial<CreatePhaseInput> = {}): CreatePhaseInput {
+        return {
+            project_id: projectId,
+            phase_name: 'Test Phase',
+            description: 'Test Phase Description',
+            start_date: new Date(),
+            end_date: new Date(Date.now() + 86400000),
+            status: 'active',
+            wbs_code: 'generated-by-action',
+            order_number: 1,
+            ...overrides
+        } as CreatePhaseInput;
+    }
+
+    function taskInput(statusMappingId: string, overrides: Partial<CreateTaskInput> = {}): CreateTaskInput {
+        return {
+            task_name: 'Test Task',
+            description: 'Test Task Description',
+            estimated_hours: 8,
+            actual_hours: 0,
+            assigned_to: null,
+            due_date: null,
+            project_status_mapping_id: statusMappingId,
+            task_type_key: 'standard',
+            ...overrides
+        } as CreateTaskInput;
+    }
+
+    async function firstStatusMappingId(projectId: string): Promise<string> {
+        const mappings = await ProjectModel.getProjectStatusMappings(db, tenantId, projectId);
+        return mappings[0].project_status_mapping_id;
+    }
+
     describe('Project Creation and Management', () => {
         it('should create a new project with initial status', async () => {
-            const wbsCode = await getNextWbsCode(db, tenantId);
-            const projectData: CreateProjectInput = {
-                client_id: clientId,
-                project_name: 'Test Project',
-                description: 'Test Project Description',
-                start_date: new Date(),
-                end_date: new Date(Date.now() + 86400000), // tomorrow
-                wbs_code: wbsCode,
-                is_inactive: false,
-                tenant: tenantId,
-                status: initialStatusId
-            };
-
-            const result = await createProject(projectData);
+            const result = await createProject(projectInput());
 
             expect(result).toMatchObject({
                 client_id: clientId,
@@ -305,33 +182,25 @@ describe('Project Management', () => {
 
             expect(result.project_id).toBeDefined();
             expect(result.status).toBeDefined();
-            expect(result.created_at).toBeInstanceOf(Date);
-            expect(result.updated_at).toBeInstanceOf(Date);
+            // Generated rather than supplied by the caller.
+            expect(result.wbs_code).toBeTruthy();
+            expect(result.project_number).toBeTruthy();
+
+            const persisted = await db('projects')
+                .where({ project_id: result.project_id, tenant: tenantId })
+                .first();
+            expect(persisted).toBeDefined();
+            expect(persisted.project_name).toBe('Test Project');
         });
 
         it('should update project details', async () => {
-            const wbsCode = await getNextWbsCode(db, tenantId);
-            const projectData: CreateProjectInput = {
-                client_id: clientId,
-                project_name: 'Initial Project',
-                description: 'Initial Description',
-                start_date: new Date(),
-                end_date: new Date(Date.now() + 86400000),
-                wbs_code: wbsCode,
-                is_inactive: false,
-                tenant: tenantId,
-                status: initialStatusId
-            };
+            const project = await createProject(projectInput({ project_name: 'Initial Project', description: 'Initial Description' }));
 
-            const project = await createProject(projectData);
-
-            const updateData = {
+            const updatedProject = await updateProject(project.project_id, {
                 project_name: 'Updated Project',
                 description: 'Updated Description',
                 is_inactive: true
-            };
-
-            const updatedProject = await updateProject(project.project_id, updateData);
+            });
 
             expect(updatedProject).toMatchObject({
                 project_id: project.project_id,
@@ -339,44 +208,25 @@ describe('Project Management', () => {
                 description: 'Updated Description',
                 is_inactive: true
             });
+
+            const persisted = await db('projects')
+                .where({ project_id: project.project_id, tenant: tenantId })
+                .first();
+            expect(persisted.project_name).toBe('Updated Project');
+            expect(persisted.is_inactive).toBe(true);
         });
     });
 
     describe('Phase Management', () => {
         let projectId: string;
-        let projectWbsCode: string;
 
         beforeEach(async () => {
-            projectWbsCode = await getNextWbsCode(db, tenantId);
-            const projectData: CreateProjectInput = {
-                client_id: clientId,
-                project_name: 'Test Project',
-                description: 'Test Description',
-                start_date: new Date(),
-                end_date: new Date(Date.now() + 86400000),
-                wbs_code: projectWbsCode,
-                is_inactive: false,
-                tenant: tenantId,
-                status: initialStatusId
-            };
-            const project = await createProject(projectData);
+            const project = await createProject(projectInput());
             projectId = project.project_id;
         });
 
         it('should create a new phase in a project', async () => {
-            const phaseWbsCode = await getNextPhaseWbsCode(db, projectWbsCode);
-            const phaseData: CreatePhaseInput = {
-                project_id: projectId,
-                phase_name: 'Test Phase',
-                description: 'Test Phase Description',
-                start_date: new Date(),
-                end_date: new Date(Date.now() + 86400000),
-                status: 'active',
-                wbs_code: phaseWbsCode,
-                order_number: 1
-            };
-
-            const result = await addProjectPhase(phaseData);
+            const result = await addProjectPhase(phaseInput(projectId));
 
             expect(result).toMatchObject({
                 project_id: projectId,
@@ -386,32 +236,24 @@ describe('Project Management', () => {
             });
 
             expect(result.phase_id).toBeDefined();
-            expect(result.created_at).toBeInstanceOf(Date);
-            expect(result.updated_at).toBeInstanceOf(Date);
+            expect(result.wbs_code).toBeTruthy();
+
+            const persisted = await db('project_phases')
+                .where({ phase_id: result.phase_id, tenant: tenantId })
+                .first();
+            expect(persisted).toBeDefined();
         });
 
         it('should update phase details', async () => {
-            const phaseWbsCode = await getNextPhaseWbsCode(db, projectWbsCode);
-            const phaseData: CreatePhaseInput = {
-                project_id: projectId,
-                phase_name: 'Initial Phase',
-                description: 'Initial Description',
-                start_date: new Date(),
-                end_date: new Date(Date.now() + 86400000),
-                status: 'active',
-                wbs_code: phaseWbsCode,
-                order_number: 1
-            };
+            const phase = await addProjectPhase(
+                phaseInput(projectId, { phase_name: 'Initial Phase', description: 'Initial Description' })
+            );
 
-            const phase = await addProjectPhase(phaseData);
-
-            const updateData = {
+            const updatedPhase = await updatePhase(phase.phase_id, {
                 phase_name: 'Updated Phase',
                 description: 'Updated Description',
                 status: 'completed'
-            };
-
-            const updatedPhase = await updatePhase(phase.phase_id, updateData);
+            });
 
             expect(updatedPhase).toMatchObject({
                 phase_id: phase.phase_id,
@@ -419,308 +261,170 @@ describe('Project Management', () => {
                 description: 'Updated Description',
                 status: 'completed'
             });
+
+            const persisted = await db('project_phases')
+                .where({ phase_id: phase.phase_id, tenant: tenantId })
+                .first();
+            expect(persisted.phase_name).toBe('Updated Phase');
         });
     });
 
     describe('Task Management', () => {
         let projectId: string;
-        let projectWbsCode: string;
         let phaseId: string;
-        let phaseWbsCode: string;
         let statusMappingId: string;
 
         beforeEach(async () => {
-            // Create project
-            projectWbsCode = await getNextWbsCode(db, tenantId);
-            const projectData: CreateProjectInput = {
-                client_id: clientId,
-                project_name: 'Test Project',
-                description: 'Test Description',
-                start_date: new Date(),
-                end_date: new Date(Date.now() + 86400000),
-                wbs_code: projectWbsCode,
-                is_inactive: false,
-                tenant: tenantId,
-                status: initialStatusId
-            };
-            const project = await createProject(projectData);
+            const project = await createProject(projectInput());
             projectId = project.project_id;
 
-            // Create phase
-            phaseWbsCode = await getNextPhaseWbsCode(db, projectWbsCode);
-            const phaseData: CreatePhaseInput = {
-                project_id: projectId,
-                phase_name: 'Test Phase',
-                description: 'Test Phase Description',
-                start_date: new Date(),
-                end_date: new Date(Date.now() + 86400000),
-                status: 'active',
-                wbs_code: phaseWbsCode,
-                order_number: 1
-            };
-            const phase = await addProjectPhase(phaseData);
+            const phase = await addProjectPhase(phaseInput(projectId));
             phaseId = phase.phase_id;
 
-            // Get status mapping
-            const statusMappings = await ProjectModel.getProjectStatusMappings(db, tenantId, projectId);
-            statusMappingId = statusMappings[0].project_status_mapping_id;
+            statusMappingId = await firstStatusMappingId(projectId);
         });
 
         it('should create a new task in a phase', async () => {
-            const taskWbsCode = `${phaseWbsCode}.1`;
-            const taskData: CreateTaskInput = {
-                task_name: 'Test Task',
-                description: 'Test Task Description',
-                estimated_hours: 8,
-                actual_hours: 0,
-                assigned_to: null,
-                due_date: null,
-                project_status_mapping_id: statusMappingId,
-                wbs_code: taskWbsCode,
-                task_type_key: 'standard'
-            };
-
-            const result = await addTaskToPhase(phaseId, taskData, []);
+            const result = await addTaskToPhase(phaseId, taskInput(statusMappingId), []);
 
             expect(result).toMatchObject({
                 task_name: 'Test Task',
                 description: 'Test Task Description',
-                estimated_hours: 8,
                 project_status_mapping_id: statusMappingId
             });
+            // project_tasks.estimated_hours is numeric, which pg returns as a string.
+            expect(Number(result!.estimated_hours)).toBe(8);
 
             expect(result?.task_id).toBeDefined();
-            expect(result?.created_at).toBeInstanceOf(Date);
-            expect(result?.updated_at).toBeInstanceOf(Date);
+
+            const persisted = await db('project_tasks')
+                .where({ task_id: result!.task_id, tenant: tenantId })
+                .first();
+            expect(persisted.phase_id).toBe(phaseId);
         });
 
         it('should update task details', async () => {
-            const taskWbsCode = `${phaseWbsCode}.1`;
-            const taskData: CreateTaskInput = {
-                task_name: 'Initial Task',
-                description: 'Initial Description',
-                estimated_hours: 8,
-                actual_hours: 0,
-                assigned_to: null,
-                due_date: null,
-                project_status_mapping_id: statusMappingId,
-                wbs_code: taskWbsCode,
-                task_type_key: 'standard'
-            };
-
-            const task = await addTaskToPhase(phaseId, taskData, []);
+            const task = await addTaskToPhase(
+                phaseId,
+                taskInput(statusMappingId, { task_name: 'Initial Task', description: 'Initial Description' }),
+                []
+            );
 
             if (!task) throw new Error('Task creation failed');
 
-            const updateData = {
+            const updatedTask = await updateTaskWithChecklist(task.task_id, {
                 task_name: 'Updated Task',
                 description: 'Updated Description',
                 estimated_hours: 16
-            };
-
-            const updatedTask = await updateTaskWithChecklist(task.task_id, updateData);
+            });
 
             expect(updatedTask).toMatchObject({
                 task_id: task.task_id,
                 task_name: 'Updated Task',
-                description: 'Updated Description',
-                estimated_hours: 16
+                description: 'Updated Description'
             });
+            expect(Number(updatedTask!.estimated_hours)).toBe(16);
+
+            const persisted = await db('project_tasks')
+                .where({ task_id: task.task_id, tenant: tenantId })
+                .first();
+            expect(persisted.task_name).toBe('Updated Task');
         });
 
         it('should move task to a different phase', async () => {
-            // Create another phase
-            const newPhaseWbsCode = await getNextPhaseWbsCode(db, projectWbsCode);
-            const newPhaseData: CreatePhaseInput = {
-                project_id: projectId,
-                phase_name: 'New Phase',
-                description: 'New Phase Description',
-                start_date: new Date(),
-                end_date: new Date(Date.now() + 86400000),
-                status: 'active',
-                wbs_code: newPhaseWbsCode,
-                order_number: 2
-            };
-            const newPhase = await addProjectPhase(newPhaseData);
+            const newPhase = await addProjectPhase(
+                phaseInput(projectId, { phase_name: 'New Phase', description: 'New Phase Description', order_number: 2 })
+            );
 
-            // Create a task
-            const taskWbsCode = `${phaseWbsCode}.1`;
-            const taskData: CreateTaskInput = {
-                task_name: 'Test Task',
-                description: 'Test Task Description',
-                estimated_hours: 8,
-                actual_hours: 0,
-                assigned_to: null,
-                due_date: null,
-                project_status_mapping_id: statusMappingId,
-                wbs_code: taskWbsCode,
-                task_type_key: 'standard'
-            };
-
-            const task = await addTaskToPhase(phaseId, taskData, []);
-
+            const task = await addTaskToPhase(phaseId, taskInput(statusMappingId), []);
             if (!task) throw new Error('Task creation failed');
 
-            // Mock the expected new WBS code
-            const expectedNewWbsCode = `${newPhaseWbsCode}.1`;
-            vi.mocked(ProjectModel.generateNextWbsCode).mockResolvedValueOnce(expectedNewWbsCode);
-
-            // Move the task
             const movedTask = await moveTaskToPhase(task.task_id, newPhase.phase_id);
 
             expect(movedTask).toMatchObject({
                 task_id: task.task_id,
                 phase_id: newPhase.phase_id,
-                task_name: 'Test Task',
-                wbs_code: expectedNewWbsCode
+                task_name: 'Test Task'
             });
+            // The task is re-numbered under its new phase.
+            expect(movedTask.wbs_code.startsWith(`${newPhase.wbs_code}.`)).toBe(true);
+
+            const persisted = await db('project_tasks')
+                .where({ task_id: task.task_id, tenant: tenantId })
+                .first();
+            expect(persisted.phase_id).toBe(newPhase.phase_id);
         });
 
         it('should move task to a different project', async () => {
-            // Create another project
-            const newProjectWbsCode = await getNextWbsCode(db, tenantId);
-            const newProjectData: CreateProjectInput = {
-                client_id: clientId,
-                project_name: 'New Project',
-                description: 'New Project Description',
-                start_date: new Date(),
-                end_date: new Date(Date.now() + 86400000),
-                wbs_code: newProjectWbsCode,
-                is_inactive: false,
-                tenant: tenantId,
-                status: initialStatusId
-            };
-            const newProject = await createProject(newProjectData);
+            const newProject = await createProject(
+                projectInput({ project_name: 'New Project', description: 'New Project Description' })
+            );
 
-            // Create phase in new project
-            const newPhaseWbsCode = await getNextPhaseWbsCode(db, newProjectWbsCode);
-            const newPhaseData: CreatePhaseInput = {
-                project_id: newProject.project_id,
-                phase_name: 'New Phase',
-                description: 'New Phase Description',
-                start_date: new Date(),
-                end_date: new Date(Date.now() + 86400000),
-                status: 'active',
-                wbs_code: newPhaseWbsCode,
-                order_number: 1
-            };
-            const newPhase = await addProjectPhase(newPhaseData);
+            const newPhase = await addProjectPhase(
+                phaseInput(newProject.project_id, { phase_name: 'New Phase', description: 'New Phase Description' })
+            );
 
-            // Get status mapping for new project
-            const newStatusMappings = await ProjectModel.getProjectStatusMappings(db, tenantId, newProject.project_id);
-            const newStatusMappingId = newStatusMappings[0].project_status_mapping_id;
+            const newStatusMappingId = await firstStatusMappingId(newProject.project_id);
 
-            // Create a task
-            const taskWbsCode = `${phaseWbsCode}.1`;
-            const taskData: CreateTaskInput = {
-                task_name: 'Test Task',
-                description: 'Test Task Description',
-                estimated_hours: 8,
-                actual_hours: 0,
-                assigned_to: null,
-                due_date: null,
-                project_status_mapping_id: statusMappingId,
-                wbs_code: taskWbsCode,
-                task_type_key: 'standard'
-            };
-
-            const task = await addTaskToPhase(phaseId, taskData, []);
-
+            const task = await addTaskToPhase(phaseId, taskInput(statusMappingId), []);
             if (!task) throw new Error('Task creation failed');
 
-            // Mock the expected new WBS code
-            const expectedNewWbsCode = `${newPhaseWbsCode}.1`;
-            vi.mocked(ProjectModel.generateNextWbsCode).mockResolvedValueOnce(expectedNewWbsCode);
-
-            // Move the task
             const movedTask = await moveTaskToPhase(task.task_id, newPhase.phase_id, newStatusMappingId);
 
             expect(movedTask).toMatchObject({
                 task_id: task.task_id,
                 phase_id: newPhase.phase_id,
                 task_name: 'Test Task',
-                project_status_mapping_id: newStatusMappingId,
-                wbs_code: expectedNewWbsCode
+                project_status_mapping_id: newStatusMappingId
             });
+            expect(movedTask.wbs_code.startsWith(`${newPhase.wbs_code}.`)).toBe(true);
         });
     });
 
     describe('Deletion Operations', () => {
         let projectId: string;
-        let projectWbsCode: string;
         let phaseId: string;
-        let phaseWbsCode: string;
         let taskId: string;
 
         beforeEach(async () => {
-            // Create project
-            projectWbsCode = await getNextWbsCode(db, tenantId);
-            const projectData: CreateProjectInput = {
-                client_id: clientId,
-                project_name: 'Test Project',
-                description: 'Test Description',
-                start_date: new Date(),
-                end_date: new Date(Date.now() + 86400000),
-                wbs_code: projectWbsCode,
-                is_inactive: false,
-                tenant: tenantId,
-                status: initialStatusId
-            };
-            const project = await createProject(projectData);
+            const project = await createProject(projectInput());
             projectId = project.project_id;
 
-            // Create phase
-            phaseWbsCode = await getNextPhaseWbsCode(db, projectWbsCode);
-            const phaseData: CreatePhaseInput = {
-                project_id: projectId,
-                phase_name: 'Test Phase',
-                description: 'Test Phase Description',
-                start_date: new Date(),
-                end_date: new Date(Date.now() + 86400000),
-                status: 'active',
-                wbs_code: phaseWbsCode,
-                order_number: 1
-            };
-            const phase = await addProjectPhase(phaseData);
+            const phase = await addProjectPhase(phaseInput(projectId));
             phaseId = phase.phase_id;
 
-            // Get status mapping
-            const statusMappings = await ProjectModel.getProjectStatusMappings(db, tenantId, projectId);
-            const statusMappingId = statusMappings[0].project_status_mapping_id;
+            const statusMappingId = await firstStatusMappingId(projectId);
 
-            // Create task
-            const taskWbsCode = `${phaseWbsCode}.1`;
-            const taskData: CreateTaskInput = {
-                task_name: 'Test Task',
-                description: 'Test Task Description',
-                estimated_hours: 8,
-                actual_hours: 0,
-                assigned_to: null,
-                due_date: null,
-                project_status_mapping_id: statusMappingId,
-                wbs_code: taskWbsCode,
-                task_type_key: 'standard'
-            };
-
-            const task = await addTaskToPhase(phaseId, taskData, []);
-
+            const task = await addTaskToPhase(phaseId, taskInput(statusMappingId), []);
             if (!task) throw new Error('Task creation failed');
             taskId = task.task_id;
         });
 
         it('should delete a task', async () => {
             await deleteTask(taskId);
-            expect(ProjectTaskModel.deleteTask).toHaveBeenCalledWith(expect.anything(), expect.any(String), taskId);
+
+            const persisted = await db('project_tasks')
+                .where({ task_id: taskId, tenant: tenantId })
+                .first();
+            expect(persisted).toBeUndefined();
         });
 
         it('should delete a phase', async () => {
             await deletePhase(phaseId);
-            expect(ProjectModel.deletePhase).toHaveBeenCalledWith(expect.anything(), expect.any(String), phaseId);
+
+            const persisted = await db('project_phases')
+                .where({ phase_id: phaseId, tenant: tenantId })
+                .first();
+            expect(persisted).toBeUndefined();
         });
 
         it('should delete a project', async () => {
             await deleteProject(projectId);
-            expect(ProjectModel.delete).toHaveBeenCalledWith(expect.anything(), expect.any(String), projectId);
+
+            const persisted = await db('projects')
+                .where({ project_id: projectId, tenant: tenantId })
+                .first();
+            expect(persisted).toBeUndefined();
         });
     });
 });

--- a/server/src/test/infrastructure/projects/projectManagement.test.ts
+++ b/server/src/test/infrastructure/projects/projectManagement.test.ts
@@ -94,7 +94,8 @@ vi.mock('@alga-psa/projects/models/project', () => {
                 is_visible: true
             })),
             addProjectStatusMapping: vi.fn(),
-            getStandardStatusesByType: vi.fn(() => [
+            // Awaited with .catch() by the action, so the mock must be a promise.
+            getStandardStatusesByType: vi.fn(() => Promise.resolve([
                 {
                     standard_status_id: uuidv4(),
                     name: 'To Do',
@@ -116,10 +117,10 @@ vi.mock('@alga-psa/projects/models/project', () => {
                     display_order: 3,
                     is_closed: true
                 }
-            ]),
+            ])),
             getCustomStatus: vi.fn(),
             getStandardStatus: vi.fn(),
-            getStatusesByType: vi.fn(() => [
+            getStatusesByType: vi.fn(() => Promise.resolve([
                 {
                     status_id: uuidv4(),
                     name: 'Active',
@@ -134,7 +135,7 @@ vi.mock('@alga-psa/projects/models/project', () => {
                     is_closed: true,
                     order_number: 2
                 }
-            ]),
+            ])),
             generateNextWbsCode: vi.fn((_knex: any, _tenant: string, parentWbsCode: string) => {
                 const parts = parentWbsCode.split('.');
                 const lastPart = parseInt(parts[parts.length - 1]);
@@ -248,17 +249,28 @@ describe('Project Management', () => {
         // Per-test isolation without rebuilding the schema: drop the rows this
         // suite creates. The full drop/migrate/seed cycle used to run here,
         // costing ~90s per test on top of taking the connection with it.
-        await cleanupTables(db, ['projects', 'project_phases', 'project_tasks'], { ignoreErrors: true });
+        await cleanupTables(
+            db,
+            ['projects', 'project_phases', 'project_tasks', 'task_checklist_items', 'project_ticket_links'],
+            { ignoreErrors: true }
+        );
 
         // Mocks must speak for the seeded tenant — the default mock tenant id
         // has no rows in this database.
         setupCommonMocks({
             tenantId,
-            user: createMockUser('admin', { tenant: tenantId })
+            // createMockUser leaves roles empty, and the default RBAC mock reads
+            // them, so the admin fixture was denied everything.
+            user: createMockUser('internal', {
+                tenant: tenantId,
+                roles: [{ role_id: 'mock-admin-role', role_name: 'Admin', description: 'Admin', tenant: tenantId }]
+            })
         });
 
         // Create test client
-        clientId = await createClient(db, tenantId, 'Test Client');
+        // clients_tenant_client_name_unique: the database is no longer rebuilt
+        // between tests, so each one needs its own name.
+        clientId = await createClient(db, tenantId, `Test Client ${uuidv4().slice(0, 8)}`);
 
         // Get initial status ID
         const status = await db('statuses')

--- a/server/src/test/infrastructure/projects/projectPermissions.test.ts
+++ b/server/src/test/infrastructure/projects/projectPermissions.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
 import {
   setupCommonMocks,
   mockNextHeaders,
@@ -16,10 +16,6 @@ import {
   createUser,
   createTestEnvironment
 } from '../../../../test-utils/testDataFactory';
-import {
-  createCleanupHook,
-  cleanupTables
-} from '../../../../test-utils/dbReset';
 import {
   expectPermissionDenied,
   expectError
@@ -104,16 +100,20 @@ describe('Project Permissions Infrastructure', () => {
     tenantScope(tenantId).tenantJoin(adminUserQuery, 'roles', 'user_roles.role_id', 'roles.role_id', { type: 'left' });
     adminUser = await adminUserQuery.first();
 
-    // Set up mocks
+    // Set up mocks. projectActions imports hasPermission from
+    // '@alga-psa/auth/rbac', a different specifier than the '@alga-psa/auth'
+    // mocked above — patching only the latter left the rbac mock on its
+    // default ("no roles => allow everything"), so the regular user was
+    // granted update/create/delete. Routing the check through
+    // setupCommonMocks drives both specifiers off the same predicate.
     setupCommonMocks({
       tenantId,
-      user: createMockUser('admin')
-    });
-
-    vi.mocked(auth.hasPermission).mockImplementation(async (user: any, resource: string, action: string): Promise<boolean> => {
-      if (user?.username === 'janeadmin') return true;
-      if (user?.username === 'johndoe' && resource === 'project' && action === 'read') return true;
-      return false;
+      user: createMockUser('admin'),
+      permissionCheck: (user: any, resource?: string, action?: string): boolean => {
+        if (user?.username === 'janeadmin') return true;
+        if (user?.username === 'johndoe' && resource === 'project' && action === 'read') return true;
+        return false;
+      }
     });
 
     // Create test project
@@ -145,16 +145,11 @@ describe('Project Permissions Infrastructure', () => {
     await tenantTable(tenantId, 'projects').insert(testProject);
   });
 
-  // Use cleanup hook for test isolation
-  afterEach(async () => {
-    // Deletion runs in reverse array order, so client_billing_profiles must sit
-    // after 'clients': every client is provisioned a default profile, and
-    // deleting the client first trips that foreign key.
-    await createCleanupHook(
-      context.db,
-      ['projects', 'clients', 'client_billing_profiles', 'users', 'roles', 'permissions']
-    )();
-  });
+  // No cleanup hook: beforeEach rolls the per-test transaction back, which
+  // already discards every fixture row. Deleting them by hand instead hit
+  // role_permissions' foreign key on `permissions`, and that error aborts the
+  // surrounding transaction — every later statement in the hook then failed
+  // with "current transaction is aborted".
 
   it('should allow regular user to view projects', async () => {
     vi.mocked(auth.getCurrentUser).mockResolvedValue(regularUser);

--- a/server/src/test/infrastructure/projects/projectPermissions.test.ts
+++ b/server/src/test/infrastructure/projects/projectPermissions.test.ts
@@ -17,7 +17,6 @@ import {
   createTestEnvironment
 } from '../../../../test-utils/testDataFactory';
 import {
-  resetDatabase,
   createCleanupHook,
   cleanupTables
 } from '../../../../test-utils/dbReset';
@@ -59,8 +58,11 @@ describe('Project Permissions Infrastructure', () => {
   });
 
   beforeEach(async () => {
-    // Reset database state
-    await resetDatabase(context.db);
+    // Roll the per-test transaction back and open a fresh one. resetDatabase()
+    // used to run here: it destroys the handle it is given and drops the
+    // database out from under the context, so every query after the first
+    // beforeEach failed with "not queryable".
+    await context.reset();
 
     // Set up common test environment
     const { tenantId, clientId } = await createTestEnvironment(context.db, {
@@ -140,7 +142,13 @@ describe('Project Permissions Infrastructure', () => {
 
   // Use cleanup hook for test isolation
   afterEach(async () => {
-    await createCleanupHook(context.db, ['projects', 'clients', 'users', 'roles', 'permissions'])();
+    // Deletion runs in reverse array order, so client_billing_profiles must sit
+    // after 'clients': every client is provisioned a default profile, and
+    // deleting the client first trips that foreign key.
+    await createCleanupHook(
+      context.db,
+      ['projects', 'clients', 'client_billing_profiles', 'users', 'roles', 'permissions']
+    )();
   });
 
   it('should allow regular user to view projects', async () => {

--- a/server/src/test/infrastructure/projects/projectPermissions.test.ts
+++ b/server/src/test/infrastructure/projects/projectPermissions.test.ts
@@ -33,7 +33,10 @@ vi.mock('@alga-psa/auth', async () => {
 
 describe('Project Permissions Infrastructure', () => {
   const context = new TestContext({
-    cleanupTables: ['projects', 'clients', 'users', 'roles', 'permissions'],
+    // No cleanupTables: each test runs in a transaction that is rolled back, and
+    // TRUNCATE ... CASCADE on clients/users took the seeded statuses and
+    // priorities with it — every fixture lookup then failed for the rest of the
+    // file.
     runSeeds: true
   });
   let testProject: IProject;
@@ -64,10 +67,10 @@ describe('Project Permissions Infrastructure', () => {
     // beforeEach failed with "not queryable".
     await context.reset();
 
-    // Set up common test environment
-    const { tenantId, clientId } = await createTestEnvironment(context.db, {
-      clientName: 'Test Client'
-    });
+    // Use the seeded tenant: createTestEnvironment mints a fresh one, which has
+    // none of the seeded statuses or priorities these fixtures look up.
+    const tenantId = context.tenantId;
+    const clientId = context.clientId;
 
     // Create users with different roles
     const regularUserId = await createUser(context.db, tenantId, {
@@ -133,6 +136,8 @@ describe('Project Permissions Infrastructure', () => {
       created_at: new Date(),
       updated_at: new Date(),
       wbs_code: 'TEST-001',
+      // projects.project_number is NOT NULL and unique per tenant.
+      project_number: `PRJ-${uuidv4().slice(0, 8)}`,
       is_inactive: false,
       status: initiatingSpellStatus.status_id
     };

--- a/server/src/test/infrastructure/tickets/ticketPermissions.test.ts
+++ b/server/src/test/infrastructure/tickets/ticketPermissions.test.ts
@@ -28,7 +28,10 @@ import { tenantDb } from '@alga-psa/db';
 
 describe('Ticket Permissions Infrastructure', () => {
   const context = new TestContext({
-    cleanupTables: ['tickets', 'categories', 'boards', 'contacts', 'clients', 'users', 'roles', 'permissions'],
+    // No cleanupTables: each test runs in a transaction that is rolled back, and
+    // TRUNCATE ... CASCADE on clients/users took the seeded statuses and
+    // priorities with it — every fixture lookup then failed for the rest of the
+    // file.
     runSeeds: true
   });
   let testTicket: ITicket;
@@ -64,10 +67,10 @@ describe('Ticket Permissions Infrastructure', () => {
     // beforeEach failed with "not queryable".
     await context.reset();
 
-    // Set up common test environment
-    const { tenantId, clientId } = await createTestEnvironment(context.db, {
-      clientName: 'Test Client'
-    });
+    // Use the seeded tenant: createTestEnvironment mints a fresh one, which has
+    // none of the seeded statuses or priorities these fixtures look up.
+    const tenantId = context.tenantId;
+    const clientId = context.clientId;
 
     // Create users with different roles
     const regularUserId = await createUser(context.db, tenantId, {
@@ -178,8 +181,7 @@ describe('Ticket Permissions Infrastructure', () => {
       updated_at: null,
       closed_at: null,
       attributes: null,
-      priority_id: priorityId,
-      estimated_hours: undefined
+      priority_id: priorityId
     };
 
     await tenantTable(tenantId, 'tickets').insert(testTicket);

--- a/server/src/test/infrastructure/tickets/ticketPermissions.test.ts
+++ b/server/src/test/infrastructure/tickets/ticketPermissions.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
 import {
   setupCommonMocks,
   mockNextHeaders,
@@ -9,6 +9,7 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 import { ITicket } from '../../interfaces/ticket.interfaces';
 import * as ticketActions from '@alga-psa/tickets/actions/ticketActions';
+import * as auth from '@alga-psa/auth';
 import { TestContext } from '../../../../test-utils/testContext';
 import {
   createTenant,
@@ -17,14 +18,18 @@ import {
   createTestEnvironment
 } from '../../../../test-utils/testDataFactory';
 import {
-  createCleanupHook,
-  cleanupTables
-} from '../../../../test-utils/dbReset';
-import {
   expectPermissionDenied,
   expectError
 } from '../../../../test-utils/errorUtils';
 import { tenantDb } from '@alga-psa/db';
+
+// Every ticket action is withAuth-wrapped, so the acting user comes from the
+// session rather than from an argument. Without this mock the real withAuth
+// resolves whatever the session stub points at, and both fixtures were denied.
+vi.mock('@alga-psa/auth', async () => {
+  const { createAuthModuleMock } = await import('../../../../test-utils/authModuleMock');
+  return createAuthModuleMock();
+});
 
 describe('Ticket Permissions Infrastructure', () => {
   const context = new TestContext({
@@ -135,7 +140,9 @@ describe('Ticket Permissions Infrastructure', () => {
       created_by: adminUser.user_id,
     });
 
-    // Create status
+    // Create status. board_id is required: creating a ticket validates that
+    // its status belongs to its board (TicketModel.validateStatusBelongsToBoard),
+    // and a boardless status fails that check.
     statusId = uuidv4();
     const uniqueOrderNumber = Math.floor(Date.now() / 1000) % 1000000 + Math.floor(Math.random() * 1000);
     await tenantTable(tenantId, 'statuses').insert({
@@ -144,6 +151,7 @@ describe('Ticket Permissions Infrastructure', () => {
       tenant: tenantId,
       created_by: adminUser.user_id,
       status_type: 'ticket',
+      board_id: boardId,
       order_number: uniqueOrderNumber
     });
 
@@ -187,19 +195,15 @@ describe('Ticket Permissions Infrastructure', () => {
     await tenantTable(tenantId, 'tickets').insert(testTicket);
   });
 
-  // Use cleanup hook for test isolation
-  afterEach(async () => {
-    // Deletion runs in reverse array order, so client_billing_profiles must sit
-    // after 'clients': every client is provisioned a default profile, and
-    // deleting the client first trips that foreign key.
-    await createCleanupHook(context.db, [
-      'tickets', 'categories', 'boards', 'contacts',
-      'clients', 'client_billing_profiles', 'users', 'roles', 'permissions'
-    ])();
-  });
+  // No cleanup hook: beforeEach rolls the per-test transaction back, which
+  // already discards every fixture row. Deleting them by hand instead hit
+  // role_permissions' foreign key on `permissions`, and that error aborts the
+  // surrounding transaction — every later statement in the hook then failed
+  // with "current transaction is aborted".
 
   it('should allow regular user to view tickets', async () => {
-    const tickets = await ticketActions.getTickets(regularUser);
+    vi.mocked(auth.getCurrentUser).mockResolvedValue(regularUser);
+    const tickets = await ticketActions.getTickets();
     expect(tickets.length).toBeGreaterThanOrEqual(1);
     expect(tickets.map((ticket): string => ticket.ticket_id!)).toContain(testTicket.ticket_id);
   });
@@ -209,7 +213,8 @@ describe('Ticket Permissions Infrastructure', () => {
       status_id: statusId,
       updated_by: adminUser.user_id,
     };
-    const result = await ticketActions.updateTicket(testTicket.ticket_id!, updateData, adminUser);
+    vi.mocked(auth.getCurrentUser).mockResolvedValue(adminUser);
+    const result = await ticketActions.updateTicket(testTicket.ticket_id!, updateData);
     expect(result).toBe('success');
 
     const updatedTicket = await tenantTable(testTicket.tenant, 'tickets').where('ticket_id', testTicket.ticket_id).first();
@@ -222,8 +227,9 @@ describe('Ticket Permissions Infrastructure', () => {
       updated_by: regularUser.user_id,
     };
 
+    vi.mocked(auth.getCurrentUser).mockResolvedValue(regularUser);
     await expectPermissionDenied(
-      () => ticketActions.updateTicket(testTicket.ticket_id!, updateData, regularUser)
+      () => ticketActions.updateTicket(testTicket.ticket_id!, updateData)
     );
 
     const unchangedTicket = await tenantTable(testTicket.tenant, 'tickets').where('ticket_id', testTicket.ticket_id).first();
@@ -241,7 +247,8 @@ describe('Ticket Permissions Infrastructure', () => {
     mockFormData.append('category_id', categoryId);
     mockFormData.append('priority_id', priorityId);
 
-    const newTicket = await ticketActions.addTicket(mockFormData, adminUser);
+    vi.mocked(auth.getCurrentUser).mockResolvedValue(adminUser);
+    const newTicket = await ticketActions.addTicket(mockFormData);
     expect(newTicket).toBeDefined();
     expect(newTicket?.title).toBe('New Test Ticket');
 
@@ -264,8 +271,9 @@ describe('Ticket Permissions Infrastructure', () => {
     mockFormData.append('category_id', categoryId);
     mockFormData.append('priority_id', priorityId);
 
+    vi.mocked(auth.getCurrentUser).mockResolvedValue(regularUser);
     await expectPermissionDenied(
-      () => ticketActions.addTicket(mockFormData, regularUser)
+      () => ticketActions.addTicket(mockFormData)
     );
   });
 });

--- a/server/src/test/infrastructure/tickets/ticketPermissions.test.ts
+++ b/server/src/test/infrastructure/tickets/ticketPermissions.test.ts
@@ -17,7 +17,6 @@ import {
   createTestEnvironment
 } from '../../../../test-utils/testDataFactory';
 import {
-  resetDatabase,
   createCleanupHook,
   cleanupTables
 } from '../../../../test-utils/dbReset';
@@ -59,8 +58,11 @@ describe('Ticket Permissions Infrastructure', () => {
   });
 
   beforeEach(async () => {
-    // Reset database state
-    await resetDatabase(context.db);
+    // Roll the per-test transaction back and open a fresh one. resetDatabase()
+    // used to run here: it destroys the handle it is given and drops the
+    // database out from under the context, so every query after the first
+    // beforeEach failed with "not queryable".
+    await context.reset();
 
     // Set up common test environment
     const { tenantId, clientId } = await createTestEnvironment(context.db, {
@@ -185,9 +187,12 @@ describe('Ticket Permissions Infrastructure', () => {
 
   // Use cleanup hook for test isolation
   afterEach(async () => {
+    // Deletion runs in reverse array order, so client_billing_profiles must sit
+    // after 'clients': every client is provisioned a default profile, and
+    // deleting the client first trips that foreign key.
     await createCleanupHook(context.db, [
       'tickets', 'categories', 'boards', 'contacts',
-      'clients', 'users', 'roles', 'permissions'
+      'clients', 'client_billing_profiles', 'users', 'roles', 'permissions'
     ])();
   });
 

--- a/server/src/test/infrastructure/time-periods/timePeriods.test.ts
+++ b/server/src/test/infrastructure/time-periods/timePeriods.test.ts
@@ -13,7 +13,6 @@ import {
   mockRBAC
 } from '../../../../test-utils/testMocks';
 import {
-  resetDatabase,
   createCleanupHook,
   cleanupTables
 } from '../../../../test-utils/dbReset';
@@ -53,8 +52,11 @@ describe('Time Periods Infrastructure', () => {
   });
 
   beforeEach(async () => {
-    // Reset database state
-    await resetDatabase(context.db);
+    // Roll the per-test transaction back and open a fresh one. resetDatabase()
+    // used to run here: it destroys the handle it is given and drops the
+    // database out from under the context, so every query after the first
+    // beforeEach failed with "not queryable".
+    await context.reset();
 
     // Get tenant from context
     tenantId = context.tenantId;

--- a/server/src/test/infrastructure/time-periods/timePeriods.test.ts
+++ b/server/src/test/infrastructure/time-periods/timePeriods.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
 import { v4 as uuidv4 } from 'uuid';
-import { tenantDb } from '@alga-psa/db';
+import { runWithTenant, tenantDb } from '@alga-psa/db';
 import { ITimePeriodSettings, ITimePeriod } from '../../../interfaces/timeEntry.interfaces';
 import { createTimePeriod, generateAndSaveTimePeriods, generateTimePeriods, createNextTimePeriod } from '@alga-psa/scheduling/actions/timePeriodsActions';
 import { ISO8601String } from '../../../types/types.d';
@@ -34,6 +34,17 @@ function tenantTable<Row extends object = Record<string, unknown>>(
 ) {
   return tenantDb(context.db, context.tenantId).table<Row>(tableExpression);
 }
+
+// createTimePeriodSettings always writes the semi-monthly columns (defaulting
+// them), and every read path validates them as numbers. Fixtures that insert a
+// bare row leave NULLs behind and fail that validation, so fill them here.
+const withSettingsDefaults = <T extends Record<string, unknown>>(setting: T) => ({
+  start_month: 1,
+  start_day_of_month: 1,
+  end_month: 12,
+  end_day_of_month: 0,
+  ...setting,
+});
 
 describe('Time Periods Infrastructure', () => {
   const context = new TestContext({
@@ -91,7 +102,7 @@ describe('Time Periods Infrastructure', () => {
       end_day: undefined
     };
 
-    await tenantTable(context, 'time_period_settings').insert(setting);
+    await tenantTable(context, 'time_period_settings').insert(withSettingsDefaults(setting));
 
     const timePeriodData: Omit<ITimePeriod, 'period_id'> = {
       start_date: '2023-01-01',
@@ -126,7 +137,7 @@ describe('Time Periods Infrastructure', () => {
       end_day: 0
     };
 
-    await tenantTable(context, 'time_period_settings').insert(setting);
+    await tenantTable(context, 'time_period_settings').insert(withSettingsDefaults(setting));
 
     const result = await generateAndSaveTimePeriods(
       '2023-01-01',
@@ -173,7 +184,7 @@ describe('Time Periods Infrastructure', () => {
       },
     ];
 
-    await tenantTable(context, 'time_period_settings').insert(settings);
+    await tenantTable(context, 'time_period_settings').insert(settings.map(withSettingsDefaults));
 
     const result = await generateAndSaveTimePeriods(
       '2023-01-01',
@@ -208,7 +219,7 @@ describe('Time Periods Infrastructure', () => {
       end_day: 0
     };
 
-    await tenantTable(context, 'time_period_settings').insert(setting);
+    await tenantTable(context, 'time_period_settings').insert(withSettingsDefaults(setting));
 
     const timePeriodData1: Omit<ITimePeriod, 'period_id'> = {
       start_date: createTestDateISO({ year: 2026, month: 1, day: 1 }),
@@ -246,7 +257,7 @@ describe('Time Periods Infrastructure', () => {
       end_day: 0
     };
 
-    await tenantTable(context, 'time_period_settings').insert(setting);
+    await tenantTable(context, 'time_period_settings').insert(withSettingsDefaults(setting));
 
     const existingPeriod: Omit<ITimePeriod, 'period_id'> = {
       start_date: '2023-01-15',
@@ -291,7 +302,7 @@ describe('Time Periods Infrastructure', () => {
       },
     ];
 
-    await tenantTable(context, 'time_period_settings').insert(settings);
+    await tenantTable(context, 'time_period_settings').insert(settings.map(withSettingsDefaults));
 
     const periods = await generateTimePeriods(
       settings,
@@ -353,7 +364,9 @@ describe('Time Periods Infrastructure', () => {
       };
       await createTimePeriod(initialPeriod);
 
-      const result = await createNextTimePeriod(settings, 7);
+      // createNextTimePeriod is a plain function, not a withAuth action: it
+      // reads the tenant from async-local context and throws without one.
+      const result = await runWithTenant(tenantId, () => createNextTimePeriod(settings, 7));
 
       expect(result).not.toBeNull();
       expect(result!.tenant).toBe(tenantId);
@@ -383,7 +396,7 @@ describe('Time Periods Infrastructure', () => {
       };
       await createTimePeriod(initialPeriod);
 
-      const result = await createNextTimePeriod(settings, 5);
+      const result = await runWithTenant(tenantId, () => createNextTimePeriod(settings, 5));
 
       expect(result).toBeNull();
     });

--- a/server/src/test/infrastructure/time-periods/timePeriods.test.ts
+++ b/server/src/test/infrastructure/time-periods/timePeriods.test.ts
@@ -38,7 +38,7 @@ function tenantTable<Row extends object = Record<string, unknown>>(
 // createTimePeriodSettings always writes the semi-monthly columns (defaulting
 // them), and every read path validates them as numbers. Fixtures that insert a
 // bare row leave NULLs behind and fail that validation, so fill them here.
-const withSettingsDefaults = <T extends Record<string, unknown>>(setting: T) => ({
+const withSettingsDefaults = <T extends object>(setting: T) => ({
   start_month: 1,
   start_day_of_month: 1,
   end_month: 12,

--- a/server/src/test/infrastructure/time-periods/timePeriodsActions.test.ts
+++ b/server/src/test/infrastructure/time-periods/timePeriodsActions.test.ts
@@ -12,7 +12,6 @@ import { ITimePeriodSettings } from 'server/src/interfaces/timeEntry.interfaces'
 import { ISO8601String } from 'server/src/types/types.d';
 import { TestContext } from '../../../../test-utils/testContext';
 import {
-  resetDatabase,
   createCleanupHook,
   cleanupTables
 } from '../../../../test-utils/dbReset';
@@ -46,8 +45,11 @@ describe('Time Periods Actions', () => {
   });
 
   beforeEach(async () => {
-    // Reset database state
-    await resetDatabase(context.db);
+    // Roll the per-test transaction back and open a fresh one. resetDatabase()
+    // used to run here: it destroys the handle it is given and drops the
+    // database out from under the context, so every query after the first
+    // beforeEach failed with "not queryable".
+    await context.reset();
 
     // Set up mocks
     setupCommonMocks({ tenantId: context.tenantId });

--- a/server/src/test/infrastructure/time-periods/timePeriodsActions.test.ts
+++ b/server/src/test/infrastructure/time-periods/timePeriodsActions.test.ts
@@ -24,6 +24,17 @@ import {
 } from '../../../../test-utils/dateUtils';
 import { toPlainDate } from 'server/src/lib/utils/dateTimeUtils';
 
+// createTimePeriodSettings always writes the semi-monthly columns (defaulting
+// them), and every read path validates them as numbers. Fixtures that insert a
+// bare row leave NULLs behind and fail that validation, so fill them here.
+const withSettingsDefaults = <T extends Record<string, unknown>>(setting: T) => ({
+  start_month: 1,
+  start_day_of_month: 1,
+  end_month: 12,
+  end_day_of_month: 0,
+  ...setting,
+});
+
 describe('Time Periods Actions', () => {
   const context = new TestContext({
     cleanupTables: ['time_periods', 'time_period_settings'],
@@ -69,7 +80,7 @@ describe('Time Periods Actions', () => {
       updated_at: createTestDateISO({ year: 2024, month: 1, day: 1 })
     };
 
-    await tenantTable('time_period_settings').insert(settings);
+    await tenantTable('time_period_settings').insert(withSettingsDefaults(settings));
   });
 
   // Use cleanup hook for test isolation

--- a/server/src/test/infrastructure/time-periods/timePeriodsActions.test.ts
+++ b/server/src/test/infrastructure/time-periods/timePeriodsActions.test.ts
@@ -27,7 +27,7 @@ import { toPlainDate } from 'server/src/lib/utils/dateTimeUtils';
 // createTimePeriodSettings always writes the semi-monthly columns (defaulting
 // them), and every read path validates them as numbers. Fixtures that insert a
 // bare row leave NULLs behind and fail that validation, so fill them here.
-const withSettingsDefaults = <T extends Record<string, unknown>>(setting: T) => ({
+const withSettingsDefaults = <T extends object>(setting: T) => ({
   start_month: 1,
   start_day_of_month: 1,
   end_month: 12,

--- a/server/src/test/unit/recordTestMetrics.unit.test.ts
+++ b/server/src/test/unit/recordTestMetrics.unit.test.ts
@@ -8,7 +8,9 @@ import {
   HEADER,
   buildRow,
   coverageByDirectory,
+  coverageFileCounts,
   coverageGroupKey,
+  runStatus,
   testCounts,
 } from '../../../../scripts/record-test-metrics.mjs';
 
@@ -44,14 +46,54 @@ describe('testCounts', () => {
         { startTime: 5_000, endTime: 121_000 },
       ],
     });
-    expect(counts).toMatchObject({ passed: 97, failed: 3, skipped: 8, todo: 2, total: 110 });
+    expect(counts).toMatchObject({ passed: 97, failed: 3, skipped: 8, todo: 2, total: 110, executed: 100 });
     expect(counts!.passPct).toBe(97);
     expect(counts!.durationS).toBe(120);
+    expect(counts!.runStatus).toBe('complete');
   });
 
   it('returns null for missing results and blank pass % when nothing ran', () => {
     expect(testCounts(null)).toBeNull();
     expect(testCounts({ numPassedTests: 0, numFailedTests: 0, numPendingTests: 5 })!.passPct).toBe('');
+  });
+
+  it('blanks pass % on a partial run but keeps the raw counts', () => {
+    // 2026-08-21 infrastructure-full: 5 of 354 executed, recorded as 100%.
+    const counts = testCounts({
+      numTotalTests: 354, numPassedTests: 5, numFailedTests: 0, numPendingTests: 349,
+      testResults: [{ startTime: 0, endTime: 163_000, assertionResults: [{ status: 'passed' }] }],
+    });
+    expect(counts).toMatchObject({ passed: 5, executed: 5, total: 354, runStatus: 'partial' });
+    expect(counts!.passPct).toBe('');
+  });
+});
+
+describe('runStatus', () => {
+  const file = (...statuses: string[]) => ({ assertionResults: statuses.map((status) => ({ status })) });
+
+  it('marks a run partial when vitest left assertions pending', () => {
+    expect(runStatus({
+      numTotalTests: 4, numPassedTests: 3, numFailedTests: 0,
+      testResults: [file('passed', 'passed', 'passed'), file('pending')],
+    })).toBe('partial');
+  });
+
+  it('marks a run partial when most collected tests never executed', () => {
+    expect(runStatus({
+      numTotalTests: 100, numPassedTests: 20, numFailedTests: 0,
+      testResults: [file('passed')],
+    })).toBe('partial');
+  });
+
+  it('keeps intentional skips and todos complete', () => {
+    expect(runStatus({
+      numTotalTests: 10, numPassedTests: 6, numFailedTests: 1,
+      testResults: [file('passed', 'failed', 'skipped', 'todo')],
+    })).toBe('complete');
+  });
+
+  it('is blank without a results file', () => {
+    expect(runStatus(null)).toBe('');
   });
 });
 
@@ -119,6 +161,23 @@ describe('coverageByDirectory', () => {
   it('returns empty for a missing summary', () => {
     expect(coverageByDirectory(null as never, repoRoot)).toEqual([]);
   });
+
+  it('totals measured vs on-disk files for the summary row', () => {
+    const counts = coverageFileCounts(
+      {
+        total: metric(99, 99),
+        [join(repoRoot, 'server/src/lib/actions/a.ts')]: metric(8, 10),
+        [join(repoRoot, 'packages/billing/src/x.ts')]: metric(5, 5),
+      },
+      repoRoot,
+    );
+    // b.ts and packages/unloaded/src/y.ts are on disk but never loaded
+    expect(counts).toEqual({ measured: 2, total: 4 });
+  });
+
+  it('reports blank file counts without a summary', () => {
+    expect(coverageFileCounts(null as never, repoRoot)).toEqual({ measured: '', total: '' });
+  });
 });
 
 describe('buildRow', () => {
@@ -140,7 +199,28 @@ describe('buildRow', () => {
     expect(get('commit')).toBe('abcdef0123');
     expect(get('passed')).toBe(4);
     expect(get('pass_pct')).toBe(80);
+    expect(get('executed')).toBe(5);
+    expect(get('run_status')).toBe('complete');
+    expect(get('files_measured')).toBe('');
     expect(get('run_url')).toBe('https://github.com/Nine-Minds/alga-psa/actions/runs/42');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('records a partial run without a pass %', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'metrics-row-partial-'));
+    writeFileSync(join(dir, 'results.json'), JSON.stringify({
+      numTotalTests: 354, numPassedTests: 5, numFailedTests: 0, numPendingTests: 349,
+    }));
+    process.env.TEST_METRICS_SUITE = 'infrastructure-full';
+    process.env.TEST_METRICS_RESULTS = join(dir, 'results.json');
+    delete process.env.TEST_METRICS_COVERAGE;
+
+    const row = buildRow();
+    const get = (col: string) => row[HEADER.indexOf(col)];
+    expect(get('run_status')).toBe('partial');
+    expect(get('pass_pct')).toBe('');
+    expect(get('executed')).toBe(5);
+    expect(get('passed')).toBe(5);
     rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/server/test-utils/authModuleMock.ts
+++ b/server/test-utils/authModuleMock.ts
@@ -72,17 +72,28 @@ export function createAuthModuleMock() {
     if (!user) throw new Error('Authentication required');
     return user;
   };
+  // The real withAuth runs the action inside runWithTenant, and plenty of code
+  // below the action reads the tenant straight off that AsyncLocalStorage store
+  // (requireTenantId in tag cleanup, getTenantContext in scheduling). Calling
+  // the action bare made those throw "tenant context not found". Imported
+  // lazily: this module is loaded from vi.mock factories, and a static import
+  // of a product module is exactly the cycle the header warns about.
+  const runInTenant = async <T>(tenant: string, fn: () => Promise<T>): Promise<T> => {
+    const { runWithTenant } = await import('@alga-psa/db');
+    return runWithTenant(tenant, fn);
+  };
   return {
     getSession,
     getCurrentUser,
     hasPermission,
     withAuth: (action: (...a: any[]) => any) => async (...args: any[]) => {
       const user = await requireUser();
-      return action(user, { tenant: user.tenant }, ...args);
+      return runInTenant(user.tenant, async () => action(user, { tenant: user.tenant }, ...args));
     },
     withOptionalAuth: (action: (...a: any[]) => any) => async (...args: any[]) => {
       const user = await getCurrentUser();
-      return action(user ?? null, user ? { tenant: user.tenant } : null, ...args);
+      if (!user) return action(null, null, ...args);
+      return runInTenant(user.tenant, async () => action(user, { tenant: user.tenant }, ...args));
     },
     withAuthCheck: (action: (...a: any[]) => any) => async (...args: any[]) => {
       const user = await requireUser();

--- a/server/test-utils/dbReset.ts
+++ b/server/test-utils/dbReset.ts
@@ -37,14 +37,28 @@ export interface DbResetOptions {
 }
 
 /**
- * Resets the database to a clean state
- * @param db Knex database instance
+ * Resets the database to a clean state.
+ *
+ * Destructive in two ways the name does not advertise: it destroys the pool of
+ * the handle it is given, and it drops and recreates the database itself. The
+ * caller's handle is dead afterwards — reconnect rather than reuse it. Suites
+ * that need per-test isolation want `TestContext.reset()` (transaction
+ * rollback), which is also two orders of magnitude faster.
+ *
+ * @param db Knex database instance (a root connection, never a transaction)
  * @param options Reset options
  */
 export async function resetDatabase(
   db: Knex,
   options: DbResetOptions = {}
 ): Promise<void> {
+  if ((db as Knex & { isTransaction?: boolean }).isTransaction) {
+    throw new Error(
+      'resetDatabase() drops and recreates the database and cannot be passed a ' +
+      'transaction — the rollback would fail on a connection the drop killed. ' +
+      'Use TestContext.reset() for per-test isolation.'
+    );
+  }
   const {
     cleanupTables = [],
     runSeeds = true,

--- a/server/test-utils/testContext.ts
+++ b/server/test-utils/testContext.ts
@@ -99,7 +99,15 @@ export class TestContext {
       }
 
       if (typeof dbModule.runWithTenant === 'function') {
-        vi.spyOn(dbModule, 'runWithTenant').mockImplementation(async (_tenant, fn) => fn());
+        // Delegate to the real implementation, pinned to this context's tenant.
+        // A bare pass-through leaves the AsyncLocalStorage store empty, so
+        // plain (non-withAuth) helpers that read getTenantContext() — e.g.
+        // createNextTimePeriod — throw "Tenant context is required" even when
+        // the caller wrapped them in runWithTenant.
+        const realRunWithTenant = dbModule.runWithTenant;
+        vi.spyOn(dbModule, 'runWithTenant').mockImplementation(
+          async (tenant, fn) => realRunWithTenant(this.tenantId ?? tenant, fn)
+        );
       }
 
       // Package actions import createTenantKnex from '@alga-psa/db', not
@@ -119,7 +127,10 @@ export class TestContext {
           vi.spyOn(pkgDbModule, 'getCurrentTenantId').mockImplementation(async () => this.tenantId ?? null);
         }
         if (typeof pkgDbModule.runWithTenant === 'function') {
-          vi.spyOn(pkgDbModule, 'runWithTenant').mockImplementation(async (_tenant: unknown, fn: () => unknown) => fn());
+          const realRunWithTenant = pkgDbModule.runWithTenant;
+          vi.spyOn(pkgDbModule, 'runWithTenant').mockImplementation(
+            async (tenant: string, fn: () => unknown) => realRunWithTenant(this.tenantId ?? tenant, fn)
+          );
         }
       } catch {
         // Unmockable namespace (file doesn't mock @alga-psa/db) — fall back to


### PR DESCRIPTION
## Summary

The `src/test/infrastructure` DB-backed billing-engine suite (invoice generation, tax, credits, projects, tickets, time periods) had drifted from the schema and business logic it was meant to exercise, so it ran mostly red or timed out without producing a usable baseline. This PR repairs the suite fixture-by-fixture against the current derived-credit-balance model, arrears billing windows, and RBAC/tenant-context behavior, fixes two real product bugs the repair work surfaced, gives the suite its own CI job with a real timeout budget, and extends the test-metrics recorder so partial/cancelled runs no longer post a false "green" to the metrics sheet.

## Changes

### CI
- Split the infrastructure suite out of the integration-tests job into its own `infrastructure-tests` job with a 45-minute job timeout, so a long infra run no longer cancels the (passing) integration suite mid-run.
- Gate metrics recording on the suite step's `outcome` (`success`/`failure`) instead of `always()`, so a run killed by the job timeout no longer posts a row for whatever fraction happened to finish.

### Test metrics tooling (`scripts/record-test-metrics.mjs`)
- Add a `runStatus` classifier (`complete`/`partial`) based on leftover `pending` assertions and a "fewer than half the collected tests executed" heuristic; blank out `pass_pct` on partial runs so it can't be averaged as a false green.
- Add `executed`, `run_status`, `files_measured`, `files_total` columns to the sheet schema (appended, not reordered, to keep existing ranges valid).
- Add `coverageFileCounts` to roll up measured-vs-on-disk file counts onto the summary row.
- Update `docs/reference/test-metrics.md` with the partial-run heuristic, the coverage-methodology break around 2026-07-31, and the infra/integration job split.

### Product bug fixes surfaced while repairing tests
- `packages/scheduling`: `generateTimePeriods` looped forever (OOM) for settings with a fixed `end_day`, since the chain-forward logic always advanced by `periodEndDate` regardless of whether the period's end chains to the next start; add `getNextPeriodStart` and terminate on a non-advancing date.
- `packages/scheduling`: `TimePeriodSuggester` computed daily period end dates one day short (`frequency - 1` instead of `frequency`), inconsistent with the half-open-interval convention used elsewhere.
- `packages/scheduling`: wrap `revalidatePath` calls in a `safeRevalidate` helper that swallows the "no request context" error, since these actions also run from background jobs/billing bootstrap.
- `packages/projects`: `updateTaskSchema`'s `.extend()` for `assigned_to` dropped the `.optional()` inherited from `.partial()`, rejecting every partial task update that omitted the field; restore `.optional()`.

### Infrastructure test suite repairs
- **Credits**: drop assertions/writes against the removed `clients.credit_balance` cache column; align expiration/priority/effects suites with the derived-from-`credit_tracking` balance model, including opening `expiredCreditsHandler`'s connection so it can see the suite's own uncommitted rows.
- **Invoices**: rebuild fixtures across generation, tax, subtotal, multi-currency, prepayment, negative-credit, and invoice-number suites to materialize recurring service periods, honor arrears billing windows, seed billing recipients/usage-tracking rows, and use exact `invoice_window` matches.
- **Quotes/pricing schedules**: re-anchor assertions to current tax computation (`quoteCalculationService` instead of a `TaxService.calculateTax` spy) and current template content.
- **Projects**: rewrite `projectManagement.test.ts` to drive real actions/persisted rows instead of mocked models; fix seeded-tenant/actor setup so RBAC checks and transactions succeed; replace `resetDatabase()`-per-test (which destroyed the suite's own connection pool and re-migrated on every test) with table cleanup or transaction rollback via `TestContext`.
- **Permissions (projects/tickets)**: stop truncating seeded reference tables inside a transaction that's about to roll back; use seeded statuses/priorities instead of fabricating a bare tenant.
- **Time periods**: align fixtures with the corrected period-generation/suggestion behavior above.
- **Billing anchors**: declare the `@alga-psa/auth/rbac` mock at file scope so it reaches the suite's module graph.

### Shared test infrastructure (`server/test-utils`)
- `authModuleMock.ts`: run mocked `withAuth`/`withOptionalAuth` actions inside `runWithTenant` (imported lazily to avoid a module cycle), matching production behavior for code that reads tenant off `AsyncLocalStorage`.
- `testContext.ts`: make the `runWithTenant` spy delegate to the real implementation pinned to the context's tenant, instead of a bare pass-through that left the tenant store empty.
- `dbReset.ts`: document `resetDatabase()`'s destructive semantics (drops the DB, kills the given connection's pool) and throw if called with a transaction handle; point suites needing per-test isolation at `TestContext.reset()`.

### Docs
- `ee/docs/plans/2026-08-22-ci-test-metrics-health/`: plan and P1 findings log for this effort.

## Testing
- `server/src/test/unit/recordTestMetrics.unit.test.ts` extended with coverage for `runStatus`, `coverageFileCounts`, and partial-run row building.
- Infrastructure suite files (credits, invoices, quotes, projects, tickets, time periods) run against the local Postgres/Redis stack as part of the CI `infrastructure-tests` job (Tier-1 subset on PR/push, full suite on schedule); results and coverage are recorded to the test-metrics sheet.
