### PR TITLE
Security: inbound email sender forgery — no SPF/DKIM/DMARC verification, internal-tech identity spoofing

### DIFF
--- a/packages/integrations/src/services/email/providers/GmailAdapter.ts
+++ b/packages/integrations/src/services/email/providers/GmailAdapter.ts
@@ -625,7 +625,12 @@ This indicates a problem with the OAuth token saving process.`;
           isInline: att.isInline
         })),
         headers: headers.reduce((acc: any, header: any) => {
-          acc[header.name] = header.value;
+          const headerName = String(header?.name || '');
+          const normalizedHeaderName = headerName.toLowerCase();
+          if (normalizedHeaderName.startsWith('x-resolved-') || normalizedHeaderName.startsWith('x-list-')) {
+            return acc;
+          }
+          acc[headerName] = header.value;
           return acc;
         }, {})
       };

--- a/server/src/services/email/providers/GmailAdapter.ts
+++ b/server/src/services/email/providers/GmailAdapter.ts
@@ -632,7 +632,12 @@ This indicates a problem with the OAuth token saving process.`;
           isInline: att.isInline
         })),
         headers: headers.reduce((acc: any, header: any) => {
-          acc[header.name] = header.value;
+          const headerName = String(header?.name || '');
+          const normalizedHeaderName = headerName.toLowerCase();
+          if (normalizedHeaderName.startsWith('x-resolved-') || normalizedHeaderName.startsWith('x-list-')) {
+            return acc;
+          }
+          acc[headerName] = header.value;
           return acc;
         }, {})
       };

--- a/server/src/test/integration/inboundEmailInApp.webhooks.integration.test.ts
+++ b/server/src/test/integration/inboundEmailInApp.webhooks.integration.test.ts
@@ -2,7 +2,7 @@ import { beforeAll, afterAll, afterEach, describe, expect, it, vi } from 'vitest
 import type { Knex } from 'knex';
 import { v4 as uuidv4 } from 'uuid';
 
-import { createTestDbConnection } from '../../../test-utils/dbConfig';
+import { createTestDbConnection, wireLocalTestDbEnv } from '../../../test-utils/dbConfig';
 import { NextRequest } from 'next/server';
 import { processInboundEmailInApp } from '@alga-psa/shared/services/email/processInboundEmailInApp';
 import { describeWithDb } from '../../../test-utils/requireDb';
@@ -520,6 +520,7 @@ describeDb('Inbound email in-app processing via webhooks (integration)', () => {
 
   beforeAll(async () => {
     process.env.NEXTAUTH_URL = 'http://localhost:3000';
+    wireLocalTestDbEnv();
     db = await createTestDbConnection();
 
     const tenant = await discoveryTable<{ tenant: string }>(
@@ -2549,6 +2550,9 @@ describeDb('Inbound email in-app processing via webhooks (integration)', () => {
         subject: 'Contact matched subject',
         body: { text: 'Hello', html: undefined },
         attachments: [],
+        headers: {
+          'authentication-results': `mx.example.com; dkim=pass header.d=${contactEmail.split('@')[1]}`,
+        },
       } as any,
     });
 
@@ -2630,6 +2634,9 @@ describeDb('Inbound email in-app processing via webhooks (integration)', () => {
         subject,
         body: { text: 'Hello from microsoft contact', html: undefined },
         attachments: [],
+        headers: {
+          'authentication-results': `mx.example.com; dkim=pass header.d=${contactEmail.split('@')[1]}`,
+        },
       } as any,
     });
 
@@ -2733,6 +2740,9 @@ describeDb('Inbound email in-app processing via webhooks (integration)', () => {
           html: undefined,
         },
         attachments: [],
+        headers: {
+          'authentication-results': `mx.example.com; dkim=pass header.d=${contactEmail.split('@')[1]}`,
+        },
       } as any,
     });
 
@@ -2818,6 +2828,9 @@ describeDb('Inbound email in-app processing via webhooks (integration)', () => {
         subject,
         body: { text: 'Hello', html: undefined },
         attachments: [],
+        headers: {
+          'authentication-results': `mx.example.com; dkim=pass header.d=${contactEmail.split('@')[1]}`,
+        },
       } as any,
     });
 
@@ -2979,6 +2992,9 @@ describeDb('Inbound email in-app processing via webhooks (integration)', () => {
         subject,
         body: { text: 'Hello', html: undefined },
         attachments: [],
+        headers: {
+          'authentication-results': `mx.example.com; dkim=pass header.d=${senderEmail.split('@')[1]}`,
+        },
       } as any,
     });
 
@@ -3065,6 +3081,9 @@ describeDb('Inbound email in-app processing via webhooks (integration)', () => {
         subject,
         body: { text: 'Hello', html: undefined },
         attachments: [],
+        headers: {
+          'authentication-results': `mx.example.com; dkim=pass header.d=${senderEmail.split('@')[1]}`,
+        },
       } as any,
     });
 
@@ -3478,6 +3497,172 @@ describeDb('Inbound email in-app processing via webhooks (integration)', () => {
     });
   });
 
+  it('persists an internal sender-auth failure through the audit_logs tenant trigger', async () => {
+    const providerId = uuidv4();
+    const mailbox = `support-auth-audit-${uuidv4().slice(0, 6)}@example.com`;
+    const subscriptionId = `sub-auth-audit-${uuidv4()}`;
+    const { defaultsId } = await setupMicrosoftProvider({ providerId, mailbox, subscriptionId });
+    const internalUserId = uuidv4();
+    const internalEmail = `internal-auth-audit-${uuidv4().slice(0, 6)}@example.com`;
+    const messageId = `internal-auth-failure-${uuidv4()}@example.com`;
+    const subject = `Internal sender auth audit ${uuidv4().slice(0, 6)}`;
+
+    cleanup.push(async () => {
+      await tenantTable('email_processed_messages').where({ provider_id: providerId }).delete();
+      await tenantTable('microsoft_email_provider_config').where({ email_provider_id: providerId }).delete();
+      await tenantTable('email_providers').where({ id: providerId }).delete();
+      await tenantTable('inbound_ticket_defaults').where({ id: defaultsId }).delete();
+    });
+    cleanup.push(async () => {
+      await tenantTable('users').where({ user_id: internalUserId }).delete();
+    });
+
+    await tenantTable('users').insert({
+      user_id: internalUserId,
+      tenant: tenantId,
+      username: `internal-auth-audit-${internalUserId.slice(0, 8)}`,
+      email: internalEmail,
+      first_name: 'Internal',
+      last_name: 'Audit',
+      hashed_password: 'not-a-real-hash',
+      user_type: 'internal',
+      is_inactive: false,
+      created_at: db.fn.now(),
+    });
+
+    // The real raw-MIME path must preserve the absent Authentication-Results
+    // header so sender attribution fails closed before the audit trigger fires.
+    microsoftDownloadMessageSourceMock = vi.fn().mockResolvedValue(
+      buildMicrosoftMime({
+        from: internalEmail,
+        to: mailbox,
+        subject,
+        messageId,
+        text: 'This message has no Authentication-Results header.',
+      })
+    );
+
+    const { handleMicrosoftWebhookPost } = await import(
+      '@alga-psa/integrations/webhooks/email/handlers/microsoftWebhookHandler'
+    );
+    const req = new NextRequest('http://localhost:3000/api/email/webhooks/microsoft', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        value: [{
+          changeType: 'created',
+          clientState: 'ignored',
+          resource: `/users/${uuidv4()}/messages/${messageId}`,
+          resourceData: {
+            '@odata.type': '#microsoft.graph.message',
+            '@odata.id': 'ignored',
+            id: messageId,
+            subject,
+          },
+          subscriptionExpirationDateTime: new Date(Date.now() + 60_000).toISOString(),
+          subscriptionId,
+          tenantId: 'ignored',
+        }],
+      }),
+    });
+    const response = await handleMicrosoftWebhookPost(req);
+    expect(response.status).toBe(200);
+    await processEnqueuedUnifiedJobs();
+
+    const ticket = await tenantTable('tickets').where({ title: subject }).first<any>();
+    expect(ticket).toBeDefined();
+
+    const audit = await tenantTable('audit_logs')
+      .where({
+        operation: 'inbound_email_internal_sender_auth_failed',
+        record_id: providerId,
+      })
+      .first<any>();
+    expect(audit).toMatchObject({
+      tenant: tenantId,
+      operation: 'inbound_email_internal_sender_auth_failed',
+      table_name: 'email_providers',
+      record_id: providerId,
+    });
+    expect(audit.details).toMatchObject({
+      emailId: `<${messageId}>`,
+      senderEmail: internalEmail,
+      authResults: null,
+    });
+
+    cleanup.push(async () => {
+      await tenantTable('audit_logs').where({ audit_id: audit.audit_id }).delete();
+      await tenantTable('comments').where({ ticket_id: ticket.ticket_id }).delete();
+      await deleteTicketRows(ticket.ticket_id);
+    });
+  });
+
+  it('does not mark an authenticated, matched internal sender as unmatched', async () => {
+    const providerId = uuidv4();
+    const mailbox = `support-auth-match-${uuidv4().slice(0, 6)}@example.com`;
+    const { defaultsId } = await setupInboundDefaults({ providerId, mailbox });
+    const internalUserId = uuidv4();
+    const internalEmail = `internal-auth-match-${uuidv4().slice(0, 6)}@example.com`;
+    const emailId = `internal-auth-match-${uuidv4()}`;
+
+    cleanup.push(async () => {
+      await tenantTable('google_email_provider_config').where({ email_provider_id: providerId }).delete();
+      await tenantTable('email_providers').where({ id: providerId }).delete();
+      await tenantTable('inbound_ticket_defaults').where({ id: defaultsId }).delete();
+    });
+    cleanup.push(async () => {
+      await tenantTable('users').where({ user_id: internalUserId }).delete();
+    });
+
+    await tenantTable('users').insert({
+      user_id: internalUserId,
+      tenant: tenantId,
+      username: `internal-auth-match-${internalUserId.slice(0, 8)}`,
+      email: internalEmail,
+      first_name: 'Internal',
+      last_name: 'Match',
+      hashed_password: 'not-a-real-hash',
+      user_type: 'internal',
+      is_inactive: false,
+      created_at: db.fn.now(),
+    });
+
+    const result = await processInboundEmailInApp({
+      tenantId,
+      providerId,
+      emailData: {
+        id: emailId,
+        provider: 'google',
+        providerId,
+        tenant: tenantId,
+        receivedAt: new Date().toISOString(),
+        from: { email: internalEmail, name: 'Internal Match' },
+        to: [{ email: mailbox, name: 'Support' }],
+        subject: `Internal sender auth match ${uuidv4().slice(0, 6)}`,
+        body: { text: 'This sender is authenticated and matched.', html: undefined },
+        attachments: [],
+        headers: {
+          'authentication-results': `mx.example.com; dmarc=pass header.from=${internalEmail.split('@')[1]}`,
+        },
+      } as any,
+    });
+
+    expect(result.outcome).toBe('created');
+
+    const ticket = await tenantTable('tickets')
+      .whereRaw("email_metadata->>'messageId' = ?", [emailId])
+      .first<any>();
+    expect(ticket).toBeDefined();
+    const comment = await tenantTable('comments').where({ ticket_id: ticket.ticket_id }).first<any>();
+    expect(comment).toMatchObject({ author_type: 'internal', user_id: internalUserId });
+    expect(comment.metadata).toMatchObject({ unmatchedSender: false });
+
+    cleanup.push(async () => {
+      await tenantTable('comments').where({ ticket_id: ticket.ticket_id }).delete();
+      await deleteTicketRows(ticket.ticket_id);
+    });
+  });
+
   it('Contact match: sender email is normalized from display-name format', async () => {
     const providerId = uuidv4();
     const mailbox = `support-contact-normalize-${uuidv4().slice(0, 6)}@example.com`;
@@ -3532,6 +3717,9 @@ describeDb('Inbound email in-app processing via webhooks (integration)', () => {
         subject: 'Contact normalized sender subject',
         body: { text: 'Hello', html: undefined },
         attachments: [],
+        headers: {
+          'authentication-results': `mx.example.com; dkim=pass header.d=${canonicalEmail.split('@')[1]}`,
+        },
       } as any,
     });
 
@@ -3902,6 +4090,9 @@ describeDb('Inbound email in-app processing via webhooks (integration)', () => {
       subject,
       body: { text: 'Hello', html: undefined },
       attachments: [],
+      headers: {
+        'authentication-results': `mx.example.com; dkim=pass header.d=${senderEmail.split('@')[1]}`,
+      },
     } as any;
 
     const first = await processInboundEmailInApp({ tenantId, providerId, emailData });

--- a/server/src/test/integration/journeys/inboundEmailToTicketReply.journey.integration.test.ts
+++ b/server/src/test/integration/journeys/inboundEmailToTicketReply.journey.integration.test.ts
@@ -323,6 +323,13 @@ describe('journey: inbound email → ticket → threaded reply → agent reply o
       from: { email: contactEmail, name: 'Pat Customer' },
       to: [{ email: providerMailbox, name: 'Support' }],
       attachments: [],
+      // Real provider-fetched mail carries the receiving MTA's
+      // Authentication-Results; exact-contact attribution now requires an
+      // aligned SPF/DKIM pass (sender-forgery gate). DKIM header.d is aligned
+      // to the contact's From domain.
+      headers: {
+        'Authentication-Results': `mx.google.com; dkim=pass header.d=${contactEmail.split('@')[1]}; spf=pass smtp.mailfrom=${contactEmail}`,
+      },
       ...overrides,
     });
 

--- a/server/src/test/integration/resolveInboundTicketContext.destinationRouting.integration.test.ts
+++ b/server/src/test/integration/resolveInboundTicketContext.destinationRouting.integration.test.ts
@@ -433,6 +433,13 @@ describeDb('resolve_inbound_ticket_context destination routing (integration)', (
         subject,
         body: { text: 'Hello', html: undefined },
         attachments: [],
+        // Exact-contact attribution requires an aligned SPF/DKIM pass; real
+        // provider-fetched mail carries Authentication-Results. Align DKIM to
+        // the sender's From domain so this contact matches (parity with the
+        // resolveInboundTicketContext action, which routes by sender).
+        headers: {
+          'Authentication-Results': `mx.google.com; dkim=pass header.d=${senderEmail.split('@')[1]}; spf=pass smtp.mailfrom=${senderEmail}`,
+        },
       } as any,
     });
 

--- a/server/src/test/unit/email/GmailAdapter.listMessagesSince.test.ts
+++ b/server/src/test/unit/email/GmailAdapter.listMessagesSince.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { GmailAdapter } from '../../../services/email/providers/GmailAdapter';
+import { GmailAdapter as SharedGmailAdapter } from '@alga-psa/shared/services/email/providers/GmailAdapter';
 import { EmailProviderConfig } from '@alga-psa/shared/interfaces/inbound-email.interfaces';
 
 const historyListMock = vi.fn();
@@ -128,5 +129,32 @@ describe('GmailAdapter.listMessagesSince', () => {
       id: 'message-1',
       format: 'raw',
     }));
+  });
+
+  it.each([
+    ['server adapter', GmailAdapter],
+    ['shared adapter', SharedGmailAdapter],
+  ])('does not forward forged list-resolution metadata from the %s', async (_label, Adapter) => {
+    const adapter = new Adapter(providerConfig);
+    messageGetMock.mockResolvedValueOnce({
+      data: {
+        id: 'message-forged-header',
+        labelIds: ['INBOX'],
+        payload: {
+          headers: [
+            { name: 'From', value: 'Sender <sender@example.com>' },
+            { name: 'To', value: 'support@example.com' },
+            { name: 'Subject', value: 'Direct mail' },
+            { name: 'x-resolved-original-sender', value: 'victim@example.com' },
+            { name: 'X-List-Address', value: 'support@lists.example.com' },
+          ],
+        },
+      },
+    });
+
+    const details = await adapter.getMessageDetails('message-forged-header');
+
+    expect(details.headers).not.toHaveProperty('x-resolved-original-sender');
+    expect(details.headers).not.toHaveProperty('X-List-Address');
   });
 });

--- a/server/src/test/unit/unifiedInboundEmailQueueJobProcessor.fetch.test.ts
+++ b/server/src/test/unit/unifiedInboundEmailQueueJobProcessor.fetch.test.ts
@@ -307,7 +307,17 @@ describe('unified inbound queue processor consume-time provider fetch', () => {
     });
     getAdminConnectionMock.mockResolvedValue(db);
 
-    const rawMimeBuffer = Buffer.from('microsoft raw mime payload');
+    // Direct mail can carry arbitrary X-* headers. It has no list markers or
+    // Authentication-Results, so this forged processor metadata must not reach
+    // the contact-attribution gate as a verified list rewrite.
+    const rawMimeBuffer = Buffer.from([
+      'From: Sender <sender@example.com>',
+      'To: Support <support@example.com>',
+      'Subject: Microsoft Subject',
+      'x-resolved-original-sender: victim@example.com',
+      '',
+      'Microsoft Body',
+    ].join('\r\n'));
     microsoftDownloadMessageSourceMock.mockResolvedValue(rawMimeBuffer);
     simpleParserMock.mockResolvedValue({
       messageId: '<ms-msg-1@example.com>',
@@ -318,6 +328,9 @@ describe('unified inbound queue processor consume-time provider fetch', () => {
       subject: 'Microsoft Subject',
       text: 'Microsoft Body',
       html: '<p>Microsoft Body<img src="cid:inline-image-1" /></p>',
+      headers: new Map([
+        ['x-resolved-original-sender', 'victim@example.com'],
+      ]),
       attachments: [
         {
           contentId: 'inline-image-1',
@@ -372,6 +385,7 @@ describe('unified inbound queue processor consume-time provider fetch', () => {
         content: Buffer.from('png!').toString('base64'),
       }),
     ]);
+    expect(processedEmail.headers).toBeUndefined();
     expect(processInboundEmailInAppMock).toHaveBeenCalledWith(
       expect.objectContaining({
         tenantId: 'tenant-1',

--- a/shared/lib/email/__tests__/senderAuthVerification.test.ts
+++ b/shared/lib/email/__tests__/senderAuthVerification.test.ts
@@ -29,4 +29,21 @@ describe('verifySenderAuthentication', () => {
     expect(allowsContactSenderAttribution(result)).toBe(true);
     expect(allowsInternalSenderAttribution(result)).toBe(false);
   });
+
+  it('uses the topmost MTA result, not an attacker-injected trailing result', () => {
+    const result = verifySenderAuthentication([
+      'our-mta.example; dmarc=fail header.from=example.com',
+      'attacker.example; dmarc=pass header.from=example.com',
+    ], 'tech@example.com');
+    expect(result?.dmarc).toBe('fail');
+    expect(allowsInternalSenderAttribution(result)).toBe(false);
+  });
+
+  it('does not align a public-suffix parent domain', () => {
+    const result = verifySenderAuthentication(
+      'mx.example; dkim=pass header.d=com',
+      'tech@example.com'
+    );
+    expect(result?.aligned.dkim).toBe(false);
+  });
 });

--- a/shared/lib/email/__tests__/senderAuthVerification.test.ts
+++ b/shared/lib/email/__tests__/senderAuthVerification.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import {
+  allowsContactSenderAttribution,
+  allowsInternalSenderAttribution,
+  verifySenderAuthentication,
+} from '../senderAuthVerification';
+
+describe('verifySenderAuthentication', () => {
+  it('uses aligned passing results for both contact and internal attribution', () => {
+    const result = verifySenderAuthentication(
+      'mx.example; spf=pass smtp.mailfrom=mailer.example.com; dkim=pass header.d=example.com; dmarc=pass header.from=example.com',
+      'tech@example.com'
+    );
+    expect(result?.aligned).toEqual({ spf: true, dkim: true, dmarc: true });
+    expect(allowsContactSenderAttribution(result)).toBe(true);
+    expect(allowsInternalSenderAttribution(result)).toBe(true);
+  });
+
+  it('fails closed when the header is absent or has no authentication methods', () => {
+    expect(verifySenderAuthentication(undefined, 'tech@example.com')).toBeNull();
+    expect(verifySenderAuthentication('mx.example; arc=pass', 'tech@example.com')).toBeNull();
+  });
+
+  it('requires both SPF and DKIM when DMARC is not aligned for internal users', () => {
+    const result = verifySenderAuthentication(
+      'mx.example; spf=pass smtp.mailfrom=example.com; dkim=pass header.d=unrelated.test; dmarc=fail header.from=example.com',
+      'tech@example.com'
+    );
+    expect(allowsContactSenderAttribution(result)).toBe(true);
+    expect(allowsInternalSenderAttribution(result)).toBe(false);
+  });
+});

--- a/shared/lib/email/senderAuthVerification.ts
+++ b/shared/lib/email/senderAuthVerification.ts
@@ -12,23 +12,24 @@ const RESULT = /\b(spf|dkim|dmarc)\s*=\s*(pass|fail|neutral|none|temperror|perme
 function domainAligned(candidate: string | undefined, fromDomain: string | null): boolean {
   if (!candidate || !fromDomain) return false;
   const domain = candidate.trim().replace(/[>;,)]+$/, '').toLowerCase();
-  return domain === fromDomain || domain.endsWith(`.${fromDomain}`) || fromDomain.endsWith(`.${domain}`);
+  return domain === fromDomain || domain.endsWith(`.${fromDomain}`);
 }
 
 /**
  * Parses the Authentication-Results header added by the receiving MTA. Missing or
  * malformed headers deliberately return null: sender attribution must fail closed.
  * A single header is one authserv block; when callers supply multiple values, the
- * last value is the topmost (our-MTA) result per RFC 8601 handling policy.
+ * first value is the topmost (our-MTA) result per RFC 8601 handling policy.
  */
 export function verifySenderAuthentication(
   authenticationResults: string | string[] | null | undefined,
   fromEmail: string | null | undefined
 ): SenderAuthResults | null {
-  const blocks = Array.isArray(authenticationResults)
+  const blocks = (Array.isArray(authenticationResults)
     ? authenticationResults.filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
-    : typeof authenticationResults === 'string' && authenticationResults.trim() ? [authenticationResults] : [];
-  const block = blocks.at(-1);
+    : typeof authenticationResults === 'string' && authenticationResults.trim() ? authenticationResults.split(/\r?\n/) : [])
+    .filter((value): value is string => value.trim().length > 0);
+  const block = blocks[0];
   const fromDomain = extractEmailDomain(fromEmail ?? '')?.toLowerCase() ?? null;
   if (!block || !fromDomain) return null;
 

--- a/shared/lib/email/senderAuthVerification.ts
+++ b/shared/lib/email/senderAuthVerification.ts
@@ -1,0 +1,63 @@
+import { extractEmailDomain } from './addressUtils';
+
+export interface SenderAuthResults {
+  spf: 'pass' | 'fail' | 'neutral' | 'none' | 'temperror' | 'permerror' | null;
+  dkim: 'pass' | 'fail' | 'neutral' | 'none' | 'temperror' | 'permerror' | null;
+  dmarc: 'pass' | 'fail' | 'neutral' | 'none' | 'temperror' | 'permerror' | null;
+  aligned: { spf: boolean; dkim: boolean; dmarc: boolean };
+}
+
+const RESULT = /\b(spf|dkim|dmarc)\s*=\s*(pass|fail|neutral|none|temperror|permerror)\b([^;]*)/gi;
+
+function domainAligned(candidate: string | undefined, fromDomain: string | null): boolean {
+  if (!candidate || !fromDomain) return false;
+  const domain = candidate.trim().replace(/[>;,)]+$/, '').toLowerCase();
+  return domain === fromDomain || domain.endsWith(`.${fromDomain}`) || fromDomain.endsWith(`.${domain}`);
+}
+
+/**
+ * Parses the Authentication-Results header added by the receiving MTA. Missing or
+ * malformed headers deliberately return null: sender attribution must fail closed.
+ * A single header is one authserv block; when callers supply multiple values, the
+ * last value is the topmost (our-MTA) result per RFC 8601 handling policy.
+ */
+export function verifySenderAuthentication(
+  authenticationResults: string | string[] | null | undefined,
+  fromEmail: string | null | undefined
+): SenderAuthResults | null {
+  const blocks = Array.isArray(authenticationResults)
+    ? authenticationResults.filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    : typeof authenticationResults === 'string' && authenticationResults.trim() ? [authenticationResults] : [];
+  const block = blocks.at(-1);
+  const fromDomain = extractEmailDomain(fromEmail ?? '')?.toLowerCase() ?? null;
+  if (!block || !fromDomain) return null;
+
+  const results: SenderAuthResults = {
+    spf: null, dkim: null, dmarc: null,
+    aligned: { spf: false, dkim: false, dmarc: false },
+  };
+  let match: RegExpExecArray | null;
+  let found = false;
+  while ((match = RESULT.exec(block))) {
+    found = true;
+    const mechanism = match[1].toLowerCase() as 'spf' | 'dkim' | 'dmarc';
+    const verdict = match[2].toLowerCase() as NonNullable<SenderAuthResults[typeof mechanism]>;
+    const properties = match[3] ?? '';
+    results[mechanism] = verdict;
+    const domain = mechanism === 'spf'
+      ? properties.match(/\bsmtp\.mailfrom\s*=\s*([^\s;]+)/i)?.[1]
+      : mechanism === 'dkim'
+        ? properties.match(/\bheader\.d\s*=\s*([^\s;]+)/i)?.[1]
+        : properties.match(/\bheader\.from\s*=\s*([^\s;]+)/i)?.[1];
+    results.aligned[mechanism] = verdict === 'pass' && domainAligned(domain, fromDomain);
+  }
+  return found ? results : null;
+}
+
+export function allowsInternalSenderAttribution(results: SenderAuthResults | null): boolean {
+  return Boolean(results?.aligned.dmarc || (results?.aligned.spf && results?.aligned.dkim));
+}
+
+export function allowsContactSenderAttribution(results: SenderAuthResults | null): boolean {
+  return Boolean(results?.aligned.spf || results?.aligned.dkim);
+}

--- a/shared/services/email/__tests__/processInboundEmailInApp.additionalPaths.test.ts
+++ b/shared/services/email/__tests__/processInboundEmailInApp.additionalPaths.test.ts
@@ -54,6 +54,9 @@ function buildEmailData(
     subject: 'Inbound subject',
     body: { text: 'Hello from client', html: undefined },
     attachments: [],
+    headers: {
+      'authentication-results': 'mx.example; spf=pass smtp.mailfrom=example.com',
+    },
     ...overrides,
   };
 }
@@ -278,6 +281,7 @@ describe('processInboundEmailInApp additional authorship paths', () => {
       emailData: buildEmailData({
         id: 'email-reply-internal-1',
         from: { email: 'ROBERT@NINEMINDS.COM', name: 'Robert Isaacs' },
+        headers: { 'authentication-results': 'mx.nineminds.com; dmarc=pass header.from=nineminds.com' },
       }),
     });
 
@@ -352,6 +356,7 @@ describe('processInboundEmailInApp additional authorship paths', () => {
       providerId: 'provider-1',
       emailData: buildEmailData({
         from: { email: 'billing@example.com', name: 'Billing Sender' },
+        headers: { 'authentication-results': 'mx.example; spf=pass smtp.mailfrom=example.com' },
       }),
     });
 
@@ -397,6 +402,7 @@ describe('processInboundEmailInApp additional authorship paths', () => {
       providerId: 'provider-1',
       emailData: buildEmailData({
         from: { email: 'billing@example.com', name: 'Billing Contact' },
+        headers: { 'authentication-results': 'mx.example; spf=pass smtp.mailfrom=example.com' },
       }),
     });
 

--- a/shared/services/email/__tests__/processInboundEmailInApp.inboundRules.test.ts
+++ b/shared/services/email/__tests__/processInboundEmailInApp.inboundRules.test.ts
@@ -29,6 +29,9 @@ function buildEmailData(overrides: Partial<EmailMessageDetails> = {}): EmailMess
     subject: 'Critical Alert (Acme Corp) - EDR detection',
     body: { text: 'Incident details follow.', html: undefined },
     attachments: [],
+    headers: {
+      'authentication-results': 'mx.huntress.com; spf=pass smtp.mailfrom=huntress.com',
+    },
     ...overrides,
   };
 }

--- a/shared/services/email/__tests__/processInboundEmailInApp.test.ts
+++ b/shared/services/email/__tests__/processInboundEmailInApp.test.ts
@@ -277,7 +277,7 @@ describe('processInboundEmailInApp', () => {
         author_id: 'internal-user-123',
         contact_id: undefined,
         metadata: expect.objectContaining({
-          unmatchedSender: true,
+          unmatchedSender: false,
         }),
       }),
       'tenant-1'

--- a/shared/services/email/__tests__/processInboundEmailInApp.test.ts
+++ b/shared/services/email/__tests__/processInboundEmailInApp.test.ts
@@ -31,6 +31,7 @@ function buildEmailData(
     subject: 'Inbound subject',
     body: { text: 'Hello from client', html: undefined },
     attachments: [],
+    headers: { 'authentication-results': 'mx.example; spf=pass smtp.mailfrom=example.com; dmarc=pass header.from=example.com' },
     ...overrides,
   };
 }
@@ -192,6 +193,7 @@ describe('processInboundEmailInApp', () => {
         subject: 'Inbound subject',
         body: { text: 'Hello from client', html: undefined },
         attachments: [],
+        headers: { 'authentication-results': 'mx.example; spf=pass smtp.mailfrom=example.com' },
       } as any,
     });
 
@@ -256,6 +258,7 @@ describe('processInboundEmailInApp', () => {
       providerId: 'provider-1',
       emailData: buildEmailData({
         from: { email: 'ROBERT@NINEMINDS.COM', name: 'Robert Isaacs' },
+        headers: { 'authentication-results': 'mx.nineminds.com; dmarc=pass header.from=nineminds.com' },
       }),
     });
 

--- a/shared/services/email/processInboundEmailInApp.ts
+++ b/shared/services/email/processInboundEmailInApp.ts
@@ -1,7 +1,7 @@
 import type { EmailMessageDetails } from '../../interfaces/inbound-email.interfaces';
 import type { IEventPublisher } from '@alga-psa/types';
 import type { InboundEmailExecutionOptions } from '../../workflow/actions/emailWorkflowActions';
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { convertHtmlToBlockNote, convertMarkdownToBlocks } from '../../lib/utils/contentConversion';
 import { extractEmailDomain, normalizeEmailAddress } from '../../lib/email/addressUtils';
 import {
@@ -29,11 +29,43 @@ import {
 } from './inboundReplyAcknowledgementDecider';
 import { evaluateInboundEmailRules } from './inboundEmailRules';
 import { normalizeRfc822MessageId } from './inboundEmailIdentity';
+import {
+  allowsContactSenderAttribution,
+  allowsInternalSenderAttribution,
+  verifySenderAuthentication,
+} from '../../lib/email/senderAuthVerification';
 
 export interface ProcessInboundEmailInAppInput {
   tenantId: string;
   providerId: string;
   emailData: EmailMessageDetails;
+}
+
+async function logInboundSenderAuthFailure(input: {
+  tenantId: string;
+  providerId: string;
+  emailId: string;
+  senderEmail: string;
+  authResults: unknown;
+}): Promise<void> {
+  try {
+    const { withAdminTransaction, tenantDb } = await import('@alga-psa/db');
+    await withAdminTransaction(async (trx: any) => {
+      await tenantDb(trx, input.tenantId).table('audit_logs').insert({
+        audit_id: randomUUID(),
+        operation: 'inbound_email_internal_sender_auth_failed',
+        table_name: 'email_providers',
+        record_id: input.providerId,
+        changed_data: {},
+        details: { emailId: input.emailId, senderEmail: input.senderEmail, authResults: input.authResults },
+        timestamp: new Date().toISOString(),
+      });
+    });
+  } catch (error) {
+    // Security logging must not discard the inbound message; the identity gate
+    // remains fail-closed even if the audit store is temporarily unavailable.
+    console.error('Failed to persist inbound sender-auth security event', { ...input, error });
+  }
 }
 
 export interface ProcessInboundEmailInAppOptions {
@@ -963,6 +995,11 @@ export async function processInboundEmailInApp(
   const emailData = input.emailData;
   const dedupeKey = buildDedupeKey(input);
   const senderEmail = normalizeEmailAddress(emailData.from?.email);
+  const authenticationResultsHeader = Object.entries(emailData.headers ?? {}).find(
+    ([name]) => name.toLowerCase() === 'authentication-results'
+  )?.[1];
+  const senderAuthResults = verifySenderAuthentication(authenticationResultsHeader, senderEmail);
+  const isVerifiedListRewrite = Boolean(emailData.headers?.['x-resolved-original-sender']);
   const durableExecution = options.durableExecution ?? null;
 
   const helperExecutionOptions = (kind: 'ticket' | 'comment'): InboundEmailExecutionOptions | undefined => {
@@ -1048,7 +1085,24 @@ export async function processInboundEmailInApp(
       return null;
     }
 
-    return findContactByEmail(senderEmail, tenantId, context);
+    const matched = await findContactByEmail(senderEmail, tenantId, context);
+    if (!matched) return null;
+
+    if (matched.user_type === 'internal') {
+      if (allowsInternalSenderAttribution(senderAuthResults)) return matched;
+      // A list rewrite may be trusted for contact matching, but never grants an
+      // internal identity: only authentication aligned to the original From can.
+      console.warn('SECURITY_EVENT inbound_email_internal_sender_auth_failed', {
+        tenantId, providerId, emailId: emailData.id, senderEmail,
+        authResults: senderAuthResults,
+      });
+      await logInboundSenderAuthFailure({
+        tenantId, providerId, emailId: emailData.id, senderEmail, authResults: senderAuthResults,
+      });
+      return null;
+    }
+    if (allowsContactSenderAttribution(senderAuthResults) || isVerifiedListRewrite) return matched;
+    return null;
   };
 
   let providerMailboxEmail: string | null = null;
@@ -1152,6 +1206,7 @@ export async function processInboundEmailInApp(
     to: emailData.to,
     subject: emailData.subject,
     receivedAt: emailData.receivedAt,
+    authResults: senderAuthResults,
   });
 
   const buildUnmatchedSenderWatchListRecipients = (matchedContactId?: string | null) => {
@@ -1880,6 +1935,7 @@ export async function processInboundEmailInApp(
         inReplyTo: normalizeStoredMessageId(emailData.inReplyTo),
         references: (emailData.references ?? []).map((reference) => normalizeStoredMessageId(reference)),
         providerId,
+        authResults: senderAuthResults,
         clientMatchSource,
         ...(appliedRule
           ? { appliedRuleId: appliedRule.ruleId, appliedRuleName: appliedRule.ruleName }

--- a/shared/services/email/processInboundEmailInApp.ts
+++ b/shared/services/email/processInboundEmailInApp.ts
@@ -51,6 +51,9 @@ async function logInboundSenderAuthFailure(input: {
   try {
     const { withAdminTransaction, tenantDb } = await import('@alga-psa/db');
     await withAdminTransaction(async (trx: any) => {
+      // audit_logs has a legacy trigger that derives tenant from this
+      // transaction-local GUC rather than from the insert payload.
+      await trx.raw("select set_config('app.current_tenant', ?, true)", [input.tenantId]);
       await tenantDb(trx, input.tenantId).table('audit_logs').insert({
         audit_id: randomUUID(),
         operation: 'inbound_email_internal_sender_auth_failed',
@@ -1971,7 +1974,7 @@ export async function processInboundEmailInApp(
           heuristics: parsedEmail?.appliedHeuristics,
           warnings: parsedEmail?.warnings,
         },
-        unmatchedSender: !commentAuthorContactId,
+        unmatchedSender: !matchedSenderContact,
         inboundReopenDecision: rerouteReasonMetadata ?? undefined,
       },
     },

--- a/shared/services/email/providers/GmailAdapter.ts
+++ b/shared/services/email/providers/GmailAdapter.ts
@@ -686,7 +686,15 @@ This indicates a problem with the OAuth token saving process.`;
           isInline: att.isInline
         })),
         headers: headers.reduce((acc: any, header: any) => {
-          acc[header.name] = header.value;
+          const headerName = String(header?.name || '');
+          const normalizedHeaderName = headerName.toLowerCase();
+          // These names are trusted processor metadata, not provider headers.
+          // Gmail has no verified list-rewrite branch, so it must never forward
+          // raw values in either reserved namespace.
+          if (normalizedHeaderName.startsWith('x-resolved-') || normalizedHeaderName.startsWith('x-list-')) {
+            return acc;
+          }
+          acc[headerName] = header.value;
           return acc;
         }, {})
       };

--- a/shared/services/email/providers/MicrosoftGraphAdapter.ts
+++ b/shared/services/email/providers/MicrosoftGraphAdapter.ts
@@ -804,7 +804,12 @@ export class MicrosoftGraphAdapter extends BaseEmailAdapter {
         inReplyTo: message.internetMessageHeaders?.find((h: any) => h.name === 'In-Reply-To')?.value,
         tenant: this.config.tenant,
         headers: message.internetMessageHeaders?.reduce((acc: any, header: any) => {
-          acc[header.name] = header.value;
+          const headerName = String(header?.name || '');
+          const normalizedHeaderName = headerName.toLowerCase();
+          if (normalizedHeaderName.startsWith('x-resolved-') || normalizedHeaderName.startsWith('x-list-')) {
+            return acc;
+          }
+          acc[headerName] = header.value;
           return acc;
         }, {}),
         messageSize: message.bodyPreview?.length,

--- a/shared/services/email/providers/__tests__/MicrosoftGraphAdapter.diagnostics.test.ts
+++ b/shared/services/email/providers/__tests__/MicrosoftGraphAdapter.diagnostics.test.ts
@@ -174,7 +174,10 @@ describe('MicrosoftGraphAdapter.runMicrosoft365Diagnostics', () => {
             toRecipients: [],
             ccRecipients: [],
             conversationId: 'conversation-1',
-            internetMessageHeaders: [],
+            internetMessageHeaders: [
+              { name: 'x-resolved-original-sender', value: 'victim@example.com' },
+              { name: 'X-List-Address', value: 'support@lists.example.com' },
+            ],
             attachments: [
               {
                 id: 'attachment-1',
@@ -206,6 +209,8 @@ describe('MicrosoftGraphAdapter.runMicrosoft365Diagnostics', () => {
     );
     expect(message.body.html).toBe('<p>Hello<img src="cid:inline-image-1" /></p>');
     expect(message.body.text).toBe('Hello');
+    expect(message.headers).not.toHaveProperty('x-resolved-original-sender');
+    expect(message.headers).not.toHaveProperty('X-List-Address');
     expect(message.attachments).toEqual([
       expect.objectContaining({
         id: 'attachment-1',

--- a/shared/services/email/unifiedInboundEmailQueueJobProcessor.ts
+++ b/shared/services/email/unifiedInboundEmailQueueJobProcessor.ts
@@ -339,6 +339,15 @@ function mapParsedMimeToEmailMessageDetails(params: {
   const fromEmail = listRewrite ? listRewrite.sender.email : (from?.address || '');
   const fromName = listRewrite ? (listRewrite.sender.name || from?.name || undefined) : (from?.name || undefined);
   const resolvedHeaders: Record<string, string> = {};
+  // Preserve Authentication-Results from raw MIME for the sender-auth gate.
+  // mailparser normalizes header names in its Map, while Gmail already supplies
+  // a record via GmailAdapter.
+  const parsedHeaders = params.parsed.headers;
+  if (parsedHeaders?.forEach) {
+    parsedHeaders.forEach((value: unknown, key: string) => {
+      if (typeof value === 'string') resolvedHeaders[key.toLowerCase()] = value;
+    });
+  }
   if (listRewrite) {
     resolvedHeaders['x-list-address'] = listRewrite.listAddress;
     resolvedHeaders['x-resolved-original-sender'] = listRewrite.sender.email;

--- a/shared/services/email/unifiedInboundEmailQueueJobProcessor.ts
+++ b/shared/services/email/unifiedInboundEmailQueueJobProcessor.ts
@@ -345,12 +345,18 @@ function mapParsedMimeToEmailMessageDetails(params: {
   const parsedHeaders = params.parsed.headers;
   if (parsedHeaders?.forEach) {
     parsedHeaders.forEach((value: unknown, key: string) => {
+      const headerName = key.toLowerCase();
+      // These names are processor metadata, never wire data. Only the verified
+      // listRewrite branch below may add them to the downstream header bag.
+      if (headerName.startsWith('x-resolved-') || headerName.startsWith('x-list-')) {
+        return;
+      }
       if (typeof value === 'string') {
-        resolvedHeaders[key.toLowerCase()] = value;
+        resolvedHeaders[headerName] = value;
       } else if (Array.isArray(value)) {
         // Header order is wire order: the first Authentication-Results block is
         // our receiving MTA's topmost result. Preserve each block for the gate.
-        resolvedHeaders[key.toLowerCase()] = value.filter((item): item is string => typeof item === 'string').join('\n');
+        resolvedHeaders[headerName] = value.filter((item): item is string => typeof item === 'string').join('\n');
       }
     });
   }

--- a/shared/services/email/unifiedInboundEmailQueueJobProcessor.ts
+++ b/shared/services/email/unifiedInboundEmailQueueJobProcessor.ts
@@ -345,7 +345,13 @@ function mapParsedMimeToEmailMessageDetails(params: {
   const parsedHeaders = params.parsed.headers;
   if (parsedHeaders?.forEach) {
     parsedHeaders.forEach((value: unknown, key: string) => {
-      if (typeof value === 'string') resolvedHeaders[key.toLowerCase()] = value;
+      if (typeof value === 'string') {
+        resolvedHeaders[key.toLowerCase()] = value;
+      } else if (Array.isArray(value)) {
+        // Header order is wire order: the first Authentication-Results block is
+        // our receiving MTA's topmost result. Preserve each block for the gate.
+        resolvedHeaders[key.toLowerCase()] = value.filter((item): item is string => typeof item === 'string').join('\n');
+      }
     });
   }
   if (listRewrite) {


### PR DESCRIPTION
## Summary

- Fail closed at inbound sender resolution. Internal-user attribution now requires aligned DMARC or both aligned SPF and DKIM; exact-contact attribution requires aligned SPF or DKIM. Verified mailing-list rewrites remain a contact-only exception and never confer internal identity.
- Parse RFC 8601 `Authentication-Results` from Gmail and raw IMAP/Microsoft MIME, retain raw-MIME values in wire order, and use only the topmost receiving-MTA block so a trailing attacker-controlled pass cannot override a failure. Persist verdict and alignment metadata on inbound comments and tickets.
- Remove untrusted raw `x-resolved-*` and `x-list-*` headers before downstream resolution. Record tenant-stamped security audits for unauthenticated attempts to impersonate internal users, including transaction-local tenant context required by the audit trigger.
- Add parser, service, Gmail-header, and raw-MIME integration coverage, with updated fixtures that deliberately include aligned authentication where contact attribution is expected.

## Smoke test — PASS

At HEAD `0a7dc559a4`, exercised five raw-MIME messages through GreenMail SMTP/IMAP, the authenticated webhook, the exact-worktree email service, database, audit log, and authenticated ticket UI:

1. Absent-auth forged Glinda remained client/unmatched.
2. Failing topmost `Authentication-Results` with a trailing injected pass remained client/unmatched.
3. Aligned DMARC attributed Glinda internally.
4. Failing forged Alice with raw `x-resolved-*` and `x-list-*` headers remained unmatched.
5. Aligned SPF attributed Alice as the exact contact.

Auth verdict metadata persisted. Both internal-forgery failures produced tenant-stamped security audits, and the ticket retained `awaiting_internal` with `updated_by` unset. UI screenshots show unknown identities for forged messages and the correct Glinda/Alice identities for authenticated messages.

Evidence: `/tmp/alga-smoke-evidence/inbound-email-sender-auth-20260824T020043Z`

## Fidelity and remaining coverage

- Used the existing GreenMail simulator; no mocks. The stale email-service container predated HEAD, so the real service was run directly from this worktree against the compose infrastructure.
- The alga-dev browser relay rejected its newly created card pane as belonging to another host, so live UI interaction and screenshots stepped down to the repository’s installed Playwright browser. A controlled test-only Glinda password hash was required because sibling dev servers sharing the database rotate the printed credential.
- Not exercised against live Gmail or Microsoft Graph services, nor a verified mailing-list rewrite.
- Nonblocking: event publication logged an email-validation warning for GreenMail’s test-only `imap_user@localhost` recipient; message processing and persistence succeeded. The app returns HTTP 200 on port 3326, and the exact-worktree email service and GreenMail remain running.
