### PR TITLE
fix(msgraph): replace fictitious API endpoints, unstick Entra sync

### DIFF
--- a/ee/packages/calendar/src/lib/services/calendar/providers/MicrosoftCalendarAdapter.ts
+++ b/ee/packages/calendar/src/lib/services/calendar/providers/MicrosoftCalendarAdapter.ts
@@ -580,15 +580,23 @@ export class MicrosoftCalendarAdapter extends BaseCalendarAdapter {
     await this.ensureValidToken();
 
     const changes: Array<{ id: string; changeType: 'updated' | 'deleted' }> = [];
-    const initialUrl = deltaLink ?? `${this.getCalendarBasePath()}/events/delta`;
-    let requestUrl: string | undefined = initialUrl;
+    // Real Graph has no /events/delta — event change tracking is served by
+    // calendarView/delta over an explicit date window, and it returns expanded
+    // occurrences rather than series masters. The window below bounds only the
+    // initial round; every later round replays the stored @odata.deltaLink,
+    // which carries the window inside its token.
+    const DELTA_WINDOW_PAST_MS = 90 * 24 * 60 * 60 * 1000;
+    const DELTA_WINDOW_FUTURE_MS = 365 * 24 * 60 * 60 * 1000;
+    const initialUrl =
+      `${this.getCalendarBasePath()}/calendarView/delta` +
+      `?startDateTime=${encodeURIComponent(new Date(Date.now() - DELTA_WINDOW_PAST_MS).toISOString())}` +
+      `&endDateTime=${encodeURIComponent(new Date(Date.now() + DELTA_WINDOW_FUTURE_MS).toISOString())}`;
+    let requestUrl: string | undefined = deltaLink ?? initialUrl;
     let nextDeltaLink: string | undefined;
 
     try {
       while (requestUrl) {
-        const response: any = await this.httpClient.get(requestUrl, {
-          headers: deltaLink ? {} : { Prefer: 'odata.track-changes' }
-        });
+        const response: any = await this.httpClient.get(requestUrl);
 
         const items = response.data?.value || [];
         for (const item of items) {

--- a/ee/server/src/__tests__/unit/cippProviderAdapter.normalization.test.ts
+++ b/ee/server/src/__tests__/unit/cippProviderAdapter.normalization.test.ts
@@ -65,6 +65,31 @@ describe('CippProviderAdapter normalization', () => {
     );
   });
 
+  it('consumes customerId, the field real CIPP ListTenants identifies tenants by', async () => {
+    axiosGetMock.mockResolvedValue({
+      data: [
+        {
+          customerId: 'customer-tenant-1',
+          displayName: 'Real CIPP Tenant',
+          defaultDomainName: 'realcipp.example.com',
+        },
+      ],
+    });
+
+    const { createCippProviderAdapter } = await import(
+      '@ee/lib/integrations/entra/providers/cipp/cippProviderAdapter'
+    );
+    const adapter = createCippProviderAdapter();
+    const tenants = await adapter.listManagedTenants({ tenant: 'tenant-real' });
+
+    expect(tenants).toHaveLength(1);
+    expect(tenants[0]).toMatchObject({
+      entraTenantId: 'customer-tenant-1',
+      displayName: 'Real CIPP Tenant',
+      primaryDomain: 'realcipp.example.com',
+    });
+  });
+
   it('T051: normalizes CIPP user responses into canonical sync-user DTO fields', async () => {
     axiosGetMock.mockResolvedValue({
       data: [
@@ -108,7 +133,38 @@ describe('CippProviderAdapter normalization', () => {
       businessPhones: ['+1 555 1051'],
     });
     expect(axiosGetMock).toHaveBeenCalledWith(
-      'https://cipp.example.com/api/listusers?tenantId=managed-tenant-51',
+      'https://cipp.example.com/api/listusers?tenantFilter=managed-tenant-51',
+      expect.objectContaining({
+        headers: {
+          Authorization: 'Bearer cipp-token',
+          'X-API-KEY': 'cipp-token',
+        },
+      })
+    );
+  });
+
+  it('filters non-security groups out of CIPP ListGroups rows', async () => {
+    // Invoke-ListGroups.ps1 returns every group type and selects
+    // securityEnabled so the caller can filter — matching the direct adapter.
+    axiosGetMock.mockResolvedValue({
+      data: [
+        { id: 'group-sec', displayName: 'Security Group', securityEnabled: true },
+        { id: 'group-dist', displayName: 'Distribution List', securityEnabled: false },
+      ],
+    });
+
+    const { createCippProviderAdapter } = await import(
+      '@ee/lib/integrations/entra/providers/cipp/cippProviderAdapter'
+    );
+    const adapter = createCippProviderAdapter();
+    const groups = await adapter.listSecurityGroupsForTenant({
+      tenant: 'tenant-groups',
+      managedTenantId: 'managed-tenant-groups',
+    });
+
+    expect(groups).toEqual([{ id: 'group-sec', displayName: 'Security Group' }]);
+    expect(axiosGetMock).toHaveBeenCalledWith(
+      'https://cipp.example.com/api/listgroups?tenantFilter=managed-tenant-groups',
       expect.objectContaining({
         headers: {
           Authorization: 'Bearer cipp-token',
@@ -119,10 +175,10 @@ describe('CippProviderAdapter normalization', () => {
   });
 
   it('T114: checks group membership from CIPP user-group endpoint payload', async () => {
+    // The shape Invoke-ListUserGroups.ps1 actually returns: a plain array with
+    // a lowercase id and PascalCase display fields.
     axiosGetMock.mockResolvedValue({
-      data: {
-        value: [{ id: 'group-114' }],
-      },
+      data: [{ id: 'group-114', DisplayName: 'Group 114', SecurityGroup: true }],
     });
 
     const { createCippProviderAdapter } = await import(
@@ -139,7 +195,7 @@ describe('CippProviderAdapter normalization', () => {
 
     expect(isMember).toBe(true);
     expect(axiosGetMock).toHaveBeenCalledWith(
-      'https://cipp.example.com/api/usergroups?tenantId=managed-tenant-114&userId=user-114',
+      'https://cipp.example.com/api/listusergroups?tenantFilter=managed-tenant-114&userId=user-114',
       expect.objectContaining({
         headers: {
           Authorization: 'Bearer cipp-token',

--- a/ee/server/src/__tests__/unit/directProviderAdapter.normalization.test.ts
+++ b/ee/server/src/__tests__/unit/directProviderAdapter.normalization.test.ts
@@ -131,6 +131,19 @@ describe('DirectProviderAdapter normalization', () => {
       mobilePhone: '+1 555 0000',
       businessPhones: ['+1 555 0001'],
     });
+    // The managed tenant's directory, read with a customer-authority token —
+    // never the invented /tenantRelationships/managedTenants/users endpoint
+    // (real Graph answers 400 for it; it shipped once and broke every sync).
+    expect(axiosGetMock).toHaveBeenCalledWith(
+      expect.stringMatching(/^https:\/\/graph\.microsoft\.com\/v1\.0\/users\?\$select=/),
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer access-token-customer' },
+      })
+    );
+    expect(refreshEntraDirectAccessTokenForTenantMock).toHaveBeenCalledWith(
+      'tenant-49',
+      'managed-tenant-49'
+    );
     expect(refreshEntraDirectTokenMock).not.toHaveBeenCalled();
   });
 

--- a/ee/server/src/lib/integrations/entra/auth/directScopes.ts
+++ b/ee/server/src/lib/integrations/entra/auth/directScopes.ts
@@ -1,8 +1,10 @@
 // Delegated scopes requested for the Direct Microsoft Partner OAuth flow.
 // ManagedTenants.Read.All is required so the access token can hit
-// /tenantRelationships/managedTenants/{tenants,users} during GDAP-backed discovery.
-// Directory.Read.All is only used by the smoke-only self-tenant mode (ENTRA_DIRECT_SMOKE_SELF_TENANT_MODE)
-// to call /organization and /users against the partner's own tenant when no GDAP relationships exist.
+// /tenantRelationships/managedTenants/tenants during GDAP-backed discovery.
+// Directory.Read.All covers the per-customer-tenant directory reads (/users,
+// /groups, checkMemberGroups) made with tokens minted against each managed
+// tenant's authority, and is also what the smoke-only self-tenant mode
+// (ENTRA_DIRECT_SMOKE_SELF_TENANT_MODE) uses against the partner's own tenant.
 // Admin consent must be granted on the Azure app registration for ManagedTenants.Read.All and Directory.Read.All.
 export const ENTRA_DIRECT_DELEGATED_SCOPES = [
   'https://graph.microsoft.com/User.Read',

--- a/ee/server/src/lib/integrations/entra/providers/cipp/cippProviderAdapter.ts
+++ b/ee/server/src/lib/integrations/entra/providers/cipp/cippProviderAdapter.ts
@@ -186,10 +186,11 @@ export class CippProviderAdapter implements EntraProviderAdapter {
       throw new Error('CIPP credentials are not configured.');
     }
 
+    // CIPP-API exposes Azure Functions by name: ListTenants is the endpoint.
+    // The REST-style aliases this adapter used to guess at (/api/tenant/list,
+    // /api/tenants) do not exist in stock CIPP.
     const payload = await this.requestFromCandidates(credentials.baseUrl, credentials.apiToken, [
       '/api/listtenants',
-      '/api/tenant/list',
-      '/api/tenants',
     ]);
     const rows = extractCollection(payload);
 
@@ -198,7 +199,9 @@ export class CippProviderAdapter implements EntraProviderAdapter {
 
     for (const row of rows) {
       const raw = toObject(row);
+      // Real CIPP ListTenants identifies a tenant as `customerId`.
       const entraTenantId =
+        toStringOrNull(raw.customerId) ||
         toStringOrNull(raw.tenantId) ||
         toStringOrNull(raw.id) ||
         toStringOrNull(raw.customerTenantId);
@@ -233,12 +236,12 @@ export class CippProviderAdapter implements EntraProviderAdapter {
       throw new Error('CIPP credentials are not configured.');
     }
 
+    // Per CIPP-API source (Invoke-ListUsers.ps1): the tenant scope parameter
+    // is `tenantFilter` — a customerId GUID or default domain — and the
+    // response is a plain array of Graph beta user objects.
     const tenantId = encodeURIComponent(input.managedTenantId);
     const payload = await this.requestFromCandidates(credentials.baseUrl, credentials.apiToken, [
-      `/api/listusers?tenantId=${tenantId}`,
-      `/api/users?tenantId=${tenantId}`,
-      `/api/tenant/${tenantId}/users`,
-      `/api/tenants/${tenantId}/users`,
+      `/api/listusers?tenantFilter=${tenantId}`,
     ]);
     const rows = extractCollection(payload);
 
@@ -301,12 +304,13 @@ export class CippProviderAdapter implements EntraProviderAdapter {
       throw new Error('CIPP credentials are not configured.');
     }
 
+    // Per CIPP-API source (Invoke-ListGroups.ps1): `tenantFilter` scopes the
+    // read, and the rows are Graph group objects that include ALL group types
+    // — securityEnabled is selected precisely so callers can filter, which
+    // the direct adapter already does and this one must match.
     const tenantId = encodeURIComponent(input.managedTenantId);
     const payload = await this.requestFromCandidates(credentials.baseUrl, credentials.apiToken, [
-      `/api/listgroups?tenantId=${tenantId}`,
-      `/api/groups?tenantId=${tenantId}`,
-      `/api/tenant/${tenantId}/groups`,
-      `/api/tenants/${tenantId}/groups`,
+      `/api/listgroups?tenantFilter=${tenantId}`,
     ]);
     const rows = extractCollection(payload);
     const groups: Array<{ id: string; displayName: string | null }> = [];
@@ -316,6 +320,7 @@ export class CippProviderAdapter implements EntraProviderAdapter {
       const raw = toObject(row);
       const id = toStringOrNull(raw.id) || toStringOrNull(raw.groupId) || toStringOrNull(raw.objectId);
       if (!id || seen.has(id)) continue;
+      if (!toBoolean(raw.securityEnabled, true)) continue;
       seen.add(id);
       groups.push({
         id,
@@ -338,13 +343,13 @@ export class CippProviderAdapter implements EntraProviderAdapter {
       throw new Error('CIPP credentials are not configured.');
     }
 
+    // Per CIPP-API source (Invoke-ListUserGroups.ps1): `tenantFilter` +
+    // `userId`, returning the user's memberOf groups with a lowercase `id`
+    // (the display fields are PascalCase — DisplayName, SecurityGroup).
     const tenantId = encodeURIComponent(input.managedTenantId);
     const userId = encodeURIComponent(input.userEntraObjectId);
     const payload = await this.requestFromCandidates(credentials.baseUrl, credentials.apiToken, [
-      `/api/usergroups?tenantId=${tenantId}&userId=${userId}`,
-      `/api/users/${userId}/groups?tenantId=${tenantId}`,
-      `/api/tenant/${tenantId}/users/${userId}/groups`,
-      `/api/tenants/${tenantId}/users/${userId}/groups`,
+      `/api/listusergroups?tenantFilter=${tenantId}&userId=${userId}`,
     ]);
     const rows = extractCollection(payload);
     const groupIds = new Set(

--- a/ee/server/src/lib/integrations/entra/providers/direct/directProviderAdapter.ts
+++ b/ee/server/src/lib/integrations/entra/providers/direct/directProviderAdapter.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError } from 'axios';
+import axios, { AxiosError, type AxiosResponse } from 'axios';
 import { getSecretProviderInstance } from '@alga-psa/core/secrets';
 import {
   getMicrosoftGraphBaseUrl,
@@ -27,9 +27,11 @@ const GRAPH_REQUEST_TIMEOUT_MS = 20_000;
 
 // Resolved per call: MICROSOFT_GRAPH_BASE_URL points the whole adapter at the
 // Graph emulator (test-harness/graph-emulator) so the integration can be walked
-// end to end without a CSP tenant. The managedTenants endpoints live on the
-// beta base (the API is beta-only; v1.0 answers 400), with its own emulator
-// override MICROSOFT_GRAPH_BETA_BASE_URL.
+// end to end without a CSP tenant. The Lighthouse tenant list lives on the
+// beta base (the managedTenants API is beta-only; v1.0 answers 400), with its
+// own emulator override MICROSOFT_GRAPH_BETA_BASE_URL. Per-customer directory
+// reads (/users, /groups) use v1.0 with a token minted against the customer
+// tenant's authority — managedTenants has no user directory.
 const graphBaseUrl = (): string => getMicrosoftGraphBaseUrl();
 const graphBetaBaseUrl = (): string => getMicrosoftGraphBetaBaseUrl();
 
@@ -120,6 +122,33 @@ function toObject(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : {};
+}
+
+/**
+ * Never let a raw AxiosError escape the adapter: its config/request dump
+ * carries the Authorization header (a live Graph token) into whatever logs the
+ * failure, and its message ("Request failed with status code 400") names
+ * neither the Graph error code nor the message Microsoft actually returned.
+ */
+function sanitizeGraphError(error: unknown): Error {
+  if (isTimeoutError(error)) {
+    return new EntraOperatorError(
+      'timeout',
+      `Microsoft did not answer within ${Math.round(GRAPH_REQUEST_TIMEOUT_MS / 1000)} seconds. Large directories are read in pages — try again in a moment.`
+    );
+  }
+  if (axios.isAxiosError(error)) {
+    if (error.response) {
+      const graphError = toObject(toObject(error.response.data).error);
+      const code = getNullableString(graphError.code);
+      const message = getNullableString(graphError.message);
+      return new Error(
+        `Microsoft Graph request failed (HTTP ${error.response.status}${code ? `, ${code}` : ''})${message ? `: ${message}` : '.'}`
+      );
+    }
+    return new Error(`Microsoft Graph could not be reached${error.code ? ` (${error.code})` : ''}.`);
+  }
+  return error instanceof Error ? error : new Error(String(error));
 }
 
 function getFirstString(value: unknown, fallback = ''): string {
@@ -280,6 +309,37 @@ export class DirectProviderAdapter implements EntraProviderAdapter {
     return accessToken;
   }
 
+  /**
+   * One Graph call against a managed (customer) tenant, authenticated with a
+   * token minted for that tenant's authority. A 401 invalidates the cached
+   * token and retries once with a fresh one.
+   */
+  private async managedTenantGraphRequest(
+    tenant: string,
+    managedTenantId: string,
+    request: (accessToken: string) => Promise<AxiosResponse>
+  ): Promise<Record<string, unknown>> {
+    const accessToken = await this.getManagedTenantAccessToken(tenant, managedTenantId);
+
+    try {
+      const response = await request(accessToken);
+      return toObject(response.data);
+    } catch (error) {
+      const status = (error as AxiosError).response?.status;
+      if (status === 401) {
+        this.managedTenantTokenCache.delete(`${tenant}:${managedTenantId}`);
+        const refreshedToken = await this.getManagedTenantAccessToken(tenant, managedTenantId);
+        try {
+          const retry = await request(refreshedToken);
+          return toObject(retry.data);
+        } catch (retryError) {
+          throw sanitizeGraphError(retryError);
+        }
+      }
+      throw sanitizeGraphError(error);
+    }
+  }
+
   private async graphGet(
     tenant: string,
     url: string
@@ -300,19 +360,14 @@ export class DirectProviderAdapter implements EntraProviderAdapter {
       if (status === 401) {
         const refreshed = await refreshEntraDirectToken(tenant);
         accessToken = refreshed.accessToken;
-        const retry = await request(accessToken);
-        return toObject(retry.data);
+        try {
+          const retry = await request(accessToken);
+          return toObject(retry.data);
+        } catch (retryError) {
+          throw sanitizeGraphError(retryError);
+        }
       }
-      // A timeout is not a refusal. Graph is up and the directory read is
-      // simply taking longer than one request is allowed to; the remedy is to
-      // try again, not to go looking at the connection.
-      if (isTimeoutError(error)) {
-        throw new EntraOperatorError(
-          'timeout',
-          `Microsoft did not answer within ${Math.round(GRAPH_REQUEST_TIMEOUT_MS / 1000)} seconds. Large directories are read in pages — try again in a moment.`
-        );
-      }
-      throw error;
+      throw sanitizeGraphError(error);
     }
   }
 
@@ -366,10 +421,8 @@ export class DirectProviderAdapter implements EntraProviderAdapter {
 
     const users: EntraManagedUserRecord[] = [];
     const seenObjectIds = new Set<string>();
-    const encodedTenant = encodeURIComponent(input.managedTenantId);
     const select = [
       'id',
-      'tenantId',
       'displayName',
       'givenName',
       'surname',
@@ -381,12 +434,24 @@ export class DirectProviderAdapter implements EntraProviderAdapter {
       'businessPhones',
     ].join(',');
 
-    let nextUrl =
-      `${graphBetaBaseUrl()}/tenantRelationships/managedTenants/users` +
-      `?$filter=tenantId eq '${encodedTenant}'&$select=${select}&$top=999`;
+    // The Lighthouse managedTenants API has no user directory (real Graph
+    // answers 400 for /tenantRelationships/managedTenants/users). A managed
+    // tenant's users are read from that tenant's own directory, with a token
+    // minted against its authority — the same GDAP pattern
+    // listSecurityGroupsForTenant already uses.
+    let nextUrl = `${graphBaseUrl()}/users?$select=${select}&$top=999`;
 
     while (nextUrl) {
-      const payload = await this.graphGet(input.tenant, nextUrl);
+      const pageUrl = nextUrl;
+      const payload = await this.managedTenantGraphRequest(
+        input.tenant,
+        input.managedTenantId,
+        (accessToken) =>
+          axios.get(pageUrl, {
+            headers: { Authorization: `Bearer ${accessToken}` },
+            timeout: GRAPH_REQUEST_TIMEOUT_MS,
+          })
+      );
       const rows = Array.isArray(payload.value) ? payload.value : [];
 
       for (const row of rows) {
@@ -579,14 +644,18 @@ export class DirectProviderAdapter implements EntraProviderAdapter {
     const groups: Array<{ id: string; displayName: string | null }> = [];
     const seen = new Set<string>();
     let nextUrl = `${graphBaseUrl()}/groups?$select=id,displayName,securityEnabled&$top=200`;
-    const accessToken = await this.getManagedTenantAccessToken(input.tenant, input.managedTenantId);
 
     while (nextUrl) {
-      const response = await axios.get(nextUrl, {
-        headers: { Authorization: `Bearer ${accessToken}` },
-        timeout: 20_000,
-      });
-      const payload = toObject(response.data);
+      const pageUrl = nextUrl;
+      const payload = await this.managedTenantGraphRequest(
+        input.tenant,
+        input.managedTenantId,
+        (accessToken) =>
+          axios.get(pageUrl, {
+            headers: { Authorization: `Bearer ${accessToken}` },
+            timeout: GRAPH_REQUEST_TIMEOUT_MS,
+          })
+      );
       const rows = Array.isArray(payload.value) ? payload.value : [];
       for (const row of rows) {
         const raw = toObject(row);
@@ -616,16 +685,19 @@ export class DirectProviderAdapter implements EntraProviderAdapter {
   }): Promise<boolean> {
     const encodedUser = encodeURIComponent(input.userEntraObjectId);
     const endpoint = `${graphBaseUrl()}/users/${encodedUser}/checkMemberGroups`;
-    const accessToken = await this.getManagedTenantAccessToken(input.tenant, input.managedTenantId);
-    const response = await axios.post(
-      endpoint,
-      { groupIds: [input.groupId] },
-      {
-        headers: { Authorization: `Bearer ${accessToken}` },
-        timeout: 20_000,
-      }
+    const payload = await this.managedTenantGraphRequest(
+      input.tenant,
+      input.managedTenantId,
+      (accessToken) =>
+        axios.post(
+          endpoint,
+          { groupIds: [input.groupId] },
+          {
+            headers: { Authorization: `Bearer ${accessToken}` },
+            timeout: GRAPH_REQUEST_TIMEOUT_MS,
+          }
+        )
     );
-    const payload = toObject(response.data);
     const values = Array.isArray(payload.value) ? payload.value : [];
     return values.some((value) => getNullableString(value) === input.groupId);
   }

--- a/ee/temporal-workflows/src/activities/entra-sync-activities.ts
+++ b/ee/temporal-workflows/src/activities/entra-sync-activities.ts
@@ -710,11 +710,14 @@ export async function recordSyncTenantResultWithDb(
   };
 
   if (existing?.run_tenant_id) {
+    // Citus forbids the distribution column (tenant) in an UPDATE's SET list;
+    // the row's identity columns never change on re-record anyway.
+    const { tenant: _tenant, run_id: _runId, managed_tenant_id: _managedTenantId, ...updatable } = row;
     await db.table('entra_sync_run_tenants')
       .where({
         run_tenant_id: existing.run_tenant_id,
       })
-      .update(row);
+      .update(updatable);
   } else {
     await db.table('entra_sync_run_tenants').insert({
       ...row,

--- a/ee/temporal-workflows/src/typings/notifications/actions/internal-notification-actions/internalNotificationActions.ts
+++ b/ee/temporal-workflows/src/typings/notifications/actions/internal-notification-actions/internalNotificationActions.ts
@@ -1,18 +1,33 @@
 /**
- * Stub for @alga-psa/notifications/actions/internal-notification-actions/internalNotificationActions
+ * Worker-side implementation of
+ * @alga-psa/notifications/actions/internal-notification-actions/internalNotificationActions.
  *
- * At runtime inside the temporal worker container, the real
- * @alga-psa/notifications package is available under packages/.
- * This stub satisfies TypeScript compilation in the Docker build
- * where the full notification package's transitive UI deps are
- * not installed.
+ * The real module is "use server" and drags next-auth and the realtime UI
+ * stack into the graph, so the worker build maps the package here instead.
+ * This used to be a throwing stub, which silently dropped every notification
+ * an activity tried to deliver (e.g. Entra sync failure alerts). It now
+ * creates the notification row through the shared dependency-light core; the
+ * row reaches the user on their next notification poll. The after-commit
+ * effects the server adds (realtime broadcast, push hooks, NOTIFICATION_SENT
+ * workflow event) are UI-facing conveniences the worker cannot perform.
  */
 
 import type { Knex } from 'knex';
+import { withTransaction } from '@alga-psa/db';
+import { createNotificationRowFromTemplate } from '../../../../../../../packages/notifications/src/actions/internal-notification-actions/createNotificationCore';
+import type {
+  CreateInternalNotificationRequest,
+  InternalNotification,
+} from '../../../../../../../packages/notifications/src/types/internalNotification';
 
 export async function createNotificationFromTemplateInternal(
-  _knex: Knex,
-  _request: any
-): Promise<any | null> {
-  throw new Error('createNotificationFromTemplateInternal stub — should not be called in temporal worker');
+  knex: Knex,
+  request: CreateInternalNotificationRequest
+): Promise<InternalNotification | null> {
+  if (typeof (knex as unknown as { transaction?: unknown } | null)?.transaction !== 'function') {
+    throw new Error('createNotificationFromTemplateInternal requires a server-side database connection');
+  }
+  return withTransaction(knex, (trx: Knex.Transaction) =>
+    createNotificationRowFromTemplate(trx, request.tenant, request.user_id, request)
+  );
 }

--- a/ee/temporal-workflows/src/workflows/activity-failure-message.ts
+++ b/ee/temporal-workflows/src/workflows/activity-failure-message.ts
@@ -1,0 +1,25 @@
+/**
+ * The message a failed activity should surface to an operator.
+ *
+ * An activity error reaches workflow code wrapped: ActivityFailure("Activity
+ * task failed") -> ApplicationFailure(original message). Storing the wrapper's
+ * message put the literal string "Activity task failed" into
+ * entra_sync_run_tenants.error_message, which names neither the cause nor the
+ * remedy. The deepest non-empty message in the cause chain is the one the
+ * adapter actually wrote for a person.
+ */
+export function activityFailureMessage(error: unknown, fallback: string): string {
+  let message = '';
+  let current: unknown = error;
+  const seen = new Set<unknown>();
+
+  while (current instanceof Error && !seen.has(current)) {
+    seen.add(current);
+    if (current.message.trim()) {
+      message = current.message.trim();
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+
+  return message || fallback;
+}

--- a/ee/temporal-workflows/src/workflows/entra-all-tenants-sync-workflow.ts
+++ b/ee/temporal-workflows/src/workflows/entra-all-tenants-sync-workflow.ts
@@ -1,4 +1,5 @@
 import { log, proxyActivities, workflowInfo } from '@temporalio/workflow';
+import { activityFailureMessage } from './activity-failure-message';
 import type {
   EntraAllTenantsSyncWorkflowInput,
   EntraSyncRunSummary,
@@ -141,7 +142,7 @@ export async function entraAllTenantsSyncWorkflow(
         ambiguous: 0,
         inactivated: 0,
         skipped: 0,
-        errorMessage: error instanceof Error ? error.message : 'Tenant sync failed.',
+        errorMessage: activityFailureMessage(error, 'Tenant sync failed.'),
       };
       tenantResults.push(failedResult);
       await activities.recordSyncTenantResultActivity({

--- a/ee/temporal-workflows/src/workflows/entra-tenant-sync-workflow.ts
+++ b/ee/temporal-workflows/src/workflows/entra-tenant-sync-workflow.ts
@@ -1,4 +1,5 @@
 import { log, proxyActivities, workflowInfo } from '@temporalio/workflow';
+import { activityFailureMessage } from './activity-failure-message';
 import type {
   EntraSyncRunSummary,
   EntraSyncWorkflowResult,
@@ -133,7 +134,7 @@ export async function entraTenantSyncWorkflow(
       ambiguous: 0,
       inactivated: 0,
       skipped: 0,
-      errorMessage: error instanceof Error ? error.message : 'Tenant sync failed.',
+      errorMessage: activityFailureMessage(error, 'Tenant sync failed.'),
     };
   }
 

--- a/packages/billing/src/components/invoice-designer/DesignerVisualWorkspace.test.tsx
+++ b/packages/billing/src/components/invoice-designer/DesignerVisualWorkspace.test.tsx
@@ -565,7 +565,12 @@ describe('DesignerVisualWorkspace', () => {
     await waitFor(() => expect(runAuthoritativeInvoiceTemplatePreviewMock).toHaveBeenCalled());
     const baselineCalls = runAuthoritativeInvoiceTemplatePreviewMock.mock.calls.length;
 
-    fireEvent.click(screen.getByRole('button', { name: 'Re-run' }));
+    const rerunButton = await waitFor(() => {
+      const button = screen.getByRole('button', { name: 'Re-run' });
+      expect(button.hasAttribute('disabled')).toBe(false);
+      return button;
+    });
+    fireEvent.click(rerunButton);
 
     await waitFor(() =>
       expect(runAuthoritativeInvoiceTemplatePreviewMock.mock.calls.length).toBeGreaterThan(baselineCalls)

--- a/packages/integrations/src/services/calendar/providers/MicrosoftCalendarAdapter.ts
+++ b/packages/integrations/src/services/calendar/providers/MicrosoftCalendarAdapter.ts
@@ -585,15 +585,23 @@ export class MicrosoftCalendarAdapter extends BaseCalendarAdapter {
     await this.ensureValidToken();
 
     const changes: Array<{ id: string; changeType: 'updated' | 'deleted' }> = [];
-    const initialUrl = deltaLink ?? `${this.getCalendarBasePath()}/events/delta`;
-    let requestUrl: string | undefined = initialUrl;
+    // Real Graph has no /events/delta — event change tracking is served by
+    // calendarView/delta over an explicit date window, and it returns expanded
+    // occurrences rather than series masters. The window below bounds only the
+    // initial round; every later round replays the stored @odata.deltaLink,
+    // which carries the window inside its token.
+    const DELTA_WINDOW_PAST_MS = 90 * 24 * 60 * 60 * 1000;
+    const DELTA_WINDOW_FUTURE_MS = 365 * 24 * 60 * 60 * 1000;
+    const initialUrl =
+      `${this.getCalendarBasePath()}/calendarView/delta` +
+      `?startDateTime=${encodeURIComponent(new Date(Date.now() - DELTA_WINDOW_PAST_MS).toISOString())}` +
+      `&endDateTime=${encodeURIComponent(new Date(Date.now() + DELTA_WINDOW_FUTURE_MS).toISOString())}`;
+    let requestUrl: string | undefined = deltaLink ?? initialUrl;
     let nextDeltaLink: string | undefined;
 
     try {
       while (requestUrl) {
-        const response = await this.httpClient.get(requestUrl, {
-          headers: deltaLink ? {} : { Prefer: 'odata.track-changes' }
-        });
+        const response = await this.httpClient.get(requestUrl);
 
         const items = response.data?.value || [];
         for (const item of items) {

--- a/packages/notifications/src/actions/internal-notification-actions/createNotificationCore.ts
+++ b/packages/notifications/src/actions/internal-notification-actions/createNotificationCore.ts
@@ -1,0 +1,301 @@
+import { tenantDb } from '@alga-psa/db';
+import { Knex } from 'knex';
+import { normalizeLocale } from '@alga-psa/core/i18n/config';
+import {
+  InternalNotification,
+  InternalNotificationTemplate,
+  InternalNotificationPriority,
+  CreateInternalNotificationRequest,
+} from '../../types/internalNotification';
+import { pickNotificationPriority } from './priorityResolution';
+
+/**
+ * The transactional heart of template-based notification creation: locale ->
+ * template -> enablement -> priority -> render -> insert.
+ *
+ * Intentionally NOT a "use server" module, and free of the realtime/auth
+ * stack, so the temporal worker (whose build stubs
+ * @alga-psa/notifications/actions to keep next-auth and the UI deps out) can
+ * import it directly and create real notification rows. The after-commit
+ * effects (workflow event, realtime broadcast, push hooks) stay with the
+ * callers that can perform them.
+ */
+
+function tenantScopedTable(conn: Knex | Knex.Transaction, table: string, tenant: string) {
+  return tenantDb(conn, tenant).table(table) as Knex.QueryBuilder<any, any>;
+}
+
+/**
+ * Get user's locale preference with fallback hierarchy:
+ *
+ * Internal (MSP) users:
+ * 1. User's language preference (user_preferences.locale)
+ * 2. Tenant MSP portal default (tenant_settings.settings.mspPortal.defaultLocale)
+ * 3. Tenant-wide default (tenant_settings.settings.defaultLocale)
+ * 4. System default ('en')
+ *
+ * Client portal users:
+ * 1. User's language preference (user_preferences.locale)
+ * 2. Client company language (clients.properties.defaultLocale)
+ * 3. Tenant client portal default (tenant_settings.settings.clientPortal.defaultLocale)
+ * 4. Tenant-wide default (tenant_settings.settings.defaultLocale)
+ * 5. System default ('en')
+ */
+export async function getUserLocale(
+  trx: Knex.Transaction,
+  tenant: string,
+  userId: string
+): Promise<string> {
+  const db = tenantDb(trx, tenant);
+  const userQuery = db.table('users as u')
+    .select('u.user_type', 'u.contact_id', 'c.properties')
+    .where('u.user_id', userId);
+  db.tenantJoin(userQuery, 'contacts as con', 'u.contact_id', 'con.contact_name_id', { type: 'left' });
+  db.tenantJoin(userQuery, 'clients as c', 'con.client_id', 'c.client_id', { type: 'left' });
+  const user = (await userQuery.first()) as any;
+
+  // 1. User's language preference (applies to both internal and client users)
+  const userPreference = await tenantScopedTable(trx, 'user_preferences', tenant)
+    .where({
+      user_id: userId,
+      setting_name: 'locale'
+    })
+    .first();
+
+  if (userPreference?.setting_value) {
+    const raw = userPreference.setting_value;
+    // Every read normalizes: these columns hold values like 'pt_BR' that name a
+    // language we ship under a code we don't, and an unnormalized one reaches
+    // the renderer as a locale with no pack behind it.
+    const locale = normalizeLocale(typeof raw === 'string' ? raw.replace(/"/g, '') : raw);
+    if (locale) return locale;
+  }
+
+  // 2. Client-specific default (client users only)
+  if (user?.user_type !== 'internal') {
+    const clientLocale = normalizeLocale(user?.properties?.defaultLocale);
+    if (clientLocale) return clientLocale;
+  }
+
+  // 3. Tenant settings — portal-specific default then tenant-wide default
+  const tenantSettings = await tenantScopedTable(trx, 'tenant_settings', tenant)
+    .select('settings')
+    .first();
+
+  if (user?.user_type === 'internal') {
+    const mspPortalLocale = normalizeLocale(tenantSettings?.settings?.mspPortal?.defaultLocale);
+    if (mspPortalLocale) return mspPortalLocale;
+  } else {
+    const clientPortalLocale = normalizeLocale(tenantSettings?.settings?.clientPortal?.defaultLocale);
+    if (clientPortalLocale) return clientPortalLocale;
+  }
+
+  const tenantDefaultLocale = normalizeLocale(tenantSettings?.settings?.defaultLocale);
+  if (tenantDefaultLocale) {
+    return tenantDefaultLocale;
+  }
+
+  // 4. System default
+  return 'en';
+}
+
+/**
+ * Get notification template in the specified language with fallback to English
+ * Note: The locale parameter comes from getUserLocale() which already handles:
+ * 1. User's language preference
+ * 2. Client company language
+ * 3. Tenant language
+ * 4. English default
+ */
+export async function getNotificationTemplate(
+  trx: Knex.Transaction,
+  tenant: string,
+  templateName: string,
+  locale: string
+): Promise<InternalNotificationTemplate | null> {
+  // 1. Try the requested language (from getUserLocale hierarchy)
+  let template = await tenantScopedTable(trx, 'internal_notification_templates', tenant)
+    .where({ name: templateName, language_code: locale })
+    .first();
+
+  if (template) return template;
+
+  // 2. Try English as final fallback
+  template = await tenantScopedTable(trx, 'internal_notification_templates', tenant)
+    .where({ name: templateName, language_code: 'en' })
+    .first();
+
+  if (template) return template;
+
+  // 3. Return null if no template found
+  return null;
+}
+
+/**
+ * Render template with provided data
+ * Supports simple {{variable}} replacement
+ */
+export function renderTemplate(template: string, data: Record<string, any>): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (match, key) => {
+    return data[key] !== undefined ? String(data[key]) : match;
+  });
+}
+
+export async function checkInternalNotificationEnabled(
+  trx: Knex.Transaction,
+  tenant: string,
+  userId: string,
+  subtypeId: number
+): Promise<boolean> {
+  // 1. Get subtype info
+  const subtype = await tenantScopedTable(trx, 'internal_notification_subtypes', tenant)
+    .where({ internal_notification_subtype_id: subtypeId })
+    .first();
+
+  if (!subtype) {
+    return false;
+  }
+
+  // 2. Check tenant-specific subtype setting (replaces global check)
+  const subtypeSetting = await tenantScopedTable(trx, 'tenant_internal_notification_subtype_settings', tenant)
+    .where({ subtype_id: subtypeId })
+    .first();
+
+  const isSubtypeEnabled = subtypeSetting?.is_enabled ?? true;
+  if (!isSubtypeEnabled) {
+    return false;
+  }
+
+  // 3. Verify category exists
+  const category = await tenantScopedTable(trx, 'internal_notification_categories', tenant)
+    .where({ internal_notification_category_id: subtype.internal_category_id })
+    .first();
+
+  if (!category) {
+    return false; // Category not found - don't send notification
+  }
+
+  // 4. Check tenant-specific category setting (replaces global check)
+  const categorySetting = await tenantScopedTable(trx, 'tenant_internal_notification_category_settings', tenant)
+    .where({ category_id: subtype.internal_category_id })
+    .first();
+
+  const isCategoryEnabled = categorySetting?.is_enabled ?? true;
+  if (!isCategoryEnabled) {
+    return false;
+  }
+
+  // 5. Check user-specific preferences (EXISTING - unchanged)
+  const userSubtypePreference = await tenantScopedTable(trx, 'user_internal_notification_preferences', tenant)
+    .where({ user_id: userId, subtype_id: subtypeId })
+    .first();
+
+  if (userSubtypePreference) {
+    return userSubtypePreference.is_enabled;
+  }
+
+  // 6. Check user category preference (EXISTING - unchanged)
+  const userCategoryPreference = await tenantScopedTable(trx, 'user_internal_notification_preferences', tenant)
+    .where({ user_id: userId, category_id: subtype.internal_category_id })
+    .whereNull('subtype_id')
+    .first();
+
+  if (userCategoryPreference) {
+    return userCategoryPreference.is_enabled;
+  }
+
+  // 7. Fall back to tenant's default
+  return subtypeSetting?.is_default_enabled ?? true;
+}
+
+/**
+ * Resolve the effective priority for a notification about to be created.
+ *
+ * Runs inside the creation transaction, alongside the enablement lookup, so
+ * call sites cannot influence the stamped priority — it is governed centrally
+ * by configuration only. Per-user priority is meaningful on subtype-level rows.
+ */
+export async function resolveNotificationPriority(
+  trx: Knex.Transaction,
+  tenant: string,
+  userId: string,
+  subtypeId: number
+): Promise<InternalNotificationPriority> {
+  const userPreference = await tenantScopedTable(trx, 'user_internal_notification_preferences', tenant)
+    .where({ user_id: userId, subtype_id: subtypeId })
+    .first();
+  const tenantSetting = await tenantScopedTable(trx, 'tenant_internal_notification_subtype_settings', tenant)
+    .where({ subtype_id: subtypeId })
+    .first();
+  const subtype = await tenantScopedTable(trx, 'internal_notification_subtypes', tenant)
+    .where({ internal_notification_subtype_id: subtypeId })
+    .first();
+
+  return pickNotificationPriority(
+    userPreference?.priority,
+    tenantSetting?.priority,
+    subtype?.default_priority
+  );
+}
+
+/**
+ * Create one notification row from a template, inside the caller's
+ * transaction. Returns null when the target user has the notification type
+ * disabled. Performs no external effects — publishing, broadcasting, and push
+ * hooks are the caller's, after commit.
+ */
+export async function createNotificationRowFromTemplate(
+  trx: Knex.Transaction,
+  tenant: string,
+  userId: string,
+  request: CreateInternalNotificationRequest
+): Promise<InternalNotification | null> {
+  // Get user's locale
+  const userLocale = await getUserLocale(trx, tenant, userId);
+
+  // Get template in user's language
+  const template = await getNotificationTemplate(trx, tenant, request.template_name, userLocale);
+
+  if (!template) {
+    throw new Error(`Template '${request.template_name}' not found`);
+  }
+
+  // Check if user has this notification type enabled
+  const subtypeId = template.subtype_id;
+  const isEnabled = await checkInternalNotificationEnabled(trx, tenant, userId, subtypeId);
+
+  if (!isEnabled) {
+    console.log(`Internal notification disabled for user ${userId}, subtype ${subtypeId}`);
+    return null;
+  }
+
+  // Resolve the configured priority (user ?? tenant ?? subtype default ?? 'normal').
+  // Governed centrally by configuration — the caller cannot supply a priority.
+  const priority = await resolveNotificationPriority(trx, tenant, userId, subtypeId);
+
+  // Render template with data
+  const title = renderTemplate(template.title, request.data);
+  const message = renderTemplate(template.message, request.data);
+
+  // Insert notification
+  const [notification] = await tenantDb(trx, tenant).table<any>('internal_notifications')
+    .insert({
+      tenant,
+      user_id: userId,
+      template_name: request.template_name,
+      language_code: userLocale,
+      title,
+      message,
+      type: request.type || 'info',
+      priority,
+      category: request.category || null,
+      link: request.link || null,
+      metadata: request.metadata ? JSON.stringify(request.metadata) : null,
+      is_read: false,
+      delivery_status: 'pending',
+      delivery_attempts: 0
+    })
+    .returning('*') as InternalNotification[];
+
+  return notification;
+}

--- a/packages/notifications/src/actions/internal-notification-actions/internalNotificationActions.ts
+++ b/packages/notifications/src/actions/internal-notification-actions/internalNotificationActions.ts
@@ -3,7 +3,6 @@
 import { tenantDb, withTransaction, registerAfterCommit } from '@alga-psa/db';
 import { Knex } from 'knex';
 import { withAuth } from '@alga-psa/auth';
-import { normalizeLocale } from '@alga-psa/core/i18n/config';
 import { hasPermissionAsync } from '../../lib/authHelpers';
 import {
   InternalNotification,
@@ -28,7 +27,10 @@ import {
 } from "../../realtime/internalNotificationBroadcaster";
 import logger from '@alga-psa/core/logger';
 import { runPostCreationHooks } from './notificationHooks';
-import { pickNotificationPriority } from './priorityResolution';
+import {
+  createNotificationRowFromTemplate,
+  resolveNotificationPriority as resolveNotificationPriorityCore,
+} from './createNotificationCore';
 import { publishWorkflowEvent } from '@alga-psa/event-bus/publishers';
 import {
   buildNotificationReadPayload,
@@ -59,105 +61,10 @@ function tenantScopedTable(conn: Knex | Knex.Transaction, table: string, tenant:
  * 4. Tenant-wide default (tenant_settings.settings.defaultLocale)
  * 5. System default ('en')
  */
-async function getUserLocale(
-  trx: Knex.Transaction,
-  tenant: string,
-  userId: string
-): Promise<string> {
-  const db = tenantDb(trx, tenant);
-  const userQuery = db.table('users as u')
-    .select('u.user_type', 'u.contact_id', 'c.properties')
-    .where('u.user_id', userId);
-  db.tenantJoin(userQuery, 'contacts as con', 'u.contact_id', 'con.contact_name_id', { type: 'left' });
-  db.tenantJoin(userQuery, 'clients as c', 'con.client_id', 'c.client_id', { type: 'left' });
-  const user = (await userQuery.first()) as any;
-
-  // 1. User's language preference (applies to both internal and client users)
-  const userPreference = await tenantScopedTable(trx, 'user_preferences', tenant)
-    .where({
-      user_id: userId,
-      setting_name: 'locale'
-    })
-    .first();
-
-  if (userPreference?.setting_value) {
-    const raw = userPreference.setting_value;
-    // Every read normalizes: these columns hold values like 'pt_BR' that name a
-    // language we ship under a code we don't, and an unnormalized one reaches
-    // the renderer as a locale with no pack behind it.
-    const locale = normalizeLocale(typeof raw === 'string' ? raw.replace(/"/g, '') : raw);
-    if (locale) return locale;
-  }
-
-  // 2. Client-specific default (client users only)
-  if (user?.user_type !== 'internal') {
-    const clientLocale = normalizeLocale(user?.properties?.defaultLocale);
-    if (clientLocale) return clientLocale;
-  }
-
-  // 3. Tenant settings — portal-specific default then tenant-wide default
-  const tenantSettings = await tenantScopedTable(trx, 'tenant_settings', tenant)
-    .select('settings')
-    .first();
-
-  if (user?.user_type === 'internal') {
-    const mspPortalLocale = normalizeLocale(tenantSettings?.settings?.mspPortal?.defaultLocale);
-    if (mspPortalLocale) return mspPortalLocale;
-  } else {
-    const clientPortalLocale = normalizeLocale(tenantSettings?.settings?.clientPortal?.defaultLocale);
-    if (clientPortalLocale) return clientPortalLocale;
-  }
-
-  const tenantDefaultLocale = normalizeLocale(tenantSettings?.settings?.defaultLocale);
-  if (tenantDefaultLocale) {
-    return tenantDefaultLocale;
-  }
-
-  // 4. System default
-  return 'en';
-}
-
-/**
- * Get notification template in the specified language with fallback to English
- * Note: The locale parameter comes from getUserLocale() which already handles:
- * 1. User's language preference
- * 2. Client company language
- * 3. Tenant language
- * 4. English default
- */
-async function getNotificationTemplate(
-  trx: Knex.Transaction,
-  tenant: string,
-  templateName: string,
-  locale: string
-): Promise<InternalNotificationTemplate | null> {
-  // 1. Try the requested language (from getUserLocale hierarchy)
-  let template = await tenantScopedTable(trx, 'internal_notification_templates', tenant)
-    .where({ name: templateName, language_code: locale })
-    .first();
-
-  if (template) return template;
-
-  // 2. Try English as final fallback
-  template = await tenantScopedTable(trx, 'internal_notification_templates', tenant)
-    .where({ name: templateName, language_code: 'en' })
-    .first();
-
-  if (template) return template;
-
-  // 3. Return null if no template found
-  return null;
-}
-
-/**
- * Render template with provided data
- * Supports simple {{variable}} replacement
- */
-function renderTemplate(template: string, data: Record<string, any>): string {
-  return template.replace(/\{\{(\w+)\}\}/g, (match, key) => {
-    return data[key] !== undefined ? String(data[key]) : match;
-  });
-}
+// getUserLocale, getNotificationTemplate, renderTemplate,
+// checkInternalNotificationEnabled, and priority resolution live in
+// createNotificationCore.ts so the temporal worker can reuse them without
+// this module's auth/realtime dependencies.
 
 function normalizeDateTime(value: unknown): string {
   if (typeof value === 'string') return value;
@@ -192,57 +99,16 @@ export async function createNotificationFromTemplateInternal(
     throw new Error('createNotificationFromTemplateInternal requires a server-side database connection');
   }
   return await withTransaction(knex, async (trx: Knex.Transaction) => {
-    // Get user's locale
-    const userLocale = await getUserLocale(trx, request.tenant, request.user_id);
-
-    // Get template in user's language
-    const template = await getNotificationTemplate(
+    const notification = await createNotificationRowFromTemplate(
       trx,
       request.tenant,
-      request.template_name,
-      userLocale
+      request.user_id,
+      request
     );
 
-    if (!template) {
-      throw new Error(`Template '${request.template_name}' not found`);
-    }
-
-    // Check if user has this notification type enabled
-    const subtypeId = template.subtype_id;
-    const isEnabled = await checkInternalNotificationEnabled(trx, request.tenant, request.user_id, subtypeId);
-
-    if (!isEnabled) {
-      console.log(`Internal notification disabled for user ${request.user_id}, subtype ${subtypeId}`);
+    if (!notification) {
       return null;
     }
-
-    // Resolve the configured priority (user ?? tenant ?? subtype default ?? 'normal').
-    // Governed centrally by configuration — the caller cannot supply a priority.
-    const priority = await resolveNotificationPriority(trx, request.tenant, request.user_id, subtypeId);
-
-    // Render template with data
-    const title = renderTemplate(template.title, request.data);
-    const message = renderTemplate(template.message, request.data);
-
-    // Insert notification
-    const [notification] = await tenantDb(trx, request.tenant).table<any>('internal_notifications')
-      .insert({
-        tenant: request.tenant,
-        user_id: request.user_id,
-        template_name: request.template_name,
-        language_code: userLocale,
-        title,
-        message,
-        type: request.type || 'info',
-        priority,
-        category: request.category || null,
-        link: request.link || null,
-        metadata: request.metadata ? JSON.stringify(request.metadata) : null,
-        is_read: false,
-        delivery_status: 'pending',
-        delivery_attempts: 0
-      })
-      .returning('*') as InternalNotification[];
 
     const createdAt = normalizeDateTime(notification?.created_at);
 
@@ -312,57 +178,16 @@ export const createNotificationFromTemplateAction = withAuth(async (
 
   try {
     return await withTransaction(knex, async (trx: Knex.Transaction) => {
-      // Get user's locale
-      const userLocale = await getUserLocale(trx, targetTenant, targetUserId);
-
-      // Get template in user's language
-      const template = await getNotificationTemplate(
+      const notification = await createNotificationRowFromTemplate(
         trx,
         targetTenant,
-        request.template_name,
-        userLocale
+        targetUserId,
+        request
       );
 
-      if (!template) {
-        throw new Error(`Template '${request.template_name}' not found`);
-      }
-
-      // Check if user has this notification type enabled
-      const subtypeId = template.subtype_id;
-      const isEnabled = await checkInternalNotificationEnabled(trx, targetTenant, targetUserId, subtypeId);
-
-      if (!isEnabled) {
-        console.log(`Internal notification disabled for user ${targetUserId}, subtype ${subtypeId}`);
+      if (!notification) {
         return null;
       }
-
-      // Resolve the configured priority (user ?? tenant ?? subtype default ?? 'normal').
-      // Governed centrally by configuration — the caller cannot supply a priority.
-      const priority = await resolveNotificationPriority(trx, targetTenant, targetUserId, subtypeId);
-
-      // Render template with data
-      const title = renderTemplate(template.title, request.data);
-      const message = renderTemplate(template.message, request.data);
-
-      // Insert notification
-      const [notification] = await tenantDb(trx, targetTenant).table<any>('internal_notifications')
-        .insert({
-          tenant: targetTenant,
-          user_id: targetUserId,
-          template_name: request.template_name,
-          language_code: userLocale,
-          title,
-          message,
-          type: request.type || 'info',
-          priority,
-          category: request.category || null,
-          link: request.link || null,
-          metadata: request.metadata ? JSON.stringify(request.metadata) : null,
-          is_read: false,
-          delivery_status: 'pending',
-          delivery_attempts: 0
-        })
-        .returning('*') as InternalNotification[];
 
       const createdAt = normalizeDateTime(notification?.created_at);
 
@@ -409,81 +234,9 @@ export const createNotificationFromTemplateAction = withAuth(async (
 });
 
 /**
- * Internal helper to check if internal notifications are enabled (used within transaction)
- */
-async function checkInternalNotificationEnabled(
-  trx: Knex.Transaction,
-  tenant: string,
-  userId: string,
-  subtypeId: number
-): Promise<boolean> {
-  // 1. Get subtype info
-  const subtype = await tenantScopedTable(trx, 'internal_notification_subtypes', tenant)
-    .where({ internal_notification_subtype_id: subtypeId })
-    .first();
-
-  if (!subtype) {
-    return false;
-  }
-
-  // 2. Check tenant-specific subtype setting (replaces global check)
-  const subtypeSetting = await tenantScopedTable(trx, 'tenant_internal_notification_subtype_settings', tenant)
-    .where({ subtype_id: subtypeId })
-    .first();
-
-  const isSubtypeEnabled = subtypeSetting?.is_enabled ?? true;
-  if (!isSubtypeEnabled) {
-    return false;
-  }
-
-  // 3. Verify category exists
-  const category = await tenantScopedTable(trx, 'internal_notification_categories', tenant)
-    .where({ internal_notification_category_id: subtype.internal_category_id })
-    .first();
-
-  if (!category) {
-    return false; // Category not found - don't send notification
-  }
-
-  // 4. Check tenant-specific category setting (replaces global check)
-  const categorySetting = await tenantScopedTable(trx, 'tenant_internal_notification_category_settings', tenant)
-    .where({ category_id: subtype.internal_category_id })
-    .first();
-
-  const isCategoryEnabled = categorySetting?.is_enabled ?? true;
-  if (!isCategoryEnabled) {
-    return false;
-  }
-
-  // 5. Check user-specific preferences (EXISTING - unchanged)
-  const userSubtypePreference = await tenantScopedTable(trx, 'user_internal_notification_preferences', tenant)
-    .where({ user_id: userId, subtype_id: subtypeId })
-    .first();
-
-  if (userSubtypePreference) {
-    return userSubtypePreference.is_enabled;
-  }
-
-  // 6. Check user category preference (EXISTING - unchanged)
-  const userCategoryPreference = await tenantScopedTable(trx, 'user_internal_notification_preferences', tenant)
-    .where({ user_id: userId, category_id: subtype.internal_category_id })
-    .whereNull('subtype_id')
-    .first();
-
-  if (userCategoryPreference) {
-    return userCategoryPreference.is_enabled;
-  }
-
-  // 7. Fall back to tenant's default
-  return subtypeSetting?.is_default_enabled ?? true;
-}
-
-/**
  * Resolve the effective priority for a notification about to be created.
- *
- * Runs inside the creation transaction, alongside the enablement lookup, so
- * call sites cannot influence the stamped priority — it is governed centrally
- * by configuration only. Per-user priority is meaningful on subtype-level rows.
+ * Delegates to createNotificationCore; kept exported here (async, per
+ * "use server" rules) for existing callers.
  */
 export async function resolveNotificationPriority(
   trx: Knex.Transaction,
@@ -491,21 +244,7 @@ export async function resolveNotificationPriority(
   userId: string,
   subtypeId: number
 ): Promise<InternalNotificationPriority> {
-  const userPreference = await tenantScopedTable(trx, 'user_internal_notification_preferences', tenant)
-    .where({ user_id: userId, subtype_id: subtypeId })
-    .first();
-  const tenantSetting = await tenantScopedTable(trx, 'tenant_internal_notification_subtype_settings', tenant)
-    .where({ subtype_id: subtypeId })
-    .first();
-  const subtype = await tenantScopedTable(trx, 'internal_notification_subtypes', tenant)
-    .where({ internal_notification_subtype_id: subtypeId })
-    .first();
-
-  return pickNotificationPriority(
-    userPreference?.priority,
-    tenantSetting?.priority,
-    subtype?.default_priority
-  );
+  return resolveNotificationPriorityCore(trx, tenant, userId, subtypeId);
 }
 
 /**

--- a/packages/notifications/src/actions/internal-notification-actions/internalNotificationActionsTenantScoped.contract.test.ts
+++ b/packages/notifications/src/actions/internal-notification-actions/internalNotificationActionsTenantScoped.contract.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
-const source = readFileSync(resolve(__dirname, 'internalNotificationActions.ts'), 'utf8');
+const source = [
+  'internalNotificationActions.ts',
+  'createNotificationCore.ts',
+].map((fileName) => readFileSync(resolve(__dirname, fileName), 'utf8')).join('\n');
 
 describe('internal notification actions tenant-scoped query contract', () => {
   it('uses structural tenant scoping for tenant-owned internal notification roots', () => {

--- a/server/src/services/calendar/providers/MicrosoftCalendarAdapter.ts
+++ b/server/src/services/calendar/providers/MicrosoftCalendarAdapter.ts
@@ -584,15 +584,23 @@ export class MicrosoftCalendarAdapter extends BaseCalendarAdapter {
     await this.ensureValidToken();
 
     const changes: Array<{ id: string; changeType: 'updated' | 'deleted' }> = [];
-    const initialUrl = deltaLink ?? `${this.getCalendarBasePath()}/events/delta`;
-    let requestUrl: string | undefined = initialUrl;
+    // Real Graph has no /events/delta — event change tracking is served by
+    // calendarView/delta over an explicit date window, and it returns expanded
+    // occurrences rather than series masters. The window below bounds only the
+    // initial round; every later round replays the stored @odata.deltaLink,
+    // which carries the window inside its token.
+    const DELTA_WINDOW_PAST_MS = 90 * 24 * 60 * 60 * 1000;
+    const DELTA_WINDOW_FUTURE_MS = 365 * 24 * 60 * 60 * 1000;
+    const initialUrl =
+      `${this.getCalendarBasePath()}/calendarView/delta` +
+      `?startDateTime=${encodeURIComponent(new Date(Date.now() - DELTA_WINDOW_PAST_MS).toISOString())}` +
+      `&endDateTime=${encodeURIComponent(new Date(Date.now() + DELTA_WINDOW_FUTURE_MS).toISOString())}`;
+    let requestUrl: string | undefined = deltaLink ?? initialUrl;
     let nextDeltaLink: string | undefined;
 
     try {
       while (requestUrl) {
-        const response: any = await this.httpClient.get(requestUrl, {
-          headers: deltaLink ? {} : { Prefer: 'odata.track-changes' }
-        });
+        const response: any = await this.httpClient.get(requestUrl);
 
         const items = response.data?.value || [];
         for (const item of items) {

--- a/server/src/test/unit/components/ExperimentalFeaturesSettings.test.tsx
+++ b/server/src/test/unit/components/ExperimentalFeaturesSettings.test.tsx
@@ -279,14 +279,15 @@ describe('ExperimentalFeaturesSettings', () => {
       </UIStateProvider>
     );
 
-    await waitFor(() => {
+    const toggle = await waitFor(() => {
       expect(getExperimentalFeatures).toHaveBeenCalledTimes(1);
+      const el = document.querySelector(
+        '[data-automation-id="experimental-feature-toggle-aiAssistant"]'
+      );
+      expect(el).toBeTruthy();
+      return el;
     });
 
-    const toggle = document.querySelector(
-      '[data-automation-id="experimental-feature-toggle-aiAssistant"]'
-    );
-    expect(toggle).toBeTruthy();
     expect(screen.queryByText('Workflow Automation')).not.toBeInTheDocument();
     expect(screen.getAllByRole('switch')).toHaveLength(1);
   });

--- a/server/src/test/unit/temporal/entraWorkflowActivityContracts.test.ts
+++ b/server/src/test/unit/temporal/entraWorkflowActivityContracts.test.ts
@@ -155,7 +155,10 @@ describe('Entra Temporal workflow/activity contracts', () => {
 
     expect(allTenantsWorkflow).toContain('catch (error: unknown)');
     expect(allTenantsWorkflow).toContain("status: 'failed'");
-    expect(allTenantsWorkflow).toContain("errorMessage: error instanceof Error ? error.message : 'Tenant sync failed.'");
+    // The activity error's cause chain carries the operator-facing message;
+    // storing the ActivityFailure wrapper's message put the literal string
+    // "Activity task failed" into run history.
+    expect(allTenantsWorkflow).toContain("errorMessage: activityFailureMessage(error, 'Tenant sync failed.')");
     expect(allTenantsWorkflow).toContain("summary.succeededTenants > 0");
     expect(allTenantsWorkflow).toContain("? 'partial'");
     expect(allTenantsWorkflow).toContain(": 'failed'");

--- a/test-harness/graph-emulator/entra.mjs
+++ b/test-harness/graph-emulator/entra.mjs
@@ -19,6 +19,7 @@ export const entraState = {
   organization: null,
   tenants: new Map(),
   users: new Map(),
+  groups: new Map(),
   /** When set, CIPP requests must present this key; when null, any key passes. */
   cippApiKey: null,
 };
@@ -27,6 +28,7 @@ export function resetEntra() {
   entraState.organization = null;
   entraState.tenants.clear();
   entraState.users.clear();
+  entraState.groups.clear();
   entraState.cippApiKey = null;
 }
 
@@ -70,8 +72,36 @@ export function upsertUser(input) {
   return user;
 }
 
+export function upsertGroup(input) {
+  const group = {
+    id: String(input.id || randomUUID()),
+    tenantId: String(input.tenantId || ''),
+    displayName: input.displayName ?? null,
+    securityEnabled: input.securityEnabled === undefined ? true : Boolean(input.securityEnabled),
+    memberIds: new Set(Array.isArray(input.memberIds) ? input.memberIds.map(String) : []),
+  };
+  if (!group.tenantId) {
+    throw new Error('a group needs a tenantId');
+  }
+  entraState.groups.set(group.id, group);
+  return group;
+}
+
 function usersForTenant(tenantId) {
   return [...entraState.users.values()].filter((user) => user.tenantId === tenantId);
+}
+
+function groupsForTenant(tenantId) {
+  return [...entraState.groups.values()].filter((group) => group.tenantId === tenantId);
+}
+
+/** A group as Graph returns it: membership stays behind checkMemberGroups. */
+function toGraphGroup(group) {
+  return {
+    id: group.id,
+    displayName: group.displayName,
+    securityEnabled: group.securityEnabled,
+  };
 }
 
 function tenantWithCounts(tenant) {
@@ -146,6 +176,26 @@ export function seedMspPreset() {
   upsertUser({ tenantId: entraState.organization.id, displayName: 'Sam Delgado', givenName: 'Sam', surname: 'Delgado', mail: 'sam@delgado-it.com', jobTitle: 'Owner' });
   upsertUser({ tenantId: entraState.organization.id, displayName: 'Rae Mbeki', givenName: 'Rae', surname: 'Mbeki', mail: 'rae@delgado-it.com', jobTitle: 'Service Desk' });
 
+  // Security groups, so group-scoped sync is exercisable: one security group
+  // covering part of Contoso, and a non-security (distribution) group that
+  // /groups consumers must filter out.
+  const contosoId = '22222222-2222-4222-8222-222222222222';
+  const contosoByMail = new Map(usersForTenant(contosoId).map((user) => [user.mail, user.id]));
+  upsertGroup({
+    id: '55555555-5555-4555-8555-555555555555',
+    tenantId: contosoId,
+    displayName: 'Contoso Synced Staff',
+    securityEnabled: true,
+    memberIds: [contosoByMail.get('ada.lovelace@contoso.com'), contosoByMail.get('grace.hopper@contoso.com')].filter(Boolean),
+  });
+  upsertGroup({
+    id: '66666666-6666-4666-8666-666666666666',
+    tenantId: contosoId,
+    displayName: 'Contoso Announcements',
+    securityEnabled: false,
+    memberIds: [...contosoByMail.values()],
+  });
+
   return summarizeEntra();
 }
 
@@ -154,14 +204,9 @@ export function summarizeEntra() {
     organization: entraState.organization,
     tenants: [...entraState.tenants.values()].map(tenantWithCounts),
     userCount: entraState.users.size,
+    groupCount: entraState.groups.size,
     cippApiKeyPinned: Boolean(entraState.cippApiKey),
   };
-}
-
-/** `$filter=tenantId eq 'x'` is the only filter the adapter sends. */
-function tenantIdFromFilter(filter) {
-  const match = /tenantId\s+eq\s+'([^']*)'/i.exec(filter || '');
-  return match ? decodeURIComponent(match[1]) : null;
 }
 
 /**
@@ -184,10 +229,24 @@ function pagedResponse(rows, url, top) {
 }
 
 /**
- * Graph endpoints the Entra integration reads. Returns true when handled, so
- * the caller can fall through to the mail surface.
+ * The directory a token reads: a token minted against a managed (customer)
+ * tenant's authority reads that tenant, the same way real Microsoft scopes a
+ * token to the authority it was requested from. Anything else ('common',
+ * 'organizations', or the partner's own tenant id) reads the partner org.
  */
-export function handleEntraGraph(req, res, graphPath, url, json) {
+function directoryScope(access) {
+  const authority = String(access?.authorityTenant || 'common');
+  const managedTenant = entraState.tenants.get(authority);
+  if (managedTenant) return managedTenant.tenantId;
+  return entraState.organization ? entraState.organization.id : null;
+}
+
+/**
+ * Graph endpoints the Entra integration reads. Returns true when handled, so
+ * the caller can fall through to the mail surface. `access` is the validated
+ * token record; `readBody` parses a request body for the POST routes.
+ */
+export async function handleEntraGraph(req, res, graphPath, url, json, access = null, readBody = null) {
   const top = Number(url.searchParams.get('$top') || 0);
 
   if (req.method === 'GET' && graphPath === '/tenantRelationships/managedTenants/tenants') {
@@ -196,10 +255,17 @@ export function handleEntraGraph(req, res, graphPath, url, json) {
     return true;
   }
 
-  if (req.method === 'GET' && graphPath === '/tenantRelationships/managedTenants/users') {
-    const tenantId = tenantIdFromFilter(url.searchParams.get('$filter'));
-    const rows = tenantId ? usersForTenant(tenantId) : [...entraState.users.values()];
-    json(res, 200, pagedResponse(rows, url, top));
+  // Faithful to real Graph: the Lighthouse managedTenant resource has no
+  // `users` relationship. This emulator once invented one, production code was
+  // e2e-tested against it, and every real-world sync then failed on this exact
+  // 400. Keep answering the way Microsoft does so that cannot happen again.
+  if (graphPath.startsWith('/tenantRelationships/managedTenants/users')) {
+    json(res, 400, {
+      error: {
+        code: 'BadRequest',
+        message: "Resource not found for the segment 'users'.",
+      },
+    });
     return true;
   }
 
@@ -209,10 +275,36 @@ export function handleEntraGraph(req, res, graphPath, url, json) {
   }
 
   if (req.method === 'GET' && graphPath === '/users') {
-    const rows = entraState.organization
-      ? usersForTenant(entraState.organization.id)
-      : [...entraState.users.values()];
+    const scope = directoryScope(access);
+    const rows = scope ? usersForTenant(scope) : [...entraState.users.values()];
+    // Real /users rows carry no tenantId property — that was part of the
+    // invented managedTenants shape. Strip it so nothing can depend on it.
+    json(res, 200, pagedResponse(rows.map(({ tenantId, ...user }) => user), url, top));
+    return true;
+  }
+
+  if (req.method === 'GET' && graphPath === '/groups') {
+    const scope = directoryScope(access);
+    const rows = (scope ? groupsForTenant(scope) : [...entraState.groups.values()]).map(toGraphGroup);
     json(res, 200, pagedResponse(rows, url, top));
+    return true;
+  }
+
+  const checkMemberGroups = req.method === 'POST' && /^\/users\/([^/]+)\/checkMemberGroups$/.exec(graphPath);
+  if (checkMemberGroups && readBody) {
+    const userId = decodeURIComponent(checkMemberGroups[1]);
+    const scope = directoryScope(access);
+    const input = await readBody(req);
+    const groupIds = Array.isArray(input.groupIds) ? input.groupIds.map(String) : [];
+    const value = groupIds.filter((groupId) => {
+      const group = entraState.groups.get(groupId);
+      return Boolean(
+        group
+        && (!scope || group.tenantId === scope)
+        && group.memberIds.has(userId)
+      );
+    });
+    json(res, 200, { value });
     return true;
   }
 
@@ -238,25 +330,36 @@ export function handleCippApi(req, res, url, json) {
     return true;
   }
 
+  // Faithful to CIPP-API: a tenant is identified by `customerId` (no
+  // `tenantId`, no `userCount` — inventing those once masked a production bug
+  // that read only fields real CIPP never returns).
   if (req.method === 'GET' && url.pathname === '/api/listtenants') {
-    json(res, 200, [...entraState.tenants.values()].map((tenant) => {
-      const withCounts = tenantWithCounts(tenant);
-      return {
-        customerId: withCounts.tenantId,
-        tenantId: withCounts.tenantId,
-        displayName: withCounts.displayName,
-        defaultDomainName: withCounts.defaultDomainName,
-        userCount: withCounts.userCount,
-      };
-    }));
+    json(res, 200, [...entraState.tenants.values()].map((tenant) => ({
+      customerId: tenant.tenantId,
+      displayName: tenant.displayName,
+      defaultDomainName: tenant.defaultDomainName,
+    })));
     return true;
   }
 
+  // Faithful to CIPP-API source (`$Request.Query.tenantFilter`): tenant
+  // scoping is `tenantFilter` (a customerId GUID or default domain), and it
+  // is required. Accepting `tenantId` here once masked production sending a
+  // parameter real CIPP ignores.
+  const requireTenantFilter = () => {
+    const tenantFilter = url.searchParams.get('tenantFilter');
+    if (!tenantFilter) {
+      json(res, 400, { error: 'BadRequest', message: 'tenantFilter is required.' });
+      return null;
+    }
+    return String(tenantFilter);
+  };
+
   if (req.method === 'GET' && url.pathname === '/api/listusers') {
-    const tenantId = url.searchParams.get('tenantId') || url.searchParams.get('TenantFilter');
-    json(res, 200, usersForTenant(String(tenantId || '')).map((user) => ({
+    const tenantFilter = requireTenantFilter();
+    if (tenantFilter === null) return true;
+    json(res, 200, usersForTenant(tenantFilter).map((user) => ({
       id: user.id,
-      tenantId: user.tenantId,
       displayName: user.displayName,
       givenName: user.givenName,
       surname: user.surname,
@@ -267,6 +370,31 @@ export function handleCippApi(req, res, url, json) {
       mobilePhone: user.mobilePhone,
       businessPhones: user.businessPhones,
     })));
+    return true;
+  }
+
+  if (req.method === 'GET' && url.pathname === '/api/listgroups') {
+    const tenantFilter = requireTenantFilter();
+    if (tenantFilter === null) return true;
+    json(res, 200, groupsForTenant(tenantFilter).map(toGraphGroup));
+    return true;
+  }
+
+  if (req.method === 'GET' && url.pathname === '/api/listusergroups') {
+    const tenantFilter = requireTenantFilter();
+    if (tenantFilter === null) return true;
+    const userId = String(url.searchParams.get('userId') || '');
+    // Faithful to Invoke-ListUserGroups.ps1's projection: lowercase `id`,
+    // PascalCase display fields — consumers must not expect Graph's
+    // `displayName`/`securityEnabled` here.
+    json(res, 200, groupsForTenant(tenantFilter)
+      .filter((group) => group.memberIds.has(userId))
+      .map((group) => ({
+        id: group.id,
+        DisplayName: group.displayName,
+        SecurityGroup: group.securityEnabled,
+        calculatedGroupType: group.securityEnabled ? 'generic' : 'distributionList',
+      })));
     return true;
   }
 
@@ -318,6 +446,13 @@ export async function handleEntraControl(req, res, url, readBody, json) {
   if (req.method === 'POST' && url.pathname === '/__control/entra/users') {
     const input = await readBody(req);
     json(res, 201, upsertUser(input));
+    return true;
+  }
+
+  if (req.method === 'POST' && url.pathname === '/__control/entra/groups') {
+    const input = await readBody(req);
+    const group = upsertGroup(input);
+    json(res, 201, { ...toGraphGroup(group), tenantId: group.tenantId, memberIds: [...group.memberIds] });
     return true;
   }
 

--- a/test-harness/graph-emulator/entra.smoke.test.mjs
+++ b/test-harness/graph-emulator/entra.smoke.test.mjs
@@ -7,6 +7,28 @@ const base = `http://127.0.0.1:${emulatorPort}`;
 const CONTOSO = '22222222-2222-4222-8222-222222222222';
 let emulator;
 let accessToken;
+let refreshToken;
+
+/**
+ * The GDAP read pattern the direct adapter uses: redeem the partner's refresh
+ * token against a CUSTOMER tenant's authority, and read that tenant's
+ * directory with the resulting token.
+ */
+async function tokenForTenant(tenantId) {
+  const response = await fetch(`${base}/${tenantId}/oauth2/v2.0/token`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: 'alga-dev',
+      client_secret: 'alga-dev-secret',
+      refresh_token: refreshToken,
+      grant_type: 'refresh_token',
+    }),
+  });
+  const payload = await response.json();
+  refreshToken = payload.refresh_token || refreshToken;
+  return payload.access_token;
+}
 
 async function waitFor(url) {
   for (let attempt = 0; attempt < 50; attempt += 1) {
@@ -57,8 +79,11 @@ before(async () => {
       grant_type: 'authorization_code',
     }),
   });
-  accessToken = (await tokenResponse.json()).access_token;
+  const tokens = await tokenResponse.json();
+  accessToken = tokens.access_token;
+  refreshToken = tokens.refresh_token;
   assert.ok(accessToken, 'expected an access token from the emulated token endpoint');
+  assert.ok(refreshToken, 'expected a refresh token from the emulated token endpoint');
 });
 
 after(() => {
@@ -98,13 +123,27 @@ test('managedTenants on v1.0 answers 400 like real Graph, so the endpoint-versio
   assert.equal(payload.error.code, 'BadRequest');
 });
 
-test('users come back per tenant, including the disabled account', async () => {
+test('managedTenants has no users segment, exactly like real Graph', async () => {
+  // The endpoint this emulator once invented; production synced against it and
+  // failed 100% of the time against real Microsoft. It must stay a 400.
   const filter = encodeURIComponent(`tenantId eq '${CONTOSO}'`);
   const response = await graph(`/tenantRelationships/managedTenants/users?$filter=${filter}&$top=999`);
+  assert.equal(response.status, 400);
+  const payload = await response.json();
+  assert.equal(payload.error.code, 'BadRequest');
+  assert.match(payload.error.message, /Resource not found for the segment/);
+});
+
+test('a customer-authority token reads that tenant, including the disabled account', async () => {
+  const contosoToken = await tokenForTenant(CONTOSO);
+  const response = await fetch(`${base}/v1.0/users?$top=999`, {
+    headers: { authorization: `Bearer ${contosoToken}` },
+  });
   const users = (await response.json()).value;
 
   assert.equal(users.length, 6);
-  assert.ok(users.every((user) => user.tenantId === CONTOSO));
+  // Real /users rows carry no tenantId — the sync must not rely on one.
+  assert.ok(users.every((user) => user.tenantId === undefined));
 
   const disabled = users.filter((user) => user.accountEnabled === false);
   assert.deepEqual(disabled.map((user) => user.mail), ['charles.babbage@contoso.com']);
@@ -114,13 +153,13 @@ test('users come back per tenant, including the disabled account', async () => {
 });
 
 test('pages with @odata.nextLink so the adapters have to follow it', async () => {
-  const filter = encodeURIComponent(`tenantId eq '${CONTOSO}'`);
-  let url = `${base}/beta/tenantRelationships/managedTenants/users?$filter=${filter}&$top=2`;
+  const contosoToken = await tokenForTenant(CONTOSO);
+  let url = `${base}/v1.0/users?$top=2`;
   const seen = [];
   let pages = 0;
 
   while (url) {
-    const payload = await (await fetch(url, { headers: { authorization: `Bearer ${accessToken}` } })).json();
+    const payload = await (await fetch(url, { headers: { authorization: `Bearer ${contosoToken}` } })).json();
     seen.push(...payload.value.map((user) => user.id));
     url = payload['@odata.nextLink'] || '';
     pages += 1;
@@ -147,17 +186,75 @@ test('self-tenant smoke mode has an organization and its own users', async () =>
 test('CIPP reads the same directory over its own API', async () => {
   const headers = { 'x-api-key': 'cipp-dev-key' };
 
+  // Faithful to real CIPP: a tenant row is identified by customerId only — no
+  // invented tenantId or userCount for production to lean on.
   const tenants = await (await fetch(`${base}/api/listtenants`, { headers })).json();
   assert.equal(tenants.length, 3);
   assert.ok(tenants.every((tenant) => tenant.customerId && tenant.defaultDomainName));
+  assert.ok(tenants.every((tenant) => tenant.tenantId === undefined && tenant.userCount === undefined));
 
-  const users = await (await fetch(`${base}/api/listusers?tenantId=${CONTOSO}`, { headers })).json();
+  const users = await (await fetch(`${base}/api/listusers?tenantFilter=${CONTOSO}`, { headers })).json();
   assert.equal(users.length, 6);
+  assert.ok(users.every((user) => user.tenantId === undefined));
+
+  // Faithful to real CIPP source ($Request.Query.tenantFilter); the tenantId
+  // param production once sent is not a substitute.
+  const wrongParam = await fetch(`${base}/api/listusers?tenantId=${CONTOSO}`, { headers });
+  assert.equal(wrongParam.status, 400);
 
   // An endpoint CIPP deployments may not have: the adapter falls through to the
   // next candidate on 404 rather than failing the connection.
   const missing = await fetch(`${base}/api/tenant/list`, { headers });
   assert.equal(missing.status, 404);
+});
+
+test('CIPP serves groups and user-group membership over the same directory', async () => {
+  const headers = { 'x-api-key': 'cipp-dev-key' };
+
+  const groups = await (await fetch(`${base}/api/listgroups?tenantFilter=${CONTOSO}`, { headers })).json();
+  assert.equal(groups.length, 2);
+  const securityGroup = groups.find((group) => group.securityEnabled === true);
+  assert.equal(securityGroup.displayName, 'Contoso Synced Staff');
+
+  const users = await (await fetch(`${base}/api/listusers?tenantFilter=${CONTOSO}`, { headers })).json();
+  const ada = users.find((user) => user.mail === 'ada.lovelace@contoso.com');
+  const memberships = await (await fetch(
+    `${base}/api/listusergroups?tenantFilter=${CONTOSO}&userId=${ada.id}`,
+    { headers },
+  )).json();
+  // ListUserGroups rows carry a lowercase id but PascalCase display fields —
+  // exactly the projection Invoke-ListUserGroups.ps1 makes.
+  const membership = memberships.find((group) => group.id === securityGroup.id);
+  assert.ok(membership);
+  assert.equal(membership.SecurityGroup, true);
+  assert.equal(membership.displayName, undefined);
+});
+
+test('a customer-authority token lists groups and checks membership like real Graph', async () => {
+  const contosoToken = await tokenForTenant(CONTOSO);
+  const graphHeaders = { authorization: `Bearer ${contosoToken}` };
+
+  const groups = (await (await fetch(`${base}/v1.0/groups?$select=id,displayName,securityEnabled&$top=200`, {
+    headers: graphHeaders,
+  })).json()).value;
+  assert.equal(groups.length, 2);
+  const securityGroup = groups.find((group) => group.securityEnabled === true);
+  const distributionGroup = groups.find((group) => group.securityEnabled === false);
+  assert.ok(securityGroup && distributionGroup);
+
+  const users = (await (await fetch(`${base}/v1.0/users?$top=999`, { headers: graphHeaders })).json()).value;
+  const ada = users.find((user) => user.mail === 'ada.lovelace@contoso.com');
+  const alan = users.find((user) => user.mail === 'alan.turing@contoso.com');
+
+  const check = async (userId) => (await (await fetch(`${base}/v1.0/users/${userId}/checkMemberGroups`, {
+    method: 'POST',
+    headers: { ...graphHeaders, 'content-type': 'application/json' },
+    body: JSON.stringify({ groupIds: [securityGroup.id, distributionGroup.id, 'not-a-group'] }),
+  })).json()).value;
+
+  // Ada is in both seeded groups; Alan only in the distribution group.
+  assert.deepEqual((await check(ada.id)).sort(), [securityGroup.id, distributionGroup.id].sort());
+  assert.deepEqual(await check(alan.id), [distributionGroup.id]);
 });
 
 test('a pinned CIPP key makes a wrong credential a 401, not a silent success', async () => {
@@ -188,7 +285,9 @@ test('offboarding a user flips accountEnabled for the next sync', async () => {
   });
   assert.deepEqual(await response.json(), { ok: true, changed: 1, accountEnabled: false });
 
-  const filter = encodeURIComponent(`tenantId eq '${CONTOSO}'`);
-  const users = (await (await graph(`/tenantRelationships/managedTenants/users?$filter=${filter}&$top=999`)).json()).value;
+  const contosoToken = await tokenForTenant(CONTOSO);
+  const users = (await (await fetch(`${base}/v1.0/users?$top=999`, {
+    headers: { authorization: `Bearer ${contosoToken}` },
+  })).json()).value;
   assert.equal(users.find((user) => user.mail === 'ada.lovelace@contoso.com').accountEnabled, false);
 });

--- a/test-harness/graph-emulator/server.mjs
+++ b/test-harness/graph-emulator/server.mjs
@@ -62,13 +62,18 @@ function requireAccess(req, res) {
   return record;
 }
 
-function issueTokens(clientId, existingRefreshToken) {
+function issueTokens(clientId, existingRefreshToken, authorityTenant = 'common') {
   const accessToken = `access-${randomUUID()}`;
   const refreshToken = existingRefreshToken && !state.rotateRefreshTokens
     ? existingRefreshToken
     : `refresh-${randomUUID()}`;
   state.accessTokens.set(accessToken, {
     clientId,
+    // Real Microsoft issues tenant-scoped tokens: the authority segment of
+    // login.microsoftonline.com/{tenant}/... decides whose directory /users
+    // answers for. The Entra direct adapter leans on this for GDAP customer
+    // reads, so the emulator must not ignore it.
+    authorityTenant,
     expiresAt: Date.now() + state.accessTokenTtlSeconds * 1000,
   });
   state.refreshTokens.set(refreshToken, { clientId, revoked: false });
@@ -208,6 +213,7 @@ async function handler(req, res) {
   if (req.method === 'POST' && /\/oauth2\/v2\.0\/token$/.test(url.pathname)) {
     const fault = injectedFault('token');
     if (fault) return json(res, fault.status, fault.body);
+    const authorityTenant = (url.pathname.match(/^\/([^/]+)\/oauth2\/v2\.0\/token$/) || [])[1] || 'common';
     const input = await body(req);
     if (state.clients.get(String(input.client_id)) !== String(input.client_secret)) {
       return json(res, 401, { error: 'invalid_client' });
@@ -218,14 +224,14 @@ async function handler(req, res) {
         return json(res, 400, { error: 'invalid_grant' });
       }
       state.codes.delete(String(input.code));
-      return json(res, 200, issueTokens(String(input.client_id)));
+      return json(res, 200, issueTokens(String(input.client_id), undefined, authorityTenant));
     }
     if (input.grant_type === 'refresh_token') {
       const refresh = state.refreshTokens.get(String(input.refresh_token));
       if (!refresh || refresh.revoked || refresh.clientId !== input.client_id) {
         return json(res, 400, { error: 'invalid_grant' });
       }
-      return json(res, 200, issueTokens(String(input.client_id), String(input.refresh_token)));
+      return json(res, 200, issueTokens(String(input.client_id), String(input.refresh_token), authorityTenant));
     }
     return json(res, 400, { error: 'unsupported_grant_type' });
   }
@@ -252,7 +258,7 @@ async function handler(req, res) {
   const fault = injectedFault(`${req.method} ${graphPath}`);
   if (fault) return json(res, fault.status, fault.body);
 
-  if (handleEntraGraph(req, res, graphPath, url, json)) return;
+  if (await handleEntraGraph(req, res, graphPath, url, json, access, body)) return;
 
   if (req.method === 'GET' && (graphPath === '/me' || /^\/users\/[^/]+$/.test(graphPath))) {
     return json(res, 200, { id: 'emulated-user', userPrincipalName: 'support@example.test', mail: 'support@example.test' });


### PR DESCRIPTION
  The Entra direct-connection per-client sync never worked against real
  Microsoft: it was built and e2e-tested against Graph endpoints that exist
  only in our test emulator. Production log analysis (customer report "Sync
  started... then nothing ever happens") plus an endpoint-by-endpoint audit
  of the emulator against Microsoft Graph docs and CIPP-API source uncovered
  one root cause and a chain of masking defects. All are fixed here.

  Entra direct provider (ee/server/.../providers/direct/directProviderAdapter.ts):
  - listUsersForTenant called GET /beta/tenantRelationships/managedTenants/users, which does not exist in Microsoft Graph (the Lighthouse managedTenant resource has no `users` relationship; real Graph answers 400 "Resource not found for the segment"). Rewritten to mint a token against the managed (customer) tenant's authority and page GET /v1.0/users — the same GDAP pattern listSecurityGroupsForTenant already used. New shared managedTenantGraphRequest helper adds 401 -> token-cache-invalidate -> retry-once to all customer-tenant calls.
  - New sanitizeGraphError: raw AxiosErrors no longer escape the adapter. The previous behavior leaked the live Authorization bearer token into worker logs (via Temporal's activity-failure dump) and collapsed Graph's error body to "Request failed with status code 400". Thrown errors now carry HTTP status + Graph error code + message, and nothing else.
  - directScopes.ts comment corrected: Directory.Read.All is what authorizes the per-customer-tenant reads; no new scopes or app-registration changes are required.

  Temporal worker (ee/temporal-workflows):
  - entra-sync-activities.ts: recordSyncTenantResultWithDb's update branch put `tenant` (the Citus distribution column) in the UPDATE SET list, which Citus rejects ("modifying the partition value of rows is not allowed"). Any re-clicked sync (same 5-minute workflow-id bucket -> reused run_id -> pre-existing run-tenant row -> update path) therefore failed to record its result and stayed at status 'running' forever — the "nothing ever happens" the customer saw. The update payload now excludes tenant/run_id/ managed_tenant_id.
  - entra-tenant-sync-workflow.ts / entra-all-tenants-sync-workflow.ts: the catch blocks stored the ActivityFailure wrapper's message, so run history showed the literal string "Activity task failed". New activity-failure-message.ts walks the cause chain and stores the deepest operator-facing message instead.
  - The worker's @alga-psa/notifications path mapping resolved to a throwing stub at runtime (tsc-alias bakes the alias into dist), silently dropping every notification worker activities tried to deliver — Entra repeated- failure alerts and SLA escalation notifications alike. The transactional creation logic (locale -> template -> enablement -> priority -> render -> insert) is extracted into dependency-light packages/notifications/.../createNotificationCore.ts (no next-auth, no realtime stack); the server actions delegate to it unchanged, and the worker stub now performs real inserts through it. Worker-created notifications appear on the next poll (no realtime broadcast/push hooks from the worker, by design).

  Calendar (all three MicrosoftCalendarAdapter copies: packages/integrations,
  server/src/services, ee/packages/calendar):
  - fetchDeltaChanges called GET {calendar}/events/delta, which also does not exist in Graph. Incremental sync now starts with GET {calendar}/calendarView/delta?startDateTime&endDateTime (-90d/+365d initial window; later rounds replay the stored @odata.deltaLink, which encodes the window). Dropped the inapplicable `Prefer: odata.track-changes` header. Note calendarView/delta yields expanded occurrences rather than series masters; the consumer re-fetches by id, so its contract is unchanged. No deltaLink migration is needed: the old endpoint never succeeded once, so no valid link was ever stored.

  CIPP provider (ee/server/.../providers/cipp/cippProviderAdapter.ts),
  verified line-for-line against KelvinTegelaar/CIPP-API source
  (Invoke-List{Tenants,Users,Groups,UserGroups}.ps1):
  - listManagedTenants now consumes `customerId` — the field real ListTenants identifies tenants by; previously ignored, which would yield zero tenants against a real CIPP instance.
  - Tenant scoping now sent as camelCase `tenantFilter` (customerId GUID or default domain) for listusers/listgroups/listusergroups; the `tenantId` param real CIPP ignores, and the invented REST-alias fallback candidates (/api/tenant/list, /api/tenants/{id}/users, ...), are removed.
  - listSecurityGroupsForTenant now filters on securityEnabled: real ListGroups returns every group type, and the unfiltered result offered distribution lists as sync scopes.

  Graph emulator (test-harness/graph-emulator) — made faithful so tests can
  no longer green-light endpoints Microsoft doesn't serve:
  - /beta/tenantRelationships/managedTenants/users now answers the same 400 real Graph does, permanently.
  - OAuth tokens are authority-scoped: the token endpoint records the {tenant} authority segment, and /users + /groups + checkMemberGroups serve the directory of the tenant the token was minted for — so the GDAP read pattern is actually exercised end to end.
  - /users rows no longer carry the invented tenantId property.
  - New coverage: GET /v1.0/groups and POST /v1.0/users/{id}/checkMemberGroups (seeded security + distribution groups, /__control/entra/groups).
  - CIPP surface matches source: ListTenants rows are customerId/displayName/ defaultDomainName only; tenantFilter is required (400 without it); listgroups/listusergroups added, the latter with CIPP's actual PascalCase projection (DisplayName/SecurityGroup, lowercase id). defaultDomainName only; tenantFilter is required (400 without it); listgroups/listusergroups added, the latter with CIPP's actual PascalCase projection (DisplayName/SecurityGroup, lowercase id).

Tests: emulator smoke suite grown to 13 (pins the 400, authority scoping, group membership, CIPP shapes); directProviderAdapter.normalization pins the /v1.0/users + customer-token contract; cippProviderAdapter.normalization pins customerId consumption, tenantFilter, and security-group filtering; entraWorkflowActivityContracts T090 updated for activityFailureMessage. Worker tsc, packages/integrations tsc, ee/packages/calendar tsc, and packages/notifications tsc are clean. Deploy note: the adapters compile into both the server (sebastian) and temporal-worker images — both need rebuilds.

"Why," said the Cheshire Cat, fading until nothing was left but its 400, "you've been syncing down a rabbit hole that was never there at all — the managedTenants garden has no /users door. Take the tenantFilter path through the looking-glass authority instead, and do stop stuffing the tenant column into UPDATE SET; the Queen of Citus shouts 'off with the partition!' every single time." 🐇🗝️📇