### PR TITLE
fix(appliance): preserve large kubectl JSON responses

### DIFF
--- a/ee/appliance/host-service/kubectl-queue.mjs
+++ b/ee/appliance/host-service/kubectl-queue.mjs
@@ -1,7 +1,10 @@
 import { spawn } from 'node:child_process';
 
 const DEFAULT_TIMEOUT_MS = 30_000;
-const MAX_OUTPUT_BYTES = 256 * 1024;
+// `kubectl get ... -o json` includes annotations and status for every object.
+// A modest appliance can exceed 256 KiB with its normal pod list, so retain
+// enough output for API consumers to parse structured Kubernetes responses.
+const MAX_OUTPUT_BYTES = 4 * 1024 * 1024;
 
 function truncateOutput(value) {
   const text = value || '';

--- a/ee/appliance/host-service/tests/kubectl-queue.test.mjs
+++ b/ee/appliance/host-service/tests/kubectl-queue.test.mjs
@@ -44,3 +44,13 @@ test('SerialCommandQueue passes provided stdin to the command', async () => {
   assert.equal(result.stdout, 'secret-value');
   assert.equal(result.command.includes('secret-value'), false);
 });
+
+test('SerialCommandQueue preserves large JSON responses for Kubernetes API consumers', async () => {
+  const queue = createKubectlQueue({ name: 'test-large-json' });
+  const result = await queue.enqueue(
+    "node -e \"process.stdout.write(JSON.stringify({items:[{metadata:{annotations:{payload:'x'.repeat(300 * 1024)}}}]}))\""
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(JSON.parse(result.stdout).items[0].metadata.annotations.payload.length, 300 * 1024);
+});


### PR DESCRIPTION
Raises the appliance control-plane kubectl output cap from 256 KiB to 4 MiB so pod-list JSON is not truncated before parsing. Includes runtime coverage for a response larger than the former cap.