### PR TITLE
Alga Migration Package (AMP)

### DIFF
--- a/server/src/test/integration/ampMigrationPipeline.integration.test.ts
+++ b/server/src/test/integration/ampMigrationPipeline.integration.test.ts
@@ -6,6 +6,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { tenantDb } from '@alga-psa/db';
+import { convertSpreadsheets, inferSpreadsheetMapping } from '@alga-psa/migration-connectors/csv';
 import { buildSamplePackage, sampleEntityRows } from '@alga-psa/migration-sdk';
 import type { AmpPackageRows } from '@alga-psa/migration-spec';
 import { createTestDbConnection, wireLocalTestDbEnv } from '../../../test-utils/dbConfig';
@@ -459,6 +460,38 @@ describe('AMP migration pipeline integration', () => {
     const packagePath = buildPackage('empty-package', {});
     expect(MigrationStager.hasImportableRecords(packagePath)).toBe(false);
   });
+
+  it('stages a legacy asset CSV after conversion through the upload guard', async () => {
+    const fixture = await createFixture();
+    const inputPath = path.join(packageDir, `legacy-assets-${uuidv4()}.csv`);
+    const packagePath = path.join(packageDir, `legacy-assets-${uuidv4()}.amp`);
+    await fs.promises.writeFile(
+      inputPath,
+      'Asset Name,Asset Type,Serial Number,MAC Address\nrouter,network_device,R-1,00:11:22:33:44:55\n'
+    );
+
+    const mapping = await inferSpreadsheetMapping(inputPath, 'assets');
+    const conversion = await convertSpreadsheets({
+      outputPath: packagePath,
+      namespace: `csv:${fixture.tenantId}`,
+      sourceSystem: 'csv-upload',
+      files: [{ entityType: 'assets', path: inputPath, mapping }],
+    }, packageDir);
+
+    expect(conversion.rowCounts).toEqual({ assets: 1 });
+    expect(MigrationStager.hasImportableRecords(packagePath)).toBe(true);
+
+    const migrationJobId = await createJob(fixture);
+    const staging = await new MigrationStager(db, fixture.tenantId).stage(migrationJobId, packagePath);
+    expect(staging.rejected).toBe(false);
+    expect(staging.stagedCounts).toMatchObject({ assets: 1 });
+    expect(await stagedCountsByEntity(fixture.tenantId, migrationJobId)).toEqual({ assets: 1 });
+
+    const job = await tenantTable(fixture.tenantId, 'migration_jobs')
+      .where({ migration_job_id: migrationJobId })
+      .first();
+    expect(job.state).toBe('needs_configuration');
+  }, HOOK_TIMEOUT);
 
   it('re-running the same job creates no duplicates', async () => {
     const fixture = await createFixture();


### PR DESCRIPTION
## Summary

- Adds a database-backed regression test for the legacy asset CSV conversion → importable-record guard → AMP staging path.
- The test protects the valid one-asset legacy CSV flow while retaining the zero-record rejection behavior.

## Smoke test

**PASS** on HEAD `7433ced3b5` using a freshly started server from this worktree on port 3114 with real Postgres, Redis, storage, Next.js UI, API routes, and staging pipeline.

- Valid legacy asset CSV upload through the UI immediately opened Configure, created job `daaec60e-a745-4a2f-8ac8-bf387c6711af` in `needs_configuration`, and staged exactly one `assets` record.
- Browser Back returned to the migration workspace.
- A direct deep link to the new job rendered Configure successfully.
- An existing native Alga export AMP rendered the configuration workspace; database evidence confirmed staged organizations, locations, contacts, tickets, ticket comments, and assets.
- Headers-only CSV showed the localized “This package contained no importable records.” error. `migration_jobs`/`external_files` remained unchanged at `34`/`99`.

## Fidelity notes

- The native sign-in button again emitted no credentials callback, so authentication was completed through the browser’s NextAuth endpoints. The temporary dev-user password reset was restored afterward.
- alga-dev has no file-picker attachment command, so browser `File`/`DataTransfer` injection selected the CSV; submission, client fetch construction, API handling, storage, conversion, staging, navigation, and rendering were real product code.
- The six-entity native AMP assertion used a previously uploaded live Alga export rather than creating another duplicate upload.

No simulator or mock was used. No release-blocking defect was found. Worktree remains clean.

Evidence: `/tmp/alga-smoke-evidence/alga-migration-package-amp-20260826T153852Z`