### PR TITLE
fix(appliance): preserve Temporal connection binding

### DIFF
--- a/ee/appliance/host-service/tests/appliance-license-workflow.test.mjs
+++ b/ee/appliance/host-service/tests/appliance-license-workflow.test.mjs
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { connectToTemporal } from '../../../../server/scripts/appliance-license-workflow.mjs';
+
+test('connectToTemporal preserves the Temporal Connection static receiver', async () => {
+  const options = { address: 'temporal.example.test:7233' };
+  const connection = {
+    ensureConnected: async () => {},
+  };
+
+  class FakeConnection {
+    static lazy(receivedOptions) {
+      assert.equal(this, FakeConnection);
+      assert.deepEqual(receivedOptions, options);
+      return connection;
+    }
+
+    static async connect(receivedOptions) {
+      const created = this.lazy(receivedOptions);
+      await created.ensureConnected();
+      return created;
+    }
+  }
+
+  assert.equal(await connectToTemporal(options, FakeConnection), connection);
+});

--- a/server/scripts/appliance-license-workflow.mjs
+++ b/server/scripts/appliance-license-workflow.mjs
@@ -1,7 +1,11 @@
 import crypto from 'node:crypto';
 import { Client, Connection } from '@temporalio/client';
 
-export async function runLicenseWorkflow({ workflowType, input, connect = Connection.connect }) {
+export function connectToTemporal(options, ConnectionClass = Connection) {
+  return ConnectionClass.connect(options);
+}
+
+export async function runLicenseWorkflow({ workflowType, input, connect = connectToTemporal }) {
   const connection = await connect({ address: process.env.TEMPORAL_ADDRESS || 'temporal-frontend.msp.svc.cluster.local:7233' });
   try {
     const client = new Client({ connection, namespace: process.env.TEMPORAL_NAMESPACE || 'default' });

--- a/server/scripts/appliance-license-workflow.mjs
+++ b/server/scripts/appliance-license-workflow.mjs
@@ -2,6 +2,7 @@ import crypto from 'node:crypto';
 import { Client, Connection } from '@temporalio/client';
 
 export function connectToTemporal(options, ConnectionClass = Connection) {
+  // Temporal's static connect() calls this.lazy(), so it must retain its class receiver.
   return ConnectionClass.connect(options);
 }
 


### PR DESCRIPTION
## Summary
- preserve the Temporal `Connection` class as the receiver of its static `connect` method
- prevent Appliance Console license redemption and application from failing before workflow submission
- add a behavioral regression test that exercises the SDK-style `connect -> this.lazy` call chain

## Verification
- `node --test ee/appliance/host-service/tests/appliance-license-workflow.test.mjs ee/appliance/host-service/tests/manage-engine.test.mjs` (20/20 passed)
- `node --check server/scripts/appliance-license-workflow.mjs`
- `node --check ee/appliance/host-service/tests/appliance-license-workflow.test.mjs`
- `git diff --check`