### PR TITLE
 Authenticate portal Git via GitHub App

### DIFF
--- a/ee/temporal-workflows/src/activities/__tests__/portal-domain-activities.git.test.ts
+++ b/ee/temporal-workflows/src/activities/__tests__/portal-domain-activities.git.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { generateKeyPairSync } from 'node:crypto';
 import os from 'os';
 import path from 'path';
 import { mkdtemp, rm } from 'node:fs/promises';
@@ -160,6 +161,7 @@ describe('portal domain git integration helpers', () => {
   afterEach(async () => {
     __setCommandRunnerForTests(null);
     __setConnectionFactoryForTests(null);
+    vi.unstubAllGlobals();
     process.env = { ...originalEnv };
     await rm(tmpDir, { recursive: true, force: true });
   });
@@ -169,12 +171,60 @@ describe('portal domain git integration helpers', () => {
     process.env.PORTAL_DOMAIN_GIT_REPO = 'https://example.com/mock/nm-mock-config.git';
     process.env.PORTAL_DOMAIN_GIT_WORKDIR = tmpDir;
 
-    const config = resolveGitConfiguration();
+    const config = await resolveGitConfiguration();
     await prepareGitRepository(config);
 
     expect(commands.map((entry) => entry.command)).toEqual(['git', 'git', 'git', 'git', 'git']);
     expect(commands[0]).toMatchObject({ command: 'git', args: ['clone', config.authenticatedRepoUrl, config.repoDir] });
     expect(commands[commands.length - 1]).toMatchObject({ command: 'git', args: ['pull', 'origin', config.branch], cwd: config.repoDir });
+  });
+
+  it('uses a GitHub App installation token for authenticated git operations', async () => {
+    const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const privateKeyPath = path.join(tmpDir, 'github-app-private-key.pem');
+    await fs.writeFile(
+      privateKeyPath,
+      privateKey.export({ type: 'pkcs8', format: 'pem' }),
+      'utf8',
+    );
+
+    delete process.env.GITHUB_ACCESS_TOKEN;
+    process.env.GITHUB_APP_ID = '2787854';
+    process.env.GITHUB_APP_INSTALLATION_ID = '107758512';
+    process.env.GITHUB_APP_PRIVATE_KEY_PATH = privateKeyPath;
+    process.env.PORTAL_DOMAIN_GIT_REPO = 'https://github.com/Nine-Minds/nm-kube-config.git';
+    process.env.PORTAL_DOMAIN_GIT_WORKDIR = tmpDir;
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        token: 'installation-token',
+        expires_at: '2099-01-01T00:00:00Z',
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const config = await resolveGitConfiguration();
+    const authenticatedUrl = new URL(config.authenticatedRepoUrl);
+
+    expect(authenticatedUrl.username).toBe('x-access-token');
+    expect(authenticatedUrl.password).toBe('installation-token');
+    expect(config.maskValues).toContain('installation-token');
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    const [requestUrl, requestOptions] = fetchMock.mock.calls[0];
+    expect(requestUrl).toBe(
+      'https://api.github.com/app/installations/107758512/access_tokens',
+    );
+    expect(requestOptions).toMatchObject({ method: 'POST' });
+
+    const authorization = requestOptions.headers.Authorization as string;
+    const jwt = authorization.replace(/^Bearer /, '');
+    const jwtPayload = JSON.parse(
+      Buffer.from(jwt.split('.')[1], 'base64url').toString('utf8'),
+    );
+    expect(jwtPayload.iss).toBe('2787854');
   });
 
   it('renders manifest yaml with expected documents', () => {

--- a/ee/temporal-workflows/src/activities/portal-domain-activities.ts
+++ b/ee/temporal-workflows/src/activities/portal-domain-activities.ts
@@ -1,4 +1,5 @@
 import { promises as dns } from "dns";
+import { createSign } from "node:crypto";
 import { promises as fs } from "node:fs";
 import { join as joinPath, dirname } from "node:path";
 import { setTimeout as delay } from "timers/promises";
@@ -338,7 +339,7 @@ export async function applyPortalDomainResources(args: { tenantId: string; porta
 
   let gitConfig: GitConfiguration;
   try {
-    gitConfig = resolveGitConfiguration();
+    gitConfig = await resolveGitConfiguration();
   } catch (error) {
     const message = formatErrorMessage(
       error,
@@ -881,8 +882,13 @@ interface GitConfiguration {
   relativePathSegments: string[];
   authorName: string;
   authorEmail: string;
-  token: string;
   maskValues: string[];
+}
+
+interface GitHubAppCredentials {
+  appId: string;
+  installationId: string;
+  privateKey: string;
 }
 
 interface CommandOptions extends ExecFileOptions {
@@ -890,7 +896,118 @@ interface CommandOptions extends ExecFileOptions {
   suppressOutput?: boolean;
 }
 
-export function resolveGitConfiguration(): GitConfiguration {
+function encodeJwtSegment(value: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
+}
+
+function createGitHubAppJwt(appId: string, privateKey: string): string {
+  const now = Math.floor(Date.now() / 1000);
+  const header = encodeJwtSegment({ alg: "RS256", typ: "JWT" });
+  const payload = encodeJwtSegment({
+    iat: now - 60,
+    exp: now + 9 * 60,
+    iss: appId,
+  });
+  const unsignedToken = `${header}.${payload}`;
+  const signer = createSign("RSA-SHA256");
+  signer.update(unsignedToken);
+  signer.end();
+  const signature = signer.sign(privateKey).toString("base64url");
+  return `${unsignedToken}.${signature}`;
+}
+
+async function resolveGitHubAppCredentials(): Promise<GitHubAppCredentials | null> {
+  const appId = process.env.GITHUB_APP_ID?.trim() ?? "";
+  const installationId =
+    process.env.GITHUB_APP_INSTALLATION_ID?.trim() ?? "";
+  const inlinePrivateKey = process.env.GITHUB_APP_PRIVATE_KEY ?? "";
+  const privateKeyPath = process.env.GITHUB_APP_PRIVATE_KEY_PATH?.trim() ?? "";
+  const appAuthenticationConfigured = Boolean(
+    appId || installationId || inlinePrivateKey || privateKeyPath,
+  );
+
+  if (!appAuthenticationConfigured) {
+    return null;
+  }
+
+  if (!appId || !installationId || (!inlinePrivateKey && !privateKeyPath)) {
+    throw new Error(
+      "GitHub App authentication is incomplete. Configure GITHUB_APP_ID, " +
+        "GITHUB_APP_INSTALLATION_ID, and either GITHUB_APP_PRIVATE_KEY or " +
+        "GITHUB_APP_PRIVATE_KEY_PATH.",
+    );
+  }
+
+  const privateKey = inlinePrivateKey
+    ? inlinePrivateKey.replace(/\\n/g, "\n")
+    : await fs.readFile(privateKeyPath, "utf8");
+
+  return { appId, installationId, privateKey };
+}
+
+async function createGitHubInstallationToken(
+  credentials: GitHubAppCredentials,
+): Promise<string> {
+  const jwt = createGitHubAppJwt(credentials.appId, credentials.privateKey);
+  const response = await fetch(
+    `https://api.github.com/app/installations/${encodeURIComponent(credentials.installationId)}/access_tokens`,
+    {
+      method: "POST",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${jwt}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    payload = null;
+  }
+
+  const token =
+    payload && typeof payload === "object" && "token" in payload
+      ? (payload as { token?: unknown }).token
+      : null;
+
+  if (!response.ok || typeof token !== "string" || token.length === 0) {
+    const apiMessage =
+      payload && typeof payload === "object" && "message" in payload
+        ? (payload as { message?: unknown }).message
+        : null;
+    const detail =
+      typeof apiMessage === "string" && apiMessage.length > 0
+        ? `: ${apiMessage}`
+        : "";
+    throw new Error(
+      `GitHub App installation token request failed with status ${response.status}${detail}`,
+    );
+  }
+
+  return token;
+}
+
+async function resolveGitAccessToken(): Promise<string> {
+  const appCredentials = await resolveGitHubAppCredentials();
+  if (appCredentials) {
+    return createGitHubInstallationToken(appCredentials);
+  }
+
+  const accessToken = process.env.GITHUB_ACCESS_TOKEN?.trim();
+  if (accessToken) {
+    return accessToken;
+  }
+
+  throw new Error(
+    "GitHub credentials are required for portal domain resource application. " +
+      "Configure GitHub App credentials or GITHUB_ACCESS_TOKEN.",
+  );
+}
+
+export async function resolveGitConfiguration(): Promise<GitConfiguration> {
   const repoUrl = process.env.PORTAL_DOMAIN_GIT_REPO;
   const branch = process.env.PORTAL_DOMAIN_GIT_BRANCH || "main";
   const workspaceDir =
@@ -901,19 +1018,16 @@ export function resolveGitConfiguration(): GitConfiguration {
     process.env.PORTAL_DOMAIN_GIT_AUTHOR_NAME || "Portal Domains Bot";
   const authorEmail =
     process.env.PORTAL_DOMAIN_GIT_AUTHOR_EMAIL || "platform@nineminds.ai";
-  const token = process.env.GITHUB_ACCESS_TOKEN;
-
-  if (!token) {
-    throw new Error('GITHUB_ACCESS_TOKEN environment variable is required for portal domain resource application.');
-  }
 
   if (!repoUrl) {
     throw new Error('PORTAL_DOMAIN_GIT_REPO environment variable is required for portal domain resource application.');
   }
 
+  const token = await resolveGitAccessToken();
+
   const url = new URL(repoUrl);
-  url.username = token;
-  url.password = "";
+  url.username = "x-access-token";
+  url.password = token;
 
   const repoDir = joinPath(workspaceDir, "nm-kube-config");
   const relativePathSegments = relativePathPosix.split("/").filter(Boolean);
@@ -928,7 +1042,6 @@ export function resolveGitConfiguration(): GitConfiguration {
     relativePathSegments,
     authorName,
     authorEmail,
-    token,
     maskValues: [token, url.toString()],
   };
 }


### PR DESCRIPTION
  Generate signed app JWTs and exchange them for installation tokens
  before portal-domain Git operations. Preserve access-token fallback,
  validate incomplete credentials, and mask generated secrets.

  Alga taught createGitHubAppJwt to ink signed bubbles while
  resolveGitConfiguration steers the repo submarine. 🐙🔐