### PR TITLE
Automatic invoices: show actionable generation failure reasons

### DIFF
--- a/docs/plans/automatic-invoices-actionable-failures.md
+++ b/docs/plans/automatic-invoices-actionable-failures.md
@@ -1,0 +1,101 @@
+# Plan — Automatic invoices: show actionable generation failure reasons
+
+Card: `7e82acbf-3b9e-4739-bdca-41d08446024b`
+
+## Problem (grounded in code)
+
+A missing billing recipient is already a first-class, coded condition in the engine:
+`validateClientBillingEmail` (`packages/billing/src/services/invoiceService.ts:294`) returns
+`{ valid:false, code:'NO_BILLING_EMAIL', params:{clientName}, error:'...' }`.
+
+But the structure is destroyed before the recurring-run UI sees it:
+
+1. Callers re-wrap it as a plain `new Error(emailValidation.error)`
+   (`invoiceGeneration.ts:1855` preview, `:2656` shared generation) — `code`/`params` dropped.
+2. The boundary mapper `invoiceGenerationActionErrorFrom` (`invoiceGeneration.ts:660`) is a
+   string-matcher; the `"Cannot generate invoice: No billing email address..."` message matches
+   nothing, so it returns `null` and the error is **re-thrown**.
+3. `generateGroupedInvoicesAsRecurringBillingRun` (`recurringBillingRunActions.ts:349`) catches the
+   throw in its generic block (`:434`) and pushes
+   `errorMessage: 'Failed to generate invoice for this billing cycle.'`
+   (`RecurringBillingRunInvoiceFailure`, `recurringBillingRunActions.shared.ts:8` — has no `code`,
+   no `clientId`).
+4. `AutomaticInvoices.tsx` renders `<ClientName>: <that flat string>` (`:2148-2177`).
+
+The manual-invoice path already does this correctly via a discriminated union + code enum + error
+class (`packages/billing/src/errors/manualInvoiceErrors.ts`) and translates through
+`t('manualInvoices.errors.NO_BILLING_EMAIL', {clientName})` — the locale key already exists at
+`server/public/locales/en/msp/invoicing.json:346` (and de/fr/es/it/nl/pl/pt). The recurring path
+just never carries a code far enough to look it up.
+
+## Design approach
+
+Preserve the existing engine code across the batch boundary, translate it in the UI, and keep
+unknown errors generic. Reuse the manual-invoice patterns rather than inventing new ones.
+
+### 1. Carry the code across the action boundary
+- Throw a coded error (reuse `ManualInvoiceError` from `manualInvoiceErrors.ts`, or a small shared
+  coded-error carrier) at the two validation sites — `invoiceGeneration.ts:1855` and `:2656` —
+  instead of `new Error(emailValidation.error)`, propagating `code` + `params`.
+- Preferred routing: teach the boundary to recognize the coded error and return a **keyed
+  `actionError`** (`errorHandling.ts` `messageKey`/`messageParams`, same mechanism the duplicate-invoice
+  path already uses at `invoiceGeneration.ts:699`). This routes it into the recurring run's
+  *returned-error* branch (`recurringBillingRunActions.ts:419`) rather than the generic throw catch.
+- Whichever branch it lands in, the run must record the structured failure (below). Unknown/internal
+  exceptions stay on the generic catch path unchanged.
+
+### 2. Extend the run failure shape (attribution preserved)
+- Add optional `code?: HandledFailureCode` + `params?` to `RecurringBillingRunInvoiceFailure`
+  (`recurringBillingRunActions.shared.ts:8`). Keep existing `billingCycleId` /
+  `executionIdentityKey` / `executionWindowKind` so client/window attribution in mixed batches is
+  unchanged (`AutomaticInvoices.tsx:1451` `resolveRecurringFailureLabel` keeps working).
+- Apply identically in both twins: grouped (`generateGroupedInvoicesAsRecurringBillingRun`) and
+  non-grouped (`generateInvoicesAsRecurringBillingRun`, catch at `:264`).
+- Server-side diagnostics unchanged: `logRecurringBillingRunInvoiceFailure` still logs full detail.
+
+### 3. Consistent mapping across all five paths
+Single mapping helper used by: preview (`buildPreviewInvoiceForSelectionInputs` /
+`previewInvoiceErrorMessage:596`), single-target, grouped-target
+(`generateInvoiceForNormalizedSelectionInputs`), and the PO-overage decision path
+(`AutomaticInvoices.tsx:1639`). Known code → keyed/structured failure; everything else → generic.
+
+### 4. Render actionable, localized guidance in the UI
+- In `AutomaticInvoices.tsx`, when a failure carries a `code`, translate it
+  (`t('manualInvoices.errors.NO_BILLING_EMAIL', {clientName})` — reuse existing key, or move it to a
+  shared `errors.*` namespace) instead of rendering the flat `errorMessage`. Failures with no code
+  fall back to the generic string.
+- Stretch (only if the existing candidate/readiness model supports it without duplicating
+  recipient-resolution rules): surface a missing recipient pre-generation via the existing
+  `'attention'` view / `blockedReason` on `IRecurringDueWorkInvoiceCandidate`
+  (`recurringTiming.interfaces.ts:568`). Do **not** re-implement recipient precedence in the UI. The
+  post-generation actionable alert is required regardless.
+
+### 5. Localized strings
+- Confirm `NO_BILLING_EMAIL` copy is reachable from the recurring UI's namespace
+  (`useTranslation('msp/invoicing')`). If the key must move/duplicate out of `manualInvoices.errors`
+  into a shared `errors.*` block, add it to all locales (en/de/fr/es/it/nl/pl/pt + pseudo xx/yy).
+
+## Non-goals (per acceptance criteria)
+No change to invoice persistence, numbering, delivery, or recipient precedence
+(`invoiceBillingRecipientService.ts` untouched). No stacks/SQL/internals in UI. Unknown failures keep
+the generic fallback.
+
+## Tests (behavioral, not source-string assertions)
+- **Action** (`recurringBillingRunActions.test.ts`): NO_BILLING_EMAIL through a grouped run yields a
+  failure carrying `code` + client/window attribution; a mixed batch keeps each failure attributed to
+  the right client/window; an unknown thrown error still yields the generic failure with no code;
+  full underlying detail still logged. Update T010 (`:394`) which currently locks the generic string.
+- **UI** (`packages/billing/tests/automaticInvoices.*.test.tsx`): a coded failure renders the
+  actionable remedy text under the correct client; an uncoded failure renders the generic fallback;
+  assert on rendered user-visible outcome, not on source strings.
+- If pre-generation attention surfacing is added: candidate with no recipient appears in the
+  `'attention'` view.
+
+## Open questions for the design session
+1. Route via keyed `actionError` (returned-error branch) vs. coded-throw detection in the catch —
+   pick one for consistency across both run twins.
+2. Keep reusing `manualInvoices.errors.NO_BILLING_EMAIL` key, or promote to a shared `errors.*`
+   namespace so manual + recurring share one string.
+3. Ship the pre-generation "Needs attention" surface now, or land the actionable post-run alert first
+   and treat attention surfacing as a fast-follow (depends on whether candidate readiness can flag it
+   without duplicating recipient resolution).

--- a/packages/billing/src/actions/invoiceGeneration.constants.ts
+++ b/packages/billing/src/actions/invoiceGeneration.constants.ts
@@ -6,3 +6,11 @@ export const DUPLICATE_RECURRING_INVOICE_CODE = 'DUPLICATE_RECURRING_INVOICE';
  * boundary rewrites.
  */
 export const DUPLICATE_RECURRING_INVOICE_MESSAGE_KEY = 'msp/billing:errors.duplicateRecurringInvoice';
+
+/**
+ * Namespaced message key for the missing-billing-recipient failure. The boundary
+ * mapper attaches it to the returned action error so the recurring billing run can
+ * recognize the coded validation failure (`NO_BILLING_EMAIL`) without matching the
+ * English sentence, which the localization boundary rewrites.
+ */
+export const NO_BILLING_EMAIL_MESSAGE_KEY = 'msp/invoicing:manualInvoices.errors.NO_BILLING_EMAIL';

--- a/packages/billing/src/actions/invoiceGeneration.ts
+++ b/packages/billing/src/actions/invoiceGeneration.ts
@@ -656,10 +656,12 @@ function previewInvoiceErrorInfo(error: unknown): {
 
   // A coded billing validation error carries its code/params straight to the UI
   // so preview surfaces the same localized remediation as its sibling flows.
-  if (error instanceof ManualInvoiceError) {
+  // Only the allowlisted NO_BILLING_EMAIL code crosses; unsupported codes take
+  // the generic fallback so raw validation detail never reaches the user.
+  if (error instanceof ManualInvoiceError && error.code === 'NO_BILLING_EMAIL') {
     return {
       message: error.message,
-      code: error.code === 'NO_BILLING_EMAIL' ? 'NO_BILLING_EMAIL' : undefined,
+      code: 'NO_BILLING_EMAIL',
       params: error.params,
     };
   }
@@ -671,12 +673,9 @@ function previewInvoiceErrorInfo(error: unknown): {
     return 'permissionError' in mapped ? { message: mapped.permissionError } : { message: mapped.actionError };
   }
 
-  // Last resort only: never swallow an actionable cause behind the generic string.
-  return {
-    message: message.trim() !== ''
-      ? message
-      : 'An error occurred while previewing the invoice',
-  };
+  // Unknown/internal exceptions never leak their raw message to the user; the
+  // full cause stays server-side in logPreviewInvoiceFailure.
+  return { message: 'An error occurred while previewing the invoice' };
 }
 
 function logPreviewInvoiceFailure(
@@ -708,6 +707,18 @@ function invoiceGenerationActionErrorFrom(error: unknown): InvoiceGenerationActi
   if (error instanceof Error) {
     if (error.message.startsWith('Permission denied')) {
       return permissionError(error.message);
+    }
+
+    // Coded billing validation error. Only the allowlisted code crosses this
+    // boundary as a keyed action error; unsupported codes are re-thrown so the
+    // recurring run's generic catch owns them (full logging, generic UI string).
+    // Checked before the message matching below, which would otherwise surface a
+    // raw, uncoded sentence for codes whose message happens to match a prefix.
+    if (error instanceof ManualInvoiceError) {
+      const messageKey = manualInvoiceErrorMessageKey(error.code);
+      return messageKey
+        ? actionError(error.message, messageKey, error.params)
+        : null;
     }
 
     // An expected, actionable refusal, not a failure: a contract covers these
@@ -746,13 +757,6 @@ function invoiceGenerationActionErrorFrom(error: unknown): InvoiceGenerationActi
     if (error.message.startsWith('Invoice already exists for this recurring execution window')) {
       // Keyed so the recurring run can recognize it after the boundary translates it.
       return actionError(error.message, DUPLICATE_RECURRING_INVOICE_MESSAGE_KEY);
-    }
-
-    if (error instanceof ManualInvoiceError) {
-      const messageKey = manualInvoiceErrorMessageKey(error.code);
-      return messageKey
-        ? actionError(error.message, messageKey, error.params)
-        : actionError(error.message);
     }
   }
 

--- a/packages/billing/src/actions/invoiceGeneration.ts
+++ b/packages/billing/src/actions/invoiceGeneration.ts
@@ -32,6 +32,7 @@ import {
   IInvoice,
   IRecurringDueSelectionInput,
   PreviewInvoiceResponse,
+  RecurringInvoiceFailureCode,
   InvoiceViewModel,
   DEFAULT_RECURRING_SERVICE_PERIOD_DUE_SELECTION_STATES,
 } from '@alga-psa/types';
@@ -2162,6 +2163,10 @@ export type RecurringGroupedPreviewResponse = {
   success: false;
   error: string;
   executionIdentityKey?: string;
+  /** Safe, known failure code so the UI can render localized guidance. */
+  code?: RecurringInvoiceFailureCode;
+  /** Interpolation values for the localized failure copy (e.g. clientName). */
+  params?: Record<string, string>;
 };
 
 export const previewGroupedInvoicesForSelectionInputs = withAuth(async (

--- a/packages/billing/src/actions/invoiceGeneration.ts
+++ b/packages/billing/src/actions/invoiceGeneration.ts
@@ -76,7 +76,12 @@ import {
   CLIENT_CADENCE_POST_DROP_OBLIGATION_TYPE,
   POST_DROP_RECURRING_OBLIGATION_TYPES,
 } from '@alga-psa/shared/billingClients/postDropRecurringObligationIdentity';
-import { DUPLICATE_RECURRING_INVOICE_CODE, DUPLICATE_RECURRING_INVOICE_MESSAGE_KEY } from './invoiceGeneration.constants';
+import { DUPLICATE_RECURRING_INVOICE_CODE, DUPLICATE_RECURRING_INVOICE_MESSAGE_KEY, NO_BILLING_EMAIL_MESSAGE_KEY } from './invoiceGeneration.constants';
+import {
+  ManualInvoiceError,
+  type HandledManualInvoiceErrorCode,
+} from '../errors/manualInvoiceErrors';
+import type { HandledRecurringFailureCode } from './recurringBillingRunActions.shared';
 import {
   detectRecurringApprovalBlockers,
   formatApprovalBlockedReason,
@@ -585,39 +590,52 @@ function withRecurringWindowErrorContext<T extends Error>(
 function buildPreviewInvoiceFailure(
   selectorInput: IRecurringDueSelectionInput,
   error: string,
+  code?: HandledRecurringFailureCode,
+  params?: Record<string, string>,
 ): PreviewInvoiceResponse {
   return {
     success: false,
     error,
+    ...(code ? { code } : {}),
+    ...(params ? { params } : {}),
     ...buildRecurringWindowErrorContext(selectorInput),
   };
 }
 
-function previewInvoiceErrorMessage(error: unknown): string {
+/**
+ * Maps a preview failure to the user-safe message plus the structured, known
+ * failure (code/params) the UI needs to render localized, actionable guidance.
+ * Unknown/internal failures carry no code, so the UI keeps the generic string.
+ */
+function previewInvoiceErrorInfo(error: unknown): {
+  message: string;
+  code?: HandledRecurringFailureCode;
+  params?: Record<string, string>;
+} {
   const message = error instanceof Error ? error.message : '';
 
   if (message.startsWith('Permission denied:')) {
-    return message;
+    return { message };
   }
 
   if (message.startsWith('Recurring service periods were not materialized')) {
-    return message;
+    return { message };
   }
 
   if (/^Billing cycle .+ not found for client .+$/.test(message)) {
-    return 'Billing cycle not found';
+    return { message: 'Billing cycle not found' };
   }
 
   if (/^Billing cycle .+ has invalid dates/.test(message)) {
-    return 'Billing cycle has invalid dates';
+    return { message: 'Billing cycle has invalid dates' };
   }
 
   if (/^Billing Error: Client .+ has active contracts in multiple currencies \(.+\)\. Mixed currency billing is not supported\.$/.test(message)) {
-    return 'This client has active contracts in multiple currencies. Mixed currency billing is not supported.';
+    return { message: 'This client has active contracts in multiple currencies. Mixed currency billing is not supported.' };
   }
 
   if (/^Client .+ not found in tenant .+$/.test(message)) {
-    return 'Client not found';
+    return { message: 'Client not found' };
   }
 
   const expectedMessages = new Set([
@@ -633,20 +651,32 @@ function previewInvoiceErrorMessage(error: unknown): string {
   ]);
 
   if (expectedMessages.has(message)) {
-    return message;
+    return { message };
+  }
+
+  // A coded billing validation error carries its code/params straight to the UI
+  // so preview surfaces the same localized remediation as its sibling flows.
+  if (error instanceof ManualInvoiceError) {
+    return {
+      message: error.message,
+      code: error.code === 'NO_BILLING_EMAIL' ? 'NO_BILLING_EMAIL' : undefined,
+      params: error.params,
+    };
   }
 
   // Same mapping the generation path uses, so preview surfaces database and
   // validation causes with the same actionable text as its sibling flows.
   const mapped = invoiceGenerationActionErrorFrom(error);
   if (mapped) {
-    return 'permissionError' in mapped ? mapped.permissionError : mapped.actionError;
+    return 'permissionError' in mapped ? { message: mapped.permissionError } : { message: mapped.actionError };
   }
 
   // Last resort only: never swallow an actionable cause behind the generic string.
-  return message.trim() !== ''
-    ? message
-    : 'An error occurred while previewing the invoice';
+  return {
+    message: message.trim() !== ''
+      ? message
+      : 'An error occurred while previewing the invoice',
+  };
 }
 
 function logPreviewInvoiceFailure(
@@ -655,6 +685,23 @@ function logPreviewInvoiceFailure(
   error: unknown,
 ): void {
   console.error(`[${action}] Invoice preview failed:`, context, error);
+}
+
+/**
+ * Maps a coded billing validation error (`ManualInvoiceError`) to the localized
+ * message key the recurring run uses to recover the structured failure. Codes the
+ * recurring flow does not handle deliberately have no key, so they fall back to the
+ * generic action-error string.
+ */
+function manualInvoiceErrorMessageKey(
+  code: HandledManualInvoiceErrorCode,
+): string | undefined {
+  switch (code) {
+    case 'NO_BILLING_EMAIL':
+      return NO_BILLING_EMAIL_MESSAGE_KEY;
+    default:
+      return undefined;
+  }
 }
 
 function invoiceGenerationActionErrorFrom(error: unknown): InvoiceGenerationActionError | null {
@@ -699,6 +746,13 @@ function invoiceGenerationActionErrorFrom(error: unknown): InvoiceGenerationActi
     if (error.message.startsWith('Invoice already exists for this recurring execution window')) {
       // Keyed so the recurring run can recognize it after the boundary translates it.
       return actionError(error.message, DUPLICATE_RECURRING_INVOICE_MESSAGE_KEY);
+    }
+
+    if (error instanceof ManualInvoiceError) {
+      const messageKey = manualInvoiceErrorMessageKey(error.code);
+      return messageKey
+        ? actionError(error.message, messageKey, error.params)
+        : actionError(error.message);
     }
   }
 
@@ -1852,7 +1906,14 @@ async function buildPreviewInvoiceForSelectionInputs(params: {
       clientForValidation.client_name,
     );
     if (!emailValidation.valid) {
-      throw withRecurringWindowErrorContext(new Error(emailValidation.error!), canonicalSelection);
+      throw withRecurringWindowErrorContext(
+        new ManualInvoiceError(
+          emailValidation.code ?? 'NO_BILLING_EMAIL',
+          emailValidation.error ?? 'Client billing email is required',
+          emailValidation.params ?? { clientName: clientForValidation.client_name },
+        ),
+        canonicalSelection,
+      );
     }
   }
 
@@ -2161,14 +2222,19 @@ export const previewGroupedInvoicesForSelectionInputs = withAuth(async (
       error,
     );
     const fallbackSelectorInput = normalizedGroupedSelections[0]?.selectorInputs?.[0];
+    const previewInfo = previewInvoiceErrorInfo(error);
     return fallbackSelectorInput
       ? buildPreviewInvoiceFailure(
           fallbackSelectorInput,
-          previewInvoiceErrorMessage(error),
+          previewInfo.message,
+          previewInfo.code,
+          previewInfo.params,
         )
       : {
           success: false,
-          error: previewInvoiceErrorMessage(error),
+          error: previewInfo.message,
+          ...(previewInfo.code ? { code: previewInfo.code } : {}),
+          ...(previewInfo.params ? { params: previewInfo.params } : {}),
         };
   }
 });
@@ -2207,9 +2273,12 @@ export const previewInvoiceForSelectionInput = withAuth(async (
       },
       error,
     );
+    const previewInfo = previewInvoiceErrorInfo(error);
     return buildPreviewInvoiceFailure(
       normalizedSelectorInput,
-      previewInvoiceErrorMessage(error),
+      previewInfo.message,
+      previewInfo.code,
+      previewInfo.params,
     );
   }
 });
@@ -2285,14 +2354,19 @@ export const previewInvoice = withAuth(async (
       },
       error,
     );
+    const previewInfo = previewInvoiceErrorInfo(error);
     return selectorInput
       ? buildPreviewInvoiceFailure(
           selectorInput,
-          previewInvoiceErrorMessage(error),
+          previewInfo.message,
+          previewInfo.code,
+          previewInfo.params,
         )
       : {
           success: false,
-          error: previewInvoiceErrorMessage(error)
+          error: previewInfo.message,
+          ...(previewInfo.code ? { code: previewInfo.code } : {}),
+          ...(previewInfo.params ? { params: previewInfo.params } : {}),
         };
   }
 });
@@ -2653,7 +2727,14 @@ export async function generateInvoiceForNormalizedSelectionInputs(params: {
   if (clientForValidation) {
     const emailValidation = await validateClientBillingEmail(knex, tenant, client_id, clientForValidation.client_name);
     if (!emailValidation.valid) {
-      throw withRecurringWindowErrorContext(new Error(emailValidation.error), normalizedSelectorInput);
+      throw withRecurringWindowErrorContext(
+        new ManualInvoiceError(
+          emailValidation.code ?? 'NO_BILLING_EMAIL',
+          emailValidation.error ?? 'Client billing email is required',
+          emailValidation.params ?? { clientName: clientForValidation.client_name },
+        ),
+        normalizedSelectorInput,
+      );
     }
   }
 

--- a/packages/billing/src/actions/recurringBillingRunActions.shared.ts
+++ b/packages/billing/src/actions/recurringBillingRunActions.shared.ts
@@ -5,11 +5,26 @@ import {
   RecurringRunExecutionWindowKind,
 } from '@alga-psa/types';
 
+/**
+ * Structured failure codes the recurring run can expose to the UI as safe,
+ * localized remediation. These are the coded billing validations the generation
+ * engine produces; everything else stays generic in the UI.
+ */
+export type HandledRecurringFailureCode = 'NO_BILLING_EMAIL';
+
 export type RecurringBillingRunInvoiceFailure = {
   billingCycleId?: string | null;
   executionIdentityKey?: string;
   executionWindowKind?: RecurringRunExecutionWindowKind;
   errorMessage: string;
+  /**
+   * Safe, known failure code carried across the action boundary so the UI can
+   * render localized, actionable guidance instead of the flat error message.
+   * Absent for unknown/internal failures, which keep the generic string.
+   */
+  code?: HandledRecurringFailureCode;
+  /** Interpolation values for the localized failure copy (e.g. clientName). */
+  params?: Record<string, string>;
 };
 
 export type RecurringBillingRunTarget = {

--- a/packages/billing/src/actions/recurringBillingRunActions.shared.ts
+++ b/packages/billing/src/actions/recurringBillingRunActions.shared.ts
@@ -3,14 +3,16 @@ import {
   IRecurringDueWorkInvoiceCandidate,
   IRecurringRunExecutionWindowIdentity,
   RecurringRunExecutionWindowKind,
+  type RecurringInvoiceFailureCode,
 } from '@alga-psa/types';
 
 /**
  * Structured failure codes the recurring run can expose to the UI as safe,
  * localized remediation. These are the coded billing validations the generation
- * engine produces; everything else stays generic in the UI.
+ * engine produces; everything else stays generic in the UI. Shares the canonical
+ * union with the preview payload (`PreviewInvoiceResponse`).
  */
-export type HandledRecurringFailureCode = 'NO_BILLING_EMAIL';
+export type HandledRecurringFailureCode = RecurringInvoiceFailureCode;
 
 export type RecurringBillingRunInvoiceFailure = {
   billingCycleId?: string | null;

--- a/packages/billing/src/actions/recurringBillingRunActions.ts
+++ b/packages/billing/src/actions/recurringBillingRunActions.ts
@@ -16,7 +16,7 @@ import {
   generateInvoiceForSelectionInput,
   generateInvoiceForSelectionInputs,
 } from './invoiceGeneration';
-import { DUPLICATE_RECURRING_INVOICE_CODE, DUPLICATE_RECURRING_INVOICE_MESSAGE_KEY } from './invoiceGeneration.constants';
+import { DUPLICATE_RECURRING_INVOICE_CODE, DUPLICATE_RECURRING_INVOICE_MESSAGE_KEY, NO_BILLING_EMAIL_MESSAGE_KEY } from './invoiceGeneration.constants';
 import {
   buildRecurringRunSelectionIdentity,
   listRecurringRunExecutionWindowKinds,
@@ -28,10 +28,16 @@ import {
 import {
   mapClientCadenceInvoiceCandidatesToRecurringRunTargets,
   type ClientCadenceRecurringRunTarget,
+  type HandledRecurringFailureCode,
   type RecurringBillingRunGroupedTarget,
   type RecurringBillingRunInvoiceFailure,
   type RecurringBillingRunResult,
   type RecurringBillingRunTarget,
+} from './recurringBillingRunActions.shared';
+
+export type {
+  HandledRecurringFailureCode,
+  RecurringBillingRunInvoiceFailure,
 } from './recurringBillingRunActions.shared';
 import {
   buildRecurringBillingRunCompletedPayload,
@@ -53,6 +59,25 @@ function isRecurringBillingRunActionError(value: unknown): value is RecurringBil
 
 function getRecurringBillingRunActionErrorMessage(error: RecurringBillingRunActionError): string {
   return 'permissionError' in error ? error.permissionError : error.actionError;
+}
+
+/**
+ * Recovers the structured, known failure (code/params) from a keyed action error
+ * returned by the invoice-generation boundary. Recognized by message key, never by
+ * the English sentence, which the localization boundary rewrites. Unknown/internal
+ * errors carry nothing, so the failure keeps the generic message for the UI.
+ */
+function handledRecurringFailureFromActionError(error: RecurringBillingRunActionError): {
+  code?: HandledRecurringFailureCode;
+  params?: Record<string, string>;
+} {
+  if (error.messageKey === NO_BILLING_EMAIL_MESSAGE_KEY) {
+    return {
+      code: 'NO_BILLING_EMAIL',
+      params: error.messageParams as Record<string, string> | undefined,
+    };
+  }
+  return {};
 }
 
 function normalizeRecurringBillingRunTargets(params: {
@@ -255,6 +280,7 @@ export async function generateInvoicesAsRecurringBillingRun(params: {
             executionIdentityKey: executionWindow.identityKey,
             executionWindowKind: executionWindow.kind,
             errorMessage: getRecurringBillingRunActionErrorMessage(invoice),
+            ...handledRecurringFailureFromActionError(invoice),
           });
           continue;
         }
@@ -425,6 +451,7 @@ export async function generateGroupedInvoicesAsRecurringBillingRun(params: {
             executionIdentityKey: executionWindow.identityKey,
             executionWindowKind: executionWindow.kind,
             errorMessage: getRecurringBillingRunActionErrorMessage(invoice),
+            ...handledRecurringFailureFromActionError(invoice),
           });
           continue;
         }

--- a/packages/billing/src/components/billing-dashboard/AutomaticInvoices.tsx
+++ b/packages/billing/src/components/billing-dashboard/AutomaticInvoices.tsx
@@ -27,7 +27,7 @@ import {
   type RecurringBillingRunInvoiceFailure,
 } from '@alga-psa/billing/actions/recurringBillingRunActions';
 import { repairAllRecurringServicePeriodsForTenant } from '@alga-psa/billing/actions/recurringServicePeriodActions';
-import { WasmInvoiceViewModel } from '@alga-psa/types';
+import { WasmInvoiceViewModel, type PreviewInvoiceResponse } from '@alga-psa/types';
 import {
   getRecurringInvoiceHistoryPaginated,
   reverseRecurringInvoice,
@@ -98,10 +98,10 @@ function localizeRecurringFailure(
  */
 function localizePreviewFailure(
   t: ManualInvoiceTranslation,
-  failure: { error: string; code?: string; params?: Record<string, string> },
+  failure: Extract<PreviewInvoiceResponse, { success: false }>,
 ): string {
   return translateManualInvoiceFailure(t, {
-    code: failure.code as RecurringBillingRunInvoiceFailure['code'],
+    code: failure.code,
     params: failure.params,
     message: failure.error,
   });
@@ -1531,10 +1531,7 @@ const AutomaticInvoices: React.FC<AutomaticInvoicesProps> = ({ onGenerateSuccess
         selectorInput: null,
       }); // Clear preview state on error
       setErrors({
-        preview: localizePreviewFailure(
-          t,
-          response as { error: string; code?: string; params?: Record<string, string> },
-        )
+        preview: localizePreviewFailure(t, response)
       });
       // Optionally open the dialog even on error to show the message
       setShowPreviewDialog(true);

--- a/packages/billing/src/components/billing-dashboard/AutomaticInvoices.tsx
+++ b/packages/billing/src/components/billing-dashboard/AutomaticInvoices.tsx
@@ -21,7 +21,11 @@ import {
   getPurchaseOrderOverageForSelectionInput,
   previewGroupedInvoicesForSelectionInputs,
 } from '@alga-psa/billing/actions/invoiceGeneration';
-import { generateGroupedInvoicesAsRecurringBillingRun, generateInvoicesAsRecurringBillingRun } from '@alga-psa/billing/actions/recurringBillingRunActions';
+import {
+  generateGroupedInvoicesAsRecurringBillingRun,
+  generateInvoicesAsRecurringBillingRun,
+  type RecurringBillingRunInvoiceFailure,
+} from '@alga-psa/billing/actions/recurringBillingRunActions';
 import { repairAllRecurringServicePeriodsForTenant } from '@alga-psa/billing/actions/recurringServicePeriodActions';
 import { WasmInvoiceViewModel } from '@alga-psa/types';
 import {
@@ -44,6 +48,10 @@ import {
   isActionMessageError,
   isActionPermissionError,
 } from '@alga-psa/ui/lib/errorHandling';
+import {
+  translateManualInvoiceFailure,
+  type ManualInvoiceTranslation,
+} from './manualInvoiceErrorTranslation';
 // Added imports for DropdownMenu
 import {
   DropdownMenu,
@@ -67,6 +75,37 @@ interface AutomaticInvoicesProps {
 const isReturnedActionError = (result: unknown) => (
   isActionMessageError(result) || isActionPermissionError(result)
 );
+
+/**
+ * Renders a recurring-run invoice failure as localized, actionable guidance when it
+ * carries a known structured code (e.g. NO_BILLING_EMAIL), and as the generic error
+ * string otherwise. Never leaks stacks, SQL, or raw exception text to the user.
+ */
+function localizeRecurringFailure(
+  t: ManualInvoiceTranslation,
+  failure: RecurringBillingRunInvoiceFailure,
+): string {
+  return translateManualInvoiceFailure(t, {
+    code: failure.code,
+    params: failure.params,
+    message: failure.errorMessage,
+  });
+}
+
+/**
+ * Same contract as {@link localizeRecurringFailure} for the preview failure
+ * payload, which carries the same structured code/params across the boundary.
+ */
+function localizePreviewFailure(
+  t: ManualInvoiceTranslation,
+  failure: { error: string; code?: string; params?: Record<string, string> },
+): string {
+  return translateManualInvoiceFailure(t, {
+    code: failure.code as RecurringBillingRunInvoiceFailure['code'],
+    params: failure.params,
+    message: failure.error,
+  });
+}
 
 // Placeholder for a DataTable while its (independent) section data loads, so the
 // rest of the screen can render immediately instead of waiting behind one spinner.
@@ -1492,7 +1531,10 @@ const AutomaticInvoices: React.FC<AutomaticInvoicesProps> = ({ onGenerateSuccess
         selectorInput: null,
       }); // Clear preview state on error
       setErrors({
-        preview: (response as { success: false; error: string }).error
+        preview: localizePreviewFailure(
+          t,
+          response as { error: string; code?: string; params?: Record<string, string> },
+        )
       });
       // Optionally open the dialog even on error to show the message
       setShowPreviewDialog(true);
@@ -1576,7 +1618,7 @@ const AutomaticInvoices: React.FC<AutomaticInvoicesProps> = ({ onGenerateSuccess
       const newErrors: { [key: string]: string } = {};
       for (const failure of runResult.failures) {
         const label = resolveRecurringFailureLabel(failure);
-        newErrors[label] = failure.errorMessage;
+        newErrors[label] = localizeRecurringFailure(t, failure);
       }
 
       if (Object.keys(newErrors).length > 0) {
@@ -1638,7 +1680,7 @@ const AutomaticInvoices: React.FC<AutomaticInvoicesProps> = ({ onGenerateSuccess
       }
       for (const failure of runResult.failures) {
         const label = resolveRecurringFailureLabel(failure);
-        newErrors[label] = failure.errorMessage;
+        newErrors[label] = localizeRecurringFailure(t, failure);
       }
 
       if (Object.keys(newErrors).length > 0) {

--- a/packages/billing/src/components/billing-dashboard/AutomaticInvoices.tsx
+++ b/packages/billing/src/components/billing-dashboard/AutomaticInvoices.tsx
@@ -20,6 +20,7 @@ import type {
 import {
   getPurchaseOrderOverageForSelectionInput,
   previewGroupedInvoicesForSelectionInputs,
+  type RecurringGroupedPreviewResponse,
 } from '@alga-psa/billing/actions/invoiceGeneration';
 import {
   generateGroupedInvoicesAsRecurringBillingRun,
@@ -98,7 +99,7 @@ function localizeRecurringFailure(
  */
 function localizePreviewFailure(
   t: ManualInvoiceTranslation,
-  failure: Extract<PreviewInvoiceResponse, { success: false }>,
+  failure: Extract<PreviewInvoiceResponse | RecurringGroupedPreviewResponse, { success: false }>,
 ): string {
   return translateManualInvoiceFailure(t, {
     code: failure.code,
@@ -1795,7 +1796,7 @@ const AutomaticInvoices: React.FC<AutomaticInvoicesProps> = ({ onGenerateSuccess
       }
       if (runResult.failures.length > 0) {
         setErrors({
-          preview: runResult.failures[0]?.errorMessage
+          preview: localizeRecurringFailure(t, runResult.failures[0])
             || t('automaticInvoices.dialogs.preview.generateError', {
               defaultValue: 'Failed to generate invoice from preview',
             }),
@@ -1858,7 +1859,7 @@ const AutomaticInvoices: React.FC<AutomaticInvoicesProps> = ({ onGenerateSuccess
       }
       if (runResult.failures.length > 0) {
         setErrors({
-          preview: runResult.failures[0]?.errorMessage || 'Failed to generate invoice from preview',
+          preview: localizeRecurringFailure(t, runResult.failures[0]) || 'Failed to generate invoice from preview',
         });
         return;
       }

--- a/packages/billing/tests/automaticInvoices.poOverageDialog.test.tsx
+++ b/packages/billing/tests/automaticInvoices.poOverageDialog.test.tsx
@@ -442,6 +442,24 @@ describe('AutomaticInvoices PO overage dialog', () => {
       });
     });
 
+    it('renders the generic preview fallback instead of any raw internal detail', async () => {
+      // Post-fix server behavior: unknown preview failures are already reduced to
+      // the fixed generic message before they reach the UI.
+      mockPreviewGroupedInvoicesForSelectionInputs.mockResolvedValue({
+        success: false,
+        error: 'An error occurred while previewing the invoice',
+      });
+
+      await selectParentAndClickPreview();
+
+      await waitFor(() => {
+        expect(
+          screen.getAllByText(/An error occurred while previewing the invoice/).length,
+        ).toBeGreaterThan(0);
+      });
+      expect(screen.queryByText(/TypeError|client_contract_id|internal/i)).toBeNull();
+    });
+
     it('renders the localized no-billing-email remediation for a coded failure on the PO-overage allow decision', async () => {
       mockGetPurchaseOrderOverageForSelectionInput.mockResolvedValue({
         overage_cents: 61250,

--- a/packages/billing/tests/automaticInvoices.poOverageDialog.test.tsx
+++ b/packages/billing/tests/automaticInvoices.poOverageDialog.test.tsx
@@ -27,16 +27,29 @@ vi.mock('next/navigation', () => ({
   }),
 }));
 
-vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
-  useTranslation: () => ({
-    t: (key: string, opts?: { defaultValue?: string } & Record<string, unknown>) =>
-      (opts && typeof opts.defaultValue === 'string' ? opts.defaultValue : key),
-  }),
-  useFormatters: () => ({
-    formatDate: (value: unknown) => String(value),
-    formatCurrency: (value: number) => `$${value}`,
-  }),
-}));
+vi.mock('@alga-psa/ui/lib/i18n/client', () => {
+  const NO_BILLING_EMAIL_COPY =
+    '{{clientName}} has no billing email. Set a billing contact, a client billing email, or an email on the billing or default location, then try again.';
+  const interpolate = (template: string, vars: Record<string, unknown>) =>
+    template.replace(/\{\{(\w+)\}\}/g, (match: string, name: string) => {
+      const value = vars?.[name];
+      return value === undefined ? match : String(value);
+    });
+  return {
+    useTranslation: () => ({
+      t: (key: string, opts?: { defaultValue?: string } & Record<string, unknown>) => {
+        if (key === 'manualInvoices.errors.NO_BILLING_EMAIL') {
+          return interpolate(NO_BILLING_EMAIL_COPY, opts ?? {});
+        }
+        return (opts && typeof opts.defaultValue === 'string' ? opts.defaultValue : key);
+      },
+    }),
+    useFormatters: () => ({
+      formatDate: (value: unknown) => String(value),
+      formatCurrency: (value: number) => `$${value}`,
+    }),
+  };
+});
 
 vi.mock('@alga-psa/billing/actions/billingAndTax', () => ({
   getAvailableRecurringDueWork: mockGetAvailableRecurringDueWork,
@@ -144,14 +157,28 @@ vi.mock('@alga-psa/ui/components/DropdownMenu', () => ({
   DropdownMenuSeparator: () => <hr />,
   DropdownMenuTrigger: ({ children }: any) => <div>{children}</div>,
 }));
-// Render dialog content so the overage message copy is assertable.
+// Render dialog content so the overage message copy is assertable, and expose the
+// decision options as buttons so the PO-overage batch decision flow is drivable.
 vi.mock('@alga-psa/ui/components/ConfirmationDialog', () => ({
-  ConfirmationDialog: ({ id, isOpen, title, message }: any) =>
+  ConfirmationDialog: ({ id, isOpen, title, message, options, onConfirm, confirmLabel = 'Confirm' }: any) =>
     isOpen
       ? (
         <div data-testid={id}>
           <div>{title}</div>
           <div>{message}</div>
+          {options?.map((option: { value: string; label: string }) => (
+            <button
+              key={option.value}
+              type="button"
+              data-testid={`${id}-${option.value}`}
+              onClick={() => onConfirm?.(option.value)}
+            >
+              {option.label}
+            </button>
+          ))}
+          {onConfirm ? (
+            <button type="button" onClick={() => onConfirm(undefined)}>{confirmLabel}</button>
+          ) : null}
         </div>
       )
       : null,
@@ -221,6 +248,23 @@ async function selectParentAndClickGenerate() {
 
   const generateButton = await screen.findByText('Generate Invoices (2)');
   fireEvent.click(generateButton);
+}
+
+async function selectParentAndClickPreview() {
+  const AutomaticInvoices = (await import('../src/components/billing-dashboard/AutomaticInvoices')).default;
+  render(<AutomaticInvoices onGenerateSuccess={() => undefined} />);
+
+  const parentCheckbox = await waitFor(() => {
+    const checkbox = document.getElementById(
+      'select-parent-group:client-1:2026-03-01:2026-04-01',
+    ) as HTMLInputElement | null;
+    expect(checkbox).not.toBeNull();
+    return checkbox as HTMLInputElement;
+  }, { timeout: 5000 });
+  fireEvent.click(parentCheckbox);
+
+  const previewButton = await screen.findByText('Preview Selected');
+  fireEvent.click(previewButton);
 }
 
 describe('AutomaticInvoices PO overage dialog', () => {
@@ -311,5 +355,122 @@ describe('AutomaticInvoices PO overage dialog', () => {
     });
     expect(screen.queryByTestId('po-overage-batch-decision')).not.toBeInTheDocument();
     expect(document.body.textContent).not.toContain('$NaN');
+  });
+
+  describe('actionable generation failure reasons', () => {
+    function noBillingEmailFailure() {
+      return {
+        billingCycleId: null,
+        executionIdentityKey: 'exec-1',
+        executionWindowKind: 'contract_cadence_window' as const,
+        errorMessage:
+          'Cannot generate invoice: No billing email address for "Acme Co". Please set a billing contact, billing email, or a billing/default location email before generating invoices.',
+        code: 'NO_BILLING_EMAIL',
+        params: { clientName: 'Acme Co' },
+      };
+    }
+
+    it('renders the localized no-billing-email remediation for a coded grouped-run failure, attributed to the client', async () => {
+      mockGenerateGroupedInvoicesAsRecurringBillingRun.mockResolvedValue({
+        runId: 'run-no-email',
+        selectionKey: 'selection-no-email',
+        retryKey: 'retry-no-email',
+        invoicesCreated: 0,
+        failedCount: 1,
+        failures: [noBillingEmailFailure()],
+      });
+
+      await selectParentAndClickGenerate();
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            /Acme Co has no billing email\. Set a billing contact, a client billing email, or an email on the billing or default location, then try again\./,
+          ),
+        ).toBeInTheDocument();
+      });
+      // The raw flat validation sentence must not leak into the UI.
+      expect(screen.queryByText(/Cannot generate invoice/i)).toBeNull();
+    });
+
+    it('renders the generic fallback for an uncoded run failure', async () => {
+      mockGenerateGroupedInvoicesAsRecurringBillingRun.mockResolvedValue({
+        runId: 'run-unknown',
+        selectionKey: 'selection-unknown',
+        retryKey: 'retry-unknown',
+        invoicesCreated: 0,
+        failedCount: 1,
+        failures: [
+          {
+            billingCycleId: null,
+            executionIdentityKey: 'exec-1',
+            executionWindowKind: 'contract_cadence_window' as const,
+            errorMessage: 'Failed to generate invoice for this billing cycle.',
+          },
+        ],
+      });
+
+      await selectParentAndClickGenerate();
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Failed to generate invoice for this billing cycle\./),
+        ).toBeInTheDocument();
+      });
+      expect(screen.queryByText(/has no billing email/i)).toBeNull();
+    });
+
+    it('renders the localized no-billing-email remediation for a coded preview failure', async () => {
+      mockPreviewGroupedInvoicesForSelectionInputs.mockResolvedValue({
+        success: false,
+        error:
+          'Cannot generate invoice: No billing email address for "Acme Co". Please set a billing contact, billing email, or a billing/default location email before generating invoices.',
+        code: 'NO_BILLING_EMAIL',
+        params: { clientName: 'Acme Co' },
+      });
+
+      await selectParentAndClickPreview();
+
+      await waitFor(() => {
+        // The coded failure renders in both the main alert and the preview dialog,
+        // so assert presence rather than a single match.
+        expect(
+          screen.getAllByText(
+            /Acme Co has no billing email\. Set a billing contact, a client billing email, or an email on the billing or default location, then try again\./,
+          ).length,
+        ).toBeGreaterThan(0);
+      });
+    });
+
+    it('renders the localized no-billing-email remediation for a coded failure on the PO-overage allow decision', async () => {
+      mockGetPurchaseOrderOverageForSelectionInput.mockResolvedValue({
+        overage_cents: 61250,
+        po_number: 'PO-123',
+      });
+      mockGenerateGroupedInvoicesAsRecurringBillingRun.mockResolvedValue({
+        runId: 'run-po-allow',
+        selectionKey: 'selection-po-allow',
+        retryKey: 'retry-po-allow',
+        invoicesCreated: 0,
+        failedCount: 1,
+        failures: [noBillingEmailFailure()],
+      });
+
+      await selectParentAndClickGenerate();
+
+      const allowButton = await screen.findByTestId('po-overage-batch-decision-allow');
+      fireEvent.click(allowButton);
+
+      await waitFor(() => {
+        expect(mockGenerateGroupedInvoicesAsRecurringBillingRun).toHaveBeenCalledWith(
+          expect.objectContaining({ allowPoOverage: true }),
+        );
+        expect(
+          screen.getByText(
+            /Acme Co has no billing email\. Set a billing contact, a client billing email, or an email on the billing or default location, then try again\./,
+          ),
+        ).toBeInTheDocument();
+      });
+    });
   });
 });

--- a/packages/billing/tests/automaticInvoices.poOverageDialog.test.tsx
+++ b/packages/billing/tests/automaticInvoices.poOverageDialog.test.tsx
@@ -19,6 +19,7 @@ const mockGetAvailableRecurringDueWork = vi.fn();
 const mockGetPurchaseOrderOverageForSelectionInput = vi.fn();
 const mockPreviewGroupedInvoicesForSelectionInputs = vi.fn();
 const mockGenerateGroupedInvoicesAsRecurringBillingRun = vi.fn(async () => ({ failures: [] }));
+const mockGenerateInvoicesAsRecurringBillingRun = vi.fn(async () => ({ failures: [] }));
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({
@@ -61,7 +62,7 @@ vi.mock('@alga-psa/billing/actions/invoiceGeneration', () => ({
 }));
 
 vi.mock('@alga-psa/billing/actions/recurringBillingRunActions', () => ({
-  generateInvoicesAsRecurringBillingRun: vi.fn(async () => ({ failures: [] })),
+  generateInvoicesAsRecurringBillingRun: mockGenerateInvoicesAsRecurringBillingRun,
   generateGroupedInvoicesAsRecurringBillingRun: mockGenerateGroupedInvoicesAsRecurringBillingRun,
 }));
 
@@ -145,7 +146,7 @@ vi.mock('@alga-psa/ui/components/Alert', () => ({
   AlertDescription: ({ children }: any) => <div>{children}</div>,
 }));
 vi.mock('@alga-psa/ui/components/Dialog', () => ({
-  Dialog: ({ children }: any) => <div>{children}</div>,
+  Dialog: ({ children, footer }: any) => <div>{children}{footer}</div>,
   DialogContent: ({ children }: any) => <div>{children}</div>,
   DialogFooter: ({ children }: any) => <div>{children}</div>,
   DialogDescription: ({ children }: any) => <div>{children}</div>,
@@ -267,6 +268,62 @@ async function selectParentAndClickPreview() {
   fireEvent.click(previewButton);
 }
 
+// Builds a successful grouped preview response carrying one selector input, so the
+// preview dialog's single-target "Generate Invoice" flow is drivable.
+function buildSinglePreviewSuccess() {
+  return {
+    success: true,
+    invoiceCount: 1,
+    previews: [
+      {
+        previewGroupKey: 'child-selection:client-1:2026-03-01:2026-04-01',
+        selectorInputs: [buildMember(1).selectorInput],
+        data: {
+          customer: { name: 'Acme Co', address: '1 Main St' },
+          invoiceNumber: 'INV-1001',
+          issueDate: '2026-03-01',
+          dueDate: '2026-04-01',
+          items: [{ id: 'item-1', description: 'Managed services', quantity: 1, unitPrice: 12500, total: 12500 }],
+          subtotal: 12500,
+          tax: 0,
+          total: 12500,
+        },
+      },
+    ],
+  };
+}
+
+async function selectSingleChildAndOpenPreview() {
+  const AutomaticInvoices = (await import('../src/components/billing-dashboard/AutomaticInvoices')).default;
+  render(<AutomaticInvoices onGenerateSuccess={() => undefined} />);
+
+  const toggle = await waitFor(() => {
+    const button = document.getElementById(
+      'toggle-group-parent-group:client-1:2026-03-01:2026-04-01',
+    ) as HTMLButtonElement | null;
+    expect(button).not.toBeNull();
+    return button as HTMLButtonElement;
+  }, { timeout: 5000 });
+  fireEvent.click(toggle);
+
+  const childCheckbox = await waitFor(() => {
+    const checkbox = document.getElementById(
+      'select-child-parent-group:client-1:2026-03-01:2026-04-01-exec-1',
+    ) as HTMLInputElement | null;
+    expect(checkbox).not.toBeNull();
+    return checkbox as HTMLInputElement;
+  }, { timeout: 5000 });
+  fireEvent.click(childCheckbox);
+
+  mockPreviewGroupedInvoicesForSelectionInputs.mockResolvedValueOnce(buildSinglePreviewSuccess());
+  const previewButton = await screen.findByText('Preview Selected');
+  fireEvent.click(previewButton);
+
+  await waitFor(() => {
+    expect(mockPreviewGroupedInvoicesForSelectionInputs).toHaveBeenCalled();
+  });
+}
+
 describe('AutomaticInvoices PO overage dialog', () => {
   afterEach(() => {
     cleanup();
@@ -277,6 +334,7 @@ describe('AutomaticInvoices PO overage dialog', () => {
     mockGetAvailableRecurringDueWork.mockReset();
     mockGetPurchaseOrderOverageForSelectionInput.mockReset();
     mockGenerateGroupedInvoicesAsRecurringBillingRun.mockClear();
+    mockGenerateInvoicesAsRecurringBillingRun.mockReset();
     mockDueWorkResponse = {
       invoiceCandidates: [
         {
@@ -489,6 +547,68 @@ describe('AutomaticInvoices PO overage dialog', () => {
           ),
         ).toBeInTheDocument();
       });
+    });
+
+    it('renders the localized no-billing-email remediation for a coded single-target failure from the preview dialog', async () => {
+      mockGenerateInvoicesAsRecurringBillingRun.mockResolvedValueOnce({
+        runId: 'run-single-no-email',
+        selectionKey: 'selection-single-no-email',
+        retryKey: 'retry-single-no-email',
+        invoicesCreated: 0,
+        failedCount: 1,
+        failures: [noBillingEmailFailure()],
+      });
+
+      await selectSingleChildAndOpenPreview();
+
+      const generateButton = await screen.findByText('Generate Invoice');
+      fireEvent.click(generateButton);
+
+      await waitFor(() => {
+        expect(mockGenerateInvoicesAsRecurringBillingRun).toHaveBeenCalledTimes(1);
+        expect(
+          screen.getAllByText(
+            /Acme Co has no billing email\. Set a billing contact, a client billing email, or an email on the billing or default location, then try again\./,
+          ).length,
+        ).toBeGreaterThan(0);
+      });
+      // The raw flat validation sentence must not leak into the UI.
+      expect(screen.queryByText(/Cannot generate invoice/i)).toBeNull();
+    });
+
+    it('renders the localized no-billing-email remediation after the PO-overage single-confirm allow decision', async () => {
+      mockGetPurchaseOrderOverageForSelectionInput.mockResolvedValue({
+        overage_cents: 61250,
+        po_number: 'PO-123',
+      });
+      mockGenerateInvoicesAsRecurringBillingRun.mockResolvedValueOnce({
+        runId: 'run-po-single-allow',
+        selectionKey: 'selection-po-single-allow',
+        retryKey: 'retry-po-single-allow',
+        invoicesCreated: 0,
+        failedCount: 1,
+        failures: [noBillingEmailFailure()],
+      });
+
+      await selectSingleChildAndOpenPreview();
+
+      const generateButton = await screen.findByText('Generate Invoice');
+      fireEvent.click(generateButton);
+
+      const proceedButton = await screen.findByText('Proceed Anyway');
+      fireEvent.click(proceedButton);
+
+      await waitFor(() => {
+        expect(mockGenerateInvoicesAsRecurringBillingRun).toHaveBeenCalledWith(
+          expect.objectContaining({ allowPoOverage: true }),
+        );
+        expect(
+          screen.getAllByText(
+            /Acme Co has no billing email\. Set a billing contact, a client billing email, or an email on the billing or default location, then try again\./,
+          ).length,
+        ).toBeGreaterThan(0);
+      });
+      expect(screen.queryByText(/Cannot generate invoice/i)).toBeNull();
     });
   });
 });

--- a/packages/types/src/interfaces/invoice.interfaces.ts
+++ b/packages/types/src/interfaces/invoice.interfaces.ts
@@ -322,6 +322,13 @@ export interface IConditionalRule {
   format?: any;
 }
 
+/**
+ * Known, safe recurring-invoice failure codes that may cross the action boundary
+ * for localized, actionable UI remediation. Absent for unknown/internal failures,
+ * which keep the generic error string. Only allowlisted codes belong here.
+ */
+export type RecurringInvoiceFailureCode = 'NO_BILLING_EMAIL';
+
 export type PreviewInvoiceResponse = {
   success: true;
   data: WasmInvoiceViewModel; // Use the imported ViewModel alias
@@ -329,6 +336,10 @@ export type PreviewInvoiceResponse = {
   success: false;
   error: string;
   executionIdentityKey?: string;
+  /** Safe, known failure code so the UI can render localized guidance. */
+  code?: RecurringInvoiceFailureCode;
+  /** Interpolation values for the localized failure copy (e.g. clientName). */
+  params?: Record<string, string>;
 };
 
 export type InvoiceStatus = 'draft' | 'sent' | 'paid' | 'overdue' | 'cancelled' | 'pending' | 'prepayment' | 'partially_applied';

--- a/server/src/interfaces/invoice.interfaces.ts
+++ b/server/src/interfaces/invoice.interfaces.ts
@@ -315,14 +315,8 @@ export interface IConditionalRule {
   format?: any;
 }
 
-export type PreviewInvoiceResponse = {
-  success: true;
-  data: WasmInvoiceViewModel; // Use the imported ViewModel alias
-} | {
-  success: false;
-  error: string;
-  executionIdentityKey?: string;
-};
+// Canonical definition lives in @alga-psa/types; re-export so the two cannot drift.
+export type { PreviewInvoiceResponse } from '@alga-psa/types';
 
 export type InvoiceStatus = 'draft' | 'sent' | 'paid' | 'overdue' | 'cancelled' | 'pending' | 'prepayment' | 'partially_applied';
 

--- a/server/src/test/unit/billing/invoiceGeneration.preview.test.ts
+++ b/server/src/test/unit/billing/invoiceGeneration.preview.test.ts
@@ -955,9 +955,13 @@ describe('invoice preview recurring timing', () => {
       executionIdentityKey: selectorInput.executionWindow.identityKey,
     });
     expect(previewResult).not.toHaveProperty('billingCycleId');
+    // The coded validation failure is returned (not re-thrown) as a keyed action
+    // error so the recurring run can recover the structured failure after the
+    // localization boundary rewrites the sentence.
     expect(generationError).toMatchObject({
-      message: 'Billing email is required before generating recurring invoices.',
-      executionIdentityKey: selectorInput.executionWindow.identityKey,
+      actionError: 'Billing email is required before generating recurring invoices.',
+      messageKey: 'msp/invoicing:manualInvoices.errors.NO_BILLING_EMAIL',
+      messageParams: { clientName: 'Acme Corp' },
     });
     expect(generationError).not.toHaveProperty('billingCycleId');
   });

--- a/server/src/test/unit/billing/invoiceGeneration.preview.test.ts
+++ b/server/src/test/unit/billing/invoiceGeneration.preview.test.ts
@@ -966,6 +966,75 @@ describe('invoice preview recurring timing', () => {
     expect(generationError).not.toHaveProperty('billingCycleId');
   });
 
+  it('keeps unknown preview failures generic instead of exposing the raw internal message', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    mocks.calculateBillingForExecutionWindow.mockRejectedValueOnce(
+      new Error("TypeError: Cannot read properties of undefined (reading 'client_contract_id')"),
+    );
+
+    const selectorInput = buildContractCadenceDueSelectionInput({
+      clientId: 'client-1',
+      contractId: 'contract-1',
+      contractLineId: 'line-1',
+      windowStart: '2025-02-08',
+      windowEnd: '2025-03-08',
+    });
+
+    const result = await previewInvoiceForSelectionInput(selectorInput);
+
+    expect(result).toMatchObject({
+      success: false,
+      error: 'An error occurred while previewing the invoice',
+      executionIdentityKey: selectorInput.executionWindow.identityKey,
+    });
+    expect(result).not.toHaveProperty('code');
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain('client_contract_id');
+    expect(serialized).not.toContain('TypeError');
+
+    // The full cause stays server-side.
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    const [, , loggedError] = consoleErrorSpy.mock.calls[0] as [string, unknown, unknown];
+    expect(loggedError).toBeInstanceOf(Error);
+    expect((loggedError as Error).message).toContain('client_contract_id');
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('routes unsupported coded validation errors to the generic path instead of surfacing them raw', async () => {
+    mocks.validateClientBillingEmail.mockResolvedValue({
+      valid: false,
+      code: 'SERVICE_NOT_FOUND',
+      error: 'Service "service-9" could not be found.',
+      params: { serviceId: 'service-9' },
+    });
+
+    const selectorInput = buildContractCadenceDueSelectionInput({
+      clientId: 'client-1',
+      contractId: 'contract-1',
+      contractLineId: 'line-1',
+      windowStart: '2025-02-08',
+      windowEnd: '2025-03-08',
+    });
+
+    const previewResult = await previewInvoiceForSelectionInput(selectorInput);
+    expect(previewResult).toMatchObject({
+      success: false,
+      error: 'An error occurred while previewing the invoice',
+    });
+    expect(previewResult).not.toHaveProperty('code');
+    expect(JSON.stringify(previewResult)).not.toContain('service-9');
+
+    // The generation boundary must not return the raw coded message as an action
+    // error: it re-throws so the recurring run's generic catch owns it.
+    const generationError = await generateInvoiceForSelectionInput(selectorInput).catch((error) => error);
+    expect(generationError).toBeInstanceOf(Error);
+    expect(generationError).not.toHaveProperty('actionError');
+    expect(generationError).not.toHaveProperty('messageKey');
+  });
+
   it('T050: selector-input recurring generation still enforces PO-required contract validation', async () => {
     mocks.calculateBillingForExecutionWindow.mockResolvedValueOnce({
       charges: [

--- a/server/src/test/unit/billing/recurringBillingRunActions.test.ts
+++ b/server/src/test/unit/billing/recurringBillingRunActions.test.ts
@@ -30,6 +30,8 @@ vi.mock('../../../../../packages/billing/src/actions/invoiceGeneration', () => (
 
 vi.mock('../../../../../packages/billing/src/actions/invoiceGeneration.constants', () => ({
   DUPLICATE_RECURRING_INVOICE_CODE: 'DUPLICATE_RECURRING_INVOICE',
+  DUPLICATE_RECURRING_INVOICE_MESSAGE_KEY: 'msp/billing:errors.duplicateRecurringInvoice',
+  NO_BILLING_EMAIL_MESSAGE_KEY: 'msp/invoicing:manualInvoices.errors.NO_BILLING_EMAIL',
 }));
 
 vi.mock('@alga-psa/event-bus/publishers', () => ({
@@ -93,6 +95,21 @@ function buildContractCadenceTarget(input: {
   return {
     selectorInput,
     executionWindow: selectorInput.executionWindow,
+  };
+}
+
+/**
+ * The returned (not thrown) action-error shape the invoice-generation boundary
+ * produces for a missing billing recipient after the localization seam has
+ * rewritten the sentence. The recurring run recognizes it by messageKey.
+ */
+function noBillingEmailActionError(clientName: string) {
+  return {
+    actionError:
+      `Cannot generate invoice: No billing email address for "${clientName}". ` +
+      'Please set a billing contact, billing email, or a billing/default location email before generating invoices.',
+    messageKey: 'msp/invoicing:manualInvoices.errors.NO_BILLING_EMAIL',
+    messageParams: { clientName },
   };
 }
 
@@ -423,6 +440,120 @@ describe('recurring billing run actions', () => {
         }),
       ],
     });
+    // Approval blockers are not a structured, known failure: they stay generic
+    // (no code), so the UI cannot translate them as client remediation.
+    expect((result.failures[0] as { code?: string })?.code).toBeUndefined();
+  });
+
+  it('carries NO_BILLING_EMAIL code and client/window attribution through a grouped recurring run', async () => {
+    const target = buildContractCadenceTarget({ contractLineId: 'line-no-email' });
+
+    mocks.generateInvoiceForSelectionInputs.mockResolvedValueOnce(
+      noBillingEmailActionError('Acme Co'),
+    );
+
+    const result = await generateGroupedInvoicesAsRecurringBillingRun({
+      groupedTargets: [
+        {
+          groupKey: 'child-selection:no-email',
+          selectorInputs: [target.selectorInput],
+          billingCycleId: 'cycle-no-email',
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      invoicesCreated: 0,
+      failedCount: 1,
+      failures: [
+        {
+          // The grouped-run normalization already drops billingCycleId; client/window
+          // attribution stays exact through executionIdentityKey + executionWindowKind.
+          billingCycleId: null,
+          executionIdentityKey: target.executionWindow.identityKey,
+          executionWindowKind: 'contract_cadence_window',
+          code: 'NO_BILLING_EMAIL',
+          params: { clientName: 'Acme Co' },
+          errorMessage: noBillingEmailActionError('Acme Co').actionError,
+        },
+      ],
+    });
+  });
+
+  it('carries NO_BILLING_EMAIL code through a single-target recurring run', async () => {
+    const target = buildContractCadenceTarget({ contractLineId: 'line-no-email-single' });
+
+    mocks.generateInvoiceForSelectionInput.mockResolvedValueOnce(
+      noBillingEmailActionError('Acme Co'),
+    );
+
+    const result = await generateInvoicesAsRecurringBillingRun({
+      targets: [target],
+    });
+
+    expect(result).toMatchObject({
+      invoicesCreated: 0,
+      failedCount: 1,
+      failures: [
+        {
+          billingCycleId: null,
+          executionIdentityKey: target.executionWindow.identityKey,
+          executionWindowKind: 'contract_cadence_window',
+          code: 'NO_BILLING_EMAIL',
+          params: { clientName: 'Acme Co' },
+        },
+      ],
+    });
+  });
+
+  it('keeps mixed-batch failures attributed to the right client/window and only codes known causes', async () => {
+    const noEmailTarget = buildContractCadenceTarget({
+      clientId: 'client-1',
+      contractLineId: 'line-no-email-mixed',
+    });
+    const unknownTarget = buildContractCadenceTarget({
+      clientId: 'client-2',
+      contractLineId: 'line-unknown-mixed',
+    });
+
+    mocks.generateInvoiceForSelectionInputs
+      .mockResolvedValueOnce(noBillingEmailActionError('Client One'))
+      .mockRejectedValueOnce(new Error('Unhandled linkage failure'));
+
+    const result = await generateGroupedInvoicesAsRecurringBillingRun({
+      groupedTargets: [
+        {
+          groupKey: 'child-selection:no-email-mixed',
+          selectorInputs: [noEmailTarget.selectorInput],
+          billingCycleId: 'cycle-no-email-mixed',
+        },
+        {
+          groupKey: 'child-selection:unknown-mixed',
+          selectorInputs: [unknownTarget.selectorInput],
+          billingCycleId: 'cycle-unknown-mixed',
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      invoicesCreated: 0,
+      failedCount: 2,
+    });
+    const [known, unknown] = (result as { failures: Array<Record<string, unknown>> }).failures;
+    expect(known).toMatchObject({
+      billingCycleId: null,
+      executionIdentityKey: noEmailTarget.executionWindow.identityKey,
+      executionWindowKind: 'contract_cadence_window',
+      code: 'NO_BILLING_EMAIL',
+      params: { clientName: 'Client One' },
+    });
+    expect(unknown).toMatchObject({
+      billingCycleId: null,
+      executionIdentityKey: unknownTarget.executionWindow.identityKey,
+      executionWindowKind: 'contract_cadence_window',
+      errorMessage: 'Failed to generate invoice for this billing cycle.',
+    });
+    expect(unknown.code).toBeUndefined();
   });
 
   it('skips duplicate recurring invoices without marking the canonical recurring run failed', async () => {
@@ -483,6 +614,8 @@ describe('recurring billing run actions', () => {
         }),
       ],
     });
+
+    expect((result as { failures: Array<{ code?: string }> }).failures[0]?.code).toBeUndefined();
 
     expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
     const [, loggedContext] = consoleErrorSpy.mock.calls[0] as [string, Record<string, unknown>];

--- a/server/src/test/unit/billing/recurringBillingRunActions.test.ts
+++ b/server/src/test/unit/billing/recurringBillingRunActions.test.ts
@@ -556,6 +556,37 @@ describe('recurring billing run actions', () => {
     expect(unknown.code).toBeUndefined();
   });
 
+  it('keeps unsupported coded errors off the recurring-run UI as raw text', async () => {
+    const target = buildContractCadenceTarget({ contractLineId: 'line-unsupported' });
+
+    // The boundary re-throws coded-but-unallowlisted errors (e.g. SERVICE_NOT_FOUND
+    // from a ManualInvoiceError) so the run's generic catch owns them.
+    mocks.generateInvoiceForSelectionInput.mockRejectedValueOnce(
+      Object.assign(
+        new Error('Cannot generate invoice: Service "service-9" could not be found.'),
+        { code: 'SERVICE_NOT_FOUND' },
+      ),
+    );
+
+    const result = await generateInvoicesAsRecurringBillingRun({
+      targets: [target],
+    });
+
+    expect(result).toMatchObject({
+      invoicesCreated: 0,
+      failedCount: 1,
+      failures: [
+        expect.objectContaining({
+          executionIdentityKey: target.executionWindow.identityKey,
+          errorMessage: 'Failed to generate invoice for this billing cycle.',
+        }),
+      ],
+    });
+    const failure = (result as { failures: Array<{ code?: string }> }).failures[0];
+    expect(failure?.code).toBeUndefined();
+    expect(JSON.stringify(result)).not.toContain('service-9');
+  });
+
   it('skips duplicate recurring invoices without marking the canonical recurring run failed', async () => {
     const duplicateInvoiceError = Object.assign(
       new Error('Invoice already exists for this recurring execution window'),


### PR DESCRIPTION
## Summary
- Preserve the allowlisted `NO_BILLING_EMAIL` validation code and parameters across invoice-preview and recurring-generation action boundaries.
- Render localized, actionable missing-recipient guidance in automatic-invoice preview, single generation, grouped batch, and PO-overage confirmation flows; unknown/internal errors remain generic.
- Add typed failure payloads and coverage for recurrence actions, preview behavior, and PO-overage rendering.

## Validation
- PASS — billing suite: 1,124 tests; server recurring/preview action tests: 34; billing, server, and types typechecks passed.
- PASS — live branch server ran on port 3712 against `alga-psa-local-test`; authenticated as the seeded MSP user and exercised Invoicing → Generate → Automatic Invoices.
  1. Preview: missing-recipient client showed localized guidance naming the client and all accepted remedies.
  2. Single generation: failure remained attributed to Smoke Replenish; its invoice count stayed 1.
  3. Mixed batch: Emerald City generated draft `INV-000060` while Smoke Replenish alone showed the actionable failure; counts changed Emerald 10→11 and Smoke Replenish 1→1.
  4. Nearby regression: no browser console errors or failed network requests; temporary fixture rows were removed afterward.

## Fidelity notes
- Refreshed stale wire-in credentials and repaired an existing fixture materialization issue with two temporary DB rows.
- Some controls required React-prop/HTMLElement click fallbacks, but server actions, persistence, localization, and rendering were real.
- `alga-dev` screenshots repeatedly timed out, so evidence contains DOM/DB/server assertion records rather than images.
- Not live-exercised: PO-overage decisions and forced unknown/internal exceptions.
- Pre-existing concern: `assertClientCadenceWindowFullyMaterialized` counts inactive contract lines because its query omits `cl.is_active`; this initially blocked the fixture but is not a defect in this change.

Evidence: `/tmp/alga-smoke-evidence/automatic-invoices-actionable-failures-20260826-202703`