### PR TITLE
Defer ticket events and route scheduled comments

### DIFF
--- a/ee/packages/microsoft-teams/src/lib/teams/actions/teamsActionRegistry.ts
+++ b/ee/packages/microsoft-teams/src/lib/teams/actions/teamsActionRegistry.ts
@@ -1,4 +1,4 @@
-import { createTenantKnex, runWithTenant, tenantDb, type ServiceContext } from '@alga-psa/db';
+import { createTenantKnex, runWithTenant, tenantDb, withTransaction, type ServiceContext } from '@alga-psa/db';
 import { ServerAnalyticsTracker } from '@alga-psa/analytics';
 import { ServerEventPublisher } from '@alga-psa/event-bus';
 import type { IUserWithRoles } from '@alga-psa/types';
@@ -1356,7 +1356,7 @@ const actionDefinitions: Record<TeamsActionId, TeamsActionDefinition> = {
       }
 
       const { knex } = await createTenantKnex(context.request.tenantId);
-      const createdTicket = await knex.transaction((trx: any) =>
+      const createdTicket = await withTransaction(knex, (trx: any) =>
         TicketModel.createTicketWithRetry(
           {
             title: String(normalized.title),
@@ -1377,7 +1377,7 @@ const actionDefinitions: Record<TeamsActionId, TeamsActionDefinition> = {
           context.request.tenantId,
           trx,
           {},
-          new ServerEventPublisher(),
+          new ServerEventPublisher(trx),
           new ServerAnalyticsTracker(),
           context.request.user.user_id,
           3

--- a/ee/temporal-workflows/src/activities/job-activities.ts
+++ b/ee/temporal-workflows/src/activities/job-activities.ts
@@ -31,6 +31,7 @@ const HUNTRESS_INCIDENT_POLL_JOB = 'huntress-incident-poll';
 const RMM_DEVICE_SYNC_JOB = 'rmm-device-sync';
 const ACCOUNTING_SYNC_CYCLE_JOB = 'accounting-sync-cycle';
 const HUDU_AUTO_SYNC_JOB = 'hudu-auto-sync';
+const PUBLISH_SCHEDULED_COMMENT_JOB = 'publish-scheduled-comment';
 const SYSTEM_TENANT_ID = '00000000-0000-0000-0000-000000000000';
 
 // Configure logger
@@ -172,6 +173,12 @@ export async function initializeJobHandlersForWorker(): Promise<void> {
   // PDF generation), so the worker forwards them like the jobs above.
   registerJobHandlerForActivities('invoice_zip', forwardJobToServer('invoice_zip'));
   registerJobHandlerForActivities('invoice_email', forwardJobToServer('invoice_email'));
+  // Scheduled comment publication reaches server-local ticket settings and job
+  // modules, so execute it through the same server-side forwarding boundary.
+  registerJobHandlerForActivities(
+    PUBLISH_SCHEDULED_COMMENT_JOB,
+    forwardJobToServer(PUBLISH_SCHEDULED_COMMENT_JOB),
+  );
 
   // User-defined workflow schedules: after the pg-boss → Temporal cutover these
   // arrive as Temporal Schedules (TemporalJobRunner.scheduleJobAt /

--- a/package-lock.json
+++ b/package-lock.json
@@ -48274,6 +48274,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@alga-psa/core": "file:../core",
+        "@alga-psa/db": "file:../db",
         "@alga-psa/event-schemas": "file:../event-schemas",
         "@alga-psa/types": "file:../types",
         "redis": "^4.7.0",

--- a/packages/client-portal/src/actions/client-portal-actions/client-tickets.ts
+++ b/packages/client-portal/src/actions/client-portal-actions/client-tickets.ts
@@ -1251,7 +1251,7 @@ export const createClientTicket = withAuth(async (user, { tenant }, data: FormDa
       };
 
       // Create adapters for client portal context
-      const eventPublisher = new ServerEventPublisher();
+      const eventPublisher = new ServerEventPublisher(trx);
       const analyticsTracker = new ServerAnalyticsTracker();
 
       // Use shared TicketModel with retry logic, events, and analytics
@@ -1294,14 +1294,11 @@ export const createClientTicket = withAuth(async (user, { tenant }, data: FormDa
 
       // Publish TICKET_ASSIGNED event if a default agent was set
       if (createTicketInput.assigned_to) {
-        await publishEvent({
-          eventType: 'TICKET_ASSIGNED',
-          payload: {
-            tenantId: tenant,
-            ticketId: ticketResult.ticket_id,
-            userId: createTicketInput.assigned_to,
-            assignedByUserId: userId
-          }
+        await eventPublisher.publishTicketAssigned({
+          tenantId: tenant,
+          ticketId: ticketResult.ticket_id,
+          userId: createTicketInput.assigned_to,
+          assignedByUserId: userId,
         });
       }
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -61,6 +61,22 @@ export { getConnection as getDbConnection, cleanupConnections } from './lib/conn
 // Transaction Helpers
 import type { Knex as KnexType } from 'knex';
 import { getAdminConnection } from './lib/admin';
+import { flushAfterCommitHooks } from './lib/afterCommit';
+
+async function runOwnedTransaction<T>(
+  knex: KnexType,
+  callback: (trx: KnexType.Transaction) => Promise<T>
+): Promise<T> {
+  let owned: KnexType.Transaction | undefined;
+  const result = await knex.transaction((trx) => {
+    owned = trx;
+    return callback(trx);
+  });
+  if (owned) {
+    await flushAfterCommitHooks(owned);
+  }
+  return result;
+}
 
 /**
  * Execute a function within a transaction
@@ -69,7 +85,7 @@ export async function withKnexTransaction<T>(
   knex: KnexType,
   callback: (trx: KnexType.Transaction) => Promise<T>
 ): Promise<T> {
-  return await knex.transaction(callback);
+  return await runOwnedTransaction(knex, callback);
 }
 
 /**
@@ -94,7 +110,7 @@ export async function withAdminTransaction<T>(
     // If we have a connection but not a transaction, create one
     if (existingConnection) {
       console.log(`[withAdminTransaction:${transactionId}] Creating transaction on existing connection`);
-      const result = await existingConnection.transaction(callback);
+      const result = await runOwnedTransaction(existingConnection as KnexType, callback);
       console.log(`[withAdminTransaction:${transactionId}] New transaction on existing connection completed successfully`);
       return result;
     }
@@ -103,7 +119,7 @@ export async function withAdminTransaction<T>(
     console.log(`[withAdminTransaction:${transactionId}] Getting admin connection for new transaction`);
     const adminDb = await getAdminConnection();
 
-    const result = await adminDb.transaction(callback);
+    const result = await runOwnedTransaction(adminDb, callback);
     return result;
   } catch (error) {
     console.error(`[withAdminTransaction:${transactionId}] Transaction failed:`, {

--- a/packages/db/src/lib/afterCommit.test.ts
+++ b/packages/db/src/lib/afterCommit.test.ts
@@ -133,4 +133,35 @@ describe('registerAfterCommit', () => {
 
     expect(hook).toHaveBeenCalledTimes(1);
   });
+
+  it('flushes hooks owned by withAdminTransaction after commit', async () => {
+    const { withAdminTransaction, registerAfterCommit } = await import('@alga-psa/db');
+    const trx = createOwnedTrx();
+    const knex = createKnex(trx);
+    const order: string[] = [];
+
+    await withAdminTransaction(async (t) => {
+      registerAfterCommit(t, () => {
+        order.push('hook');
+      });
+      order.push('callback');
+    }, knex);
+
+    expect(order).toEqual(['callback', 'hook']);
+    expect(trx.commit).toHaveBeenCalledTimes(1);
+  });
+
+  it('flushes hooks owned by withKnexTransaction after commit', async () => {
+    const { withKnexTransaction, registerAfterCommit } = await import('@alga-psa/db');
+    const trx = createOwnedTrx();
+    const knex = createKnex(trx);
+    const hook = vi.fn();
+
+    await withKnexTransaction(knex, async (t) => {
+      registerAfterCommit(t, hook);
+    });
+
+    expect(hook).toHaveBeenCalledTimes(1);
+    expect(trx.commit).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/event-bus/package.json
+++ b/packages/event-bus/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@alga-psa/core": "file:../core",
+    "@alga-psa/db": "file:../db",
     "@alga-psa/event-schemas": "file:../event-schemas",
     "@alga-psa/types": "file:../types",
     "redis": "^4.7.0",

--- a/packages/event-bus/src/adapters/serverEventPublisher.test.ts
+++ b/packages/event-bus/src/adapters/serverEventPublisher.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  publishWorkflowEvent: vi.fn(),
+  registerAfterCommit: vi.fn(),
+}));
+
+vi.mock('../publishers', () => ({
+  publishWorkflowEvent: mocks.publishWorkflowEvent,
+}));
+
+vi.mock('@alga-psa/db', () => ({
+  registerAfterCommit: mocks.registerAfterCommit,
+}));
+
+import { ServerEventPublisher } from './serverEventPublisher';
+
+describe('ServerEventPublisher', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.publishWorkflowEvent.mockResolvedValue(undefined);
+  });
+
+  it('publishes immediately when no transaction is supplied', async () => {
+    await new ServerEventPublisher().publishTicketCreated({
+      tenantId: 'tenant-1',
+      ticketId: 'ticket-1',
+      userId: 'user-1',
+    });
+
+    expect(mocks.registerAfterCommit).not.toHaveBeenCalled();
+    expect(mocks.publishWorkflowEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('defers TICKET_CREATED until the creating transaction commits', async () => {
+    const trx = {} as any;
+
+    await new ServerEventPublisher(trx).publishTicketCreated({
+      tenantId: 'tenant-1',
+      ticketId: 'ticket-1',
+      userId: 'user-1',
+      metadata: { source: 'client_portal' },
+    });
+
+    expect(mocks.publishWorkflowEvent).not.toHaveBeenCalled();
+    expect(mocks.registerAfterCommit).toHaveBeenCalledWith(
+      trx,
+      expect.any(Function),
+      'TICKET_CREATED ticket=ticket-1',
+    );
+
+    const hook = mocks.registerAfterCommit.mock.calls[0][1] as () => Promise<void>;
+    await hook();
+
+    expect(mocks.publishWorkflowEvent).toHaveBeenCalledWith({
+      eventType: 'TICKET_CREATED',
+      payload: {
+        ticketId: 'ticket-1',
+        createdByUserId: 'user-1',
+        createdAt: expect.any(String),
+        source: 'client_portal',
+      },
+      ctx: {
+        tenantId: 'tenant-1',
+        actor: { actorType: 'USER', actorUserId: 'user-1' },
+      },
+    });
+  });
+});

--- a/packages/event-bus/src/adapters/serverEventPublisher.ts
+++ b/packages/event-bus/src/adapters/serverEventPublisher.ts
@@ -4,9 +4,12 @@
  */
 
 import type { IEventPublisher } from '@alga-psa/types';
+import { registerAfterCommit } from '@alga-psa/db';
 import { publishWorkflowEvent } from '../publishers';
 
 export class ServerEventPublisher implements IEventPublisher {
+  constructor(private readonly trx?: Parameters<typeof registerAfterCommit>[0]) {}
+
   async publishTicketCreated(data: {
     tenantId: string;
     ticketId: string;
@@ -95,18 +98,31 @@ export class ServerEventPublisher implements IEventPublisher {
     actorUserId: string | undefined,
     payload: Record<string, unknown>
   ): Promise<void> {
-    try {
-      await publishWorkflowEvent({
-        eventType: eventType as any,
-        payload,
-        ctx: {
-          tenantId,
-          actor: actorUserId ? { actorType: 'USER', actorUserId } : { actorType: 'SYSTEM' }
-        }
-      });
-    } catch (error) {
-      console.error(`Failed to publish ${eventType} event:`, error);
-      // Don't throw - event publishing failure shouldn't break ticket operations
+    const publish = async () => {
+      try {
+        await publishWorkflowEvent({
+          eventType: eventType as any,
+          payload,
+          ctx: {
+            tenantId,
+            actor: actorUserId ? { actorType: 'USER', actorUserId } : { actorType: 'SYSTEM' }
+          }
+        });
+      } catch (error) {
+        console.error(`Failed to publish ${eventType} event:`, error);
+        // Don't throw - event publishing failure shouldn't break ticket operations
+      }
+    };
+
+    if (this.trx) {
+      registerAfterCommit(
+        this.trx,
+        publish,
+        `${eventType} ticket=${String(payload.ticketId ?? 'unknown')}`
+      );
+      return;
     }
+
+    await publish();
   }
 }

--- a/server/src/lib/eventBus/subscribers/slaSubscriber.ts
+++ b/server/src/lib/eventBus/subscribers/slaSubscriber.ts
@@ -159,10 +159,10 @@ async function handleTicketCreatedEvent(event: unknown): Promise<void> {
           const { knex } = await createTenantKnex();
           const db = tenantDb(knex, tenantId);
 
-          // The main creation paths publish TICKET_CREATED after their
-          // transaction commits, so the row is normally visible immediately.
-          // Some paths still publish in-transaction; retry the read briefly
-          // (outside any transaction, so no locks are held while waiting).
+          // Supported creation paths publish TICKET_CREATED after commit (or
+          // through a transactional outbox), so the row should be visible.
+          // Keep a short defensive retry for rolling deployments and transient
+          // database visibility delays; no locks are held while waiting.
           let ticket: { client_id: string; board_id: string; priority_id: string; entered_at: string | Date | null } | undefined;
           for (let attempt = 0; attempt < 5; attempt++) {
             if (attempt > 0) {

--- a/server/src/test/unit/jobs/jobEnqueueSeam.wiring.test.ts
+++ b/server/src/test/unit/jobs/jobEnqueueSeam.wiring.test.ts
@@ -62,6 +62,36 @@ function enqueuedJobNames(): string[] {
   return [...new Set(names)];
 }
 
+/** Job names passed through the future-dated scheduling seam. */
+function scheduledJobNames(): string[] {
+  const names: string[] = [];
+  const stack = [path.join(repoRoot, 'packages')];
+
+  while (stack.length) {
+    const dir = stack.pop()!;
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (!['node_modules', 'dist', '.next', 'tests'].includes(entry.name)) stack.push(full);
+      } else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) {
+        const text = readFileSync(full, 'utf8');
+        if (!text.includes('scheduleBackgroundJobAt(')) continue;
+
+        const literals = new Map<string, string>();
+        for (const m of text.matchAll(/const\s+([A-Z0-9_]+)\s*=\s*'([^']+)'/g)) {
+          literals.set(m[1], m[2]);
+        }
+        for (const m of text.matchAll(/scheduleBackgroundJobAt\(\s*'([^']+)'/g)) names.push(m[1]);
+        for (const m of text.matchAll(/scheduleBackgroundJobAt\(\s*([A-Z0-9_]+)\s*,/g)) {
+          const value = literals.get(m[1]);
+          if (value) names.push(value);
+        }
+      }
+    }
+  }
+  return [...new Set(names)];
+}
+
 /** Job names the Temporal worker can execute, run in-worker or forwarded. */
 function workerHandledJobNames(source: string): string[] {
   const literals = new Map<string, string>();
@@ -102,7 +132,7 @@ function workerHandledJobNames(source: string): string[] {
   return [...new Set(handled)];
 }
 
-describe('enqueueImmediateJob seam wiring', () => {
+describe('job enqueue seam wiring', () => {
   it('enqueues through the job runner, not the pg-boss-only scheduler', () => {
     const body = enqueuerBody(initializeAppSource);
     expect(body).toContain('await initializeJobRunner()');
@@ -127,6 +157,24 @@ describe('enqueueImmediateJob seam wiring', () => {
         ? ''
         : `${missing.join(', ')} — enqueued via enqueueImmediateJob but not registered in ` +
           'ee/temporal-workflows/src/activities/job-activities.ts. On EE the workflow starts ' +
+          'and fails with "No handler registered for job type".',
+    ).toEqual([]);
+  });
+
+  it('every future-dated job name has a Temporal worker registration', () => {
+    const scheduled = scheduledJobNames();
+    const handled = workerHandledJobNames(jobActivitiesSource);
+
+    // Guards the scanner and the scheduled-comment regression that motivated it.
+    expect(scheduled).toContain('publish-scheduled-comment');
+
+    const missing = scheduled.filter((name) => !handled.includes(name));
+    expect(
+      missing,
+      missing.length === 0
+        ? ''
+        : `${missing.join(', ')} — enqueued through the future-dated job seam but not registered in ` +
+          'ee/temporal-workflows/src/activities/job-activities.ts. On EE the delayed workflow starts ' +
           'and fails with "No handler registered for job type".',
     ).toEqual([]);
   });

--- a/server/src/test/unit/ticketCreatedPublishers.afterCommit.contract.test.ts
+++ b/server/src/test/unit/ticketCreatedPublishers.afterCommit.contract.test.ts
@@ -1,0 +1,31 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = path.resolve(__dirname, '../../../..');
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+describe('ticket creation publisher commit ordering', () => {
+  it('binds client-portal ticket events to the creating transaction', () => {
+    const source = readRepoFile('packages/client-portal/src/actions/client-portal-actions/client-tickets.ts');
+
+    expect(source).toContain('const eventPublisher = new ServerEventPublisher(trx)');
+    expect(source).toContain('await eventPublisher.publishTicketAssigned({');
+  });
+
+  it('binds Teams message-extension ticket events to an owned transaction', () => {
+    const source = readRepoFile('ee/packages/microsoft-teams/src/lib/teams/actions/teamsActionRegistry.ts');
+
+    expect(source).toContain('await withTransaction(knex, (trx: any) =>');
+    expect(source).toContain('new ServerEventPublisher(trx)');
+  });
+
+  it('binds non-durable inbound-email ticket events to the admin transaction', () => {
+    const source = readRepoFile('shared/workflow/actions/emailWorkflowActions.ts');
+
+    expect(source).toContain('new WorkflowEventPublisher({ transaction: trx })');
+  });
+});

--- a/shared/workflow/actions/emailWorkflowActions.ts
+++ b/shared/workflow/actions/emailWorkflowActions.ts
@@ -1204,10 +1204,12 @@ export async function createTicketFromEmail(
   const { WorkflowEventPublisher } = await import('../adapters/workflowEventPublisher');
   const { WorkflowAnalyticsTracker } = await import('../adapters/workflowAnalyticsTracker');
 
-  const eventPublisher = executionOptions?.eventPublisher ?? new WorkflowEventPublisher();
   const analyticsTracker = executionOptions?.analyticsTracker ?? new WorkflowAnalyticsTracker();
 
   return await withAdminTransaction(async (trx: Knex.Transaction) => {
+      // Durable inbound processing injects its transactional outbox publisher.
+      // Every other path defers event-bus publication until this transaction commits.
+      const eventPublisher = executionOptions?.eventPublisher ?? new WorkflowEventPublisher({ transaction: trx });
       const db = tenantDb(trx, tenant);
       // Determine assigned_to: use provided value or fall back to board's default
       let assignedTo = ticketData.assigned_to;
@@ -1524,6 +1526,7 @@ export async function createCommentFromEmail(
         executionOptions?.eventPublisher ??
         new WorkflowEventPublisher({
           suppressCommentEmail: commentData.suppressTechEmailNotification ?? false,
+          transaction: trx,
         });
       // The durable outbox publisher distinguishes the initial comment (in-app
       // only) from a reply comment; drive that from this call's flag.

--- a/shared/workflow/adapters/__tests__/workflowEventPublisher.test.ts
+++ b/shared/workflow/adapters/__tests__/workflowEventPublisher.test.ts
@@ -1,15 +1,44 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const publishEventMock = vi.fn();
+const registerAfterCommitMock = vi.fn();
 
 vi.mock('@alga-psa/event-bus/publishers', () => ({
   publishEvent: (...args: any[]) => publishEventMock(...args),
+}));
+
+vi.mock('@alga-psa/db', () => ({
+  registerAfterCommit: (...args: any[]) => registerAfterCommitMock(...args),
 }));
 
 describe('WorkflowEventPublisher', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     publishEventMock.mockResolvedValue(undefined);
+  });
+
+  it('defers ticket-created publication until the creating transaction commits', async () => {
+    const { WorkflowEventPublisher } = await import('../workflowEventPublisher');
+    const trx = {} as any;
+    const publisher = new WorkflowEventPublisher({ transaction: trx });
+
+    await publisher.publishTicketCreated({
+      tenantId: '91a53464-0b67-4e3f-ae88-922d9c5af6ed',
+      ticketId: '7fa265ac-3a50-4ad6-9454-4a860d884996',
+      metadata: { source: 'email' },
+    });
+
+    expect(publishEventMock).not.toHaveBeenCalled();
+    expect(registerAfterCommitMock).toHaveBeenCalledWith(
+      trx,
+      expect.any(Function),
+      'TICKET_CREATED ticket=7fa265ac-3a50-4ad6-9454-4a860d884996',
+    );
+
+    const hook = registerAfterCommitMock.mock.calls[0][1] as () => Promise<void>;
+    await hook();
+
+    expect(publishEventMock).toHaveBeenCalledTimes(1);
   });
 
   it('publishes ticket-created events through the configured event bus fanout', async () => {

--- a/shared/workflow/adapters/workflowEventPublisher.ts
+++ b/shared/workflow/adapters/workflowEventPublisher.ts
@@ -5,6 +5,8 @@
  */
 
 import type { IEventPublisher } from '@alga-psa/types';
+import { registerAfterCommit } from '@alga-psa/db';
+import type { Knex } from 'knex';
 import type { PublishOptions } from '@alga-psa/event-bus/publishers';
 
 /**
@@ -38,11 +40,32 @@ async function publishNotificationEvent(
 
 export class WorkflowEventPublisher implements IEventPublisher {
   private readonly suppressCommentEmail: boolean;
+  private readonly trx?: Knex.Transaction;
 
   // suppressCommentEmail keeps comment events on the in-app channel only. Used for the
   // first comment on a new inbound-email ticket, which the TICKET_CREATED email already covers.
-  constructor(options?: { suppressCommentEmail?: boolean }) {
+  constructor(options?: { suppressCommentEmail?: boolean; transaction?: Knex.Transaction }) {
     this.suppressCommentEmail = options?.suppressCommentEmail ?? false;
+    this.trx = options?.transaction;
+  }
+
+  private async publish(
+    eventType: string,
+    payload: Record<string, any>,
+    options?: PublishOptions
+  ): Promise<void> {
+    const publish = () => publishNotificationEvent(eventType, payload, options);
+
+    if (this.trx) {
+      registerAfterCommit(
+        this.trx,
+        publish,
+        `${eventType} ticket=${String(payload.ticketId ?? 'unknown')}`
+      );
+      return;
+    }
+
+    await publish();
   }
 
   async publishTicketCreated(data: {
@@ -58,7 +81,7 @@ export class WorkflowEventPublisher implements IEventPublisher {
       ...data.metadata
     };
 
-    await publishNotificationEvent('TICKET_CREATED', payload);
+    await this.publish('TICKET_CREATED', payload);
   }
 
   async publishTicketUpdated(data: {
@@ -76,7 +99,7 @@ export class WorkflowEventPublisher implements IEventPublisher {
       ...data.metadata
     };
 
-    await publishNotificationEvent('TICKET_UPDATED', payload);
+    await this.publish('TICKET_UPDATED', payload);
   }
 
   async publishTicketClosed(data: {
@@ -92,7 +115,7 @@ export class WorkflowEventPublisher implements IEventPublisher {
       ...data.metadata
     };
 
-    await publishNotificationEvent('TICKET_CLOSED', payload);
+    await this.publish('TICKET_CLOSED', payload);
   }
 
   async publishCommentCreated(data: {
@@ -122,7 +145,7 @@ export class WorkflowEventPublisher implements IEventPublisher {
     const options = this.suppressCommentEmail
       ? { channel: 'internal-notifications' }
       : undefined;
-    await publishNotificationEvent('TICKET_COMMENT_ADDED', payload, options);
+    await this.publish('TICKET_COMMENT_ADDED', payload, options);
   }
 
   /**
@@ -141,6 +164,6 @@ export class WorkflowEventPublisher implements IEventPublisher {
       assignedByUserId: data.assignedByUserId
     };
 
-    await publishNotificationEvent('TICKET_ASSIGNED', payload);
+    await this.publish('TICKET_ASSIGNED', payload);
   }
 }


### PR DESCRIPTION
  Flush after-commit hooks for owned transactions and bind ticket event
  publishers to their creating transactions. Route publish-scheduled-comment
  through Temporal's server forwarding boundary, with regression coverage
  for future-dated jobs.

  The White Rabbit now waits for COMMIT before pulling scheduled comments from the Mad Hatter's Temporal queue. 🐇⏰🎩