### PR TITLE
docs: calendar sync troubleshooting — document not-authorized error (2026-08-29)

### DIFF
--- a/docs/integrations/calendar-sync-operations.md
+++ b/docs/integrations/calendar-sync-operations.md
@@ -35,11 +35,12 @@ This runbook covers the day-to-day operational tasks for the Google and Microsof
 3. The provider is removed and a toast confirms success. Any scheduled jobs referencing the provider will skip automatically.
 
 ## Troubleshooting Checklist
-- **Authorization failures**: ensure the OAuth popup is not blocked and that tenant secrets are valid.
+- **"Calendar provider has not completed OAuth authorization yet"**: this message appears immediately when **Sync Now** is clicked on a provider that has no stored OAuth tokens — the OAuth consent flow was never finished. Open the provider's settings card, click **Authorize**, complete the consent flow until you see the **OAuth Complete** badge, save the form, then retry the sync.
+- **Authorization failures (other)**: ensure the OAuth popup is not blocked, that tenant secrets are valid, and that the provider credentials have not been revoked.
 - **Stale last sync**: run a manual sync to force a pass; if the timestamp does not advance check webhook subscriptions.
-- **Webhook errors**: consult the `calendar-webhook-maintenance` job logs. Google uses Calendar “watch” channels (webhook) and Microsoft uses Graph subscriptions; both are renewed by maintenance jobs.
+- **Webhook errors**: consult the `calendar-webhook-maintenance` job logs. Google uses Calendar "watch" channels (webhook) and Microsoft uses Graph subscriptions; both are renewed by maintenance jobs.
 - **Multi-tenant bleed**: confirm the provider belongs to the active tenant. All actions enforce tenant scoping; mismatches result in `Forbidden` errors.
-- **Conflicts stuck**: if repeated conflicts appear, reset the mapping’s `sync_status` through the conflict resolution workflow and retry.
+- **Conflicts stuck**: if repeated conflicts appear, reset the mapping's `sync_status` through the conflict resolution workflow and retry.
 
 ## Escalation
 - Pager duty rotation: **Platform Integrations**.


### PR DESCRIPTION
## Source PRs

- [#3277 Fix/broken link etc](https://github.com/Nine-Minds/alga-psa/pull/3277) — merged 2026-08-28

## Files edited

### `docs/integrations/calendar-sync-operations.md`

**Behavior change conveyed:** Calendar sync now detects providers that never completed the OAuth consent flow (no stored access/refresh tokens) before attempting any sync work, and immediately returns an actionable error — "This calendar provider has not completed OAuth authorization yet. Open its settings and click Authorize, then sync again." — instead of letting a confusing adapter-level failure propagate and stamp an opaque error onto the provider card.

The troubleshooting checklist previously had a single vague "Authorization failures" bullet. This edit splits it into two entries: one dedicated to the new specific `not_authorized` condition with the correct resolution path (click **Authorize** in the provider card), and a second for all other auth failures (blocked popup, revoked credentials, etc.).

## Needs human review

**PRs audited but no in-scope doc drift found:**

| PR | Reason no edit made |
|---|---|
| [#3283 Fix scheduled comment publish on Citus](https://github.com/Nine-Minds/alga-psa/pull/3283) | Bug fix restoring previously expected webhook dispatch behavior (TICKET_COMMENT_ADDED, TICKET_RESPONSE_STATE_CHANGED). No new behavior; docs already reflect correct expected behavior. |
| [#3281 Fix opportunity stages, PO terms, and glossaries](https://github.com/Nine-Minds/alga-psa/pull/3281) | Localization-only changes (pt-BR and pl locales). No English product behavior change. |
| [#3280 get labels monitored](https://github.com/Nine-Minds/alga-psa/pull/3280) | Bug fix making Gmail label filtering consistent across both sync paths (history and time-window reconcile). Restores expected behavior; `email-sync-settings.md` in nm-store does not document label_filters at all — no stale prose to correct. |
| [#3278 Unify permission catalog as single source of truth](https://github.com/Nine-Minds/alga-psa/pull/3278) | The PR itself updated `docs/security/action-security-updates.md`, including a note explaining the rename from `timeentry`/`timesheet`/`timeperiod` to `time_entry`/`time_sheet`/`time_period`. No residual in-scope drift. |
| [#3276 update version number](https://github.com/Nine-Minds/alga-psa/pull/3276) | Version bump only. |
| [#3257 Add Microsoft Graph endpoint guard, surface Entra auth errors, fix mobile ticket description rendering](https://github.com/Nine-Minds/alga-psa/pull/3257) | The PR added `ee/docs/guides/entra-integration-phase-1.md` (out of scope). The nm-store `microsoft-entra-sync-integration.md` already correctly documents `AADSTS65001` as a client-tenant consent issue with the right resolution ("reconnecting your own tenant does not fix this"). No residual in-scope drift. |

---
_Generated by [Claude Code](https://claude.ai/code/session_01MturuNEYrQnCiZV6z1stpq)_