### PR TITLE
Add South African Rand (ZAR) currency support

### DIFF
--- a/ee/server/src/lib/payments/StripePaymentProvider.ts
+++ b/ee/server/src/lib/payments/StripePaymentProvider.ts
@@ -188,7 +188,7 @@ export class StripePaymentProvider implements PaymentProvider {
       supportsHostedCheckout: true,
       supportsEmbeddedCheckout: true,
       supportsWebhooks: true,
-      supportedCurrencies: ['USD', 'EUR', 'GBP', 'CAD', 'AUD', 'JPY', 'CHF', 'NZD', 'ARS', 'BRL'],
+      supportedCurrencies: ['USD', 'EUR', 'GBP', 'CAD', 'AUD', 'JPY', 'CHF', 'NZD', 'ARS', 'BRL', 'ZAR'],
       supportsPartialPayments: false, // Not implementing partial payments initially
       supportsRefunds: true,
       supportsSavedPaymentMethods: true,

--- a/packages/core/src/constants/currency.ts
+++ b/packages/core/src/constants/currency.ts
@@ -15,6 +15,7 @@ export const CURRENCY_OPTIONS: CurrencyOption[] = [
   { value: 'BRL', label: 'BRL (R$)', symbol: 'R$' },
   { value: 'JPY', label: 'JPY (¥)', symbol: '¥' },
   { value: 'CHF', label: 'CHF (Fr.)', symbol: 'Fr.' },
+  { value: 'ZAR', label: 'ZAR (R)', symbol: 'R' },
 ];
 
 export const getCurrencySymbol = (code: string): string => {

--- a/server/src/constants/currency.ts
+++ b/server/src/constants/currency.ts
@@ -16,6 +16,7 @@ export const CURRENCY_OPTIONS: CurrencyOption[] = [
   { value: 'BRL', label: 'BRL (R$)', symbol: 'R$' },
   { value: 'JPY', label: 'JPY (¥)', symbol: '¥' },
   { value: 'CHF', label: 'CHF (Fr.)', symbol: 'Fr.' },
+  { value: 'ZAR', label: 'ZAR (R)', symbol: 'R' },
 ];
 
 export const getCurrencySymbol = (code: string): string => {

--- a/server/src/invoice-templates/assemblyscript/assembly/common/currency.ts
+++ b/server/src/invoice-templates/assemblyscript/assembly/common/currency.ts
@@ -9,5 +9,6 @@ export function getCurrencySymbol(code: string): string {
   if (code == "NZD") return "NZ$";
   if (code == "CHF") return "Fr.";
   if (code == "BRL") return "R$";
+  if (code == "ZAR") return "R";
   return "$"; // Default to USD/Generic Dollar
 }

--- a/server/src/test/stubs/next-server.ts
+++ b/server/src/test/stubs/next-server.ts
@@ -52,6 +52,71 @@ class StubResponseCookies {
   delete(name: string): this {
     return this.set(name, '', { maxAge: 0 });
   }
+
+  // Next's ResponseCookies reads back what the route just set, attributes
+  // included. Reparse the Set-Cookie headers rather than caching state so
+  // cookies written straight onto the headers are visible too.
+  get(name: string): StubCookieObjectForm | undefined {
+    const matches = this.getAll().filter((cookie) => cookie.name === name);
+    return matches.length === 0 ? undefined : matches[matches.length - 1];
+  }
+
+  getAll(): StubCookieObjectForm[] {
+    return this.rawCookies().map((raw) => parseSetCookie(raw));
+  }
+
+  has(name: string): boolean {
+    return this.get(name) !== undefined;
+  }
+
+  private rawCookies(): string[] {
+    const headers = this.headers as Headers & { getSetCookie?: () => string[] };
+    if (typeof headers.getSetCookie === 'function') {
+      return headers.getSetCookie();
+    }
+    const joined = this.headers.get('set-cookie');
+    return joined ? [joined] : [];
+  }
+}
+
+function parseSetCookie(raw: string): StubCookieObjectForm {
+  const [pair, ...attributes] = raw.split(';');
+  const idx = pair.indexOf('=');
+  const cookie: StubCookieObjectForm = {
+    name: (idx === -1 ? pair : pair.slice(0, idx)).trim(),
+    value: idx === -1 ? '' : decodeURIComponent(pair.slice(idx + 1).trim()),
+  };
+
+  for (const attribute of attributes) {
+    const attrIdx = attribute.indexOf('=');
+    const key = (attrIdx === -1 ? attribute : attribute.slice(0, attrIdx)).trim().toLowerCase();
+    const attrValue = attrIdx === -1 ? '' : attribute.slice(attrIdx + 1).trim();
+    switch (key) {
+      case 'path':
+        cookie.path = attrValue;
+        break;
+      case 'domain':
+        cookie.domain = attrValue;
+        break;
+      case 'max-age':
+        cookie.maxAge = Number(attrValue);
+        break;
+      case 'expires':
+        cookie.expires = new Date(attrValue);
+        break;
+      case 'httponly':
+        cookie.httpOnly = true;
+        break;
+      case 'secure':
+        cookie.secure = true;
+        break;
+      case 'samesite':
+        cookie.sameSite = attrValue.toLowerCase() as StubCookieSetOptions['sameSite'];
+        break;
+    }
+  }
+
+  return cookie;
 }
 
 class StubRequestCookies {

--- a/server/src/test/unit/product/hardcodedCurrency.contract.test.ts
+++ b/server/src/test/unit/product/hardcodedCurrency.contract.test.ts
@@ -118,21 +118,38 @@ const SOURCE_FILE = /\.(t|j)sx?$/;
 // adding a currency to CURRENCY_OPTIONS automatically extends this guard
 // (including multi-character symbols like "C$" and "Fr.").
 const escapeRegex = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-const SYMBOL_ALT = [...new Set(CURRENCY_OPTIONS.map((option) => option.symbol))]
-  .sort((a, b) => b.length - a.length)
-  .map(escapeRegex)
-  .join("|");
+const SYMBOLS = [
+  ...new Set(CURRENCY_OPTIONS.map((option) => option.symbol)),
+].sort((a, b) => b.length - a.length);
+const alternation = (symbols: string[]) => symbols.map(escapeRegex).join("|");
+const SYMBOL_ALT = alternation(SYMBOLS);
 
 // A literal currency amount: a symbol followed by a digit (one optional
 // space). Bare symbols ('¥' in a currency map) are fine; symbol+digit is a
 // hardcoded price. $ is the only symbol with regex/template homonyms; the
 // others are unambiguous everywhere.
-const AMOUNT = new RegExp(`(?:${SYMBOL_ALT}) ?\\d`);
+//
+// Letter-only symbols ("R" for ZAR) are the exception: unanchored they read
+// base64 blobs, opaque ids and "Portland, OR 97205" as prices, so they only
+// count when nothing alphanumeric precedes the symbol and no letter follows
+// the digit — which still catches R500, R 1,250.00 and R299/mo.
+const isAlphaSymbol = (s: string) => /^[A-Za-z]+$/.test(s);
+const SYMBOLIC = SYMBOLS.filter((s) => !isAlphaSymbol(s));
+const ALPHABETIC = SYMBOLS.filter(isAlphaSymbol);
+const AMOUNT_SOURCE = [
+  SYMBOLIC.length ? `(?:${alternation(SYMBOLIC)}) ?\\d` : null,
+  ALPHABETIC.length
+    ? `(?<![A-Za-z0-9])(?:${alternation(ALPHABETIC)}) ?\\d(?![A-Za-z])`
+    : null,
+]
+  .filter(Boolean)
+  .join("|");
+const AMOUNT = new RegExp(AMOUNT_SOURCE);
 // Cheap prefilter so only files that could possibly violate get AST-parsed.
 // symbol+digit catches strings/JSX amounts; "$" before "{" catches both the
 // `$${x}` template shape and the JSX `<span>${x}</span>` shape.
 const CANDIDATE = new RegExp(
-  `(?:${SYMBOL_ALT}) ?\\d|\\$\\$?\\{|(?:${SYMBOL_ALT})\\s*<|['"](?:${SYMBOL_ALT})['"]`,
+  `${AMOUNT_SOURCE}|\\$\\$?\\{|(?:${SYMBOL_ALT})\\s*<|['"](?:${SYMBOL_ALT})['"]`,
 );
 // Exactly one bare currency symbol (an input adornment or symbol fallback).
 const BARE_SYMBOL = new RegExp(`^(?:${SYMBOL_ALT})$`);


### PR DESCRIPTION
## Summary

Adds ZAR (South African Rand) as a supported currency across billing configuration, Stripe payments, and invoice templates, and updates the hardcoded-currency guard test so its symbol-detection regex correctly handles letter-only currency symbols like ZAR's `R` without producing false positives on unrelated alphanumeric text.

## Changes

**Currency support**
- `packages/core/src/constants/currency.ts` / `server/src/constants/currency.ts`: add `ZAR` (`R`) to `CURRENCY_OPTIONS`.
- `server/src/invoice-templates/assemblyscript/assembly/common/currency.ts`: return `"R"` for `ZAR` in the AssemblyScript `getCurrencySymbol` helper used by invoice templates.
- `ee/server/src/lib/payments/StripePaymentProvider.ts`: add `ZAR` to Stripe's `supportedCurrencies` list.

**Test guard**
- `server/src/test/unit/product/hardcodedCurrency.contract.test.ts`: split currency symbols into symbolic (`$`, `€`, `£`, …) and alphabetic (`R`) groups, since letter-only symbols need lookaround boundaries to avoid matching things like base64 blobs, opaque ids, or "Portland, OR 97205" as prices. Alphabetic symbols now only match when not preceded by an alphanumeric character and not followed by a letter after the digit, while still catching amounts like `R500`, `R 1,250.00`, and `R299/mo`. The candidate prefilter regex was updated to reuse this bounded pattern.

## Testing
- `npx vitest run server/src/test/unit/product/hardcodedCurrency.contract.test.ts`
