### PR TITLE
docs: retire teams-v2 flag references in teams-v2.md

### DIFF
--- a/docs/features/teams-v2.md
+++ b/docs/features/teams-v2.md
@@ -1,6 +1,6 @@
 # Teams V2
 
-The Teams V2 feature adds comprehensive team management capabilities to AlgaPSA: team member roles, team avatars, team assignment to tickets/tasks/templates, board-level default teams, organizational hierarchy with reports-to chains, and an org chart visualization. All UI is gated behind the **`teams-v2`** PostHog feature flag.
+The Teams V2 feature adds comprehensive team management capabilities to AlgaPSA: team member roles, team avatars, team assignment to tickets/tasks/templates, board-level default teams, organizational hierarchy with reports-to chains, and an org chart visualization. **All Teams V2 UI is unconditionally enabled for all tenants as of v1.5.** The `teams-v2` PostHog feature flag was retired when v1.5 shipped (see PR #3297); there is no flag to configure.
 
 ## Core Features
 
@@ -64,7 +64,7 @@ A `reports_to` column on the `users` table establishes manager relationships ind
 - Time sheet approval chains
 - Scheduling and availability
 
-Configured per-user in User Details settings (only visible when `teams-v2` flag is enabled).
+Configured per-user in User Details settings.
 
 ### Org Chart Visualization
 
@@ -188,7 +188,7 @@ Display component wrapping `EntityAvatar`. Shows the team's uploaded avatar imag
 
 ## Integration Points
 
-| Component | Package | Team Functionality | Feature Flag |
+| Component | Package | Team Functionality | Always On Since v1.5 |
 |---|---|---|---|
 | TaskForm | projects | Assign team via primary/additional agent pickers | Yes |
 | TaskCard | projects | Display team badge | Yes |
@@ -206,29 +206,23 @@ Display component wrapping `EntityAvatar`. Shows the team's uploaded avatar imag
 | TicketingDashboard | tickets | Team filter, team avatars in columns | Yes |
 | ticket-columns | tickets | Team avatar in assigned-to column | Yes |
 | optimizedTicketActions | tickets | Team join, team filter in queries | N/A (backend) |
-| ClientKanbanBoard | client-portal | Read-only team badge on tasks | No (display only) |
-| ClientTaskListView | client-portal | Read-only team badge in list | No (display only) |
-| TicketDetails (client) | client-portal | Read-only team badge | No (display only) |
-| TicketList (client) | client-portal | Team avatar in columns | No (display only) |
+| ClientKanbanBoard | client-portal | Read-only team badge on tasks | N/A (display only, was never flag-gated) |
+| ClientTaskListView | client-portal | Read-only team badge in list | N/A (display only, was never flag-gated) |
+| TicketDetails (client) | client-portal | Read-only team badge | N/A (display only, was never flag-gated) |
+| TicketList (client) | client-portal | Team avatar in columns | N/A (display only, was never flag-gated) |
 | UserDetails | server/settings | Reports-to dropdown | Yes |
 | OrgChart | server/settings | Org chart visualization | Yes |
 | BoardsSettings | server/settings | Default team per board | Yes |
 
 ---
 
-## Feature Flag
+## Feature Flag (Retired)
 
-All teams-v2 UI is gated behind the `teams-v2` PostHog feature flag:
+The `teams-v2` PostHog feature flag was retired in v1.5 (PR #3297). All Teams V2 UI is now unconditionally rendered for all tenants; there is no flag to configure or enable.
 
-```typescript
-const { enabled: teamsV2Enabled } = useFeatureFlag('teams-v2', { defaultValue: false });
-```
+Prior to v1.5, the flag controlled whether team-aware pickers (`UserAndTeamPicker`, `MultiUserAndTeamPicker`) were rendered instead of the basic user-only pickers, and whether team badges, team assignment UI, org chart, and the reports-to field in User Details were visible. All of that UI is now always active.
 
-When disabled:
-- Standard `UserPicker` / `MultiUserPicker` are rendered instead of team-aware pickers
-- Team badges, team assignment UI, and org chart are hidden
-- Database columns exist but remain null
-- Client portal team display is unconditional (shows data if present)
+Client portal team display was never flag-gated and remains unconditional.
 
 ---
 


### PR DESCRIPTION
## Source PR(s)

- [#3297 Remove release-v1-5-feature flag](https://github.com/Nine-Minds/alga-psa/pull/3297) — retired the `release-v1-5-feature` PostHog flag and made all v1.5-gated behavior unconditional. As part of that work, the `teams-v2` PostHog feature flag was also removed from the codebase (confirmed: no `useFeatureFlag('teams-v2')` calls remain in source after the merge).

## Files edited

### `docs/features/teams-v2.md`

**Rationale:** The doc's opening paragraph stated "All UI is gated behind the `teams-v2` PostHog feature flag," and its closing section gave a code example using `useFeatureFlag('teams-v2', { defaultValue: false })` along with a "When disabled" behavior list. The flag no longer exists in the codebase; the Teams V2 UI is unconditionally rendered for all tenants.

Changes made:
- Removed the flag-gating sentence from the opening paragraph; added an explicit statement that Teams V2 is unconditionally enabled as of v1.5.
- Renamed the `## Feature Flag` section to `## Feature Flag (Retired)` and replaced the usage example + "When disabled" list with prose explaining what the flag previously controlled and confirming it is no longer active.
- Renamed the `Integration Points` table's "Feature Flag" column to "Always On Since v1.5" and replaced all "Yes" values with "Yes" (always on) and clarified the client-portal rows as "N/A (display only, was never flag-gated)."

Note: `docs/integrations/teams-setup.md` and `docs/integrations/teams-meetings-setup.md` were already updated by PR #3297 itself (prerequisite section, diagnostics step, troubleshooting entry). Those files are accurate on main.

## Needs human review

1. **PR #3297 — broader v1.5 flag graduation across nm-store**: The agent analysis identified numerous additional features that were ungated: notification priority system, bucket pool editor, credit draw-down, deferred revenue report, appearance settings, credit history button, hour blocks cards, and more. The nm-store customer docs for these features do not contain flag-gate language (confirmed by spot-checks of `notifications.md`, `deferred-revenue-report.md`, `prepaid-balance-alerts.md`, `microsoft-teams-phone.md`, `password-vault.md`), so no nm-store edits were drafted. However, docs for **themes and white labeling** (`themes-and-white-label.md`) and **community vs enterprise edition** (`community-vs-enterprise-edition.md`) were not read and may reference v1.5 rollout language worth reviewing.

2. **PR #3297 — `docs/features/feature-flags.md`**: This doc lists active PostHog flags (billing-enabled, advanced-features-enabled, etc.). It does not list `teams-v2` or `release-v1-5-feature`, so no edit was needed. However, a reader may notice the list does not mention the just-removed flags; a brief historical note or "retired flags" appendix could be useful — left to human discretion.

3. **PRs #3299 and #3300 — ZAR and SEK currency support**: No doc in alga-psa or nm-store enumerates supported currencies, so no doc update was needed. If a supported-currencies list is ever added to the billing docs or the Stripe setup guide, it should be kept in sync with `CURRENCY_OPTIONS` and `StripePaymentProvider.supportedCurrencies`.

4. **nm-store `team-management.md`**: This doc covers only the basic team settings page (create/add/remove members). It does not describe the v2 capabilities now universally available — team assignment to tickets and tasks, org chart, reports-to, board default team. Expanding it is out of scope for a flag-removal patch, but the doc may be worth enriching as a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5NeLskfvsycjag6R8yUmq)_