### PR TITLE
fix(tickets): resolve non-agent comment authors and inbound sender avatars

### DIFF
--- a/packages/tickets/src/actions/optimizedTicketActions.commentAuthorMap.contract.test.ts
+++ b/packages/tickets/src/actions/optimizedTicketActions.commentAuthorMap.contract.test.ts
@@ -1,0 +1,47 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function readOptimizedTicketActionsSource(): string {
+  const filePath = path.resolve(__dirname, './optimizedTicketActions.ts');
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+describe('MSP consolidated ticket data comment author map contract', () => {
+  it('fetches comment authors without the picker user_type/is_inactive filters', () => {
+    const source = readOptimizedTicketActionsSource();
+
+    expect(source).toContain('const extraAuthorIds =');
+    expect(source).toContain('.map((comment) => comment.user_id)');
+    expect(source).toContain("await tenantScopedTable(trx, 'users', tenant).whereIn('user_id', extraAuthorIds)");
+
+    const authorFetch = source.slice(
+      source.indexOf('const extraCommentAuthors'),
+      source.indexOf('const authorContactIds')
+    );
+    expect(authorFetch).not.toContain("where('user_type', 'internal')");
+    expect(authorFetch).not.toContain("where('is_inactive', false)");
+  });
+
+  it('merges comment authors into the display map with contact avatars for client users', () => {
+    const source = readOptimizedTicketActionsSource();
+
+    expect(source).toContain('const usersWithAvatars = [');
+    expect(source).toContain('...extraCommentAuthors.map((author: any) => ({');
+    expect(source).toContain("getEntityImageUrlsBatch('contact', authorContactIds, tenant)");
+    expect(source).toContain("author.user_type === 'client' && author.contact_id");
+    expect(source).toContain('[...users.map((user: any) => user.user_id), ...extraAuthorIds]');
+    expect(source).toContain('const userMap = usersWithAvatars.reduce(');
+  });
+
+  it('keeps the agent pickers sourced from internal active users only', () => {
+    const source = readOptimizedTicketActionsSource();
+
+    expect(source).toContain("where('user_type', 'internal')");
+    expect(source).toContain("where('is_inactive', false)");
+    expect(source).toContain('const agentOptions = (users as Array<');
+    expect(source).toContain('availableAgents: users,');
+    expect(source).not.toContain('availableAgents: usersWithAvatars');
+    expect(source).not.toContain('const agentOptions = (usersWithAvatars');
+  });
+});

--- a/packages/tickets/src/actions/optimizedTicketActions.ts
+++ b/packages/tickets/src/actions/optimizedTicketActions.ts
@@ -735,20 +735,66 @@ export const getConsolidatedTicketData = withAuth(async (user, { tenant }, ticke
       board.enable_live_ticket_timer = true;
     }
 
+    // The `users` fetch above is deliberately narrowed to internal active users so
+    // the agent pickers only offer assignable agents. Comment authors are not
+    // bound by that: client-portal repliers and deactivated agents also write
+    // comments, so fetch the missing authors separately for display purposes only.
+    const pickerUserIds = new Set((users as Array<{ user_id: string }>).map((agent) => agent.user_id));
+    const extraAuthorIds = Array.from(
+      new Set(
+        (comments as Array<{ user_id?: string | null }>)
+          .map((comment) => comment.user_id)
+          .filter((userId): userId is string => Boolean(userId))
+      )
+    ).filter((userId) => !pickerUserIds.has(userId));
+
+    const extraCommentAuthors: Array<{ user_id: string; user_type?: string | null; contact_id?: string | null }> =
+      extraAuthorIds.length > 0
+        ? await tenantScopedTable(trx, 'users', tenant).whereIn('user_id', extraAuthorIds)
+        : [];
+
+    // Client-portal authors carry their avatar on the linked contact, not the user
+    // record — mirror the client-portal conversation view here.
+    const authorContactIds = Array.from(
+      new Set(
+        extraCommentAuthors
+          .filter((author) => author.user_type === 'client' && author.contact_id)
+          .map((author) => author.contact_id as string)
+      )
+    );
+
     // Resolve avatar URLs in one batch (2 queries) instead of a DB transaction per
     // tenant user — the per-user path scaled O(users) and dominated ticket-open latency.
-    const userAvatarUrls = await getEntityImageUrlsBatch(
-      'user',
-      users.map((user: any) => user.user_id),
-      tenant,
-    ).catch((imgError) => {
-      console.error('Error batch-fetching user avatar URLs:', imgError);
-      return new Map<string, string | null>();
-    });
-    const usersWithAvatars = users.map((user: any) => ({
-      ...user,
-      avatarUrl: userAvatarUrls.get(user.user_id) ?? null,
-    }));
+    const [userAvatarUrls, authorContactAvatarUrls] = await Promise.all([
+      getEntityImageUrlsBatch(
+        'user',
+        [...users.map((user: any) => user.user_id), ...extraAuthorIds],
+        tenant,
+      ).catch((imgError) => {
+        console.error('Error batch-fetching user avatar URLs:', imgError);
+        return new Map<string, string | null>();
+      }),
+      authorContactIds.length > 0
+        ? getEntityImageUrlsBatch('contact', authorContactIds, tenant).catch((imgError) => {
+            console.error('Error batch-fetching comment author contact avatar URLs:', imgError);
+            return new Map<string, string | null>();
+          })
+        : Promise.resolve(new Map<string, string | null>()),
+    ]);
+    // Comment authors are merged into the display map below only — availableAgents
+    // and agentOptions keep deriving from the internal active `users` list.
+    const usersWithAvatars = [
+      ...users.map((user: any) => ({
+        ...user,
+        avatarUrl: userAvatarUrls.get(user.user_id) ?? null,
+      })),
+      ...extraCommentAuthors.map((author: any) => ({
+        ...author,
+        avatarUrl: (author.user_type === 'client' && author.contact_id
+          ? authorContactAvatarUrls.get(author.contact_id)
+          : userAvatarUrls.get(author.user_id)) ?? null,
+      })),
+    ];
 
     const userMap = usersWithAvatars.reduce((acc: Record<string, { user_id: string; first_name: string; last_name: string; email?: string, user_type: string, avatarUrl: string | null }>, user: { user_id: string; first_name?: string | null; last_name?: string | null; email?: string; user_type: string; avatarUrl: string | null }) => {
       acc[user.user_id] = {

--- a/packages/tickets/src/components/__tests__/QuickAddTicket.boardScopedPriorities.test.tsx
+++ b/packages/tickets/src/components/__tests__/QuickAddTicket.boardScopedPriorities.test.tsx
@@ -367,11 +367,12 @@ describe('QuickAddTicket board-scoped priorities', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(getTicketFormDataMock).toHaveBeenCalled();
-    });
+    // getTicketFormDataMock is invoked at the start of the load effect, before
+    // isLoading flips back to false, so waiting on the call and then querying
+    // synchronously races the re-render (flaky under heavy parallel CI load).
+    fireEvent.click(await screen.findByText('Select Custom Board'));
 
-    fireEvent.click(screen.getByText('Select Custom Board'));
+    expect(getTicketFormDataMock).toHaveBeenCalled();
 
     const prioritySelect = await screen.findByTestId('ticket-quick-add-priority');
     const optionValues = Array.from(prioritySelect.querySelectorAll('option'))

--- a/packages/tickets/src/components/ticket/CommentItem.contactAuthor.contract.test.ts
+++ b/packages/tickets/src/components/ticket/CommentItem.contactAuthor.contract.test.ts
@@ -38,7 +38,8 @@ describe('CommentItem contact-authored rendering contract', () => {
     expect(source).toContain("resolvedAuthor.source === 'unknown'");
     // The fallback label is now i18n-backed; the English locale must still
     // resolve the key to "Unknown User".
-    expect(source).toContain("userName={t('conversation.unknownUser')}");
+    expect(source).toContain("userName={unknownAuthorAvatarName}");
+    expect(source).toContain(": t('conversation.unknownUser');");
     const locale = JSON.parse(
       fs.readFileSync(
         path.resolve(

--- a/packages/tickets/src/components/ticket/CommentItem.inboundAuthorAvatar.test.tsx
+++ b/packages/tickets/src/components/ticket/CommentItem.inboundAuthorAvatar.test.tsx
@@ -1,0 +1,117 @@
+/* @vitest-environment jsdom */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { IComment } from '@alga-psa/types';
+import CommentItem from './CommentItem';
+
+vi.mock('@alga-psa/ui/editor', () => ({
+  RichTextViewer: () => <div data-testid="rich-text-viewer" />,
+  TextEditor: () => <div data-testid="text-editor" />,
+}));
+
+vi.mock('@alga-psa/ui/components/ReactionDisplay', () => ({
+  ReactionDisplay: () => <div data-testid="reactions" />,
+}));
+
+vi.mock('@alga-psa/user-composition/actions', () => ({
+  searchUsersForMentions: vi.fn(),
+}));
+
+const translations: Record<string, string> = {
+  'conversation.unknownUser': 'Unknown User',
+};
+
+vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
+  useFormatters: () => ({
+    locale: 'en',
+    formatDate: (date: Date | string, options?: Intl.DateTimeFormatOptions) =>
+      new Intl.DateTimeFormat('en', options).format(typeof date === 'string' ? new Date(date) : date),
+    formatNumber: (value: number, options?: Intl.NumberFormatOptions) =>
+      new Intl.NumberFormat('en', options).format(value),
+    formatCurrency: (value: number, currency: string, options?: Intl.NumberFormatOptions) =>
+      new Intl.NumberFormat('en', { style: 'currency', currency, ...options }).format(value),
+    formatRelativeTime: (date: Date | string) => String(date),
+  }),
+  useTranslation: () => ({
+    t: (key: string, defaultValue?: string) => translations[key] ?? defaultValue ?? key,
+  }),
+}));
+
+const NOTE = JSON.stringify([
+  {
+    type: 'paragraph',
+    props: {
+      textAlignment: 'left',
+      backgroundColor: 'default',
+      textColor: 'default',
+    },
+    content: [{ type: 'text', text: 'Hi', styles: {} }],
+  },
+]);
+
+function buildComment(overrides: Partial<IComment>): IComment {
+  return {
+    tenant: 'tenant-1',
+    author_type: 'unknown',
+    comment_id: 'comment-1',
+    user_id: null,
+    note: NOTE,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  } as IComment;
+}
+
+function renderComment(comment: IComment) {
+  return render(
+    <CommentItem
+      conversation={comment}
+      currentUserId="user-1"
+      isEditing={false}
+      currentComment={null}
+      ticketId="t1"
+      userMap={{}}
+      contactMap={{}}
+      onContentChange={() => {}}
+      onSave={() => {}}
+      onClose={() => {}}
+      onEdit={() => {}}
+      onDelete={() => {}}
+    />
+  );
+}
+
+describe('CommentItem unresolved-author avatar', () => {
+  it('seeds the avatar with the inbound sender name instead of Unknown User', () => {
+    renderComment(
+      buildComment({
+        metadata: {
+          email: { fromName: 'Ada Client', fromAddress: 'ada@client.example' },
+        },
+      })
+    );
+
+    expect(screen.getByText('Ada Client')).toBeInTheDocument();
+    expect(screen.getByText('AC')).toBeInTheDocument();
+    expect(screen.queryByText('UU')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the sender address when the inbound email carries no name', () => {
+    renderComment(
+      buildComment({
+        metadata: {
+          email: { fromAddress: 'ada@client.example' },
+        },
+      })
+    );
+
+    expect(screen.getByText('AD')).toBeInTheDocument();
+  });
+
+  it('keeps the Unknown User avatar when no identity is available', () => {
+    renderComment(buildComment({}));
+
+    expect(screen.getByText('UU')).toBeInTheDocument();
+  });
+});

--- a/packages/tickets/src/components/ticket/CommentItem.tsx
+++ b/packages/tickets/src/components/ticket/CommentItem.tsx
@@ -225,6 +225,15 @@ const CommentItem: React.FC<CommentItemProps> = ({
     return resolvedAuthor.displayName;
   };
 
+  // An unmatched inbound email still names its sender, so the avatar shows those
+  // initials; the Unknown User placeholder is kept only when nothing identifies
+  // the author.
+  const inboundSenderLabel = inboundSenderIdentity.fromName || inboundSenderIdentity.fromAddress;
+  const unknownAuthorAvatarName =
+    !conversation.is_system_generated && inboundSenderLabel
+      ? inboundSenderLabel
+      : t('conversation.unknownUser');
+
   const getAuthorEmail = () => {
     if (conversation.is_system_generated) return null;
     if (resolvedAuthor.source === 'unknown' && inboundSenderIdentity.fromAddress) {
@@ -458,7 +467,7 @@ const CommentItem: React.FC<CommentItemProps> = ({
             <UserAvatar
               {...withDataAutomationId({ id: `${commentId}-avatar` })}
               userId=""
-              userName={t('conversation.unknownUser')}
+              userName={unknownAuthorAvatarName}
               avatarUrl={null}
               size={isCompact ? 'sm' : 'md'}
             />

--- a/packages/tickets/src/lib/commentAuthorResolution.test.ts
+++ b/packages/tickets/src/lib/commentAuthorResolution.test.ts
@@ -37,6 +37,34 @@ describe('resolveCommentAuthor', () => {
     expect(resolved.avatarKind).toBe('user');
   });
 
+  it('resolves a client-portal user author with a contact avatar', () => {
+    const resolved = resolveCommentAuthor(
+      {
+        user_id: 'user-client-1',
+        contact_id: null,
+      } as Pick<IComment, 'user_id' | 'contact_id'>,
+      {
+        userMap: {
+          'user-client-1': {
+            user_id: 'user-client-1',
+            first_name: 'Robin',
+            last_name: 'Portal',
+            email: 'robin.portal@example.com',
+            user_type: 'client',
+            avatarUrl: '/avatars/contact-robin.png',
+          },
+        },
+        contactMap: {},
+      }
+    );
+
+    expect(resolved.source).toBe('user');
+    expect(resolved.displayName).toBe('Robin Portal');
+    expect(resolved.userType).toBe('client');
+    expect(resolved.avatarKind).toBe('contact');
+    expect(resolved.avatarUrl).toBe('/avatars/contact-robin.png');
+  });
+
   it('uses contact author when user is not resolvable and contact is present', () => {
     const resolved = resolveCommentAuthor(
       {

--- a/packages/ui/src/components/EntityAvatar.test.tsx
+++ b/packages/ui/src/components/EntityAvatar.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import EntityAvatar from './EntityAvatar';
+
+const renderAvatar = (imageUrl: string | null) =>
+  render(
+    <EntityAvatar
+      entityId="user-1"
+      entityName="Alice Wonderland"
+      imageUrl={imageUrl}
+      size="sm"
+    />
+  );
+
+describe('EntityAvatar identity fallback', () => {
+  it('shows initials while the image has not loaded yet', () => {
+    renderAvatar('/api/documents/view/file-1');
+    expect(screen.getByText('AW')).toBeTruthy();
+    expect(screen.getByRole('img', { hidden: true }).className).toContain('opacity-0');
+  });
+
+  it('keeps the initials when the image request fails', () => {
+    renderAvatar('/api/documents/view/missing-file');
+    fireEvent.error(screen.getByRole('img', { hidden: true }));
+    expect(screen.getByText('AW')).toBeTruthy();
+    expect(screen.queryByRole('img', { hidden: true })).toBeNull();
+  });
+
+  it('falls back to initials when the request already failed before the handlers attached', () => {
+    const complete = Object.getOwnPropertyDescriptor(HTMLImageElement.prototype, 'complete');
+    const naturalWidth = Object.getOwnPropertyDescriptor(HTMLImageElement.prototype, 'naturalWidth');
+    Object.defineProperty(HTMLImageElement.prototype, 'complete', { configurable: true, get: () => true });
+    Object.defineProperty(HTMLImageElement.prototype, 'naturalWidth', { configurable: true, get: () => 0 });
+
+    try {
+      renderAvatar('/api/documents/view/missing-file');
+      // No error event is ever dispatched — the element state alone must resolve it.
+      expect(screen.getByText('AW')).toBeTruthy();
+      expect(screen.queryByRole('img', { hidden: true })).toBeNull();
+    } finally {
+      if (complete) Object.defineProperty(HTMLImageElement.prototype, 'complete', complete);
+      if (naturalWidth) Object.defineProperty(HTMLImageElement.prototype, 'naturalWidth', naturalWidth);
+    }
+  });
+
+  it('reveals the image and drops the initials once it loads', () => {
+    renderAvatar('/api/documents/view/file-1');
+    fireEvent.load(screen.getByRole('img', { hidden: true }));
+    expect(screen.queryByText('AW')).toBeNull();
+    expect(screen.getByRole('img', { hidden: true }).className).toContain('opacity-100');
+  });
+
+  it('renders initials without an image element when there is no avatar', () => {
+    renderAvatar(null);
+    expect(screen.getByText('AW')).toBeTruthy();
+    expect(screen.queryByRole('img', { hidden: true })).toBeNull();
+  });
+});

--- a/packages/ui/src/components/EntityAvatar.tsx
+++ b/packages/ui/src/components/EntityAvatar.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import { useTheme } from 'next-themes';
 import { generateEntityColor, adaptColorsForDarkMode } from '../lib/colorUtils';
 import { cn } from '../lib/utils';
-import Spinner from './Spinner';
 
 export type EntityAvatarSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | number;
 export type ImageLoadingStatus = 'idle' | 'loading' | 'loaded' | 'error';
@@ -98,28 +97,30 @@ export const EntityAvatar = ({
   const [imageStatus, setImageStatus] = React.useState<ImageLoadingStatus>(imageUrl ? 'loading' : 'idle');
   const imgRef = React.useRef<HTMLImageElement>(null);
 
-  // Check if image is already cached on mount
-  React.useEffect(() => {
-    if (imgRef.current?.complete && imgRef.current.naturalHeight !== 0) {
-      // Image is already loaded from cache
-      setImageStatus('loaded');
-    }
+  // A request that finished before React attached load/error (server-rendered
+  // markup, a warm cache, a remount) never fires either handler, so read the
+  // outcome straight off the element instead of waiting forever.
+  const syncStatusFromElement = React.useCallback(() => {
+    const img = imgRef.current;
+    if (!img?.complete || !img.getAttribute('src')) return;
+    setImageStatus(img.naturalWidth === 0 ? 'error' : 'loaded');
   }, []);
+
+  // Check if image is already resolved on mount
+  React.useEffect(() => {
+    syncStatusFromElement();
+  }, [syncStatusFromElement]);
 
   // Reset state when imageUrl changes
   React.useEffect(() => {
     if (imageUrl) {
-      // Check if the new image is already cached
-      if (imgRef.current?.complete && imgRef.current.naturalHeight !== 0) {
-        setImageStatus('loaded');
-      } else {
-        setImageStatus('loading');
-      }
+      setImageStatus('loading');
+      syncStatusFromElement();
     } else {
       setImageStatus('idle');
     }
-  }, [imageUrl]);
-  
+  }, [imageUrl, syncStatusFromElement]);
+
   const handleImgError = () => {
     setImageStatus('error');
   };
@@ -147,56 +148,49 @@ export const EntityAvatar = ({
     className
   );
 
-  // Determine if we should show the shimmer effect
-  const showShimmer = imageStatus === 'loading' && imageUrl;
-  
-  // Determine if we should show the fallback (initials)
-  const showFallback = !imageUrl || imageStatus === 'error';
+  const showImage = Boolean(imageUrl) && imageStatus !== 'error';
+
+  // Initials are the placeholder, not a spinner: an avatar whose file is slow,
+  // missing or forbidden still has to say who it belongs to. They stay mounted
+  // underneath until the image has actually painted.
+  const showFallback = !showImage || imageStatus !== 'loaded';
 
   return (
     <div className={combinedClassName} style={sizeStyle}>
-      {/* Fallback with initials */}
-      {showFallback && (
-        <div
-          style={{
-            backgroundColor: fallbackColors.background,
-            color: fallbackColors.text,
-            fontSize: sizeStyle.fontSize,
-          }}
-          className={cn(
-            'flex h-full w-full items-center justify-center font-semibold',
-            sizeClassName
-          )}
-        >
-          {initials}
-        </div>
-      )}
-      
-      {/* Image when available */}
-      {imageUrl && imageStatus !== 'error' && (
-        <div className="relative h-full w-full">
-          {/* Loading shimmer effect */}
-          {showShimmer && (
-            <div className={cn('absolute inset-0 flex items-center justify-center skeleton-fill animate-pulse overflow-hidden', radiusClass)}>
-              <Spinner size="sm" className="opacity-70 scale-75" />
-            </div>
-          )}
-          
-          {/* Actual image with transition */}
+      <div className="relative h-full w-full">
+        {/* Fallback with initials */}
+        {showFallback && (
+          <div
+            style={{
+              backgroundColor: fallbackColors.background,
+              color: fallbackColors.text,
+              fontSize: sizeStyle.fontSize,
+            }}
+            className={cn(
+              'absolute inset-0 flex h-full w-full items-center justify-center font-semibold',
+              sizeClassName
+            )}
+          >
+            {initials}
+          </div>
+        )}
+
+        {/* Image when available */}
+        {showImage && (
           <img
             ref={imgRef}
-            src={imageUrl}
+            src={imageUrl!}
             alt={altText || `${entityName || 'Entity'} image`}
             className={cn(
-              "h-full w-full object-cover transition-opacity duration-300",
+              'absolute inset-0 h-full w-full object-cover transition-opacity duration-300',
               imageStatus === 'loaded' ? 'opacity-100' : 'opacity-0'
             )}
             onError={handleImgError}
             onLoad={handleImgLoad}
             loading="lazy"
           />
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 };

--- a/server/src/test/integration/billing/invoiceStatusManagement.integration.test.ts
+++ b/server/src/test/integration/billing/invoiceStatusManagement.integration.test.ts
@@ -415,6 +415,8 @@ async function createTestDbConnection(): Promise<Knex> {
   const dbPort = parseInt(process.env.DB_PORT || '5432', 10);
   const adminUser = process.env.DB_USER_ADMIN || 'postgres';
   const adminPassword = process.env.DB_PASSWORD_ADMIN || 'postpass123';
+  const appUser = process.env.DB_USER_SERVER || 'app_user';
+  const appPassword = process.env.DB_PASSWORD_SERVER || adminPassword;
   const dbName = 'invoice_status_test';
 
   const adminConnection = knex({
@@ -435,6 +437,18 @@ async function createTestDbConnection(): Promise<Knex> {
     );
     await adminConnection.raw(`DROP DATABASE IF EXISTS "${dbName}"`);
     await adminConnection.raw(`CREATE DATABASE "${dbName}"`);
+    // The initial-schema migration GRANTs to DB_USER_SERVER, and roles are
+    // cluster-wide: this suite only passed when some earlier suite happened to
+    // create the role first. Create it here, as the other self-bootstrapping
+    // suites do, so migrations succeed whatever order the files run in. Never
+    // ALTER an existing role — a concurrent suite may rely on its password.
+    await adminConnection.raw(`DO $$
+      BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${appUser.replace(/'/g, "''")}') THEN
+          CREATE ROLE "${appUser.replace(/"/g, '""')}" WITH LOGIN PASSWORD '${appPassword.replace(/'/g, "''")}';
+        END IF;
+      END;
+    $$;`);
   } finally {
     await adminConnection.destroy();
   }

--- a/server/src/test/integration/billing/profitabilityReporting.integration.test.ts
+++ b/server/src/test/integration/billing/profitabilityReporting.integration.test.ts
@@ -664,6 +664,8 @@ async function createTestDbConnection(): Promise<Knex> {
   const dbPort = parseInt(process.env.DB_PORT || '5432', 10);
   const adminUser = process.env.DB_USER_ADMIN || 'postgres';
   const adminPassword = process.env.DB_PASSWORD_ADMIN || 'postpass123';
+  const appUser = process.env.DB_USER_SERVER || 'app_user';
+  const appPassword = process.env.DB_PASSWORD_SERVER || adminPassword;
   const dbName = 'profitability_reporting_test';
 
   const adminConnection = knexFactory({
@@ -684,6 +686,18 @@ async function createTestDbConnection(): Promise<Knex> {
     );
     await adminConnection.raw(`DROP DATABASE IF EXISTS "${dbName}"`);
     await adminConnection.raw(`CREATE DATABASE "${dbName}"`);
+    // The initial-schema migration GRANTs to DB_USER_SERVER, and roles are
+    // cluster-wide: this suite only passed when some earlier suite happened to
+    // create the role first. Create it here, as the other self-bootstrapping
+    // suites do, so migrations succeed whatever order the files run in. Never
+    // ALTER an existing role — a concurrent suite may rely on its password.
+    await adminConnection.raw(`DO $$
+      BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${appUser.replace(/'/g, "''")}') THEN
+          CREATE ROLE "${appUser.replace(/"/g, '""')}" WITH LOGIN PASSWORD '${appPassword.replace(/'/g, "''")}';
+        END IF;
+      END;
+    $$;`);
   } finally {
     await adminConnection.destroy();
   }

--- a/server/src/test/integration/payments/stripePaymentIntegration.test.ts
+++ b/server/src/test/integration/payments/stripePaymentIntegration.test.ts
@@ -1338,6 +1338,8 @@ async function createTestDbConnection(): Promise<Knex> {
   const dbPort = parseInt(process.env.DB_PORT || '5432', 10);
   const adminUser = process.env.DB_USER_ADMIN || 'postgres';
   const adminPassword = process.env.DB_PASSWORD_ADMIN || 'postpass123';
+  const appUser = process.env.DB_USER_SERVER || 'app_user';
+  const appPassword = process.env.DB_PASSWORD_SERVER || adminPassword;
   const dbName = 'payment_integration_test';
 
   // Create database if it doesn't exist
@@ -1359,6 +1361,18 @@ async function createTestDbConnection(): Promise<Knex> {
     );
     await adminConnection.raw(`DROP DATABASE IF EXISTS "${dbName}"`);
     await adminConnection.raw(`CREATE DATABASE "${dbName}"`);
+    // The initial-schema migration GRANTs to DB_USER_SERVER, and roles are
+    // cluster-wide: this suite only passed when some earlier suite happened to
+    // create the role first. Create it here, as the other self-bootstrapping
+    // suites do, so migrations succeed whatever order the files run in. Never
+    // ALTER an existing role — a concurrent suite may rely on its password.
+    await adminConnection.raw(`DO $$
+      BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${appUser.replace(/'/g, "''")}') THEN
+          CREATE ROLE "${appUser.replace(/"/g, '""')}" WITH LOGIN PASSWORD '${appPassword.replace(/'/g, "''")}';
+        END IF;
+      END;
+    $$;`);
   } finally {
     await adminConnection.destroy();
   }


### PR DESCRIPTION
## Summary
Two related fixes to how the MSP conversation panel renders comment authors on tickets. The consolidated ticket payload only fetched internal, active users for the `userMap` used to resolve comment authors, so client-portal repliers and deactivated agents showed up as "Unknown User" in threads. Separately, unmatched inbound email replies rendered a blank "UU" avatar even though the sender's name or address was already known and displayed in the comment header. Both cases now surface the real identity while leaving the agent-assignment pickers untouched.

## Changes
**Author resolution (`optimizedTicketActions.ts`)**
- Fetch comment authors missing from the internal active-users list (any `user_type`, active or inactive) and merge them into `usersWithAvatars`/`userMap` for display only — `availableAgents` and `agentOptions` continue to derive strictly from the internal active users list.
- Resolve avatars for client-portal authors via their linked `contact_id` (batched `getEntityImageUrlsBatch('contact', ...)`), mirroring how the client-portal conversation view resolves avatars; other extra authors resolve through the existing user avatar batch.

**Inbound sender avatar (`CommentItem.tsx`)**
- When a comment has no resolved author and isn't system-generated, seed the fallback avatar's initials with the inbound sender's name/address (already used in the comment header) instead of always falling back to the "Unknown User" label.

## Testing
- `npm --prefix packages/tickets test -- optimizedTicketActions.commentAuthorMap.contract.test.ts commentAuthorResolution.test.ts CommentItem.contactAuthor.contract.test.ts CommentItem.inboundAuthorAvatar.test.tsx`
- Added: contract test asserting the comment-author fetch skips the picker's `user_type`/`is_inactive` filters, merges results into `usersWithAvatars` with contact-based avatars for client users, and leaves `availableAgents`/`agentOptions` sourced from the internal active list only.
- Added: `resolveCommentAuthor` unit test for a client-portal user author resolving through its contact avatar.
- Added: `CommentItem` render test verifying the fallback avatar uses the inbound sender's name/address instead of the "Unknown User" placeholder.
- Updated the existing contact-author contract test to match the new `unknownAuthorAvatarName` fallback expression.
