### PR TITLE
docs: documentation drift audit 2026-09-02

### DIFF
--- a/docs/billing/invoice_number_flowchart.md
+++ b/docs/billing/invoice_number_flowchart.md
@@ -14,10 +14,14 @@ flowchart TD
     J -->|Yes| K[Use Candidate]
     J -->|No| H
     I -->|No| K
-    K --> L[Format Number]
+    K --> L{Date Format Set?}
     H --> L
-    L --> M[Release Lock]
-    M --> N[Return Formatted Number]
+    L -->|Yes| M[Expand Date Tokens in Tenant Timezone]
+    L -->|No| N[Format: prefix + padded counter]
+    M --> O[Format: prefix + expanded date + padded counter]
+    N --> P[Release Lock]
+    O --> P
+    P --> Q[Return Formatted Number]
 ```
 
 ## Key Steps Explanation
@@ -28,5 +32,6 @@ flowchart TD
 4. **Number Analysis**: Extracts and analyzes existing numbers
 5. **Conflict Check**: Determines if candidate is safe to use
 6. **Gap Detection**: Finds available gaps in number sequence
-7. **Formatting**: Applies prefix and padding as needed
-8. **Cleanup**: Releases lock and returns result
+7. **Date Token Expansion** *(optional)*: If a `prefix_date_format` is configured on the document type, the tokens `{YYYY}`, `{YY}`, `{MM}`, and `{DD}` are expanded to the issuance date in the tenant's configured timezone (UTC fallback). The expanded string is inserted between the static prefix and the padded counter, producing numbers of the form `<prefix><date><counter>` — for example, prefix `INV-` with date format `{YYYY}-{MM}-` and counter `1` (padding 6) yields `INV-2026-09-000001`. The sequential counter never resets on a date boundary.
+8. **Formatting**: Assembles the final number string from the static prefix, the optional expanded date string, and the zero-padded counter.
+9. **Cleanup**: Releases lock and returns result

--- a/docs/features/analytics-events-reference.md
+++ b/docs/features/analytics-events-reference.md
@@ -62,6 +62,7 @@ This document provides a comprehensive reference of all analytics events tracked
 | `dashboard_viewed` | Dashboard accessed | `dashboard_type`, `widgets_count` |
 | `power_user_score_calculated` | Power user score calculated | `score`, `unique_features_used`, `advanced_features_used` |
 | `role_based_usage_pattern` | Usage pattern by role | `user_role`, `adoption_rate` |
+| `ui.resources_menu.select` | Resources menu link clicked from application header | `target` (`'resources-documentation'` or `'resources-support'`) |
 
 ### 8. Error Tracking Events
 


### PR DESCRIPTION
## Source PRs

- [#3305 Add optional date tokens to number prefixes](https://github.com/Nine-Minds/alga-psa/pull/3305)
- [#3303 Add header resources menu for documentation and support links](https://github.com/Nine-Minds/alga-psa/pull/3303)

## Files edited

### `docs/billing/invoice_number_flowchart.md`
**Rationale (PR #3305):** The flowchart previously described step 7 as "Applies prefix and padding as needed." The PR introduces a `prefix_date_format` column on the `next_number` table that, when set, expands date tokens (`{YYYY}`, `{YY}`, `{MM}`, `{DD}`) in the tenant's configured timezone and inserts the result between the static prefix and the zero-padded counter — producing numbers like `INV-2026-09-000001`. The Mermaid diagram now shows the date-format decision branch; the Key Steps section describes the new formatting model and the fact that the sequential counter never resets on a date boundary.

### `docs/features/analytics-events-reference.md`
**Rationale (PR #3303):** The PR adds a `ResourcesMenu` component to the application header that fires `analytics.capture('ui.resources_menu.select', { target: link.id })` when either the Documentation or Contact Support link is clicked. The `target` value is `'resources-documentation'` or `'resources-support'`. This event was not listed in the reference; it is now added under User Behavior Events.

## Needs human review

1. **PR #3304 — comment author resolution (skipped):** This fixes "Unknown User" display for client-portal repliers and deactivated agents in ticket conversation threads. No existing in-repo doc describes this resolution behavior, so no update was drafted. Flag if a doc on the conversation panel or client portal is planned.

2. **PR #3303 — header resources menu in nm-store customer docs:** The nm-store `understanding-the-main-navigation-sidebar-menu.md` covers the sidebar, which PR #3303 left unchanged. The new "?" header button provides a second entry point to documentation and support. There is currently no nm-store doc covering header navigation elements. A brief mention in a navigation or getting-started doc may be worth adding — left to human discretion.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kn35LmRSxcP25PjejrHEQc)_