### PR TITLE
fix(appliance): unblock Entra sync token writes

### DIFF
--- a/docs/plans/2026-08-25-appliance-temporal-worker-shared-tenant-secrets.md
+++ b/docs/plans/2026-08-25-appliance-temporal-worker-shared-tenant-secrets.md
@@ -303,3 +303,21 @@ Deployment. Because the selector addition is delivered through `extraSelectorLab
 overlay rather than the default template, hosted Deployments (two-label selector) and the appliance
 Deployment (three-label selector) both upgrade in place without an immutable-selector migration
 failure.
+
+### Correction (2026-09-03): the worker writes to the store
+
+GitHub issue #3315 (fresh appliance, Entra contact sync) showed the D1 audit missed a write path.
+`DirectProviderAdapter` refreshes Entra OAuth tokens inside the worker and persists them through
+`saveEntraDirectTokenSet` / `saveEntraDirectRefreshToken` (`ee/server/src/lib/integrations/entra/auth/`):
+discovery rewrites the whole token set whenever the access token is near expiry, and every user sync
+stores the refresh token Microsoft rotates on redemption. With the read-only mount every sync failed
+with `EROFS`. With a writable mount it still failed: the image's non-root `temporal` user (UID 999)
+cannot write into the root-owned 0755 tenant directories alga-core creates, and `fsGroup` does not
+apply to hostPath volumes.
+
+Resolution (chart 0.1.4): the chart default is now `sharedTenantSecrets.readOnly: false`; the appliance
+overlay sets it explicitly and runs the worker as root (`securityContext.runAsUser: 0`), matching
+alga-core and email-service on the same host directory. T1 pins the writable mount and the root
+security context for the overlay. Separately, the stable release manifest still pinned worker image
+`84d3a55b` (2026-08-12), which predates the `/v1.0/users` fix in `907702138d`; re-pin it alongside this
+chart bump.

--- a/ee/appliance/flux/base/releases/temporal-worker.yaml
+++ b/ee/appliance/flux/base/releases/temporal-worker.yaml
@@ -22,7 +22,7 @@ spec:
   chart:
     spec:
       chart: temporal-worker
-      version: 0.1.3
+      version: 0.1.4
       interval: 10m
       reconcileStrategy: Revision
       sourceRef:

--- a/ee/appliance/flux/profiles/single-node/values/temporal-worker.single-node.yaml
+++ b/ee/appliance/flux/profiles/single-node/values/temporal-worker.single-node.yaml
@@ -9,11 +9,20 @@ deploymentProfile: appliance
 extraSelectorLabels:
   app.kubernetes.io/component: temporal-worker
 
-# Share the tenant-secret store with alga-core so the pinned Microsoft profile
-# client secret alga-core writes via the filesystem provider is readable here,
-# letting polling reconciliation resolve client_secret_ref.
+# Share the tenant-secret store with alga-core: polling reconciliation reads the
+# pinned Microsoft profile client secret alga-core writes there, and Entra sync
+# writes refreshed OAuth tokens back to it.
 sharedTenantSecrets:
   enabled: true
+  readOnly: false
+
+# alga-core creates the hostPath as root (0755 dirs, 0644 files) and fsGroup
+# does not apply to hostPath volumes, so the image's non-root `temporal` user
+# cannot write refreshed Entra tokens. Run as root on the appliance, matching
+# alga-core and email-service on the same host directory.
+securityContext:
+  runAsUser: 0
+  runAsGroup: 0
 
 image:
   repository: ghcr.io/nine-minds/temporal-worker

--- a/ee/helm/temporal-worker/Chart.yaml
+++ b/ee/helm/temporal-worker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: temporal-worker
 description: A Helm chart for the AlgaPSA Temporal Worker component
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "1.0"
 home: https://github.com/Nine-Minds/alga-psa
 maintainers:

--- a/ee/helm/temporal-worker/values.yaml
+++ b/ee/helm/temporal-worker/values.yaml
@@ -203,13 +203,15 @@ extraVolumeMounts: []
 
 # Shared tenant-secret store on the single-node appliance. When enabled, mounts
 # a hostPath into the pod and points the filesystem secret provider at it via
-# SECRET_FS_BASE_PATH so this worker reads the same tenant secrets alga-core
+# SECRET_FS_BASE_PATH so this worker shares the tenant secrets alga-core
 # writes. Disabled by default → cloud/hosted rendering is unchanged.
+# Read-write: Entra sync refreshes OAuth tokens in this worker and persists
+# them through the same provider, so a read-only mount fails every sync (EROFS).
 sharedTenantSecrets:
   enabled: false
   hostPath: /var/lib/alga-appliance/tenant-secrets
   mountPath: /shared-tenant-secrets
-  readOnly: true
+  readOnly: false
 
 # Database configuration
 # These values should be provided by the parent chart or overridden in production

--- a/ee/temporal-workflows/src/__tests__/temporal-worker-shared-tenant-secrets.helm.test.ts
+++ b/ee/temporal-workflows/src/__tests__/temporal-worker-shared-tenant-secrets.helm.test.ts
@@ -44,7 +44,7 @@ describe.skipIf(!helmAvailable)('temporal-worker shared tenant secrets Helm rend
     });
   });
 
-  it('renders the shared hostPath, read-only mount, and filesystem base path when enabled', () => {
+  it('renders the shared hostPath, writable mount, and filesystem base path when enabled', () => {
     const secrets = sharedTenantSecrets(renderDeployment(['--set', 'sharedTenantSecrets.enabled=true']));
 
     expect(secrets.volume).toEqual({
@@ -54,12 +54,24 @@ describe.skipIf(!helmAvailable)('temporal-worker shared tenant secrets Helm rend
         type: 'DirectoryOrCreate',
       },
     });
+    // Entra sync persists refreshed tokens through this mount; readOnly must not render.
+    expect(secrets.mount).toEqual({
+      name: 'shared-tenant-secrets',
+      mountPath: '/shared-tenant-secrets',
+    });
+    expect(secrets.env).toEqual({ name: 'SECRET_FS_BASE_PATH', value: '/shared-tenant-secrets' });
+  });
+
+  it('still honours an explicit read-only opt-in', () => {
+    const secrets = sharedTenantSecrets(
+      renderDeployment(['--set', 'sharedTenantSecrets.enabled=true', '--set', 'sharedTenantSecrets.readOnly=true'])
+    );
+
     expect(secrets.mount).toEqual({
       name: 'shared-tenant-secrets',
       mountPath: '/shared-tenant-secrets',
       readOnly: true,
     });
-    expect(secrets.env).toEqual({ name: 'SECRET_FS_BASE_PATH', value: '/shared-tenant-secrets' });
   });
 
   it('does not change the default hosted Deployment object graph', () => {
@@ -70,15 +82,23 @@ describe.skipIf(!helmAvailable)('temporal-worker shared tenant secrets Helm rend
     });
   });
 
-  it('enables the shared mount through the single-node Flux values overlay', () => {
-    const secrets = sharedTenantSecrets(renderDeployment(['--values', applianceValuesPath]));
+  it('enables a writable shared mount through the single-node Flux values overlay', () => {
+    const deployment = renderDeployment(['--values', applianceValuesPath]);
+    const secrets = sharedTenantSecrets(deployment);
 
-    expect(secrets.mount).toMatchObject({
+    expect(secrets.mount).toEqual({
       name: 'shared-tenant-secrets',
       mountPath: '/shared-tenant-secrets',
-      readOnly: true,
     });
     expect(secrets.env).toEqual({ name: 'SECRET_FS_BASE_PATH', value: '/shared-tenant-secrets' });
+  });
+
+  it('runs the appliance worker as root so it can write into the root-owned hostPath', () => {
+    const container = renderDeployment(['--values', applianceValuesPath]).spec.template.spec.containers.find(
+      (candidate: any) => candidate.name === 'temporal-worker'
+    );
+
+    expect(container.securityContext).toEqual({ runAsUser: 0, runAsGroup: 0 });
   });
 });
 

--- a/ee/temporal-workflows/src/activities/entra-sync-activities.ts
+++ b/ee/temporal-workflows/src/activities/entra-sync-activities.ts
@@ -338,9 +338,9 @@ export async function syncTenantUsersActivity(
 
   const users = await adapter.listUsersForTenant({
     tenant: input.tenantId,
-    // Adapter expects the Microsoft tenant GUID (used as `tenantId eq ...` filter
-    // in the managedTenants/users Graph call). The DB's managed_tenant_id is a
-    // local PK and must not be passed here.
+    // Adapter expects the Microsoft tenant GUID (the authority the customer
+    // tenant token is minted against). The DB's managed_tenant_id is a local
+    // PK and must not be passed here.
     managedTenantId: input.mapping.entraTenantId,
   });
   const filteredUsers = await filterEntraUsersForTenant(input.tenantId, users);


### PR DESCRIPTION
Issue #3315: on a fresh Appliance the Entra contact sync failed with EROFS. The temporal-worker chart mounted /shared-tenant-secrets readOnly, but DirectProviderAdapter refreshes Entra OAuth tokens inside the worker and persists them through the filesystem secret provider — discovery rewrites the whole token set near expiry, and every user sync stores the refresh token Microsoft rotates on redemption. The 2026-08-25 D1 audit missed this write path. Even read-write, the image's non-root `temporal` user (UID 999) cannot write into the root-owned 0755 tenant directories alga-core creates, and fsGroup does not apply to hostPath.

- temporal-worker chart: sharedTenantSecrets.readOnly defaults to false; the hosted render (enabled: false) is unchanged
- single-node overlay: readOnly: false explicitly, and the worker runs as root (securityContext.runAsUser/runAsGroup: 0), matching alga-core and email-service on the same hostPath
- chart + appliance HelmRelease bumped 0.1.3 -> 0.1.4
- Helm render test pins the writable mount and root security context, and keeps an explicit readOnly=true opt-in covered
- entra-sync-activities: comment no longer describes the removed managedTenants/users call
- plan doc: correction section recording why D1 was wrong

The stable appliance release manifest still pins worker image 84d3a55b, which predates the /v1.0/users fix in 907702138d; re-pin it when publishing chart 0.1.4.

"Off with the readOnly!" cried the Queen of Hearts, as the temporal-worker, still wearing its UID 999 nametag, scratched at a root-owned 0755 door that would not open. "But I've a freshly rotated refresh token to put away!" it pleaded. The Cheshire Cat grinned down from chart 0.1.4: "Then be root, dear worker — alga-core has been root at this hostPath all along, and EROFS was never a door, only a wall painted to look like one." 🗝️🐇🔓