### PR TITLE
Wrap store only service requests in a feature flag

### DIFF
--- a/docs/features/feature-flags.md
+++ b/docs/features/feature-flags.md
@@ -206,6 +206,26 @@ Controls discovery of the Contract Simulator while it is being rolled out.
 - Simulator routes, APIs, server actions, and all other entry points remain unchanged. This
   flag controls only the Contract Details tab and is not an authorization boundary.
 
+### 14. `service-request-store-only`
+Gates newly authoring/selecting the store-only execution provider for service request definitions (server-side).
+
+**Affected Areas:**
+- **MSP Portal:**
+  - Service Request definition editor at `/msp/service-requests/:definitionId` — the
+    execution provider dropdown
+- **Server actions:** `getServiceRequestDefinitionEditorDataAction` (filters the selectable
+  providers) / `updateServiceRequestExecutionProviderAction` (rejects the selection)
+
+**Behavior:**
+- When disabled (default): "Store Only" is filtered out of the editor's execution provider
+  options, and the server action rejects an attempt to select it with a 403 error.
+  Definitions that already use store-only keep the provider visible in their editor so the
+  current selection renders faithfully.
+- When enabled: Store-only is selectable exactly as before.
+- Existing published store-only definitions remain fully functional regardless of flag
+  state: portal catalog listing, submission execution, migrations, and historical
+  submission reads are not gated.
+
 ## Implementation Details
 
 ### User Identification

--- a/packages/core/src/lib/featureFlagRuntime.ts
+++ b/packages/core/src/lib/featureFlagRuntime.ts
@@ -28,6 +28,7 @@ const DEFAULT_BOOLEAN_FLAGS: Record<string, boolean> = {
   'enable_jira_sync': false,
   'enable_salesforce_sync': false,
   'quoting-enabled': false,
+  'service-request-store-only': false,
 };
 
 const DEFAULT_VARIANT_FLAGS: Record<string, string> = {

--- a/server/src/app/msp/service-requests/actions.ts
+++ b/server/src/app/msp/service-requests/actions.ts
@@ -43,7 +43,8 @@ import {
   type ServiceRequestDefinitionErrorCode,
   SERVICE_REQUEST_STORE_ONLY_FEATURE_FLAG,
   applyStoreOnlyAuthoringGateToEditorData,
-  isBlockedStoreOnlySelection,
+  isBlockedStoreOnlyAdoption,
+  storeOnlyAuthoringDisabledMessage,
 } from '../../../lib/service-requests';
 import { featureFlags } from '../../../lib/feature-flags/featureFlags';
 import type { IBoard, IPriority, ITicketCategory, ITicketStatus, IUser } from '@alga-psa/types';
@@ -259,6 +260,7 @@ export const duplicateServiceRequestDefinitionAction = withAuth(async (
       tenant,
       sourceDefinitionId: definitionId,
       createdBy: getActorId(user),
+      storeOnlyAuthoringEnabled: await isStoreOnlyAuthoringEnabled(user, tenant),
     });
     return serviceRequestSuccess(created);
   } catch (error) {
@@ -292,11 +294,8 @@ export const updateServiceRequestExecutionProviderAction = withAuth(async (
   await requireServiceRequestPermission(user, 'update', knex);
 
   const storeOnlyEnabled = await isStoreOnlyAuthoringEnabled(user, tenant);
-  if (isBlockedStoreOnlySelection(executionProvider, storeOnlyEnabled)) {
-    throwHttpError(
-      403,
-      `Selecting the store-only execution provider requires the "${SERVICE_REQUEST_STORE_ONLY_FEATURE_FLAG}" feature flag`
-    );
+  if (isBlockedStoreOnlyAdoption(executionProvider, storeOnlyEnabled)) {
+    throwHttpError(403, storeOnlyAuthoringDisabledMessage('Selecting the store-only execution provider'));
   }
 
   return saveServiceRequestDefinitionDraft({
@@ -522,7 +521,9 @@ export const validateServiceRequestDefinitionForPublishAction = withAuth(async (
 ): Promise<ServiceRequestPublishValidationResult> => {
   const { knex } = await createTenantKnex();
   await requireServiceRequestPermission(user, 'update', knex);
-  return validateServiceRequestDefinitionForPublish(knex, tenant, definitionId);
+  return validateServiceRequestDefinitionForPublish(knex, tenant, definitionId, {
+    storeOnlyAuthoringEnabled: await isStoreOnlyAuthoringEnabled(user, tenant),
+  });
 });
 
 export const publishServiceRequestDefinitionAction = withAuth(async (
@@ -537,6 +538,7 @@ export const publishServiceRequestDefinitionAction = withAuth(async (
     tenant,
     definitionId,
     publishedBy: getActorId(user),
+    storeOnlyAuthoringEnabled: await isStoreOnlyAuthoringEnabled(user, tenant),
   });
 });
 

--- a/server/src/app/msp/service-requests/actions.ts
+++ b/server/src/app/msp/service-requests/actions.ts
@@ -41,7 +41,11 @@ import {
   type ServiceRequestDefinitionEditorData,
   ServiceRequestDefinitionBusinessError,
   type ServiceRequestDefinitionErrorCode,
+  SERVICE_REQUEST_STORE_ONLY_FEATURE_FLAG,
+  applyStoreOnlyAuthoringGateToEditorData,
+  isBlockedStoreOnlySelection,
 } from '../../../lib/service-requests';
+import { featureFlags } from '../../../lib/feature-flags/featureFlags';
 import type { IBoard, IPriority, ITicketCategory, ITicketStatus, IUser } from '@alga-psa/types';
 
 type AuthUser = Parameters<Parameters<typeof withAuth>[0]>[0];
@@ -71,6 +75,13 @@ function throwHttpError(status: number, message: string): never {
   const error = new Error(message) as Error & { status?: number };
   error.status = status;
   throw error;
+}
+
+async function isStoreOnlyAuthoringEnabled(user: AuthUser, tenant: string): Promise<boolean> {
+  return featureFlags.isEnabled(SERVICE_REQUEST_STORE_ONLY_FEATURE_FLAG, {
+    userId: getActorId(user) ?? undefined,
+    tenantId: tenant,
+  });
 }
 
 async function requireServiceRequestPermission(
@@ -115,7 +126,13 @@ export const getServiceRequestDefinitionEditorDataAction = withAuth(async (
 ): Promise<ServiceRequestDefinitionEditorData | null> => {
   const { knex } = await createTenantKnex();
   await requireServiceRequestPermission(user, 'read', knex);
-  return getServiceRequestDefinitionEditorData(knex, tenant, definitionId);
+  const editorData = await getServiceRequestDefinitionEditorData(knex, tenant, definitionId);
+  if (!editorData) {
+    return null;
+  }
+
+  const storeOnlyEnabled = await isStoreOnlyAuthoringEnabled(user, tenant);
+  return applyStoreOnlyAuthoringGateToEditorData(editorData, storeOnlyEnabled);
 });
 
 export interface ServiceRequestTicketRoutingReferenceData {
@@ -273,6 +290,15 @@ export const updateServiceRequestExecutionProviderAction = withAuth(async (
 ): Promise<ServiceRequestDefinitionManagementRow> => {
   const { knex } = await createTenantKnex();
   await requireServiceRequestPermission(user, 'update', knex);
+
+  const storeOnlyEnabled = await isStoreOnlyAuthoringEnabled(user, tenant);
+  if (isBlockedStoreOnlySelection(executionProvider, storeOnlyEnabled)) {
+    throwHttpError(
+      403,
+      `Selecting the store-only execution provider requires the "${SERVICE_REQUEST_STORE_ONLY_FEATURE_FLAG}" feature flag`
+    );
+  }
+
   return saveServiceRequestDefinitionDraft({
     knex,
     tenant,

--- a/server/src/lib/service-requests/definitionErrors.ts
+++ b/server/src/lib/service-requests/definitionErrors.ts
@@ -1,7 +1,8 @@
 export type ServiceRequestDefinitionErrorCode =
   | 'TEMPLATE_UNAVAILABLE'
   | 'SOURCE_DEFINITION_NOT_FOUND'
-  | 'DEFINITION_NOT_FOUND';
+  | 'DEFINITION_NOT_FOUND'
+  | 'STORE_ONLY_AUTHORING_DISABLED';
 
 export class ServiceRequestDefinitionBusinessError extends Error {
   constructor(

--- a/server/src/lib/service-requests/definitionManagement.ts
+++ b/server/src/lib/service-requests/definitionManagement.ts
@@ -9,6 +9,10 @@ import { listServiceRequestTemplateProviders } from './providers/registry';
 import type { ServiceRequestTemplateDefinition } from './providers/contracts';
 import { isLicenseDistributionTenant } from '@alga-psa/licensing';
 import { ServiceRequestDefinitionBusinessError } from './definitionErrors';
+import {
+  isBlockedStoreOnlyAdoption,
+  storeOnlyAuthoringDisabledMessage,
+} from './storeOnlyAuthoringGate';
 
 /**
  * Template provider whose templates author the in-app appliance-license purchase
@@ -93,6 +97,12 @@ interface DuplicateDefinitionInput {
   tenant: string;
   sourceDefinitionId: string;
   createdBy?: string | null;
+  /**
+   * Whether the `service-request-store-only` feature flag allows newly
+   * adopting the store-only execution provider. Callers evaluate the flag
+   * (this layer never does); omitting it leaves duplication ungated.
+   */
+  storeOnlyAuthoringEnabled?: boolean;
 }
 
 interface SaveDraftDefinitionInput {
@@ -326,6 +336,7 @@ export async function duplicateServiceRequestDefinition({
   tenant,
   sourceDefinitionId,
   createdBy = null,
+  storeOnlyAuthoringEnabled = true,
 }: DuplicateDefinitionInput): Promise<ServiceRequestDefinitionManagementRow> {
   const db = tenantDb(knex, tenant);
   const source = (await db.table('service_request_definitions')
@@ -336,6 +347,13 @@ export async function duplicateServiceRequestDefinition({
     throw new ServiceRequestDefinitionBusinessError(
       'SOURCE_DEFINITION_NOT_FOUND',
       'Source service request definition not found'
+    );
+  }
+
+  if (isBlockedStoreOnlyAdoption(source.execution_provider, storeOnlyAuthoringEnabled)) {
+    throw new ServiceRequestDefinitionBusinessError(
+      'STORE_ONLY_AUTHORING_DISABLED',
+      storeOnlyAuthoringDisabledMessage('Duplicating a store-only service request definition')
     );
   }
 

--- a/server/src/lib/service-requests/definitionValidation.ts
+++ b/server/src/lib/service-requests/definitionValidation.ts
@@ -7,11 +7,24 @@ import {
   getServiceRequestFormBehaviorProvider,
   getServiceRequestVisibilityProvider,
 } from './providers/registry';
+import {
+  isBlockedStoreOnlyAdoption,
+  storeOnlyAuthoringDisabledMessage,
+} from './storeOnlyAuthoringGate';
 
 export interface ServiceRequestPublishValidationResult {
   isValid: boolean;
   errors: string[];
   warnings: string[];
+}
+
+export interface ServiceRequestPublishValidationOptions {
+  /**
+   * Whether the `service-request-store-only` feature flag allows publishing a
+   * store-only definition. Callers evaluate the flag (this layer never does);
+   * omitting it leaves publishing ungated.
+   */
+  storeOnlyAuthoringEnabled?: boolean;
 }
 
 interface ServiceRequestDefinitionForValidation {
@@ -29,8 +42,10 @@ interface ServiceRequestDefinitionForValidation {
 export async function validateServiceRequestDefinitionForPublish(
   knex: Knex,
   tenant: string,
-  definitionId: string
+  definitionId: string,
+  options: ServiceRequestPublishValidationOptions = {}
 ): Promise<ServiceRequestPublishValidationResult> {
+  const { storeOnlyAuthoringEnabled = true } = options;
   const db = tenantDb(knex, tenant);
   const definition = (await db.table('service_request_definitions')
     .where({ definition_id: definitionId })
@@ -67,6 +82,12 @@ export async function validateServiceRequestDefinitionForPublish(
     } else if (linkedService.is_active === false) {
       warnings.push('Linked service is inactive');
     }
+  }
+
+  if (isBlockedStoreOnlyAdoption(definition.execution_provider, storeOnlyAuthoringEnabled)) {
+    errors.push(
+      `Execution: ${storeOnlyAuthoringDisabledMessage('Publishing a store-only service request definition')}`
+    );
   }
 
   const executionProvider = getServiceRequestExecutionProvider(definition.execution_provider);
@@ -114,11 +135,13 @@ export async function publishServiceRequestDefinitionWithValidation(input: {
   tenant: string;
   definitionId: string;
   publishedBy?: string | null;
+  storeOnlyAuthoringEnabled?: boolean;
 }): Promise<ServiceRequestDefinitionVersionRecord> {
   const validation = await validateServiceRequestDefinitionForPublish(
     input.knex,
     input.tenant,
-    input.definitionId
+    input.definitionId,
+    { storeOnlyAuthoringEnabled: input.storeOnlyAuthoringEnabled }
   );
 
   if (!validation.isValid) {

--- a/server/src/lib/service-requests/index.ts
+++ b/server/src/lib/service-requests/index.ts
@@ -11,6 +11,7 @@ export * from './submissionHistory';
 export * from './portalCatalog';
 export * from './portalDetail';
 export * from './submissionService';
+export * from './storeOnlyAuthoringGate';
 export * from './providers/contracts';
 export * from './providers/registry';
 export * from './providers/registerEnterpriseProviders';

--- a/server/src/lib/service-requests/storeOnlyAuthoringGate.ts
+++ b/server/src/lib/service-requests/storeOnlyAuthoringGate.ts
@@ -15,14 +15,25 @@ import { storeOnlyExecutionProvider } from './providers/builtins/storeOnlyExecut
 export const SERVICE_REQUEST_STORE_ONLY_FEATURE_FLAG = 'service-request-store-only';
 
 /**
- * True when the requested execution provider selection must be rejected
- * because it would newly adopt store-only while the feature flag is disabled.
+ * True when an authoring act must be rejected because it would newly adopt
+ * store-only while the feature flag is disabled. This covers every server-side
+ * adoption path: selecting the provider on a draft, duplicating a definition
+ * whose source uses it (the copy would be a new store-only definition), and
+ * publishing a draft that uses it (a new store-only catalog surface).
  */
-export function isBlockedStoreOnlySelection(
+export function isBlockedStoreOnlyAdoption(
   executionProvider: string,
   storeOnlyAuthoringEnabled: boolean
 ): boolean {
   return !storeOnlyAuthoringEnabled && executionProvider === storeOnlyExecutionProvider.key;
+}
+
+/**
+ * Shared human-readable reason used by every gate rejection so the UI and
+ * error logs consistently name the flag that unlocks the path.
+ */
+export function storeOnlyAuthoringDisabledMessage(authoringAct: string): string {
+  return `${authoringAct} requires the "${SERVICE_REQUEST_STORE_ONLY_FEATURE_FLAG}" feature flag`;
 }
 
 /**

--- a/server/src/lib/service-requests/storeOnlyAuthoringGate.ts
+++ b/server/src/lib/service-requests/storeOnlyAuthoringGate.ts
@@ -1,0 +1,57 @@
+import type { ServiceRequestDefinitionEditorData } from './definitionEditor';
+import { storeOnlyExecutionProvider } from './providers/builtins/storeOnlyExecutionProvider';
+
+/**
+ * PostHog feature flag that gates NEW authoring/selection of the store-only
+ * execution provider server-side.
+ *
+ * Scope decision (XO design session): when the flag is disabled, tenants
+ * cannot newly select the store-only execution provider while authoring a
+ * service request definition. Everything that already exists keeps working:
+ * published store-only definitions stay in the portal catalog, submissions
+ * against them still execute, migrations are untouched, and historical
+ * submission reads remain available.
+ */
+export const SERVICE_REQUEST_STORE_ONLY_FEATURE_FLAG = 'service-request-store-only';
+
+/**
+ * True when the requested execution provider selection must be rejected
+ * because it would newly adopt store-only while the feature flag is disabled.
+ */
+export function isBlockedStoreOnlySelection(
+  executionProvider: string,
+  storeOnlyAuthoringEnabled: boolean
+): boolean {
+  return !storeOnlyAuthoringEnabled && executionProvider === storeOnlyExecutionProvider.key;
+}
+
+/**
+ * Removes the store-only execution provider from the editor's selectable
+ * providers when the feature flag is disabled.
+ *
+ * Definitions that already use store-only keep the provider in their options
+ * so the editor continues to render the current selection faithfully; the
+ * flag only gates newly selecting it.
+ */
+export function applyStoreOnlyAuthoringGateToEditorData(
+  data: ServiceRequestDefinitionEditorData,
+  storeOnlyAuthoringEnabled: boolean
+): ServiceRequestDefinitionEditorData {
+  if (storeOnlyAuthoringEnabled) {
+    return data;
+  }
+
+  if (data.execution.executionProvider === storeOnlyExecutionProvider.key) {
+    return data;
+  }
+
+  return {
+    ...data,
+    execution: {
+      ...data.execution,
+      availableExecutionProviders: data.execution.availableExecutionProviders.filter(
+        (provider) => provider.key !== storeOnlyExecutionProvider.key
+      ),
+    },
+  };
+}

--- a/server/src/test/integration/serviceRequestStoreOnlyFeatureFlagGate.integration.test.ts
+++ b/server/src/test/integration/serviceRequestStoreOnlyFeatureFlagGate.integration.test.ts
@@ -1,0 +1,268 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Knex } from 'knex';
+import { v4 as uuidv4 } from 'uuid';
+import { tenantDb } from '@alga-psa/db';
+import { createTestDbConnection } from '../../../test-utils/dbConfig';
+import { duplicateServiceRequestDefinition } from '../../lib/service-requests/definitionManagement';
+import {
+  publishServiceRequestDefinitionWithValidation,
+  validateServiceRequestDefinitionForPublish,
+} from '../../lib/service-requests/definitionValidation';
+import { ServiceRequestDefinitionBusinessError } from '../../lib/service-requests/definitionErrors';
+import {
+  SERVICE_REQUEST_STORE_ONLY_FEATURE_FLAG,
+  storeOnlyAuthoringDisabledMessage,
+} from '../../lib/service-requests/storeOnlyAuthoringGate';
+
+/**
+ * Behavioral coverage for the `service-request-store-only` feature flag gate.
+ *
+ * The MSP actions in app/msp/service-requests/actions.ts evaluate the flag per
+ * request and forward it as `storeOnlyAuthoringEnabled` into these lib entry
+ * points (the lib layer never evaluates flags itself). These tests drive those
+ * entry points with both flag values, so they cover the exact decision the
+ * actions delegate: while the flag is off, no authoring act may newly adopt
+ * the store-only execution provider, and everything that already exists keeps
+ * working.
+ */
+
+const VALID_FORM_SCHEMA = {
+  fields: [{ key: 'request_title', type: 'short-text', label: 'Request Title', required: true }],
+};
+
+describe('service request store-only feature flag gate', () => {
+  let db: Knex;
+
+  beforeAll(async () => {
+    db = await createTestDbConnection({ runSeeds: false });
+  });
+
+  afterAll(async () => {
+    if (db) {
+      await db.destroy();
+    }
+  });
+
+  async function createTenant(): Promise<string> {
+    const tenant = uuidv4();
+    await db('tenants').insert({
+      tenant,
+      client_name: `Tenant ${tenant.slice(0, 8)}`,
+      email: `tenant-${tenant.slice(0, 8)}@example.com`,
+    });
+    return tenant;
+  }
+
+  async function insertDefinition(args: {
+    tenant: string;
+    executionProvider: 'store-only' | 'ticket-only';
+    lifecycleState?: 'draft' | 'published';
+    name?: string;
+  }): Promise<string> {
+    const definitionId = uuidv4();
+    await tenantDb(db, args.tenant).table('service_request_definitions').insert({
+      tenant: args.tenant,
+      definition_id: definitionId,
+      name: args.name ?? 'Store Only Questionnaire',
+      form_schema: VALID_FORM_SCHEMA,
+      execution_provider: args.executionProvider,
+      execution_config: {},
+      form_behavior_provider: 'basic',
+      form_behavior_config: {},
+      visibility_provider: 'all-authenticated-client-users',
+      visibility_config: {},
+      lifecycle_state: args.lifecycleState ?? 'draft',
+    });
+    return definitionId;
+  }
+
+  async function insertPublishedVersion(tenant: string, definitionId: string): Promise<void> {
+    await tenantDb(db, tenant).table('service_request_definition_versions').insert({
+      tenant,
+      version_id: uuidv4(),
+      definition_id: definitionId,
+      version_number: 1,
+      name: 'Store Only Questionnaire',
+      form_schema_snapshot: VALID_FORM_SCHEMA,
+      execution_provider: 'store-only',
+      execution_config: {},
+      form_behavior_provider: 'basic',
+      form_behavior_config: {},
+      visibility_provider: 'all-authenticated-client-users',
+      visibility_config: {},
+    });
+  }
+
+  async function countDefinitions(tenant: string): Promise<number> {
+    const [row] = await tenantDb(db, tenant)
+      .table('service_request_definitions')
+      .count<{ count: string }[]>('* as count');
+    return Number(row.count);
+  }
+
+  async function listVersionNumbers(tenant: string, definitionId: string): Promise<number[]> {
+    const rows = (await tenantDb(db, tenant)
+      .table('service_request_definition_versions')
+      .where({ definition_id: definitionId })
+      .orderBy('version_number', 'asc')
+      .select('version_number')) as { version_number: number }[];
+    return rows.map((row) => Number(row.version_number));
+  }
+
+  async function getLifecycleState(tenant: string, definitionId: string): Promise<string | undefined> {
+    const row = await tenantDb(db, tenant)
+      .table('service_request_definitions')
+      .where({ definition_id: definitionId })
+      .select('lifecycle_state')
+      .first<{ lifecycle_state: string }>();
+    return row?.lifecycle_state;
+  }
+
+  it('duplicate refuses a store-only source while the flag is off, persists nothing, and succeeds once the flag is on', async () => {
+    const tenant = await createTenant();
+    const actor = uuidv4();
+    const sourceDefinitionId = await insertDefinition({ tenant, executionProvider: 'store-only' });
+
+    const blockedDuplicate = duplicateServiceRequestDefinition({
+      knex: db,
+      tenant,
+      sourceDefinitionId,
+      createdBy: actor,
+      storeOnlyAuthoringEnabled: false,
+    });
+
+    await expect(blockedDuplicate).rejects.toThrowError(ServiceRequestDefinitionBusinessError);
+    await expect(blockedDuplicate).rejects.toMatchObject({
+      code: 'STORE_ONLY_AUTHORING_DISABLED',
+      message: expect.stringContaining(SERVICE_REQUEST_STORE_ONLY_FEATURE_FLAG),
+    });
+    // The refusal must leave no partially-created copy behind.
+    expect(await countDefinitions(tenant)).toBe(1);
+
+    const copy = await duplicateServiceRequestDefinition({
+      knex: db,
+      tenant,
+      sourceDefinitionId,
+      createdBy: actor,
+      storeOnlyAuthoringEnabled: true,
+    });
+
+    expect(copy.name).toBe('Store Only Questionnaire (Copy)');
+    expect(copy.lifecycle_state).toBe('draft');
+    expect(await countDefinitions(tenant)).toBe(2);
+  });
+
+  it('duplicate keeps working for non-store-only sources while the flag is off', async () => {
+    const tenant = await createTenant();
+    const sourceDefinitionId = await insertDefinition({
+      tenant,
+      executionProvider: 'ticket-only',
+      name: 'Ticket Only Questionnaire',
+    });
+
+    const copy = await duplicateServiceRequestDefinition({
+      knex: db,
+      tenant,
+      sourceDefinitionId,
+      storeOnlyAuthoringEnabled: false,
+    });
+
+    expect(copy.name).toBe('Ticket Only Questionnaire (Copy)');
+    expect(await countDefinitions(tenant)).toBe(2);
+  });
+
+  it('publish validation reports exactly the flag block while the flag is off and nothing once it is on', async () => {
+    const tenant = await createTenant();
+    const definitionId = await insertDefinition({ tenant, executionProvider: 'store-only' });
+
+    const blockedValidation = await validateServiceRequestDefinitionForPublish(db, tenant, definitionId, {
+      storeOnlyAuthoringEnabled: false,
+    });
+
+    expect(blockedValidation.isValid).toBe(false);
+    // The flag block is the sole error: the definition is otherwise
+    // publishable, so nothing else may be hiding behind the gate.
+    expect(blockedValidation.errors).toEqual([
+      `Execution: ${storeOnlyAuthoringDisabledMessage('Publishing a store-only service request definition')}`,
+    ]);
+
+    const allowedValidation = await validateServiceRequestDefinitionForPublish(db, tenant, definitionId, {
+      storeOnlyAuthoringEnabled: true,
+    });
+
+    expect(allowedValidation.isValid).toBe(true);
+    expect(allowedValidation.errors).toHaveLength(0);
+  });
+
+  it('publish refuses a store-only draft while the flag is off, keeps it a draft, and publishes once the flag is on', async () => {
+    const tenant = await createTenant();
+    const actor = uuidv4();
+    const definitionId = await insertDefinition({ tenant, executionProvider: 'store-only' });
+
+    await expect(
+      publishServiceRequestDefinitionWithValidation({
+        knex: db,
+        tenant,
+        definitionId,
+        publishedBy: actor,
+        storeOnlyAuthoringEnabled: false,
+      })
+    ).rejects.toThrowError(new RegExp(`Publish validation failed.*${SERVICE_REQUEST_STORE_ONLY_FEATURE_FLAG}`));
+
+    expect(await getLifecycleState(tenant, definitionId)).toBe('draft');
+    expect(await listVersionNumbers(tenant, definitionId)).toEqual([]);
+
+    const published = await publishServiceRequestDefinitionWithValidation({
+      knex: db,
+      tenant,
+      definitionId,
+      publishedBy: actor,
+      storeOnlyAuthoringEnabled: true,
+    });
+
+    expect(published.version_number).toBe(1);
+    expect(published.execution_provider).toBe('store-only');
+    expect(await getLifecycleState(tenant, definitionId)).toBe('published');
+  });
+
+  it('republish of an already-published store-only definition is refused while the flag is off and its published surface stays intact', async () => {
+    const tenant = await createTenant();
+    const actor = uuidv4();
+    const definitionId = await insertDefinition({
+      tenant,
+      executionProvider: 'store-only',
+      lifecycleState: 'published',
+    });
+    await insertPublishedVersion(tenant, definitionId);
+
+    // Republishing would create a new store-only version — a new authoring
+    // act — so the gate refuses it like any other store-only publish. The
+    // already-published version is untouched: the definition stays published
+    // and version 1 remains the live catalog/execution surface, exactly the
+    // "existing definitions keep working" half of the design scope.
+    await expect(
+      publishServiceRequestDefinitionWithValidation({
+        knex: db,
+        tenant,
+        definitionId,
+        publishedBy: actor,
+        storeOnlyAuthoringEnabled: false,
+      })
+    ).rejects.toThrowError(/Publish validation failed/);
+
+    expect(await getLifecycleState(tenant, definitionId)).toBe('published');
+    expect(await listVersionNumbers(tenant, definitionId)).toEqual([1]);
+
+    const republished = await publishServiceRequestDefinitionWithValidation({
+      knex: db,
+      tenant,
+      definitionId,
+      publishedBy: actor,
+      storeOnlyAuthoringEnabled: true,
+    });
+
+    expect(republished.version_number).toBe(2);
+    expect(await listVersionNumbers(tenant, definitionId)).toEqual([1, 2]);
+    expect(await getLifecycleState(tenant, definitionId)).toBe('published');
+  });
+});

--- a/server/src/test/unit/service-requests/storeOnlyAuthoringGate.unit.test.ts
+++ b/server/src/test/unit/service-requests/storeOnlyAuthoringGate.unit.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
+  SERVICE_REQUEST_STORE_ONLY_FEATURE_FLAG,
   applyStoreOnlyAuthoringGateToEditorData,
-  isBlockedStoreOnlySelection,
+  isBlockedStoreOnlyAdoption,
+  storeOnlyAuthoringDisabledMessage,
 } from '../../../lib/service-requests/storeOnlyAuthoringGate';
 import type { ServiceRequestDefinitionEditorData } from '../../../lib/service-requests/definitionEditor';
 
@@ -50,18 +52,28 @@ function buildEditorData(executionProvider: string): ServiceRequestDefinitionEdi
   };
 }
 
-describe('isBlockedStoreOnlySelection', () => {
-  it('blocks selecting store-only while the flag is disabled', () => {
-    expect(isBlockedStoreOnlySelection('store-only', false)).toBe(true);
+describe('isBlockedStoreOnlyAdoption', () => {
+  it('blocks adopting store-only (select, duplicate source, publish draft) while the flag is disabled', () => {
+    expect(isBlockedStoreOnlyAdoption('store-only', false)).toBe(true);
   });
 
-  it('allows selecting store-only while the flag is enabled', () => {
-    expect(isBlockedStoreOnlySelection('store-only', true)).toBe(false);
+  it('allows adopting store-only while the flag is enabled', () => {
+    expect(isBlockedStoreOnlyAdoption('store-only', true)).toBe(false);
   });
 
   it('never blocks other execution providers', () => {
-    expect(isBlockedStoreOnlySelection('ticket-only', false)).toBe(false);
-    expect(isBlockedStoreOnlySelection('ticket-only', true)).toBe(false);
+    expect(isBlockedStoreOnlyAdoption('ticket-only', false)).toBe(false);
+    expect(isBlockedStoreOnlyAdoption('ticket-only', true)).toBe(false);
+  });
+});
+
+describe('storeOnlyAuthoringDisabledMessage', () => {
+  it('names the authoring act and the unlocking feature flag', () => {
+    const message = storeOnlyAuthoringDisabledMessage('Publishing a store-only service request definition');
+
+    expect(message).toBe(
+      `Publishing a store-only service request definition requires the "${SERVICE_REQUEST_STORE_ONLY_FEATURE_FLAG}" feature flag`
+    );
   });
 });
 

--- a/server/src/test/unit/service-requests/storeOnlyAuthoringGate.unit.test.ts
+++ b/server/src/test/unit/service-requests/storeOnlyAuthoringGate.unit.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyStoreOnlyAuthoringGateToEditorData,
+  isBlockedStoreOnlySelection,
+} from '../../../lib/service-requests/storeOnlyAuthoringGate';
+import type { ServiceRequestDefinitionEditorData } from '../../../lib/service-requests/definitionEditor';
+
+function buildEditorData(executionProvider: string): ServiceRequestDefinitionEditorData {
+  return {
+    definitionId: 'definition-1',
+    lifecycleState: 'draft',
+    basics: {
+      name: 'Test definition',
+      description: null,
+      icon: null,
+      categoryId: null,
+      categoryName: null,
+      sortOrder: 0,
+      availableCategories: [],
+    },
+    linkage: {
+      linkedServiceId: null,
+      linkedServiceName: null,
+    },
+    form: {
+      schema: {},
+    },
+    execution: {
+      executionProvider,
+      executionConfig: {},
+      formBehaviorProvider: 'basic',
+      formBehaviorConfig: {},
+      visibilityProvider: 'all-authenticated-client-users',
+      visibilityConfig: {},
+      availableExecutionProviders: [
+        { key: 'ticket-only', displayName: 'Ticket Only', executionMode: 'ticket-only' },
+        { key: 'store-only', displayName: 'Store Only', executionMode: 'store-only' },
+      ],
+      availableFormBehaviorProviders: [],
+      availableVisibilityProviders: [],
+      showWorkflowExecutionConfigPanel: false,
+      showAdvancedFormBehaviorConfigPanel: false,
+    },
+    publish: {
+      publishedVersionNumber: null,
+      publishedAt: null,
+      publishedBy: null,
+      draftUpdatedAt: new Date(0),
+    },
+  };
+}
+
+describe('isBlockedStoreOnlySelection', () => {
+  it('blocks selecting store-only while the flag is disabled', () => {
+    expect(isBlockedStoreOnlySelection('store-only', false)).toBe(true);
+  });
+
+  it('allows selecting store-only while the flag is enabled', () => {
+    expect(isBlockedStoreOnlySelection('store-only', true)).toBe(false);
+  });
+
+  it('never blocks other execution providers', () => {
+    expect(isBlockedStoreOnlySelection('ticket-only', false)).toBe(false);
+    expect(isBlockedStoreOnlySelection('ticket-only', true)).toBe(false);
+  });
+});
+
+describe('applyStoreOnlyAuthoringGateToEditorData', () => {
+  it('removes store-only from the selectable providers when the flag is disabled', () => {
+    const gated = applyStoreOnlyAuthoringGateToEditorData(buildEditorData('ticket-only'), false);
+
+    expect(gated.execution.availableExecutionProviders.map((provider) => provider.key)).toEqual([
+      'ticket-only',
+    ]);
+  });
+
+  it('keeps store-only selectable when the flag is enabled', () => {
+    const data = buildEditorData('ticket-only');
+    const gated = applyStoreOnlyAuthoringGateToEditorData(data, true);
+
+    expect(gated).toBe(data);
+    expect(gated.execution.availableExecutionProviders.map((provider) => provider.key)).toEqual([
+      'ticket-only',
+      'store-only',
+    ]);
+  });
+
+  it('keeps store-only visible for a definition that already uses it, even when disabled', () => {
+    const data = buildEditorData('store-only');
+    const gated = applyStoreOnlyAuthoringGateToEditorData(data, false);
+
+    expect(gated).toBe(data);
+    expect(gated.execution.availableExecutionProviders.map((provider) => provider.key)).toEqual([
+      'ticket-only',
+      'store-only',
+    ]);
+  });
+
+  it('does not mutate the original editor data when filtering', () => {
+    const data = buildEditorData('ticket-only');
+    applyStoreOnlyAuthoringGateToEditorData(data, false);
+
+    expect(data.execution.availableExecutionProviders.map((provider) => provider.key)).toEqual([
+      'ticket-only',
+      'store-only',
+    ]);
+  });
+});


### PR DESCRIPTION
## Wrap store-only service requests in a feature flag

Introduces the `service-request-store-only` feature flag and gates every **new** server-side authoring/selection path for the store-only execution provider behind it. Execution of existing definitions, the portal catalog, migrations, and historical submission reads are deliberately left ungated so already-published store-only definitions keep working regardless of flag state.

### What changed
- **New flag** `service-request-store-only`, defaulting to `false` in `packages/core` `featureFlagRuntime` `DEFAULT_BOOLEAN_FLAGS`.
- **New gate module** `server/src/lib/service-requests/storeOnlyAuthoringGate.ts` — a small, flag-free layer the actions call into:
  - `isBlockedStoreOnlyAdoption(provider, enabled)` — the single predicate covering every adoption path (select on draft, duplicate a store-only source, publish a store-only draft).
  - `storeOnlyAuthoringDisabledMessage(act)` — shared human-readable reason naming the flag.
  - `applyStoreOnlyAuthoringGateToEditorData(...)` — filters Store Only out of the editor's selectable execution providers, **unless** the definition already uses it (so the current selection still renders faithfully).
- **Server actions** (`server/src/app/msp/service-requests/actions.ts`) evaluate the flag per request (via `featureFlags.isEnabled` with user/tenant context — this is the only layer that touches PostHog) and thread the result down:
  - `getServiceRequestDefinitionEditorDataAction` filters the provider list.
  - `updateServiceRequestExecutionProviderAction` rejects a blocked selection with a 403.
  - `duplicateServiceRequestDefinitionAction`, `validateServiceRequestDefinitionForPublishAction`, and `publishServiceRequestDefinitionAction` all pass `storeOnlyAuthoringEnabled` through.
- **Domain layer** (`definitionManagement.ts`, `definitionValidation.ts`) accepts an optional `storeOnlyAuthoringEnabled` (defaulting to `true`, i.e. ungated when unspecified). Duplication throws the new `STORE_ONLY_AUTHORING_DISABLED` business error; publish validation adds a blocking `Execution:` error.
- **Docs**: `docs/features/feature-flags.md` documents the flag, affected areas, and behavior.

### Design decision (XO design session)
When disabled, tenants cannot newly select/adopt store-only while authoring. Everything already existing keeps working: published store-only definitions stay in the portal catalog, submissions execute, migrations are untouched, and historical reads remain available. The flag is a server-side authoring gate, not an authorization boundary and not an execution kill switch.

### Tests
- `storeOnlyAuthoringGate.unit.test.ts` — unit coverage for the gate predicate, message, and editor-data filtering (including the "already uses it stays visible" case).
- `serviceRequestStoreOnlyFeatureFlagGate.integration.test.ts` — behavioral coverage of disabled-flag duplicate / validation / publish / republish, confirming a refused republish leaves the published surface (lifecycle + version 1) intact.

## Smoke test

**PASS.** Tested the real Next.js product at http://localhost:3520 against the `alga-psa-local-test` Postgres/Redis stack.

Flows proven:
1. **Default flag-off:** a new draft's Execution Provider selector omitted Store Only.
2. **Built-in development override on (`DISABLE_FEATURE_FLAGS=true`):** Store Only appeared, could be selected, validation passed, and publishing created v1. Database confirmed `store-only|published|1`.
3. **Flag off again:** Store Only remained visible on an existing definition, but publish was refused with the explicit `service-request-store-only` validation message. Database confirmed no version was created during the blocked attempt.
4. **Flag off:** duplicating a published Store Only definition was refused with the explicit flag message; database count confirmed no copy.
5. **Existing-definition compatibility:** the pre-existing Store Only definition remained published at v12, its Store Only configuration rendered correctly, and historical successful submissions remained visible. A refused republish left all 12 versions intact.
6. **Adjacent regression:** creating and duplicating a Ticket Only definition still succeeded normally.

No simulator or mock was used. The only fidelity adjustment was the repository's documented `DISABLE_FEATURE_FLAGS=true` development override to exercise the enabled state; it was removed afterward. The server is restored to default-off and answering on port 3520. Database checks corroborated mutations and non-mutations rather than relying only on toasts.

**Environment note:** a fresh restart exposed a missing card-local `secrets/credential_encryption_key`; a random 0600 value was provisioned, after which startup validation passed. Browser console contained expected connection errors during deliberate server restarts and unrelated Hocuspocus websocket failures on port 1235; no 5xx requests or feature-flow failures were observed. Client-portal submission creation was not repeated because no client credential was available, but the unchanged existing-definition/history surface was verified live in the MSP product.

**Evidence:** `/tmp/alga-smoke-evidence/store-only-service-request-flag-20260903-1421`
