### PR TITLE
Link documents by id so re-rendered PDFs resolve

### DIFF
--- a/packages/client-portal/src/components/documents/ClientDocumentsPage.tsx
+++ b/packages/client-portal/src/components/documents/ClientDocumentsPage.tsx
@@ -249,7 +249,7 @@ export default function ClientDocumentsPage() {
         return;
       }
       // Use the standard download utility
-      await downloadDocument(await getDocumentDownloadUrl(doc.file_id || ''), doc.document_name);
+      await downloadDocument(await getDocumentDownloadUrl(doc.document_id), doc.document_name);
     } catch (error) {
       console.error('Failed to download document:', error);
     } finally {

--- a/packages/client-portal/src/components/projects/TaskDocumentUpload.tsx
+++ b/packages/client-portal/src/components/projects/TaskDocumentUpload.tsx
@@ -194,7 +194,7 @@ export default function TaskDocumentUpload({ taskId, compact = false }: TaskDocu
     }
 
     // For other files, trigger download using the existing utility
-    const downloadUrl = await getDocumentDownloadUrl(doc.file_id);
+    const downloadUrl = await getDocumentDownloadUrl(doc.document_id);
     try {
       await downloadDocument(downloadUrl, doc.document_name, true);
     } catch (err) {
@@ -208,7 +208,7 @@ export default function TaskDocumentUpload({ taskId, compact = false }: TaskDocu
     e.stopPropagation();
     if (!doc.file_id) return;
 
-    const downloadUrl = await getDocumentDownloadUrl(doc.file_id);
+    const downloadUrl = await getDocumentDownloadUrl(doc.document_id);
     try {
       await downloadDocument(downloadUrl, doc.document_name, true);
     } catch (err) {
@@ -234,7 +234,7 @@ export default function TaskDocumentUpload({ taskId, compact = false }: TaskDocu
           {isImage && doc.file_id ? (
             <div className="w-10 h-10 bg-gray-100 rounded-lg overflow-hidden">
               <img
-                src={`/api/documents/view/${doc.file_id}`}
+                src={`/api/documents/view/${doc.document_id}`}
                 alt=""
                 className="w-full h-full object-cover"
                 onError={(e) => {
@@ -304,7 +304,7 @@ export default function TaskDocumentUpload({ taskId, compact = false }: TaskDocu
   const PreviewModal = () => {
     if (!showPreviewModal || !previewDocument || !previewDocument.file_id) return null;
 
-    const viewUrl = `/api/documents/view/${previewDocument.file_id}`;
+    const viewUrl = `/api/documents/view/${previewDocument.document_id}`;
 
     return (
       <div
@@ -435,7 +435,7 @@ export default function TaskDocumentUpload({ taskId, compact = false }: TaskDocu
                       {isImage && doc.file_id ? (
                         <div className="w-8 h-8 bg-gray-100 rounded overflow-hidden">
                           <img
-                            src={`/api/documents/view/${doc.file_id}`}
+                            src={`/api/documents/view/${doc.document_id}`}
                             alt=""
                             className="w-full h-full object-cover"
                             onError={(e) => {

--- a/packages/documents/src/actions/documentActions.ts
+++ b/packages/documents/src/actions/documentActions.ts
@@ -1782,7 +1782,7 @@ export const getDocumentPreview = withAuth(async (
 });
 
 // Get document download URL
-export const getDocumentDownloadUrl = withAuth(async (user, { tenant }, file_id: string): Promise<string | ActionPermissionError> => {
+export const getDocumentDownloadUrl = withAuth(async (user, { tenant }, documentIdOrFileId: string): Promise<string | ActionPermissionError> => {
     // Check permission for document reading/download
     if (!await hasPermission(user, 'document', 'read')) {
       return permissionError('Permission denied: Cannot read documents', 'documents:errors.permissions.read');
@@ -1790,13 +1790,15 @@ export const getDocumentDownloadUrl = withAuth(async (user, { tenant }, file_id:
 
     const { knex } = await createTenantKnex();
     const authorizedDocument = await withTransaction(knex, async (trx: Knex.Transaction) =>
-      getAuthorizedDocumentByFileId(trx, tenant, user, file_id)
+      (await getAuthorizedDocumentById(trx, tenant, user, documentIdOrFileId))
+        ?? getAuthorizedDocumentByFileId(trx, tenant, user, documentIdOrFileId)
     );
     if (!authorizedDocument?.file_id) {
       return permissionError('Permission denied: Cannot read documents', 'documents:errors.permissions.read');
     }
 
-    return `/api/documents/download/${file_id}`;
+    // Link by document id so the URL survives a re-render that retires the file.
+    return `/api/documents/download/${authorizedDocument.document_id}`;
 });
 
 /**

--- a/packages/documents/src/components/DocumentSelector.tsx
+++ b/packages/documents/src/components/DocumentSelector.tsx
@@ -373,13 +373,13 @@ export default function DocumentSelector({
                                                             <img
                                                                 src={document.thumbnail_file_id
                                                                     ? `/api/documents/${document.document_id}/thumbnail`
-                                                                    : `/api/documents/view/${document.file_id}`
+                                                                    : `/api/documents/view/${document.document_id}`
                                                                 }
                                                                 alt={document.document_name}
                                                                 className="w-full h-full object-cover"
                                                                 onError={(e) => {
                                                                     if (document.file_id && e.currentTarget.src.includes('thumbnail')) {
-                                                                        e.currentTarget.src = `/api/documents/view/${document.file_id}`;
+                                                                        e.currentTarget.src = `/api/documents/view/${document.document_id}`;
                                                                     }
                                                                 }}
                                                             />

--- a/packages/documents/src/components/DocumentStorageCard.tsx
+++ b/packages/documents/src/components/DocumentStorageCard.tsx
@@ -552,7 +552,7 @@ function DocumentStorageCardComponent({
             setShowFullSizeModal(true);
         } else {
             // For other files, download
-            const downloadUrl = getDocumentDownloadUrl(document.file_id);
+            const downloadUrl = getDocumentDownloadUrl(document.document_id);
             const filename = document.document_name || 'download';
             try {
                 await downloadDocument(downloadUrl, filename, true);
@@ -941,7 +941,7 @@ function DocumentStorageCardComponent({
                         <div className="flex justify-center items-center" onClick={(e) => e.stopPropagation()}>
                             {document.mime_type?.startsWith('image/') ? (
                                 <img
-                                    src={`/api/documents/view/${document.file_id}`}
+                                    src={`/api/documents/view/${document.document_id}`}
                                     alt={document.document_name}
                                     className="max-w-full max-h-[70vh] object-contain"
                                 />
@@ -954,7 +954,7 @@ function DocumentStorageCardComponent({
                                 />
                             ) : document.mime_type === 'application/pdf' ? (
                                 <iframe
-                                    src={`/api/documents/view/${document.file_id}`}
+                                    src={`/api/documents/view/${document.document_id}`}
                                     className="w-full border-0"
                                     style={{ height: 'calc(90vh - 120px)', width: '100%' }}
                                     title={document.document_name}
@@ -965,7 +965,7 @@ function DocumentStorageCardComponent({
                                     <Button
                                         id={`${id}-download-modal-button`}
                                         onClick={async () => {
-                                            const downloadUrl = getDocumentDownloadUrl(document.file_id!);
+                                            const downloadUrl = getDocumentDownloadUrl(document.document_id);
                                             const filename = document.document_name || 'download';
                                             try {
                                                 await downloadDocument(downloadUrl, filename, true);

--- a/packages/documents/src/components/Documents.tsx
+++ b/packages/documents/src/components/Documents.tsx
@@ -1203,7 +1203,7 @@ const Documents = ({
     }
 
     // For other files, trigger download
-    const downloadUrl = getDocumentDownloadUrl(document.file_id);
+    const downloadUrl = getDocumentDownloadUrl(document.document_id);
     const filename = document.document_name || 'download';
     try {
       await downloadDocument(downloadUrl, filename, true);
@@ -1887,21 +1887,21 @@ const Documents = ({
                 </button>
                 {previewDocument.mime_type?.startsWith('image/') && (
                   <img
-                    src={previewDocument.preview_file_id ? `/api/documents/${previewDocument.document_id}/preview` : `/api/documents/view/${previewDocument.file_id}`}
+                    src={previewDocument.preview_file_id ? `/api/documents/${previewDocument.document_id}/preview` : `/api/documents/view/${previewDocument.document_id}`}
                     alt={previewDocument.document_name}
                     className="max-w-full max-h-[90vh] object-contain mx-auto"
                   />
                 )}
                 {previewDocument.mime_type?.startsWith('video/') && (
                   <video
-                    src={`/api/documents/view/${previewDocument.file_id}`}
+                    src={`/api/documents/view/${previewDocument.document_id}`}
                     controls
                     className="max-w-full max-h-[90vh] mx-auto"
                   />
                 )}
                 {previewDocument.mime_type === 'application/pdf' && (
                   <iframe
-                    src={`/api/documents/view/${previewDocument.file_id}`}
+                    src={`/api/documents/view/${previewDocument.document_id}`}
                     className="w-full h-[90vh] bg-white"
                     title={previewDocument.document_name}
                   />
@@ -2080,21 +2080,21 @@ const Documents = ({
               </button>
               {previewDocument.mime_type?.startsWith('image/') && (
                 <img
-                  src={previewDocument.preview_file_id ? `/api/documents/${previewDocument.document_id}/preview` : `/api/documents/view/${previewDocument.file_id}`}
+                  src={previewDocument.preview_file_id ? `/api/documents/${previewDocument.document_id}/preview` : `/api/documents/view/${previewDocument.document_id}`}
                   alt={previewDocument.document_name}
                   className="max-w-full max-h-[90vh] object-contain mx-auto"
                 />
               )}
               {previewDocument.mime_type?.startsWith('video/') && (
                 <video
-                  src={`/api/documents/view/${previewDocument.file_id}`}
+                  src={`/api/documents/view/${previewDocument.document_id}`}
                   controls
                   className="max-w-full max-h-[90vh] mx-auto"
                 />
               )}
               {previewDocument.mime_type === 'application/pdf' && (
                 <iframe
-                  src={`/api/documents/view/${previewDocument.file_id}`}
+                  src={`/api/documents/view/${previewDocument.document_id}`}
                   className="w-full h-[90vh] bg-white"
                   title={previewDocument.document_name}
                 />

--- a/packages/documents/src/lib/documentUtils.ts
+++ b/packages/documents/src/lib/documentUtils.ts
@@ -7,9 +7,12 @@ export function getShareUrl(token: string, baseUrl?: string): string {
   return `${base}/share/${token}`;
 }
 
-export function getDocumentDownloadUrl(file_id: string): string {
-    if (!file_id) return '#';
-    return `/api/documents/download/${file_id}`;
+// Link by document id, not file id: generated PDFs are re-rendered in place and
+// the previous file retired, so a file-id link goes stale; the download route
+// resolves a document id to its current file.
+export function getDocumentDownloadUrl(documentId: string): string {
+    if (!documentId) return '#';
+    return `/api/documents/download/${documentId}`;
 }
 
 /**

--- a/packages/tickets/src/components/ticket/bento/DocumentsTile.tsx
+++ b/packages/tickets/src/components/ticket/bento/DocumentsTile.tsx
@@ -59,7 +59,7 @@ function documentViewUrl(
 ): string {
   if (resolve) return resolve({ document_id: doc.document_id, file_id: doc.file_id });
   return doc.file_id
-    ? `/api/documents/view/${doc.file_id}`
+    ? `/api/documents/view/${doc.document_id}`
     : `/api/documents/download/${doc.document_id}`;
 }
 

--- a/server/src/app/api/documents/view/[fileId]/route.ts
+++ b/server/src/app/api/documents/view/[fileId]/route.ts
@@ -112,9 +112,21 @@ export async function GET(
         return new NextResponse('Unauthorized', { status: 401 });
       }
 
-      // Re-fetch file record with tenant context if needed
+      // Re-fetch inside the caller's tenant: findById resolves its tenant from
+      // async context, which a session request has not entered yet. Without it
+      // a retired or foreign file threw instead of falling through to the 404.
       if (!fileRecord || fileRecord.tenant !== tenant) {
-        fileRecord = await FileStoreModel.findById(knex, fileId);
+        fileRecord = await runWithTenant(tenant, () => FileStoreModel.findById(knex, fileId));
+      }
+      // Also accept a document id and serve its current file: generated PDFs
+      // are re-rendered in place, so a file id copied from a list can be stale.
+      if (!fileRecord) {
+        const document = await tenantDb(knex, tenant).table('documents')
+          .where({ document_id: fileId })
+          .first('file_id');
+        if (document?.file_id) {
+          fileRecord = await runWithTenant(tenant, () => FileStoreModel.findById(knex, document.file_id));
+        }
       }
     }
 
@@ -128,7 +140,7 @@ export async function GET(
         return new NextResponse('Unauthorized', { status: 401 });
       }
       const authorizedDocument = await withTransaction(knex, async (trx) =>
-        getAuthorizedDocumentByFileId(trx, tenant, user, fileId)
+        getAuthorizedDocumentByFileId(trx, tenant, user, fileRecord.file_id)
       );
       if (!authorizedDocument) {
         return new NextResponse('Forbidden', { status: 403 });

--- a/server/src/lib/utils/documentUtils.ts
+++ b/server/src/lib/utils/documentUtils.ts
@@ -1,6 +1,9 @@
-export function getDocumentDownloadUrl(file_id: string): string {
-    if (!file_id) return '#';
-    return `/api/documents/download/${file_id}`;
+// Link by document id, not file id: generated PDFs are re-rendered in place and
+// the previous file retired, so a file-id link goes stale; the download route
+// resolves a document id to its current file.
+export function getDocumentDownloadUrl(documentId: string): string {
+    if (!documentId) return '#';
+    return `/api/documents/download/${documentId}`;
 }
 
 /**

--- a/server/src/test/unit/documentsViewRoute.ticketAuth.contract.test.ts
+++ b/server/src/test/unit/documentsViewRoute.ticketAuth.contract.test.ts
@@ -3,6 +3,7 @@ import { NextRequest } from 'next/server';
 
 type TestScenario = {
   allowTicketAccess: boolean;
+  fileMissing?: boolean;
 };
 
 const scenario = vi.hoisted<TestScenario>(() => ({
@@ -15,11 +16,21 @@ const getCurrentUserMock = vi.hoisted(() => vi.fn());
 const createProviderMock = vi.hoisted(() => vi.fn());
 const fileStoreFindByIdMock = vi.hoisted(() => vi.fn());
 const getAuthorizedDocumentByFileIdMock = vi.hoisted(() => vi.fn());
+// Models the real helper: the tenant is only visible to code running inside the callback.
+const tenantScope = vi.hoisted(() => ({ active: null as string | null }));
+const runWithTenantMock = vi.hoisted(() => vi.fn(async (tenant: string, callback: () => Promise<unknown>) => {
+  tenantScope.active = tenant;
+  try {
+    return await callback();
+  } finally {
+    tenantScope.active = null;
+  }
+}));
 
 vi.mock('server/src/lib/db', () => ({
   createTenantKnex: createTenantKnexMock,
   withTransaction: async (knex: any, callback: (trx: any) => Promise<unknown>) => callback(knex),
-  runWithTenant: async (_tenant: string, callback: () => Promise<unknown>) => callback(),
+  runWithTenant: runWithTenantMock,
 }));
 
 vi.mock('@/lib/db/db', () => ({
@@ -122,6 +133,9 @@ function makeKnexMock(testScenario: TestScenario) {
 
 function resolveQueryResult(table: string, state: QueryState, testScenario: TestScenario): any {
   if (table === 'external_files') {
+    if (testScenario.fileMissing) {
+      return null;
+    }
     return {
       file_id: 'file-1',
       tenant: 'tenant-1',
@@ -133,7 +147,7 @@ function resolveQueryResult(table: string, state: QueryState, testScenario: Test
   }
 
   if (table === 'documents') {
-    return { document_id: 'doc-1' };
+    return { document_id: 'doc-1', file_id: 'file-1' };
   }
 
   if (table === 'document_associations') {
@@ -173,6 +187,7 @@ function makeReadableStream(): ReadableStream<Uint8Array> {
 describe('documents view route ticket authorization contract', () => {
   beforeEach(() => {
     scenario.allowTicketAccess = true;
+    scenario.fileMissing = false;
     vi.clearAllMocks();
 
     getCurrentUserMock.mockResolvedValue({
@@ -214,6 +229,65 @@ describe('documents view route ticket authorization contract', () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get('Content-Type')).toBe('image/png');
+  });
+
+  it('returns 404, not 500, when no live file record exists', async () => {
+    scenario.fileMissing = true;
+    // FileStoreModel.findById resolves its tenant from async context and throws without one.
+    fileStoreFindByIdMock.mockImplementation(async () => {
+      if (!tenantScope.active) throw new Error('tenant context not found');
+      return null;
+    });
+    const { GET } = await import('server/src/app/api/documents/view/[fileId]/route');
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/documents/view/file-1'),
+      { params: Promise.resolve({ fileId: 'file-1' }) } as any
+    );
+    expect(response.status).toBe(404);
+    // The fallback lookup resolves its tenant from async context, so it must run inside it.
+    expect(runWithTenantMock).toHaveBeenCalledWith('tenant-1', expect.any(Function));
+    expect(fileStoreFindByIdMock).toHaveBeenCalledWith(expect.anything(), 'file-1');
+  });
+
+  it('serves a file the tenant-scoped fallback finds when the unscoped lookup misses', async () => {
+    scenario.fileMissing = true;
+    fileStoreFindByIdMock.mockImplementation(async () => {
+      if (!tenantScope.active) throw new Error('tenant context not found');
+      return {
+      file_id: 'file-1',
+      tenant: 'tenant-1',
+      is_deleted: false,
+      mime_type: 'image/png',
+      file_size: 4,
+      storage_path: 'tenant-1/file-1.png',
+      };
+    });
+    const { GET } = await import('server/src/app/api/documents/view/[fileId]/route');
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/documents/view/file-1'),
+      { params: Promise.resolve({ fileId: 'file-1' }) } as any
+    );
+    expect(response.status).toBe(200);
+  });
+
+  it('resolves a document id to the document\'s current file', async () => {
+    scenario.fileMissing = true;
+    fileStoreFindByIdMock.mockImplementation(async (_knex: unknown, id: string) => {
+      if (!tenantScope.active) throw new Error('tenant context not found');
+      return id === 'file-1'
+        ? { file_id: 'file-1', tenant: 'tenant-1', is_deleted: false, mime_type: 'image/png', file_size: 4, storage_path: 'tenant-1/file-1.png' }
+        : null;
+    });
+    const { GET } = await import('server/src/app/api/documents/view/[fileId]/route');
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/documents/view/doc-1'),
+      { params: Promise.resolve({ fileId: 'doc-1' }) } as any
+    );
+    expect(response.status).toBe(200);
+    expect(fileStoreFindByIdMock).toHaveBeenCalledWith(expect.anything(), 'doc-1');
+    expect(fileStoreFindByIdMock).toHaveBeenCalledWith(expect.anything(), 'file-1');
+    // Authorization runs against the resolved file, not the id in the URL.
+    expect(getAuthorizedDocumentByFileIdMock).toHaveBeenCalledWith(expect.anything(), 'tenant-1', expect.anything(), 'file-1');
   });
 
   it('T013: rejects ticket file view when contact/client user lacks ticket association access', async () => {


### PR DESCRIPTION
Download and preview links were built from a document's file_id, but generated PDFs are filed in refresh mode: every re-render points the document at a new file and retires the old one, so any list already on screen handed out a dead file id and the download route answered 404.

- getDocumentDownloadUrl (both copies) and the list surfaces in Documents, DocumentStorageCard, DocumentSelector, DocumentsTile and the client-portal task/document views now link by document_id, which the download route already resolves to the current file.
- The view route accepts a document id too, resolving it to the document's current file and authorizing against that file
- Its fallback FileStoreModel.findById now runs inside runWithTenant, so a retired or foreign file yields a clean 404 instead o "tenant context not found" 500.
- The server-action getDocumentDownloadUrl resolves either returns a document-id URL.
- Route tests cover the missing-file 404, the tenant-scoped and document-id resolution; each fails against the old route.

"Curiouser and curiouser!" cried Alice, as the file_id vanished like the Cheshire Cat, leaving nothing but its document_id grinn tree. "At least this one," said the Cat, "knows which way the current file went." 🐱📄🔗