### PR TITLE
ci: raise integration-tests job timeout to 120 minutes

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -61,7 +61,7 @@ jobs:
     # `needs` is skipped entirely on schedule; `always()` lets the nightly run proceed.
     if: always() && (github.event_name == 'schedule' || needs.check-changes.outputs.should_run == 'true')
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
 
     services:
       postgres:

--- a/docs/plans/2026-08-28-microsoft-outbound-shared-mailbox-send/PRD.md
+++ b/docs/plans/2026-08-28-microsoft-outbound-shared-mailbox-send/PRD.md
@@ -1,0 +1,118 @@
+# Microsoft Outbound Email From Shared Mailboxes
+
+## Problem
+
+Outbound email through Microsoft Graph fails with HTTP 403 whenever the configured sending mailbox is not the mailbox of the user who authorized the connection. Most MSP service desks run on a shared mailbox, so this is the normal case rather than an edge case.
+
+Two defects combine to produce it.
+
+`MICROSOFT_EMAIL_OAUTH_SCOPES` in `shared/services/email/microsoftGraphEndpoints.ts:12` requests `Mail.Read`, `Mail.Read.Shared`, `Mail.Send`, `User.Read`, and `offline_access`. It does not request `Mail.Send.Shared`. Delegated `Mail.Send` authorizes sending only as the signed-in user. Sending as any other mailbox requires `Mail.Send.Shared`.
+
+`MicrosoftGraphAdapter.sendMail` at `shared/services/email/providers/MicrosoftGraphAdapter.ts:491` posts to `/users/{mailbox}/sendMail` unconditionally. The read path already distinguishes the two cases: `getMailboxPath()` returns `/me` when the configured mailbox matches the authenticated user, and `/users/{mailbox}` otherwise. The send path never got that treatment, so even a personal mailbox is addressed as though it belonged to someone else.
+
+Inbound mail is unaffected because `Mail.Read.Shared` is requested. A tenant can read its shared mailbox every day and still never send from it.
+
+A third defect compounds the failure. When the Graph provider fails to initialize, `TenantEmailService.getEmailProvider()` falls back to the system Resend provider and the send carries the tenant's own from-address. The shared Resend account only has `algapsa.com` verified, so Resend returns 403 for every tenant sending domain.
+
+The outbound Graph path shipped in `187db3db76` on 2026-08-02. `Mail.Send.Shared` has been absent since then, so this is an original defect rather than a regression.
+
+## Production evidence
+
+Joymode Business Solutions (tenant `917d38c4-092e-4577-9f2a-547d671bc9c3`, mailbox `service@joymode.io`) has sent no outbound notification since 2026-08-13.
+
+| Window | Attempts | Outcome |
+| --- | --- | --- |
+| 2026-08-13 | 3 | Sent through the Resend fallback, from `noreply@algapsa.com` |
+| 2026-08-14 to 2026-08-27 | 98 | Failed, Microsoft Graph 403 |
+| 2026-08-14 to 2026-08-18 | 44 | Failed, Resend 403, `joymode.io` not a verified domain |
+
+The live access token on that provider carries `email Mail.Read Mail.Read.Shared Mail.Send openid profile User.Read` and identifies the authenticated user as `munjal@techff.com`. The configured mailbox is `service@joymode.io`, so the send resolves to `/users/service@joymode.io/sendMail` without `Mail.Send.Shared`.
+
+Across all active Microsoft providers, the presence of `Mail.Send.Shared` predicts success exactly. Five providers fail with the identical error and none hold the scope: `service@joymode.io`, `support@hody.dev`, `support@meihlstech.com`, `support@itxp.com.au`, and one since-deleted provider. One provider sends successfully, `helpdesk@mycompguy.co`, whose Entra admin granted `Mail.Send.Shared` tenant-wide. There are no counterexamples in either direction.
+
+Nineteen active providers currently sit in the failing configuration. Four more have a mailbox that matches the authenticated user and are blocked only by the hardcoded `/users/` path.
+
+## Goals
+
+Restore outbound email for tenants sending from a shared mailbox, without requiring every one of them to reconfigure Exchange.
+
+Stop addressing a personal mailbox as though it were someone else's.
+
+Stop the system fallback provider from attempting sends it cannot complete, and make the resulting failure legible to an administrator.
+
+Tell an administrator what is actually wrong when a send is rejected, so the next occurrence does not require a database investigation.
+
+## Non-goals
+
+App-only authentication through the client credentials flow. That removes this entire class of failure and is the correct long-term design, but it changes the consent model and needs its own scoping work. It is tracked separately.
+
+Any change to Teams behavior, bindings, or credentials.
+
+Any change to inbound mail processing.
+
+Automatic remediation of the affected tenants. Each one must reauthorize, because a new scope cannot be added to an existing grant.
+
+## Product behavior
+
+### Scope request
+
+Connect and reconnect request `https://graph.microsoft.com/Mail.Send.Shared` alongside the existing scopes. Existing connections keep working under their current grant until the tenant reconnects. A tenant sending from a shared mailbox must reconnect before outbound email recovers.
+
+### Send path resolution
+
+`sendMail` resolves the mailbox path the same way the read path does. When the configured mailbox matches the authenticated user, the send posts to `/me/sendMail`. Otherwise it posts to `/users/{mailbox}/sendMail`. A tenant whose service mailbox is the authorizing user's own mailbox recovers without reconnecting and without any Exchange change.
+
+### Fallback from-address
+
+When the system provider handles a send for a tenant, the from-address is a verified system domain. The tenant's display name is preserved in the from-name, and the tenant's address moves to `Reply-To`. A tenant sending domain is never handed to the shared Resend account.
+
+### Provisioned app registration
+
+Requesting a scope only works if the app registration declares it. The registration we provision through `createMicrosoftEmailApplicationManifest` declares `Mail.Read`, `Mail.Read.Shared`, `offline_access`, and `User.Read`, and `packages/integrations/src/lib/microsoftEmailSetup.test.ts:51` asserts that `Mail.Send` never appears in the manifest. That assertion is a holdover from the period when the connector was documented as inbound-only.
+
+The manifest declares the outbound permissions as well, and the assertion inverts to require them. Without this, a tenant onboarded through the automated setup path cannot send outbound mail at all, and reconnecting does not help, because administrator consent covers only declared permissions. Twenty-eight of forty-two providers sit on the shared platform registration; the rest are provisioned or tenant-owned and need the manifest change to have any path to sending.
+
+### Failure reporting
+
+A 403 from Graph records which precondition is missing. The stored error distinguishes an absent `Mail.Send.Shared` scope, which the token proves directly, from an Exchange delegation failure, which it cannot. The provider health surface shows the outbound state, so an administrator can see that sending is broken without reading `email_sending_logs`.
+
+## Rollout
+
+1. Ship the send path resolution and the fallback from-address change. Neither needs a reconnect, and the four matched-mailbox tenants recover on deploy.
+2. Ship the scope addition and the failure reporting.
+3. Notify the affected tenants that they must reconnect the mailbox. Include the Exchange Send As step, since the scope alone does not grant the Exchange permission.
+4. Watch `email_sending_logs` for Microsoft providers. A reconnected tenant that still returns 403 is missing Send As on the mailbox rather than the scope.
+
+## Customer remediation
+
+Reconnecting grants the scope. It does not grant the Exchange permission.
+
+The authorizing user needs Send As on the shared mailbox, granted in the Microsoft 365 admin center under Teams & groups, Shared mailboxes, Manage mailbox permissions, or through Exchange PowerShell:
+
+```powershell
+Add-RecipientPermission -Identity "<mailbox>" -Trustee "<authorizing user>" -AccessRights SendAs -Confirm:$false
+```
+
+Send As is the correct grant. Send on Behalf renders in Outlook as "user on behalf of mailbox", which exposes the authorizing user's address to the tenant's own clients.
+
+Full Access is not sufficient and does not imply Send As. A tenant whose inbound mail works has Full Access already, which says nothing about its ability to send. Exchange permission changes can take up to an hour to take effect.
+
+Shared mailboxes have sign-in disabled, so the authorizing user is always a licensed human account. That constraint is what makes app-only authentication the better long-term answer.
+
+## Risks
+
+Adding a scope changes the consent screen. A tenant whose administrator previously consented may now need administrator approval again, depending on their consent policy. Reconnect can fail for tenants that could previously connect unattended.
+
+A tenant that reconnects but never configures Send As sees the same 403 and may reasonably conclude the fix did not work. Step 3 of the rollout has to state both requirements together.
+
+`Mail.Send.Shared` widens what the connection can do. It authorizes sending as any mailbox the user has been delegated in Exchange, not only the configured one. Exchange delegation remains the constraint that bounds it.
+
+## Acceptance criteria
+
+- Connect and reconnect request `Mail.Send.Shared`.
+- A send from a mailbox that matches the authenticated user posts to `/me/sendMail`.
+- A send from any other mailbox posts to `/users/{mailbox}/sendMail`.
+- A tenant holding `Mail.Send.Shared` and Send As sends successfully from a shared mailbox.
+- The system fallback provider never sends from an unverified tenant domain, and the tenant address appears in `Reply-To`.
+- A 403 caused by a missing scope is recorded differently from a 403 caused by Exchange delegation.
+- Inbound processing, Teams, and every non-Microsoft outbound provider are unchanged.

--- a/docs/plans/2026-08-28-microsoft-outbound-shared-mailbox-send/SCRATCHPAD.md
+++ b/docs/plans/2026-08-28-microsoft-outbound-shared-mailbox-send/SCRATCHPAD.md
@@ -1,0 +1,94 @@
+# Scratchpad
+
+## How the failure was traced
+
+Reported as "outbound email notifications not sending" for Joymode Business Solutions.
+
+Tenant resolution:
+
+```sql
+select tenant, client_name, email from tenants where client_name ilike '%joymode%';
+-- 917d38c4-092e-4577-9f2a-547d671bc9c3, munjal@joymode.io
+```
+
+`email_sending_logs` gave the outage boundary immediately. Grouping by day and status showed the last success on 2026-08-13 and nothing but failures afterwards. Grouping by `error_message` gave the two distinct causes without any log searching.
+
+`email_provider_health` and the Loki app logs were both dead ends here. The Graph error code never reaches the logs: `toProviderError` in `packages/email/src/providers/MicrosoftGraphEmailProvider.ts` logs `status`, `code`, `requestId`, but `code` arrives already flattened to an axios value such as `ERR_BAD_REQUEST`. The useful evidence was entirely in `email_sending_logs.error_message` and in the token itself. F013 exists to close that gap.
+
+## Decoding the stored token
+
+The access token in `microsoft_email_provider_config` is a plain JWT, not encrypted at rest. Decoding the payload settled the diagnosis in one step, and it is the fastest check for any future report of this shape.
+
+Run from a `sebastian` pod, which already has DB env vars and `pg` under `/app`:
+
+```js
+// claims.cjs, run as: cd /app && node claims.cjs
+const { Client } = require('pg');
+const c = new Client({
+  host: process.env.DB_HOST, port: Number(process.env.DB_PORT || 5432),
+  user: process.env.DB_USER_SERVER, password: process.env.DB_PASSWORD_SERVER,
+  database: process.env.DB_NAME_SERVER,
+});
+(async () => {
+  await c.connect();
+  const r = await c.query(
+    'select access_token from microsoft_email_provider_config where tenant = $1',
+    ['<tenant-uuid>']
+  );
+  const p = r.rows[0].access_token.split('.')[1];
+  const n = p.replace(/-/g, '+').replace(/_/g, '/');
+  console.log(JSON.parse(Buffer.from(n.padEnd(Math.ceil(n.length / 4) * 4, '='), 'base64').toString()));
+  await c.end();
+})();
+```
+
+For Joymode this returned `upn: munjal@techff.com` and `scp: email Mail.Read Mail.Read.Shared Mail.Send openid profile User.Read`. The mailbox is `service@joymode.io`. Mailbox does not equal `upn`, and `Mail.Send.Shared` is absent, so the send is unauthorized before Exchange is ever consulted.
+
+## Why the correlation is conclusive
+
+Running the same decode across every active Microsoft provider and joining it to 30 days of `email_sending_logs` produced a clean split with no counterexamples:
+
+- Five providers failing with the identical 403 message. None hold `Mail.Send.Shared`.
+- One provider sending successfully, `helpdesk@mycompguy.co`, 174 sends. It holds `Mail.Send.Shared`.
+
+The mycompguy tenant did not get the scope from us, since we never request it. Their Entra administrator granted the delegated permission on the enterprise application, so it lands in `scp` on consent. That is the only reason any tenant sends from a shared mailbox today.
+
+## Population, as of 2026-08-28
+
+Of 40 active Microsoft providers with a decodable token:
+
+- 19 send from a mailbox other than the authenticated user and lack `Mail.Send.Shared`. These need both a reconnect and an Exchange Send As grant.
+- 4 send from a mailbox that matches the authenticated user. These are broken only by the hardcoded `/users/` path and recover on deploy, with no reconnect.
+- 6 already hold `Mail.Send.Shared`. These are unaffected.
+
+A further 10 providers have no decodable token. Their state is unknown and they should be re-checked after the deploy.
+
+Failing providers with recorded 403s: `service@joymode.io` (98), `support@hody.dev` (188), `support@meihlstech.com` (9), `support@itxp.com.au` (2), and provider `3145d5f1` (2, since deleted). `support@meihlstech.com` has since acquired `Mail.Send.Shared` and should recover on its own.
+
+## The Resend fallback interaction
+
+Joymode shows both error types interleaved between 2026-08-14 and 2026-08-18, which initially looked like a send-time fallback chain. It is not one. `BaseEmailService` has no send-time fallback. The fallback lives in `TenantEmailService.getEmailProvider()` and only fires when the tenant provider fails to *initialize*.
+
+The interleaving comes from `TenantEmailService.instances`, a per-process singleton map. Different `sebastian` pods held different cached providers over that window. Pods where `assertMailSendConsent` threw had cached the system Resend provider; pods where it passed sent through Graph. Both appear in the same minute in the logs.
+
+That also explains why the Resend errors stop on 2026-08-18 while the Graph errors continue. Once every pod's token carried `Mail.Send`, initialization stopped throwing and the fallback stopped being reachable. The tenant moved from one broken path to a different broken path.
+
+Anyone reasoning about provider selection from log timestamps alone needs to account for this cache. Two adjacent log lines can come from processes with different provider state.
+
+## Why Full Access is not evidence of Send As
+
+Inbound works for every affected tenant, which proves the authorizing user has Full Access to the mailbox. In Exchange these are separate grants and Full Access does not imply Send As. Do not treat healthy inbound as evidence that sending will work once the scope lands.
+
+There is no Graph API for reading Send As. It is `Get-RecipientPermission` in Exchange PowerShell only, so we cannot check it from our side and cannot pre-flight it during connect. This is a hard limit on how good the connect-time validation can get, and it is a strong argument for the app-only path, where the permission is not needed at all.
+
+## Cross-tenant appearance
+
+`munjal@techff.com` sending as `service@joymode.io` looks like cross-tenant delegation, which Exchange Online does not support. It is not. Our inbound reads hit `/users/service@joymode.io` with that user's delegated token and succeed daily, and Graph only permits that within one tenant. `joymode.io` is an additional verified domain on the `techff.com` Entra tenant. Send As is grantable normally.
+
+The stored `microsoft_email_provider_config.tenant_id` is `951536bd-...` (the Nine Minds tenant) while the token's `tid` is `92bbe6d8-...`. That mismatch is widespread across providers and is unrelated to this failure. Worth a separate look.
+
+## Related
+
+- `187db3db76` introduced outbound Graph sending on 2026-08-02, without `Mail.Send.Shared`.
+- Teams already uses app-only auth: `ee/packages/microsoft-teams/src/lib/graphAuth.ts:23`. Email is the outlier at `MicrosoftGraphAdapter.ts:388`, which only ever does `grant_type: 'refresh_token'`.
+- `packages/emulators/msgraph/src/core.ts:366` already models the client credentials grant, so the emulator can cover an app-only path when it is built.

--- a/docs/plans/2026-08-28-microsoft-outbound-shared-mailbox-send/features.json
+++ b/docs/plans/2026-08-28-microsoft-outbound-shared-mailbox-send/features.json
@@ -1,0 +1,177 @@
+[
+  {
+    "id": "F001",
+    "title": "Request Mail.Send.Shared",
+    "description": "Add https://graph.microsoft.com/Mail.Send.Shared to MICROSOFT_EMAIL_OAUTH_SCOPES in shared/services/email/microsoftGraphEndpoints.ts.",
+    "implemented": false,
+    "prdRefs": ["Product behavior / Scope request"]
+  },
+  {
+    "id": "F002",
+    "title": "Scope applies to connect",
+    "description": "The initial connect authorization URL carries the new scope.",
+    "implemented": false,
+    "prdRefs": ["Product behavior / Scope request"]
+  },
+  {
+    "id": "F003",
+    "title": "Scope applies to reconnect",
+    "description": "The reconnect authorization URL carries the new scope so existing providers can upgrade their grant.",
+    "implemented": false,
+    "prdRefs": ["Product behavior / Scope request"]
+  },
+  {
+    "id": "F004",
+    "title": "Send path resolution",
+    "description": "MicrosoftGraphAdapter.sendMail resolves its endpoint through the same mailbox-path logic the read path uses instead of hardcoding /users/{mailbox}.",
+    "implemented": false,
+    "prdRefs": ["Product behavior / Send path resolution"]
+  },
+  {
+    "id": "F005",
+    "title": "Personal mailbox sends via /me",
+    "description": "When the configured mailbox equals the authenticated user, sendMail posts to /me/sendMail.",
+    "implemented": false,
+    "prdRefs": ["Product behavior / Send path resolution"]
+  },
+  {
+    "id": "F006",
+    "title": "Shared mailbox sends via /users",
+    "description": "When the configured mailbox differs from the authenticated user, sendMail posts to /users/{mailbox}/sendMail.",
+    "implemented": false,
+    "prdRefs": ["Product behavior / Send path resolution"]
+  },
+  {
+    "id": "F007",
+    "title": "Mailbox comparison is case-insensitive",
+    "description": "Mailbox-to-authenticated-user matching ignores case and surrounding whitespace, matching the read path's behavior.",
+    "implemented": false,
+    "prdRefs": ["Product behavior / Send path resolution"]
+  },
+  {
+    "id": "F008",
+    "title": "Unknown authenticated user falls back to /users",
+    "description": "When the authenticated user's address has not been resolved, sendMail uses /users/{mailbox} rather than guessing /me.",
+    "implemented": false,
+    "prdRefs": ["Product behavior / Send path resolution"]
+  },
+  {
+    "id": "F009",
+    "title": "Consent assertion accounts for shared sends",
+    "description": "assertMailSendConsent in MicrosoftGraphEmailProvider requires Mail.Send.Shared when the configured mailbox is not the authenticated user, and Mail.Send otherwise.",
+    "implemented": false,
+    "prdRefs": ["Product behavior / Failure reporting"]
+  },
+  {
+    "id": "F010",
+    "title": "Consent failure names the missing scope",
+    "description": "A provider that cannot send because of an absent scope reports which scope is missing and that a reconnect is required.",
+    "implemented": false,
+    "prdRefs": ["Product behavior / Failure reporting"]
+  },
+  {
+    "id": "F011",
+    "title": "403 distinguishes scope from delegation",
+    "description": "toProviderError inspects the token's scopes when Graph returns 403 and reports a missing-scope failure separately from an Exchange delegation failure.",
+    "implemented": false,
+    "prdRefs": ["Product behavior / Failure reporting"]
+  },
+  {
+    "id": "F012",
+    "title": "Send As guidance in the delegation error",
+    "description": "The Exchange delegation error names the mailbox and the authorizing user so an administrator knows exactly which grant to add.",
+    "implemented": false,
+    "prdRefs": ["Product behavior / Failure reporting", "Customer remediation"]
+  },
+  {
+    "id": "F013",
+    "title": "Graph error code is retained",
+    "description": "The Graph error code and request id survive into the stored error metadata rather than being flattened to an axios code.",
+    "implemented": false,
+    "prdRefs": ["Product behavior / Failure reporting"]
+  },
+  {
+    "id": "F014",
+    "title": "System fallback uses a verified from-address",
+    "description": "When the system provider handles a tenant send, the from-address is a verified system domain rather than the tenant's configured address.",
+    "implemented": false,
+    "prdRefs": ["Product behavior / Fallback from-address"]
+  },
+  {
+    "id": "F015",
+    "title": "Tenant name survives the fallback",
+    "description": "The tenant's display name is preserved as the from-name on a system-provider send.",
+    "implemented": false,
+    "prdRefs": ["Product behavior / Fallback from-address"]
+  },
+  {
+    "id": "F016",
+    "title": "Tenant address moves to Reply-To",
+    "description": "A system-provider send sets Reply-To to the tenant's configured address so replies still reach the service desk.",
+    "implemented": false,
+    "prdRefs": ["Product behavior / Fallback from-address"]
+  },
+  {
+    "id": "F017",
+    "title": "Outbound state on provider health",
+    "description": "Provider health records whether outbound sending currently succeeds, so a broken sender is visible without querying email_sending_logs.",
+    "implemented": false,
+    "prdRefs": ["Product behavior / Failure reporting"]
+  },
+  {
+    "id": "F018",
+    "title": "Settings surface shows the outbound failure",
+    "description": "The email settings screen shows the outbound failure reason and the required remediation for a provider that cannot send.",
+    "implemented": false,
+    "prdRefs": ["Product behavior / Failure reporting"]
+  },
+  {
+    "id": "F019",
+    "title": "Reconnect prompt for stale grants",
+    "description": "A connected Microsoft provider whose token lacks the scope its mailbox requires prompts for reconnect rather than waiting for the next send to fail.",
+    "implemented": false,
+    "prdRefs": ["Rollout"]
+  },
+  {
+    "id": "F020",
+    "title": "Setup documentation covers Send As",
+    "description": "docs/inbound-email/setup/microsoft.md states that a shared sending mailbox needs both the reconnect and an Exchange Send As grant, and gives the admin center path and the PowerShell equivalent.",
+    "implemented": false,
+    "prdRefs": ["Customer remediation"]
+  },
+  {
+    "id": "F021",
+    "title": "Send As is recommended over Send on Behalf",
+    "description": "The documentation states why Send As is the correct grant and what Send on Behalf does to the visible sender.",
+    "implemented": false,
+    "prdRefs": ["Customer remediation"]
+  },
+  {
+    "id": "F023",
+    "title": "Manifest declares outbound permissions",
+    "description": "createMicrosoftEmailApplicationManifest declares Mail.Send and Mail.Send.Shared, with their delegated permission ids added to MICROSOFT_EMAIL_DELEGATED_PERMISSION_IDS.",
+    "implemented": false,
+    "prdRefs": ["Product behavior / Provisioned app registration"]
+  },
+  {
+    "id": "F024",
+    "title": "Manifest assertion inverted",
+    "description": "The microsoftEmailSetup test requires the outbound permissions in the manifest instead of asserting Mail.Send is absent.",
+    "implemented": false,
+    "prdRefs": ["Product behavior / Provisioned app registration"]
+  },
+  {
+    "id": "F025",
+    "title": "Existing provisioned apps are re-consented",
+    "description": "A tenant whose provisioned registration predates the manifest change is prompted through admin consent again, so the new permissions are actually granted rather than only declared.",
+    "implemented": false,
+    "prdRefs": ["Product behavior / Provisioned app registration", "Rollout"]
+  },
+  {
+    "id": "F022",
+    "title": "Affected tenant report",
+    "description": "A query identifies active Microsoft providers whose stored token lacks the scope their configured mailbox requires, for use in the rollout notification.",
+    "implemented": false,
+    "prdRefs": ["Rollout"]
+  }
+]

--- a/docs/plans/2026-08-28-microsoft-outbound-shared-mailbox-send/tests.json
+++ b/docs/plans/2026-08-28-microsoft-outbound-shared-mailbox-send/tests.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "T001",
+    "description": "The authorization URL for both connect and reconnect contains Mail.Send.Shared alongside the existing scopes.",
+    "implemented": false,
+    "featureIds": ["F001", "F002", "F003"]
+  },
+  {
+    "id": "T002",
+    "description": "sendMail posts to /me/sendMail when the configured mailbox equals the authenticated user, and to /users/{mailbox}/sendMail when it does not, including a case- and whitespace-differing match and an unresolved authenticated user.",
+    "implemented": false,
+    "featureIds": ["F004", "F005", "F006", "F007", "F008"]
+  },
+  {
+    "id": "T003",
+    "description": "A shared mailbox whose token carries Mail.Send but not Mail.Send.Shared is refused at initialization with an error naming the missing scope, while the same token sending from its own mailbox initializes successfully.",
+    "implemented": false,
+    "featureIds": ["F009", "F010"]
+  },
+  {
+    "id": "T004",
+    "description": "A Graph 403 on a token that holds every required scope is reported as an Exchange delegation failure naming the mailbox and authorizing user, and a 403 on a token missing the scope is reported as a scope failure; both retain the Graph error code and request id.",
+    "implemented": false,
+    "featureIds": ["F011", "F012", "F013"]
+  },
+  {
+    "id": "T005",
+    "description": "A system-provider send for a tenant with a custom sending domain uses a verified system from-address, preserves the tenant display name, and sets Reply-To to the tenant address.",
+    "implemented": false,
+    "featureIds": ["F014", "F015", "F016"]
+  },
+  {
+    "id": "T006",
+    "description": "DB-backed: a failed outbound send records the outbound state on provider health, and a subsequent successful send clears it.",
+    "implemented": false,
+    "featureIds": ["F017"]
+  },
+  {
+    "id": "T007",
+    "description": "DB-backed: the affected-tenant report returns providers whose stored token lacks the scope their mailbox requires and excludes providers whose mailbox matches the authenticated user.",
+    "implemented": false,
+    "featureIds": ["F019", "F022"]
+  },
+  {
+    "id": "T009",
+    "description": "The provisioned application manifest declares Mail.Send and Mail.Send.Shared alongside the existing permissions, and every scope the adapter requests at authorize time is present in the manifest.",
+    "implemented": false,
+    "featureIds": ["F001", "F023", "F024"]
+  },
+  {
+    "id": "T008",
+    "description": "The email settings screen shows the outbound failure reason and remediation for a provider that cannot send, and shows nothing for a healthy provider.",
+    "implemented": false,
+    "featureIds": ["F018"]
+  }
+]

--- a/ee/appliance/host-service/kubectl-queue.mjs
+++ b/ee/appliance/host-service/kubectl-queue.mjs
@@ -1,7 +1,10 @@
 import { spawn } from 'node:child_process';
 
 const DEFAULT_TIMEOUT_MS = 30_000;
-const MAX_OUTPUT_BYTES = 256 * 1024;
+// `kubectl get ... -o json` includes annotations and status for every object.
+// A modest appliance can exceed 256 KiB with its normal pod list, so retain
+// enough output for API consumers to parse structured Kubernetes responses.
+const MAX_OUTPUT_BYTES = 4 * 1024 * 1024;
 
 function truncateOutput(value) {
   const text = value || '';

--- a/ee/appliance/host-service/tests/kubectl-queue.test.mjs
+++ b/ee/appliance/host-service/tests/kubectl-queue.test.mjs
@@ -44,3 +44,13 @@ test('SerialCommandQueue passes provided stdin to the command', async () => {
   assert.equal(result.stdout, 'secret-value');
   assert.equal(result.command.includes('secret-value'), false);
 });
+
+test('SerialCommandQueue preserves large JSON responses for Kubernetes API consumers', async () => {
+  const queue = createKubectlQueue({ name: 'test-large-json' });
+  const result = await queue.enqueue(
+    "node -e \"process.stdout.write(JSON.stringify({items:[{metadata:{annotations:{payload:'x'.repeat(300 * 1024)}}}]}))\""
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(JSON.parse(result.stdout).items[0].metadata.annotations.payload.length, 300 * 1024);
+});


### PR DESCRIPTION
## What
Raise the job-level `timeout-minutes` on the `integration-tests` job in `.github/workflows/integration-tests.yml` from 90 to 120.

## Why
The integration suite has been running close to the 90-minute cap; the extra headroom prevents legitimate runs from being cancelled by the job timeout.

## Testing
Workflow-only change, no application code touched. Step-level timeouts for the non-blocking infrastructure steps are unchanged.