### PR TITLE
ci: raise integration-tests job timeout to 120 minutes

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -61,7 +61,7 @@ jobs:
     # `needs` is skipped entirely on schedule; `always()` lets the nightly run proceed.
     if: always() && (github.event_name == 'schedule' || needs.check-changes.outputs.should_run == 'true')
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
 
     services:
       postgres:


### PR DESCRIPTION
## What
Raise the job-level `timeout-minutes` on the `integration-tests` job in `.github/workflows/integration-tests.yml` from 90 to 120.

## Why
The integration suite has been running close to the 90-minute cap; the extra headroom prevents legitimate runs from being cancelled by the job timeout.

## Testing
Workflow-only change, no application code touched. Step-level timeouts for the non-blocking infrastructure steps are unchanged.

Supersedes #3321, which accidentally carried unrelated local commits and was in a conflicting state.