### PR TITLE
Use Pro price as the AlgaDesk upgrade target

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -166,6 +166,8 @@ STRIPE_PRO_PRICE_ID=price_pro_per_seat_here
 # AlgaDesk prices (per-user only, no base fee — tenants with product_code='algadesk')
 # STRIPE_ALGADESK_USER_PRICE_ID=price_algadesk_per_user_here
 # STRIPE_ALGADESK_USER_ANNUAL_PRICE_ID=price_algadesk_per_user_annual_here
+# The AlgaDesk -> AlgaPSA upgrade targets STRIPE_PRO_PRICE_ID / STRIPE_PRO_ANNUAL_PRICE_ID
+# (set STRIPE_ALGAPSA_USER_PRICE_ID / STRIPE_ALGAPSA_USER_ANNUAL_PRICE_ID only to override)
 
 # Email Configuration
 EMAIL_ENABLE=false  # Required: Boolean

--- a/ee/server/src/__tests__/unit/stripeService.productUpgrade.test.ts
+++ b/ee/server/src/__tests__/unit/stripeService.productUpgrade.test.ts
@@ -34,6 +34,8 @@ function createService(options: {
   algadeskAnnualPriceId?: string | null;
   algapsaPriceId?: string | null;
   algapsaAnnualPriceId?: string | null;
+  proPriceId?: string | null;
+  proAnnualPriceId?: string | null;
   invoiceAmountDue?: number;
   hasCanonicalSubscription?: boolean;
 } = {}) {
@@ -115,6 +117,8 @@ function createService(options: {
     algapsaUserAnnualPriceId: options.algapsaAnnualPriceId === undefined
       ? 'price_algapsa_year'
       : options.algapsaAnnualPriceId,
+    proPriceId: options.proPriceId ?? null,
+    proAnnualPriceId: options.proAnnualPriceId ?? null,
   };
   service.stripe = {
     subscriptions,
@@ -267,11 +271,24 @@ describe('StripeService AlgaDesk to AlgaPSA product upgrade', () => {
     expectNoDestructiveStripeCalls(context);
   });
 
-  it('T037 reports a missing monthly AlgaPSA env var before any Stripe API call', async () => {
+  it('targets STRIPE_PRO_PRICE_ID when no AlgaPSA override is configured', async () => {
+    const context = createService({ algapsaPriceId: null, proPriceId: 'price_pro_month' });
+
+    await expect(context.service.swapSubscriptionToPsaProduct('tenant-product-upgrade'))
+      .resolves.toEqual({ swapped: true });
+
+    expect(context.subscriptions.update).toHaveBeenCalledWith(
+      'sub_product_upgrade',
+      expect.objectContaining({ items: [{ id: context.itemId, price: 'price_pro_month' }] }),
+    );
+    expectNoDestructiveStripeCalls(context);
+  });
+
+  it('T037 reports a missing monthly target price env var before any Stripe API call', async () => {
     const context = createService({ algapsaPriceId: null });
 
     await expect(context.service.swapSubscriptionToPsaProduct('tenant-product-upgrade'))
-      .rejects.toThrow('STRIPE_ALGAPSA_USER_PRICE_ID environment variable is not configured');
+      .rejects.toThrow('STRIPE_PRO_PRICE_ID environment variable is not configured');
 
     expect(context.subscriptions.retrieve).not.toHaveBeenCalled();
     expect(context.subscriptions.update).not.toHaveBeenCalled();

--- a/ee/server/src/lib/stripe/StripeService.ts
+++ b/ee/server/src/lib/stripe/StripeService.ts
@@ -1917,12 +1917,18 @@ export class StripeService {
     product: 'ALGADESK' | 'ALGAPSA',
     interval: 'month' | 'year',
   ): string {
-    const envName = `STRIPE_${product}_USER_${interval === 'year' ? 'ANNUAL_' : ''}PRICE_ID`;
+    const annual = interval === 'year';
+    // The AlgaPSA per-seat price is the Pro price; STRIPE_ALGAPSA_USER_* only overrides it.
     const priceId = product === 'ALGADESK'
-      ? (interval === 'year' ? this.config.algadeskUserAnnualPriceId : this.config.algadeskUserPriceId)
-      : (interval === 'year' ? this.config.algapsaUserAnnualPriceId : this.config.algapsaUserPriceId);
+      ? (annual ? this.config.algadeskUserAnnualPriceId : this.config.algadeskUserPriceId)
+      : (annual
+        ? (this.config.algapsaUserAnnualPriceId || this.config.proAnnualPriceId)
+        : (this.config.algapsaUserPriceId || this.config.proPriceId));
 
     if (!priceId) {
+      const envName = product === 'ALGADESK'
+        ? `STRIPE_ALGADESK_USER_${annual ? 'ANNUAL_' : ''}PRICE_ID`
+        : `STRIPE_PRO_${annual ? 'ANNUAL_' : ''}PRICE_ID`;
       throw new Error(`${envName} environment variable is not configured`);
     }
 

--- a/ee/temporal-workflows/src/activities/__tests__/product-upgrade-activities.test.ts
+++ b/ee/temporal-workflows/src/activities/__tests__/product-upgrade-activities.test.ts
@@ -160,6 +160,31 @@ describe('product_upgrade_stripe_swap', () => {
     expect(setup.scheduleCancel).not.toHaveBeenCalled();
   });
 
+  it('targets STRIPE_PRO_PRICE_ID when no AlgaPSA override is configured', async () => {
+    const setup = dependencies(subscription());
+    setup.deps.env = {
+      STRIPE_ALGADESK_USER_PRICE_ID: 'price_algadesk_month',
+      STRIPE_PRO_PRICE_ID: 'price_pro_month',
+    } as NodeJS.ProcessEnv;
+
+    await expect(product_upgrade_stripe_swap('tenant-1', setup.deps)).resolves.toEqual({
+      swapped: true,
+    });
+    expect(setup.update).toHaveBeenCalledWith(
+      'sub_license',
+      expect.objectContaining({ items: [{ id: 'si_users', price: 'price_pro_month' }] }),
+    );
+  });
+
+  it('refuses without mutating Stripe when the interval pair is not configured', async () => {
+    const setup = dependencies(subscription());
+    setup.deps.env = { STRIPE_ALGADESK_USER_PRICE_ID: 'price_algadesk_month' } as NodeJS.ProcessEnv;
+
+    await expect(product_upgrade_stripe_swap('tenant-1', setup.deps))
+      .rejects.toThrow('STRIPE_PRO_PRICE_ID is not configured in the temporal worker');
+    expect(setup.update).not.toHaveBeenCalled();
+  });
+
   it('selects the annual target for an annual AlgaDesk item', async () => {
     const live = subscription();
     live.items.data[0].price.id = 'price_algadesk_year';

--- a/ee/temporal-workflows/src/activities/product-upgrade-activities.ts
+++ b/ee/temporal-workflows/src/activities/product-upgrade-activities.ts
@@ -28,10 +28,10 @@ interface StripePriceRow {
 }
 
 interface StripePriceConfig {
-  algadeskMonthly: string;
-  algadeskAnnual: string;
-  algapsaMonthly: string;
-  algapsaAnnual: string;
+  algadeskMonthly?: string;
+  algadeskAnnual?: string;
+  algapsaMonthly?: string;
+  algapsaAnnual?: string;
 }
 
 export interface ProductUpgradeStripeClient {
@@ -78,12 +78,22 @@ function requiredEnv(env: NodeJS.ProcessEnv, key: string): string {
   return value;
 }
 
+function optionalEnv(env: NodeJS.ProcessEnv, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = env[key]?.trim();
+    if (value) return value;
+  }
+  return undefined;
+}
+
+// Only the pair for the subscription's own interval is required, at the point of use.
+// The AlgaPSA per-seat price is the Pro price; STRIPE_ALGAPSA_USER_* only overrides it.
 function readStripePriceConfig(env: NodeJS.ProcessEnv): StripePriceConfig {
   return {
-    algadeskMonthly: requiredEnv(env, 'STRIPE_ALGADESK_USER_PRICE_ID'),
-    algadeskAnnual: requiredEnv(env, 'STRIPE_ALGADESK_USER_ANNUAL_PRICE_ID'),
-    algapsaMonthly: requiredEnv(env, 'STRIPE_ALGAPSA_USER_PRICE_ID'),
-    algapsaAnnual: requiredEnv(env, 'STRIPE_ALGAPSA_USER_ANNUAL_PRICE_ID'),
+    algadeskMonthly: optionalEnv(env, 'STRIPE_ALGADESK_USER_PRICE_ID'),
+    algadeskAnnual: optionalEnv(env, 'STRIPE_ALGADESK_USER_ANNUAL_PRICE_ID'),
+    algapsaMonthly: optionalEnv(env, 'STRIPE_ALGAPSA_USER_PRICE_ID', 'STRIPE_PRO_PRICE_ID'),
+    algapsaAnnual: optionalEnv(env, 'STRIPE_ALGAPSA_USER_ANNUAL_PRICE_ID', 'STRIPE_PRO_ANNUAL_PRICE_ID'),
   };
 }
 
@@ -161,7 +171,7 @@ export async function product_upgrade_stripe_swap(
   const env = dependencies.env ?? process.env;
   const log = dependencies.log ?? activityLog();
   const prices = readStripePriceConfig(env);
-  const knownPriceIds = Object.values(prices);
+  const knownPriceIds = Object.values(prices).filter((id): id is string => Boolean(id));
   const loadSubscription = dependencies.loadCanonicalSubscription
     ?? loadCanonicalActiveLicenseSubscription;
   const subscriptionRow = await loadSubscription(tenantId, knownPriceIds);
@@ -209,8 +219,21 @@ export async function product_upgrade_stripe_swap(
     );
   }
 
-  const sourcePrice = interval === 'year' ? prices.algadeskAnnual : prices.algadeskMonthly;
-  const targetPrice = interval === 'year' ? prices.algapsaAnnual : prices.algapsaMonthly;
+  const annual = interval === 'year';
+  const sourcePrice = annual ? prices.algadeskAnnual : prices.algadeskMonthly;
+  const targetPrice = annual ? prices.algapsaAnnual : prices.algapsaMonthly;
+  if (!sourcePrice) {
+    refuse(
+      `STRIPE_ALGADESK_USER_${annual ? 'ANNUAL_' : ''}PRICE_ID is not configured in the temporal worker`,
+      'missing-configuration',
+    );
+  }
+  if (!targetPrice) {
+    refuse(
+      `STRIPE_PRO_${annual ? 'ANNUAL_' : ''}PRICE_ID is not configured in the temporal worker`,
+      'missing-configuration',
+    );
+  }
   if (userItem.price.id === targetPrice) {
     log.info('Stripe subscription is already on the AlgaPSA price', {
       tenantId,

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -908,6 +908,14 @@ spec:
           - name: STRIPE_PRO_ANNUAL_PRICE_ID
             value: "{{ .Values.stripe.pro_annual_price_id }}"
           {{- end }}
+          {{- if .Values.stripe.algadesk_user_price_id }}
+          - name: STRIPE_ALGADESK_USER_PRICE_ID
+            value: "{{ .Values.stripe.algadesk_user_price_id }}"
+          {{- end }}
+          {{- if .Values.stripe.algadesk_user_annual_price_id }}
+          - name: STRIPE_ALGADESK_USER_ANNUAL_PRICE_ID
+            value: "{{ .Values.stripe.algadesk_user_annual_price_id }}"
+          {{- end }}
           {{- if .Values.stripe.early_adopters_base_price_id }}
           - name: STRIPE_EARLY_ADOPTERS_BASE_PRICE_ID
             value: "{{ .Values.stripe.early_adopters_base_price_id }}"


### PR DESCRIPTION
StripeService and the temporal swap activity now resolve the AlgaPSA target from STRIPE_PRO_PRICE_ID / STRIPE_PRO_ANNUAL_PRICE_ID, the per-seat price Pro tenants already bill on. STRIPE_ALGAPSA_USER_* remain as optional overrides instead of a mandatory duplicate of the same id.

The worker's readStripePriceConfig reads the ids tolerantly and requires only the AlgaDesk/Pro pair for the subscription's own interval at the point of use. It previously demanded all four ids up front, so a monthly-only configuration would have refused every swap, including monthly ones.

helm/templates/deployment.yaml gains guarded env slots for stripe.algadesk_user_price_id and stripe.algadesk_user_annual_price_id; the sebastian chart had no way to set STRIPE_ALGADESK_USER_PRICE_ID at all.

Prod never had the AlgaDesk price configured, so every self-serve upgrade attempt failed at preview with "STRIPE_ALGADESK_USER_PRICE_ID environment variable is not configured". Pairs with nm-kube-config 43ac61b, which sets the AlgaDesk id and gives the worker both prices. Tests cover the Pro fallback and the missing-configuration refusal in both suites.

🐛 "Which way to AlgaPSA?" asked Alice. "That depends a good deal on your billing interval," said the Cheshire Cat, and faded away until nothing was left but the grin of STRIPE_PRO_PRICE_ID, which readStripePriceConfig now admits had been the target all along. 😸🎩