### PR TITLE
Inbound email: reply parser truncates body at inline blockquotes (alga0002339)

### DIFF
--- a/server/src/lib/api/services/TicketService.ts
+++ b/server/src/lib/api/services/TicketService.ts
@@ -32,6 +32,7 @@ import {
 import { deleteEntityWithValidation } from '@alga-psa/core/server';
 import { publishWorkflowEvent } from 'server/src/lib/eventBus/publishers';
 import { NotFoundError, ValidationError, ConflictError, ForbiddenError } from '../middleware/apiMiddleware';
+import { hasPermission } from '../../auth/rbac';
 import { TicketModel, CreateTicketInput } from '@shared/models/ticketModel';
 import {
   TICKET_ACTIVITY_ACTOR,
@@ -2209,7 +2210,11 @@ export class TicketService extends BaseService<ITicket> {
   }
 
   /**
-   * Update an existing comment (only the comment author may edit)
+   * Update an existing comment. Only the comment author may edit their own
+   * comment. Comments with no authoring user (user_id null — e.g. inbound
+   * email comments attributed to a contact) have no owner who could ever
+   * edit them, so an operator holding the `comment:update` RBAC permission
+   * may repair them; the repair is recorded in the comment metadata.
    */
   async updateComment(
     ticketId: string,
@@ -2232,16 +2237,46 @@ export class TicketService extends BaseService<ITicket> {
         throw new ValidationError('System-generated comments cannot be edited');
       }
 
+      let operatorRepair = false;
       if (comment.user_id !== context.userId) {
-        throw new ValidationError('You can only edit your own comments');
+        // Fail closed: the operator path requires a loaded caller user record
+        // (the API controller always provides one) and the RBAC permission.
+        const canOperatorRepair =
+          comment.user_id == null &&
+          context.user != null &&
+          (await hasPermission(context.user, 'comment', 'update', trx));
+        if (!canOperatorRepair) {
+          throw new ValidationError('You can only edit your own comments');
+        }
+        operatorRepair = true;
+      }
+
+      const update: Record<string, unknown> = {
+        note: data.comment_text,
+        updated_at: knex.raw('now()'),
+      };
+      if (operatorRepair) {
+        // Preserve existing metadata (parser results, email threading data,
+        // attachments references) and append an attributable audit record.
+        const existingMetadata =
+          typeof comment.metadata === 'string'
+            ? JSON.parse(comment.metadata)
+            : comment.metadata ?? {};
+        const operatorEdits = Array.isArray(existingMetadata.operatorEdits)
+          ? existingMetadata.operatorEdits
+          : [];
+        update.metadata = {
+          ...existingMetadata,
+          operatorEdits: [
+            ...operatorEdits,
+            { userId: context.userId, at: new Date().toISOString() },
+          ],
+        };
       }
 
       const [updated] = await tenantScopedTable(trx, 'comments', context.tenant)
         .where({ comment_id: commentId })
-        .update({
-          note: data.comment_text,
-          updated_at: knex.raw('now()'),
-        })
+        .update(update)
         .returning('*');
 
       return {

--- a/server/src/lib/api/services/TicketService.ts
+++ b/server/src/lib/api/services/TicketService.ts
@@ -2213,8 +2213,9 @@ export class TicketService extends BaseService<ITicket> {
    * Update an existing comment. Only the comment author may edit their own
    * comment. Comments with no authoring user (user_id null — e.g. inbound
    * email comments attributed to a contact) have no owner who could ever
-   * edit them, so an operator holding the `comment:update` RBAC permission
-   * may repair them; the repair is recorded in the comment metadata.
+   * edit them, so an operator holding the `ticket:update` RBAC permission
+   * (which covers updating tickets and their comments) may repair them; the
+   * repair is recorded in the comment metadata.
    */
   async updateComment(
     ticketId: string,
@@ -2244,7 +2245,7 @@ export class TicketService extends BaseService<ITicket> {
         const canOperatorRepair =
           comment.user_id == null &&
           context.user != null &&
-          (await hasPermission(context.user, 'comment', 'update', trx));
+          (await hasPermission(context.user, 'ticket', 'update', trx));
         if (!canOperatorRepair) {
           throw new ValidationError('You can only edit your own comments');
         }

--- a/server/src/test/integration/inboundEmailInApp.webhooks.integration.test.ts
+++ b/server/src/test/integration/inboundEmailInApp.webhooks.integration.test.ts
@@ -922,6 +922,177 @@ describeDb('Inbound email in-app processing via webhooks (integration)', () => {
     expect(() => JSON.parse(comments[0].note)).not.toThrow();
   });
 
+  // Run one raw multipart MIME message through the real path a live inbound email
+  // takes (webhook pointer -> unified queue job -> simpleParser -> reply parser ->
+  // ticket + comment) and return what landed in the database. The replyParser unit
+  // tests cannot catch a stale bundle or a divergence between fixture HTML and what
+  // mailparser actually emits; this can (alga0002339 shipped exactly that way).
+  async function processMicrosoftRawMime(params: {
+    subject: string;
+    text: string;
+    html: string;
+  }): Promise<{ ticket: any; comment: any; parserMeta: any }> {
+    const providerId = uuidv4();
+    const mailbox = `support-mime-${uuidv4().slice(0, 6)}@example.com`;
+    const subscriptionId = `sub-mime-${uuidv4()}`;
+    const { defaultsId } = await setupMicrosoftProvider({ providerId, mailbox, subscriptionId });
+    const messageId = `ms-mime-${uuidv4()}`;
+    cleanup.push(async () => {
+      await tenantTable('email_processed_messages').where({ provider_id: providerId }).delete();
+      await tenantTable('microsoft_email_provider_config').where({ email_provider_id: providerId }).delete();
+      await tenantTable('email_providers').where({ id: providerId }).delete();
+      await tenantTable('inbound_ticket_defaults').where({ id: defaultsId }).delete();
+    });
+
+    microsoftDownloadMessageSourceMock = vi.fn().mockResolvedValue(
+      buildMicrosoftMime({
+        from: 'sender@example.com',
+        to: mailbox,
+        subject: params.subject,
+        messageId,
+        text: params.text,
+        html: params.html,
+      })
+    );
+
+    const payload = {
+      value: [
+        {
+          changeType: 'created',
+          clientState: MS_WEBHOOK_CLIENT_STATE,
+          resource: `/users/${uuidv4()}/messages/${messageId}`,
+          resourceData: {
+            '@odata.type': '#microsoft.graph.message',
+            '@odata.id': 'ignored',
+            id: messageId,
+            subject: params.subject,
+          },
+          subscriptionExpirationDateTime: new Date(Date.now() + 60_000).toISOString(),
+          subscriptionId,
+          tenantId: 'ignored',
+        },
+      ],
+    };
+
+    const { handleMicrosoftWebhookPost } = await import(
+      '@alga-psa/integrations/webhooks/email/handlers/microsoftWebhookHandler'
+    );
+    const req = new NextRequest('http://localhost:3000/api/email/webhooks/microsoft', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    const res = await handleMicrosoftWebhookPost(req);
+    expect(res.status).toBe(200);
+
+    await processEnqueuedUnifiedJobs();
+
+    const tickets = await tenantTable('tickets').where({ title: params.subject });
+    expect(tickets).toHaveLength(1);
+    const ticketId = tickets[0].ticket_id;
+    cleanup.push(async () => {
+      await tenantTable('comments').where({ ticket_id: ticketId }).delete();
+      await deleteTicketRows(ticketId);
+    });
+
+    const comments = await tenantTable('comments').where({ ticket_id: ticketId });
+    expect(comments).toHaveLength(1);
+    const metadata =
+      typeof comments[0].metadata === 'string' ? JSON.parse(comments[0].metadata) : comments[0].metadata;
+    return { ticket: tickets[0], comment: comments[0], parserMeta: metadata?.parser ?? {} };
+  }
+
+  it('Raw MIME: inline Outlook elementToProof blockquote does not truncate the body (alga0002339)', async () => {
+    const { comment, parserMeta } = await processMicrosoftRawMime({
+      subject: `Inline blockquote survives ${uuidv4().slice(0, 6)}`,
+      text: [
+        'Hi support team,',
+        '',
+        'For example, today I told a customer:',
+        '',
+        '> I will follow up with you on Friday morning.',
+        '',
+        'POST BLOCKQUOTE SURVIVES CLEAN BOOT',
+        '',
+        'Follow-up types we need:',
+        '- Call the customer back',
+        '- Send a summary email',
+        '',
+        'Kept promises are the whole ballgame.',
+      ].join('\r\n'),
+      html: [
+        '<html><body>',
+        '<p>Hi support team,</p>',
+        '<p>For example, today I told a customer:</p>',
+        '<blockquote class="elementToProof" style="border-left:3px solid rgb(200,200,200); padding-left:8px">',
+        'I will follow up with you on Friday morning.',
+        '</blockquote>',
+        '<p>POST BLOCKQUOTE SURVIVES CLEAN BOOT</p>',
+        '<p>Follow-up types we need:</p>',
+        '<ul><li>Call the customer back</li><li>Send a summary email</li></ul>',
+        '<p>Kept promises are the whole ballgame.</p>',
+        '</body></html>',
+      ].join(''),
+    });
+
+    // The authored content after the inline quote must reach the stored comment.
+    expect(comment.note).toContain('POST BLOCKQUOTE SURVIVES CLEAN BOOT');
+    expect(comment.note).toContain('Call the customer back');
+    expect(comment.note).toContain('Kept promises are the whole ballgame');
+    // And the parser must not claim a high-confidence blockquote cut it did not earn.
+    expect(parserMeta.heuristics ?? []).not.toContain('html-blockquote-trim');
+    expect(`${parserMeta.strategy}/${parserMeta.confidence}`).not.toBe('custom-boundary/high');
+  });
+
+  it('Raw MIME: inline blockquote followed by quoted history keeps the authored suffix and cuts the history', async () => {
+    const { comment } = await processMicrosoftRawMime({
+      subject: `Inline then history ${uuidv4().slice(0, 6)}`,
+      text: [
+        'The vendor told me:',
+        '',
+        '> The replacement part ships Monday.',
+        '',
+        'Please plan the install for Wednesday.',
+        '',
+        'On Tue, Sep 1, 2026 at 9:00 AM Support <support@example.com> wrote:',
+        '> Vendor has not confirmed a ship date yet.',
+      ].join('\r\n'),
+      html: [
+        '<html><body>',
+        '<p>The vendor told me:</p>',
+        '<blockquote class="elementToProof">The replacement part ships Monday.</blockquote>',
+        '<p>Please plan the install for Wednesday.</p>',
+        '<div class="gmail_quote"><div>On Tue, Sep 1, 2026 at 9:00 AM Support wrote:</div>',
+        '<blockquote class="gmail_quote"><p>Vendor has not confirmed a ship date yet.</p></blockquote></div>',
+        '</body></html>',
+      ].join(''),
+    });
+
+    expect(comment.note).toContain('The replacement part ships Monday');
+    expect(comment.note).toContain('Please plan the install for Wednesday');
+    expect(comment.note).not.toContain('has not confirmed a ship date');
+  });
+
+  it('Raw MIME: bottom-posted reply keeps the answer below the quoted block', async () => {
+    const { comment } = await processMicrosoftRawMime({
+      subject: `Bottom post answer ${uuidv4().slice(0, 6)}`,
+      text: [
+        '> Could you confirm the maintenance window for tonight?',
+        '',
+        'Yes, use 10pm Eastern.',
+      ].join('\r\n'),
+      html: [
+        '<html><body>',
+        '<blockquote type="cite"><p>Could you confirm the maintenance window for tonight?</p></blockquote>',
+        '<p>Yes, use 10pm Eastern.</p>',
+        '</body></html>',
+      ].join(''),
+    });
+
+    expect(comment.note).toContain('10pm Eastern');
+    expect(comment.note).not.toContain('Could you confirm the maintenance window');
+  });
+
   it('Microsoft: in-app path persists regular attachment, embedded image, and original .eml via shared artifact orchestrator', async () => {
     const providerId = uuidv4();
     const mailbox = `support-ms-artifacts-${uuidv4().slice(0, 6)}@example.com`;

--- a/server/src/test/unit/api/ticketService.updateComment.operatorRepair.test.ts
+++ b/server/src/test/unit/api/ticketService.updateComment.operatorRepair.test.ts
@@ -1,0 +1,54 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function readTicketServiceSource(): string {
+  const filePath = path.resolve(__dirname, '../../../lib/api/services/TicketService.ts');
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+function updateCommentBody(source: string): string {
+  const start = source.indexOf('async updateComment(');
+  expect(start).toBeGreaterThan(-1);
+  const end = source.indexOf('async search(', start);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+describe('TicketService.updateComment operator repair contract', () => {
+  it('keeps the author-only rule for comments that have an authoring user', () => {
+    const body = updateCommentBody(readTicketServiceSource());
+
+    expect(body).toContain('comment.user_id !== context.userId');
+    expect(body).toContain('You can only edit your own comments');
+  });
+
+  it('allows an operator with comment:update RBAC to repair ownerless comments, failing closed without a loaded user', () => {
+    const body = updateCommentBody(readTicketServiceSource());
+
+    // The operator path applies only to comments with no authoring user
+    // (user_id null — e.g. inbound email comments attributed to a contact).
+    expect(body).toContain('comment.user_id == null');
+    // Fail closed: a missing caller user record denies the repair.
+    expect(body).toContain('context.user != null');
+    // The RBAC gate is the comment update permission, checked in-transaction.
+    expect(body).toContain("hasPermission(context.user, 'comment', 'update', trx)");
+  });
+
+  it('preserves existing metadata and appends an attributable operatorEdits audit record', () => {
+    const body = updateCommentBody(readTicketServiceSource());
+
+    // Existing metadata (parser results, email threading data) is spread, not replaced.
+    expect(body).toContain('...existingMetadata');
+    expect(body).toContain('operatorEdits: [');
+    expect(body).toContain('...operatorEdits');
+    expect(body).toContain('userId: context.userId');
+  });
+
+  it('never rewrites system-generated comments', () => {
+    const body = updateCommentBody(readTicketServiceSource());
+
+    expect(body).toContain('comment.is_system_generated');
+    expect(body).toContain('System-generated comments cannot be edited');
+  });
+});

--- a/server/src/test/unit/api/ticketService.updateComment.operatorRepair.test.ts
+++ b/server/src/test/unit/api/ticketService.updateComment.operatorRepair.test.ts
@@ -23,7 +23,7 @@ describe('TicketService.updateComment operator repair contract', () => {
     expect(body).toContain('You can only edit your own comments');
   });
 
-  it('allows an operator with comment:update RBAC to repair ownerless comments, failing closed without a loaded user', () => {
+  it('allows an operator with ticket:update RBAC to repair ownerless comments, failing closed without a loaded user', () => {
     const body = updateCommentBody(readTicketServiceSource());
 
     // The operator path applies only to comments with no authoring user
@@ -31,8 +31,9 @@ describe('TicketService.updateComment operator repair contract', () => {
     expect(body).toContain('comment.user_id == null');
     // Fail closed: a missing caller user record denies the repair.
     expect(body).toContain('context.user != null');
-    // The RBAC gate is the comment update permission, checked in-transaction.
-    expect(body).toContain("hasPermission(context.user, 'comment', 'update', trx)");
+    // The RBAC gate is the established ticket update permission (the
+    // `comment` RBAC resource is deprecated), checked in-transaction.
+    expect(body).toContain("hasPermission(context.user, 'ticket', 'update', trx)");
   });
 
   it('preserves existing metadata and appends an attributable operatorEdits audit record', () => {

--- a/shared/lib/email/__fixtures__/apple-mail-reply.html
+++ b/shared/lib/email/__fixtures__/apple-mail-reply.html
@@ -1,0 +1,6 @@
+<div dir="auto">Works now, thank you! The new build fixed the crash on startup.</div>
+<div dir="auto"><br /></div>
+<blockquote type="cite">
+  <div>On 2 Sep 2025, at 14:31, Alga Support &lt;support@nineminds.com&gt; wrote:</div>
+  <div>Please try the new build we pushed this morning and let us know.</div>
+</blockquote>

--- a/shared/lib/email/__fixtures__/apple-mail-reply.txt
+++ b/shared/lib/email/__fixtures__/apple-mail-reply.txt
@@ -1,0 +1,4 @@
+Works now, thank you! The new build fixed the crash on startup.
+
+> On 2 Sep 2025, at 14:31, Alga Support <support@nineminds.com> wrote:
+> Please try the new build we pushed this morning and let us know.

--- a/shared/lib/email/__fixtures__/bottom-post-reply.html
+++ b/shared/lib/email/__fixtures__/bottom-post-reply.html
@@ -1,0 +1,5 @@
+<p>On Tue, Sep 2, 2025 at 9:12 AM Priya Sharma &lt;priya@example.com&gt; wrote:</p>
+<blockquote type="cite">
+  <p>Could you confirm the maintenance window for Thursday night?</p>
+</blockquote>
+<p>Confirmed &mdash; we will start at 10pm Eastern and expect roughly two hours of downtime.</p>

--- a/shared/lib/email/__fixtures__/bottom-post-reply.txt
+++ b/shared/lib/email/__fixtures__/bottom-post-reply.txt
@@ -1,0 +1,3 @@
+> Could you confirm the maintenance window for Thursday night?
+
+Confirmed - we will start at 10pm Eastern and expect roughly two hours of downtime.

--- a/shared/lib/email/__fixtures__/inline-then-history.html
+++ b/shared/lib/email/__fixtures__/inline-then-history.html
@@ -1,0 +1,10 @@
+<p>Thanks for the update.</p>
+<blockquote style="margin:0 0 0 40px">
+  <p>The vendor said the replacement part ships Monday at the earliest.</p>
+</blockquote>
+<p>Given that, let's plan the install for Wednesday afternoon instead.</p>
+<p>On Tue, Sep 2, 2025 at 3:04 PM Alga Support &lt;support@nineminds.com&gt; wrote:</p>
+<blockquote class="gmail_quote" style="margin:0 0 0 .8ex;border-left:1px #ccc solid;padding-left:1ex">
+  <p>Ticket Update: Parts order delay</p>
+  <p>Hello, the vendor has not confirmed a ship date yet. We will follow up tomorrow.</p>
+</blockquote>

--- a/shared/lib/email/__fixtures__/inline-then-history.txt
+++ b/shared/lib/email/__fixtures__/inline-then-history.txt
@@ -1,0 +1,10 @@
+Thanks for the update.
+
+    The vendor said the replacement part ships Monday at the earliest.
+
+Given that, let's plan the install for Wednesday afternoon instead.
+
+On Tue, Sep 2, 2025 at 3:04 PM Alga Support <support@nineminds.com> wrote:
+
+> Ticket Update: Parts order delay
+> Hello, the vendor has not confirmed a ship date yet. We will follow up tomorrow.

--- a/shared/lib/email/__fixtures__/outlook-inline-blockquote.html
+++ b/shared/lib/email/__fixtures__/outlook-inline-blockquote.html
@@ -1,0 +1,32 @@
+<div class="elementToProof">Hi team,</div>
+<div class="elementToProof"><br /></div>
+<div class="elementToProof">I have a feature request that I think would make a big difference for how we run follow-ups.</div>
+<div class="elementToProof"><br /></div>
+<div class="elementToProof">Right now there is no way to schedule a promised follow-up on a ticket so it actually shows up where technicians live during the day.</div>
+<div class="elementToProof"><br /></div>
+<div class="elementToProof">We make commitments to customers constantly and then rely on memory or sticky notes to keep them.</div>
+<div class="elementToProof"><br /></div>
+<div class="elementToProof">For example, today I told a customer:</div>
+<blockquote class="elementToProof" style="margin:0 0 0 40px;border:none;padding:0">
+  <div>"I will follow up with you on Friday morning about the parts order and confirm the install window."</div>
+</blockquote>
+<div class="elementToProof">That promise now lives nowhere except my head. What I would love is a follow-up scheduler on the ticket that supports different follow-up types:</div>
+<ul>
+  <li>Call the customer back</li>
+  <li>Check on a vendor or parts order</li>
+  <li>Confirm a fix actually held</li>
+  <li>Chase an approval or signature</li>
+</ul>
+<div class="elementToProof">Outlook calendar: the scheduled follow-up should create a calendar entry on my Outlook calendar so it blocks time and moves with my day.</div>
+<div class="elementToProof"><br /></div>
+<div class="elementToProof">Teams notifications: a Teams message when the follow-up comes due would meet technicians where they already are.</div>
+<div class="elementToProof"><br /></div>
+<div class="elementToProof">Mobile push: for techs in the field, a push notification on the mobile app is the only thing that actually gets seen.</div>
+<div class="elementToProof"><br /></div>
+<div class="elementToProof">Desktop notifications: a native desktop notification for people who keep the PSA open all day.</div>
+<div class="elementToProof"><br /></div>
+<div class="elementToProof">The reason this matters: kept promises are the whole ballgame in managed services. A PSA that helps us keep every single promise we make would be a genuine differentiator.</div>
+<div class="elementToProof"><br /></div>
+<div class="elementToProof">Thanks,</div>
+<div class="elementToProof">Munjal Thakkar</div>
+<div class="elementToProof">Sent from Outlook</div>

--- a/shared/lib/email/__fixtures__/outlook-inline-blockquote.txt
+++ b/shared/lib/email/__fixtures__/outlook-inline-blockquote.txt
@@ -1,0 +1,32 @@
+Hi team,
+
+I have a feature request that I think would make a big difference for how we run follow-ups.
+
+Right now there is no way to schedule a promised follow-up on a ticket so it actually shows up where technicians live during the day.
+
+We make commitments to customers constantly and then rely on memory or sticky notes to keep them.
+
+For example, today I told a customer:
+
+    "I will follow up with you on Friday morning about the parts order and confirm the install window."
+
+That promise now lives nowhere except my head. What I would love is a follow-up scheduler on the ticket that supports different follow-up types:
+
+  - Call the customer back
+  - Check on a vendor or parts order
+  - Confirm a fix actually held
+  - Chase an approval or signature
+
+Outlook calendar: the scheduled follow-up should create a calendar entry on my Outlook calendar so it blocks time and moves with my day.
+
+Teams notifications: a Teams message when the follow-up comes due would meet technicians where they already are.
+
+Mobile push: for techs in the field, a push notification on the mobile app is the only thing that actually gets seen.
+
+Desktop notifications: a native desktop notification for people who keep the PSA open all day.
+
+The reason this matters: kept promises are the whole ballgame in managed services. A PSA that helps us keep every single promise we make would be a genuine differentiator.
+
+Thanks,
+Munjal Thakkar
+Sent from Outlook

--- a/shared/lib/email/__tests__/replyParser.test.ts
+++ b/shared/lib/email/__tests__/replyParser.test.ts
@@ -3,13 +3,13 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-import { getDefaultReplyParserConfig, parseEmailReply } from './replyParser';
+import { getDefaultReplyParserConfig, parseEmailReply } from '../replyParser';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 function readFixture(file: string): string {
-  return fs.readFileSync(path.join(__dirname, '__fixtures__', file), 'utf8');
+  return fs.readFileSync(path.join(__dirname, '..', '__fixtures__', file), 'utf8');
 }
 
 describe('replyParser', () => {

--- a/shared/lib/email/replyParser.test.ts
+++ b/shared/lib/email/replyParser.test.ts
@@ -79,6 +79,71 @@ describe('replyParser', () => {
     expect(result.sanitizedText).toMatchInlineSnapshot('"Quick confirmation that everything works as expected."');
   });
 
+  it('keeps content after an inline Outlook elementToProof blockquote (alga0002339)', () => {
+    const text = readFixture('outlook-inline-blockquote.txt');
+    const html = readFixture('outlook-inline-blockquote.html');
+
+    const result = parseEmailReply({ text, html });
+
+    // The inline quote is the author's own content, not reply history.
+    expect(result.appliedHeuristics).not.toContain('html-blockquote-trim');
+    expect(result.strategy).toBe('signature-trim');
+    expect(result.confidence).not.toBe('high');
+
+    // Everything after the inline blockquote must survive in both renditions.
+    expect(result.sanitizedHtml).toContain('I will follow up with you on Friday morning');
+    expect(result.sanitizedHtml).toContain('Call the customer back');
+    expect(result.sanitizedHtml).toContain('Outlook calendar');
+    expect(result.sanitizedHtml).toContain('Teams notifications');
+    expect(result.sanitizedHtml).toContain('Mobile push');
+    expect(result.sanitizedHtml).toContain('Desktop notifications');
+    expect(result.sanitizedHtml).toContain('kept promises are the whole ballgame');
+    expect(result.sanitizedText).toContain('I will follow up with you on Friday morning');
+    expect(result.sanitizedText).toContain('Call the customer back');
+    expect(result.sanitizedText).toContain('kept promises are the whole ballgame');
+  });
+
+  it('cuts at the quoted-history blockquote, not an earlier inline one', () => {
+    const text = readFixture('inline-then-history.txt');
+    const html = readFixture('inline-then-history.html');
+
+    const result = parseEmailReply({ text, html });
+
+    expect(result.appliedHeuristics).toContain('html-blockquote-trim');
+    // The inline quote and the text after it are the author's message.
+    expect(result.sanitizedHtml).toContain('replacement part ships Monday');
+    expect(result.sanitizedHtml).toContain("plan the install for Wednesday");
+    // The gmail_quote history block is removed.
+    expect(result.sanitizedHtml).not.toContain('has not confirmed a ship date');
+    expect(result.sanitizedText).toContain("plan the install for Wednesday");
+    expect(result.sanitizedText).not.toContain('has not confirmed a ship date');
+  });
+
+  it('trims trailing Apple Mail type="cite" history', () => {
+    const text = readFixture('apple-mail-reply.txt');
+    const html = readFixture('apple-mail-reply.html');
+
+    const result = parseEmailReply({ text, html });
+
+    expect(result.appliedHeuristics).toContain('html-blockquote-trim');
+    expect(result.sanitizedHtml).toContain('The new build fixed the crash on startup');
+    expect(result.sanitizedHtml).not.toContain('Please try the new build');
+    expect(result.sanitizedText).toContain('The new build fixed the crash on startup');
+  });
+
+  it('retains the answer in a bottom-posted reply below a quoted block', () => {
+    const text = readFixture('bottom-post-reply.txt');
+    const html = readFixture('bottom-post-reply.html');
+
+    const result = parseEmailReply({ text, html });
+
+    // The quoted block is removed as a span; the authored answer below it survives.
+    expect(result.sanitizedHtml).toContain('10pm Eastern');
+    expect(result.sanitizedHtml).not.toContain('Could you confirm the maintenance window');
+    expect(result.sanitizedText).toContain('10pm Eastern');
+    expect(result.sanitizedText).not.toContain('Could you confirm the maintenance window');
+  });
+
   it('recovers tokens wrapped/quoted by Gmail', () => {
     const text = `let's see if replies work now
 *Robert Isaacs* | *CEO*

--- a/shared/lib/email/replyParser.ts
+++ b/shared/lib/email/replyParser.ts
@@ -156,7 +156,6 @@ function isCoherentQuotedHeaderBlock(lines: string[], startIndex: number): boole
   return fields.has('from') && fields.has('sent') && fields.has('to') && fields.has('subject');
 }
 
-const blockquoteRegex = /<blockquote[\s\S]*?$/i;
 const htmlCommentTokenRegex = /<!--\s*alga:reply-token:(?<payload>[^-]+)-->?/i;
 const htmlTokenAttributeRegex = /data-alga-reply-token="(?<token>[^"]+)"/i;
 const htmlTicketAttributeRegex = /data-alga-ticket-id="(?<ticket>[^"]+)"/i;
@@ -269,6 +268,175 @@ function trimAtExplicitDelimiter(text: string, config: ReplyParserConfig): TrimR
   return { text: normalized };
 }
 
+/** Classes/ids that mail clients attach to quoted-history blockquotes. */
+const KNOWN_QUOTE_MARKER_TOKENS = ['gmail_quote', 'yahoo_quoted', 'protonmail_quote', 'moz-cite-prefix'];
+
+/** How much visible text before a blockquote to inspect for a provider reply header. */
+const REPLY_HEADER_LOOKBEHIND_CHARS = 300;
+
+/** Convert an HTML fragment to visible text, preserving block-level line breaks. */
+function htmlToVisibleText(html: string): string {
+  const withBreaks = html
+    .replace(/<(?:style|script)\b[\s\S]*?<\/(?:style|script)>/gi, ' ')
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(/<(?:br|\/p|\/div|\/li|\/tr|\/h[1-6]|\/blockquote|\/table)\b[^>]*>/gi, '\n')
+    .replace(/<[^>]+>/g, ' ');
+  return decodeHtml(withBreaks)
+    .split('\n')
+    .map((line) => line.replace(/\s+/g, ' ').trim())
+    .join('\n');
+}
+
+/**
+ * Does the blockquote's opening tag carry a marker mail clients use for quoted history?
+ * Outlook's `elementToProof` class is explicitly NOT such a marker: it appears on
+ * blockquotes an author writes inline in a fresh message.
+ */
+function blockquoteTagIndicatesQuotedHistory(openTag: string): boolean {
+  if (/\btype\s*=\s*["']?\s*cite\b/i.test(openTag)) {
+    return true;
+  }
+
+  const attributeValues: string[] = [];
+  for (const attribute of ['class', 'id']) {
+    const match = new RegExp(`\\b${attribute}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s>]+))`, 'i').exec(openTag);
+    if (match) {
+      attributeValues.push(match[1] ?? match[2] ?? match[3] ?? '');
+    }
+  }
+  if (attributeValues.length === 0) {
+    return false;
+  }
+
+  const combined = attributeValues.join(' ').toLowerCase();
+  if (KNOWN_QUOTE_MARKER_TOKENS.some((token) => combined.includes(token))) {
+    return true;
+  }
+
+  // Generic quote/cite markers, excluding Outlook's elementToProof (not a quote marker).
+  const withoutElementToProof = combined.replace(/elementtoproof/gi, '');
+  return /quote|cite/i.test(withoutElementToProof);
+}
+
+/** Does the visible text immediately preceding the blockquote end with a provider reply header? */
+function endsWithProviderReplyHeader(prefixHtml: string, config: ReplyParserConfig): boolean {
+  const visibleTail = htmlToVisibleText(prefixHtml).slice(-REPLY_HEADER_LOOKBEHIND_CHARS);
+  const lines = visibleTail
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length === 0) {
+    return false;
+  }
+
+  const lastLine = lines[lines.length - 1];
+  return (
+    config.providerReplyHeaders.some((regex) => regex.test(lastLine)) ||
+    config.forwardedReplyHeaders.some((regex) => regex.test(lastLine))
+  );
+}
+
+/**
+ * Find the end index (just past `</blockquote>`) of the tag whose opening tag ends at
+ * `afterOpenIndex`, depth-counting to handle nesting. Returns -1 when unclosed.
+ */
+function findMatchingBlockquoteCloseEnd(html: string, afterOpenIndex: number): number {
+  const tokenRegex = /<\/?blockquote\b[^>]*>/gi;
+  tokenRegex.lastIndex = afterOpenIndex;
+  let depth = 1;
+  let match: RegExpExecArray | null;
+  while ((match = tokenRegex.exec(html)) !== null) {
+    if (match[0].startsWith('</')) {
+      depth -= 1;
+      if (depth === 0) {
+        return match.index + match[0].length;
+      }
+    } else {
+      depth += 1;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Substantive = non-whitespace visible text, ignoring a trailing signature block
+ * (a suffix whose first visible line matches one of the configured signature markers).
+ */
+function hasSubstantiveVisibleText(suffixHtml: string, config: ReplyParserConfig): boolean {
+  const lines = htmlToVisibleText(suffixHtml)
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length === 0) {
+    return false;
+  }
+  return !config.signatureMarkers.some((regex) => regex.test(lines[0]));
+}
+
+interface QuotedHistoryTrimResult {
+  html: string;
+  removedQuote: boolean;
+}
+
+/**
+ * Remove quoted reply history from an HTML body without destroying authored content.
+ *
+ * A blockquote is treated as quoted history only when at least one of these holds:
+ * 1. its tag carries a known quote marker (`type="cite"`, gmail_quote, yahoo_quoted,
+ *    protonmail_quote, moz-cite-prefix, or a generic quote/cite id/class — excluding
+ *    Outlook's `elementToProof`);
+ * 2. the visible text immediately before it ends with a provider reply header
+ *    ("On … wrote:", "From:", "-----Original Message-----", …);
+ * 3. it is trailing: after its matching close tag there is no substantive visible
+ *    text (a trailing signature block does not count as substantive).
+ *
+ * Trailing history is cut off; a recognized quote span embedded mid-message is removed
+ * without discarding the authored text that follows it. A blockquote that matches none
+ * of the criteria (e.g. an author quoting something inline and continuing to write) is
+ * kept untouched. Preserving too much is the safe failure mode.
+ */
+function trimQuotedHistoryBlockquotes(html: string, config: ReplyParserConfig): QuotedHistoryTrimResult {
+  let result = html;
+  let removedQuote = false;
+  let searchFrom = 0;
+
+  for (;;) {
+    const openRegex = /<blockquote\b[^>]*>/gi;
+    openRegex.lastIndex = searchFrom;
+    const openMatch = openRegex.exec(result);
+    if (!openMatch) {
+      break;
+    }
+
+    const openIndex = openMatch.index;
+    const openTag = openMatch[0];
+    const closeEnd = findMatchingBlockquoteCloseEnd(result, openIndex + openTag.length);
+    const recognizedQuote =
+      blockquoteTagIndicatesQuotedHistory(openTag) ||
+      endsWithProviderReplyHeader(result.slice(0, openIndex), config);
+    const trailing = closeEnd === -1 || !hasSubstantiveVisibleText(result.slice(closeEnd), config);
+
+    if (trailing) {
+      result = result.slice(0, openIndex).trimEnd();
+      removedQuote = true;
+      break;
+    }
+
+    if (recognizedQuote) {
+      // Embedded recognized quote span: drop the span, keep the authored suffix.
+      result = result.slice(0, openIndex) + result.slice(closeEnd);
+      removedQuote = true;
+      searchFrom = openIndex;
+      continue;
+    }
+
+    // Inline authored quote: keep it (and its contents) and keep scanning past it.
+    searchFrom = closeEnd;
+  }
+
+  return { html: result, removedQuote };
+}
+
 function trimHtmlAtBoundary(html: string, config: ReplyParserConfig): TrimResult {
   const attributeIndex = html.toLowerCase().indexOf(config.htmlBoundaryAttribute.toLowerCase());
 
@@ -280,11 +448,11 @@ function trimHtmlAtBoundary(html: string, config: ReplyParserConfig): TrimResult
     };
   }
 
-  // Fallback: cut at first blockquote which usually encapsulates quoted history.
-  const blockquoteMatch = blockquoteRegex.exec(html);
-  if (blockquoteMatch) {
+  // Fallback: remove blockquotes that actually look like quoted reply history.
+  const blockquoteTrim = trimQuotedHistoryBlockquotes(html, config);
+  if (blockquoteTrim.removedQuote) {
     return {
-      text: html.slice(0, blockquoteMatch.index).trim(),
+      text: blockquoteTrim.html.trim(),
       matched: '<blockquote',
       heuristic: 'html-blockquote-trim',
     };
@@ -562,11 +730,11 @@ export function parseEmailReply(input: ReplyParserInput, config: Partial<ReplyPa
   let sanitizedHtml: string | undefined;
   if (originalHtml) {
     const baselineHtml = trimmedHtmlResult ? trimmedHtmlResult.text : originalHtml;
-    // Attempt to keep html aligned with text heuristics by removing blockquotes if none already removed
+    // Attempt to keep html aligned with text heuristics by removing quoted history if none already removed
     if (!trimmedHtmlResult?.heuristic?.includes('blockquote')) {
-      const blockquoteMatch = blockquoteRegex.exec(baselineHtml);
-      if (blockquoteMatch) {
-        sanitizedHtml = baselineHtml.slice(0, blockquoteMatch.index).trim();
+      const blockquoteTrim = trimQuotedHistoryBlockquotes(baselineHtml, mergedConfig);
+      if (blockquoteTrim.removedQuote) {
+        sanitizedHtml = blockquoteTrim.html.trim();
         appliedHeuristics.push('html-blockquote-trim');
         if (strategy === 'fallback') {
           strategy = 'quoted-block';
@@ -589,6 +757,20 @@ export function parseEmailReply(input: ReplyParserInput, config: Partial<ReplyPa
         'i',
       );
       sanitizedHtml = sanitizedHtml.replace(htmlSignatureRegex, '').trim();
+    }
+
+    // Safety net: if the blockquote cut removed a much larger share of the message than
+    // the text heuristics did, the cut was likely a false positive — prefer the text
+    // result so future misfires leak quoted history instead of destroying content.
+    if (sanitizedHtml && appliedHeuristics.includes('html-blockquote-trim')) {
+      const htmlVisibleLength = htmlToVisibleText(sanitizedHtml).replace(/\s+/g, ' ').trim().length;
+      const textLength = trimmedText.replace(/\s+/g, ' ').trim().length;
+      if (textLength > 0 && htmlVisibleLength < textLength * 0.5) {
+        warnings.push(
+          'HTML blockquote trim removed significantly more content than text heuristics; using text result.',
+        );
+        sanitizedHtml = undefined;
+      }
     }
 
     if (!sanitizedHtml) {


### PR DESCRIPTION
## Inbound email: reply parser truncates body at inline blockquotes (alga0002339)

### Problem
The inbound reply parser cut the HTML body at the **first** `<blockquote>` (`blockquoteRegex = /<blockquote[\s\S]*?$/i`). That regex treats every blockquote as quoted history, so any message where the author *writes inline* inside a blockquote — most notably Outlook, which wraps authored content in `<blockquote class="elementToProof">` — lost the author's own text and everything after it. This is the alga0002339 truncation.

### Fix — span-aware, centralized blockquote handling
`shared/lib/email/replyParser.ts` replaces the blunt first-blockquote cut with `trimQuotedHistoryBlockquotes()`, which walks every blockquote (depth-counting nested tags) and only treats one as quoted history when it has real evidence:

1. **Tag marker** — `type="cite"`, `gmail_quote`, `yahoo_quoted`, `protonmail_quote`, `moz-cite-prefix`, or a generic `quote`/`cite` id/class. Outlook's `elementToProof` is explicitly **excluded** — it marks authored inline content, not quoted history.
2. **Preceding reply header** — the visible text immediately before the blockquote ends with a provider reply header (`On … wrote:`, `From:`, `-----Original Message-----`, …).
3. **Trailing position** — nothing substantive follows the blockquote's matching close tag (a trailing signature block does not count as substantive).

Behavior by case:
- **Trailing** quoted history is cut off.
- An **embedded recognized** quote span is removed in place, keeping the authored suffix that follows it.
- An **inline authored** blockquote matching none of the criteria is kept untouched.

Preserving too much is the deliberate safe failure mode. A final **safety net** discards the HTML blockquote trim (falling back to the text result, with a warning) whenever it removed more than half of the message's visible text relative to the text heuristics — so a future misfire leaks quoted history rather than destroying content. The same `trimQuotedHistoryBlockquotes` path now feeds both `trimHtmlAtBoundary` and the HTML/text alignment step, so the logic is centralized.

### Live inbound path was running stale code
The mitigation round found the live failure was not in the parser source at all: the inbound queue consumer runs inside the **email-service container**, whose image was built 2026-08-02 (a month before the parser fix) with the pre-fix `replyParser` compiled into its `dist` bundle — so restarting the 3489 server never touched the code that parses inbound mail. Rebuilding the image from this worktree fixes the live path. To catch stale-bundle / fixture-vs-mailparser divergence in CI, this adds raw-multipart-MIME integration tests that drive the **real** webhook → unified queue job → `simpleParser` → reply parser → ticket/comment pipeline. `replyParser.test.ts` also moves into `shared/lib/email/__tests__/` — the shared vitest include patterns never matched its old location, so those unit tests were silently not running.

### Operator comment-repair route (alga0002339 remediation)
`TicketService.updateComment` previously enforced caller-owns-comment, which made inbound email comments (`user_id` null — no owner exists) permanently uneditable. A caller holding the **`ticket:update`** RBAC permission (the `comment` resource is deprecated per migration `20250703193155`) may now repair such ownerless comments. The repair preserves existing metadata (parser results, email threading data, attachment references), appends an attributable `metadata.operatorEdits` audit record, and leaves `user_id` null. It fails closed — a loaded caller user record plus the RBAC check are both required. Author-owned and system-generated comments keep their existing rules. Once this branch deploys, the hosted alga0002339 first-comment restore runs through this same PUT, regenerating the full-body content from the ticket's attached `.eml` via `parseEmailReply` + `convertHtmlToBlockNote`.

### Tests
- New/updated parser unit tests plus fixtures for Outlook inline blockquote, inline-then-history, bottom-post, and Apple-mail cases.
- Integration test `inboundEmailInApp.webhooks.integration.test.ts` drives the real webhook → queue → parse → ticket/comment pipeline.
- `TicketService.updateComment.operatorRepair.test.ts` covers the RBAC-gated operator repair.
- Focused parser + RBAC suites pass 14/14.

### Smoke test
**PASS.** Exercised the real GreenMail SMTP → IMAP email-service → 3489 webhook → ticket creation → UI path with four fresh multipart messages. TIC001080 preserved the Outlook `elementToProof` inline quote and all following paragraphs/lists; metadata was signature-trim/medium without html-blockquote-trim. TIC001081 retained the inline quote and authored suffix while removing the later Gmail history. TIC001083 still trimmed trailing Apple `type=cite` history. TIC001082 retained the bottom-posted answer while removing the quoted question. DB assertions passed for all four, and the changed content was confirmed in the real ticket UI. The operator-repair PUT was also exercised against TIC001080: HTTP 200, email/parser metadata preserved, `operatorEdits` appended, and `user_id` remained null. The temporary smoke API key was deactivated afterward. Focused parser and RBAC tests passed 14/14; worktree remained clean. No mocks were used; the only simulator was the existing deterministic SMTP sender feeding real GreenMail.

**Non-blocking:** the local Hocuspocus service on port 1235 was absent, causing unrelated WebSocket console errors; no failed HTTP requests occurred. Hosted alga0002339's description was already restored, but its first-comment remediation remains pending deployment of this branch and therefore was not performed against hosted production during this local smoke.

Evidence directory: `/tmp/alga-smoke-evidence/inbound-reply-parser-20260903-205444`
