### PR TITLE
Inbound email: sender-auth gate rejects Google-format Authentication-Results, dropping contact/client match

### DIFF
--- a/shared/lib/email/__tests__/senderAuthVerification.test.ts
+++ b/shared/lib/email/__tests__/senderAuthVerification.test.ts
@@ -46,4 +46,54 @@ describe('verifySenderAuthentication', () => {
     );
     expect(result?.aligned.dkim).toBe(false);
   });
+
+  it('parses a real Google Authentication-Results header (ticket alga0002339)', () => {
+    const result = verifySenderAuthentication(
+      `mx.google.com;
+       dkim=pass header.i=@techff.onmicrosoft.com header.s=selector1-techff-onmicrosoft-com header.b="cmLi/gLS";
+       arc=pass (i=1 spf=pass spfdomain=joymode.io dkim=pass dkdomain=joymode.io dmarc=pass fromdomain=joymode.io);
+       spf=pass (google.com: domain of munjal@joymode.io designates 2a01:111:f403:c005::5 as permitted sender) smtp.mailfrom=munjal@joymode.io`,
+      'munjal@joymode.io'
+    );
+    expect(result?.spf).toBe('pass');
+    expect(result?.dkim).toBe('pass');
+    expect(result?.dmarc).toBeNull();
+    // smtp.mailfrom is a full address; only its domain aligns with the From domain.
+    expect(result?.aligned.spf).toBe(true);
+    // Signer domain (onmicrosoft.com) never matches joymode.io; header.i must not fabricate alignment.
+    expect(result?.aligned.dkim).toBe(false);
+    expect(result?.aligned.dmarc).toBe(false);
+    expect(allowsContactSenderAttribution(result)).toBe(true);
+    expect(allowsInternalSenderAttribution(result)).toBe(false);
+  });
+
+  it('aligns DKIM via header.i when header.d is absent and the signer matches the From domain', () => {
+    const result = verifySenderAuthentication(
+      'mx.google.com; dkim=pass header.i=@joymode.io header.s=selector1-joymode-io header.b="abc"; spf=pass smtp.mailfrom=joymode.io',
+      'munjal@joymode.io'
+    );
+    expect(result?.aligned.dkim).toBe(true);
+    expect(allowsContactSenderAttribution(result)).toBe(true);
+    expect(allowsInternalSenderAttribution(result)).toBe(true);
+  });
+
+  it('does not treat comment text inside arc=pass (...) as top-level results', () => {
+    const result = verifySenderAuthentication(
+      'mx.google.com; arc=pass (i=1 spf=pass spfdomain=joymode.io dkim=pass dkdomain=joymode.io dmarc=pass fromdomain=joymode.io)',
+      'munjal@joymode.io'
+    );
+    // No top-level mechanism survives comment stripping: fail closed.
+    expect(result).toBeNull();
+    expect(allowsContactSenderAttribution(result)).toBe(false);
+    expect(allowsInternalSenderAttribution(result)).toBe(false);
+  });
+
+  it('keeps parsing a topmost block when later blocks are present in a single string', () => {
+    const result = verifySenderAuthentication(
+      'our-mta.example; dmarc=fail header.from=example.com\nattacker.example; dmarc=pass header.from=example.com',
+      'tech@example.com'
+    );
+    expect(result?.dmarc).toBe('fail');
+    expect(allowsInternalSenderAttribution(result)).toBe(false);
+  });
 });

--- a/shared/lib/email/senderAuthVerification.ts
+++ b/shared/lib/email/senderAuthVerification.ts
@@ -9,9 +9,48 @@ export interface SenderAuthResults {
 
 const RESULT = /\b(spf|dkim|dmarc)\s*=\s*(pass|fail|neutral|none|temperror|permerror)\b([^;]*)/gi;
 
+/**
+ * Unfolds RFC 5322 continuation lines (a CRLF followed by whitespace continues
+ * the previous header line) so a folded Authentication-Results header is parsed
+ * as a single authserv block.
+ */
+function unfoldHeader(value: string): string {
+  return value.replace(/\r?\n[ \t]+/g, ' ');
+}
+
+/**
+ * Strips RFC 8601 parenthesized comments from a header block. Comment text must
+ * not feed mechanism/property matching (e.g. the `spf=pass dmarc=pass` tokens
+ * Google nests inside `arc=pass (...)` or its free-text SPF comment).
+ * Repeatedly removes innermost `(…)` spans until none remain, which handles
+ * balanced nesting without a full recursive parser.
+ */
+function stripComments(value: string): string {
+  let current = value;
+  let previous: string;
+  do {
+    previous = current;
+    current = current.replace(/\([^()]*\)/g, ' ');
+  } while (current !== previous);
+  return current;
+}
+
+/**
+ * Reduces a domain-bearing property value to its bare domain: a value may be a
+ * plain domain (`example.com`), an address (`munjal@example.com`), or Google's
+ * DKIM signer `header.i` shape (`@example.com` / `user@example.com`). In every
+ * case only the text after the last `@` matters for alignment.
+ */
+function extractDomain(value: string | undefined): string {
+  if (!value) return '';
+  const atIndex = value.lastIndexOf('@');
+  const withoutLocalPart = atIndex >= 0 ? value.slice(atIndex + 1) : value;
+  return withoutLocalPart.trim().replace(/[>;,)]+$/, '').toLowerCase();
+}
+
 function domainAligned(candidate: string | undefined, fromDomain: string | null): boolean {
   if (!candidate || !fromDomain) return false;
-  const domain = candidate.trim().replace(/[>;,)]+$/, '').toLowerCase();
+  const domain = extractDomain(candidate);
   return domain === fromDomain || domain.endsWith(`.${fromDomain}`);
 }
 
@@ -25,13 +64,25 @@ export function verifySenderAuthentication(
   authenticationResults: string | string[] | null | undefined,
   fromEmail: string | null | undefined
 ): SenderAuthResults | null {
-  const blocks = (Array.isArray(authenticationResults)
-    ? authenticationResults.filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
-    : typeof authenticationResults === 'string' && authenticationResults.trim() ? authenticationResults.split(/\r?\n/) : [])
-    .filter((value): value is string => value.trim().length > 0);
+  // Multiple values are multiple authserv blocks; a single string may still fold
+  // across physical lines, so unfold continuation lines first, then split on
+  // remaining newlines and keep only the topmost block (RFC 8601 handling).
+  const rawBlocks = Array.isArray(authenticationResults)
+    ? authenticationResults
+    : typeof authenticationResults === 'string' && authenticationResults.trim()
+      ? unfoldHeader(authenticationResults).split(/\r?\n/)
+      : [];
+  const blocks = rawBlocks
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .map(unfoldHeader);
   const block = blocks[0];
   const fromDomain = extractEmailDomain(fromEmail ?? '')?.toLowerCase() ?? null;
   if (!block || !fromDomain) return null;
+
+  // Drop parenthesized comments before mechanism matching so comment text
+  // (e.g. the `spf=pass dmarc=pass` tokens inside Google's `arc=pass (...)` or
+  // its free-text SPF comment) cannot fabricate results.
+  const commentFree = stripComments(block);
 
   const results: SenderAuthResults = {
     spf: null, dkim: null, dmarc: null,
@@ -39,7 +90,7 @@ export function verifySenderAuthentication(
   };
   let match: RegExpExecArray | null;
   let found = false;
-  while ((match = RESULT.exec(block))) {
+  while ((match = RESULT.exec(commentFree))) {
     found = true;
     const mechanism = match[1].toLowerCase() as 'spf' | 'dkim' | 'dmarc';
     const verdict = match[2].toLowerCase() as NonNullable<SenderAuthResults[typeof mechanism]>;
@@ -49,6 +100,7 @@ export function verifySenderAuthentication(
       ? properties.match(/\bsmtp\.mailfrom\s*=\s*([^\s;]+)/i)?.[1]
       : mechanism === 'dkim'
         ? properties.match(/\bheader\.d\s*=\s*([^\s;]+)/i)?.[1]
+          ?? properties.match(/\bheader\.i\s*=\s*([^\s;]+)/i)?.[1]
         : properties.match(/\bheader\.from\s*=\s*([^\s;]+)/i)?.[1];
     results.aligned[mechanism] = verdict === 'pass' && domainAligned(domain, fromDomain);
   }

--- a/shared/services/email/__tests__/processInboundEmailInApp.additionalPaths.test.ts
+++ b/shared/services/email/__tests__/processInboundEmailInApp.additionalPaths.test.ts
@@ -426,4 +426,61 @@ describe('processInboundEmailInApp additional authorship paths', () => {
       'tenant-1'
     );
   });
+
+  it('T040: Gmail-shaped Authentication-Results resolves a known contact as email_match', async () => {
+    findContactByEmailMock.mockResolvedValue({
+      contact_id: 'contact-gmail-1',
+      client_id: 'client-gmail-1',
+      user_id: 'client-user-gmail-1',
+      email: 'munjal@joymode.io',
+      name: 'Munjal Thakkar',
+      client_name: 'Joymode Business Solutions',
+    });
+
+    const { processInboundEmailInApp } = await import('../processInboundEmailInApp');
+
+    const result = await processInboundEmailInApp({
+      tenantId: 'tenant-1',
+      providerId: 'provider-1',
+      emailData: buildEmailData({
+        from: { email: 'munjal@joymode.io', name: 'Munjal Thakkar' },
+        headers: {
+          'authentication-results': `mx.google.com;
+       dkim=pass header.i=@techff.onmicrosoft.com header.s=selector1-techff-onmicrosoft-com header.b="cmLi/gLS";
+       arc=pass (i=1 spf=pass spfdomain=joymode.io dkim=pass dkdomain=joymode.io dmarc=pass fromdomain=joymode.io);
+       spf=pass (google.com: domain of munjal@joymode.io designates 2a01:111:f403:c005::5 as permitted sender) smtp.mailfrom=munjal@joymode.io`,
+        },
+      }),
+    });
+
+    expect(result.outcome).toBe('created');
+    expect(findContactByEmailMock).toHaveBeenCalledWith('munjal@joymode.io', 'tenant-1', {
+      defaultClientId: 'default-client-id',
+    });
+    expect(createTicketFromEmailMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        client_id: 'client-gmail-1',
+        contact_id: 'contact-gmail-1',
+        email_metadata: expect.objectContaining({
+          clientMatchSource: 'email_match',
+          authResults: expect.objectContaining({
+            aligned: { spf: true, dkim: false, dmarc: false },
+            dmarc: null,
+          }),
+        }),
+      }),
+      'tenant-1'
+    );
+    expect(createCommentFromEmailMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        author_type: 'contact',
+        author_id: 'client-user-gmail-1',
+        contact_id: 'contact-gmail-1',
+        metadata: expect.objectContaining({
+          unmatchedSender: false,
+        }),
+      }),
+      'tenant-1'
+    );
+  });
 });


### PR DESCRIPTION
## Inbound email: sender-auth gate rejects Google-format Authentication-Results, dropping contact/client match

### Problem
The inbound sender-authentication gate only understood Microsoft's `Authentication-Results` header shape. Every message arriving via the Gmail-hosted IMAP support mailbox therefore failed SPF/DKIM/DMARC alignment and fell through to the provider-default client — losing the contact and client match that a Google-shaped header should have produced.

### Fix
`shared/lib/email/senderAuthVerification.ts` — four Google-specific parsing corrections, with the fail-closed policy left intact:

- **Strip RFC 8601 parenthesized comments before mechanism matching.** Google nests free-text tokens like `spf=pass dmarc=pass` inside `arc=pass (...)` and SPF comments; these previously fabricated results. Comments are removed by repeatedly collapsing innermost `(…)` spans (handles balanced nesting), and the header now **fails closed to `null`** when no top-level mechanism survives stripping.
- **Domain extraction from address-bearing values.** `smtp.mailfrom` / `header.from` may carry a full address; alignment now uses only the domain after the last `@`.
- **DKIM `header.i` fallback.** DKIM prefers `header.d`, then falls back to `header.i` (stripping a leading `@` and any local part) — Google emits `header.i`, never `header.d`.
- **Unfold CRLF+WSP continuation lines** so a folded header parses as one authserv block, while topmost-block-only handling is preserved.

Topmost-block policy and the absent/empty-header fail-closed invariants are unchanged. Contact and internal-admission semantics are untouched.

### Tests
- `senderAuthVerification.test.ts` — parser cases built on the real `alga0002339` header (spf aligned, dkim unaligned, dmarc null; contact allowed / internal denied), `header.i` alignment, and comment-only ARC rejection.
- `processInboundEmailInApp.additionalPaths.test.ts` — integration assertion that a Gmail-shaped header resolves a known contact via `clientMatchSource=email_match`.

### Smoke test — PASS
Exercised the real SMTP → GreenMail → IMAP polling → webhook → email-service processing → database → ticket UI path using an isolated raw-email sender.

- **Google-format header:** `TIC001089` matched *Gate Contact Alpha* and client *SmokeGate A Contact Only*. DB metadata: `spf=pass/aligned=true`, `dkim=pass/aligned=false`, `dmarc=null`, `clientMatchSource=email_match`; initial comment has the contact and `unmatchedSender=false`. UI confirms the contact/client and a contact-authored timeline entry.
- **ARC-comment-only header:** `TIC001087` remained fail-closed. DB: `authResults=null`, `provider_default`, no contact, `unmatchedSender=true`; UI shows default client *Wonderland* and *Add contact*.
- **Microsoft-format regression:** `TIC001088` remained fully aligned and `email_match` with the known contact/client.
- **Focused parser and process integration tests:** 16/16 passed.

**Fidelity compromise:** a minimal SMTP simulator injected the raw headers; all receiving and product processing used real services. The simulator was saved with the evidence and removed from the worktree.

The first attempt exposed stale environment wiring: email-service was built from a sibling worktree and reproduced the old failure. The real email-service image was rebuilt from *this* worktree and all flows reran successfully. The stack remains running on port 3720 with that worktree-built image.

**Not executed:** production ticket repairs/sweep and post-deploy Loki verification — the production tenant/tickets are absent from the reachable synthetic database, and no production/deployed environment was available. Startup also emits unrelated Temporal/credential-vault configuration warnings, which did not prevent these flows.

**Evidence directory:** `/tmp/alga-smoke-evidence/inbound-email-google-auth-20260903-222838`
