### PR TITLE
feat(entra): discover tenants from the console

### DIFF
--- a/ee/server/src/__tests__/unit/entraConsoleOverview.test.tsx
+++ b/ee/server/src/__tests__/unit/entraConsoleOverview.test.tsx
@@ -6,6 +6,7 @@ import { EntraConsole } from '@ee/components/settings/integrations/entra/EntraCo
 import type { EntraStatusResponse } from '@alga-psa/integrations/actions';
 
 const {
+  discoverEntraManagedTenantsMock,
   getEntraConfirmedMappingsMock,
   getEntraReconciliationQueueMock,
   getEntraSyncRunDetailMock,
@@ -14,6 +15,7 @@ const {
   saveEntraSyncScheduleMock,
   startEntraSyncMock,
 } = vi.hoisted(() => ({
+  discoverEntraManagedTenantsMock: vi.fn(),
   getEntraConfirmedMappingsMock: vi.fn(),
   getEntraReconciliationQueueMock: vi.fn(),
   getEntraSyncRunDetailMock: vi.fn(),
@@ -30,6 +32,7 @@ vi.mock('@alga-psa/ui/lib/i18n/client', async () => {
 
 vi.mock('@alga-psa/integrations/actions', () => ({
   disconnectEntraIntegration: vi.fn(),
+  discoverEntraManagedTenants: discoverEntraManagedTenantsMock,
   getEntraConfirmedMappings: getEntraConfirmedMappingsMock,
   getEntraReconciliationQueue: getEntraReconciliationQueueMock,
   getEntraSyncRunDetail: getEntraSyncRunDetailMock,
@@ -114,6 +117,7 @@ const FABRIKAM = {
 
 describe('EntraConsole overview', () => {
   beforeEach(() => {
+    discoverEntraManagedTenantsMock.mockReset();
     getEntraConfirmedMappingsMock.mockReset();
     getEntraReconciliationQueueMock.mockReset();
     getEntraSyncRunDetailMock.mockReset();
@@ -488,6 +492,55 @@ describe('EntraConsole overview', () => {
     expect(document.getElementById('entra-connection-method-chooser')).not.toBeNull();
     // The controls that need an existing connection stay out of the way.
     expect((document.getElementById('entra-console-rotate') as HTMLButtonElement)?.disabled).toBe(true);
+  });
+
+  it('discovers tenants onboarded after setup, from the console', async () => {
+    // Discovery only ever existed on the setup wizard, which the console
+    // replaces once setup is done — so a client onboarded later could never be
+    // found again without hand-patching the build.
+    window.history.replaceState({}, '', '/msp/settings/integrations/entra?tab=connection');
+    discoverEntraManagedTenantsMock.mockResolvedValue({
+      success: true,
+      data: { discoveredTenantCount: 1, discoveredTenants: [{ managedTenantId: 'managed-3' }] },
+    });
+
+    renderConsole();
+
+    await waitFor(() =>
+      expect(document.getElementById('entra-console-run-discovery')).not.toBeNull()
+    );
+    const loadsBefore = getEntraConfirmedMappingsMock.mock.calls.length;
+
+    fireEvent.click(document.getElementById('entra-console-run-discovery') as HTMLButtonElement);
+
+    await waitFor(() => expect(discoverEntraManagedTenantsMock).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(document.getElementById('entra-console-message')?.textContent).toBe(
+        'Discovery completed. 1 tenant discovered.'
+      )
+    );
+    // The newly discovered tenant is only useful once the console has re-read
+    // what it can map.
+    expect(getEntraConfirmedMappingsMock.mock.calls.length).toBeGreaterThan(loadsBefore);
+  });
+
+  it('says why a discovery failed rather than reporting nothing found', async () => {
+    window.history.replaceState({}, '', '/msp/settings/integrations/entra?tab=connection');
+    discoverEntraManagedTenantsMock.mockResolvedValue({
+      error: 'CIPP returned 401',
+    });
+
+    renderConsole();
+
+    await waitFor(() =>
+      expect(document.getElementById('entra-console-run-discovery')).not.toBeNull()
+    );
+    fireEvent.click(document.getElementById('entra-console-run-discovery') as HTMLButtonElement);
+
+    await waitFor(() =>
+      expect(document.getElementById('entra-console-error')?.textContent).toBe('CIPP returned 401')
+    );
+    expect(document.getElementById('entra-console-message')).toBeNull();
   });
 
   it('summarises the overwrite rules that are actually in force', async () => {

--- a/ee/server/src/components/settings/integrations/entra/EntraConsole.tsx
+++ b/ee/server/src/components/settings/integrations/entra/EntraConsole.tsx
@@ -25,6 +25,7 @@ import { CustomTabs, type TabContent } from '@alga-psa/ui/components/CustomTabs'
 import { useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import {
   disconnectEntraIntegration,
+  discoverEntraManagedTenants,
   getEntraConfirmedMappings,
   initiateEntraDirectOAuth,
   unmapEntraTenant,
@@ -225,6 +226,7 @@ export function EntraConsole({
   const [loaded, setLoaded] = React.useState(false);
   const [loadError, setLoadError] = React.useState<string | null>(null);
   const [syncAllBusy, setSyncAllBusy] = React.useState(false);
+  const [discoveryBusy, setDiscoveryBusy] = React.useState(false);
   const [pauseBusy, setPauseBusy] = React.useState(false);
   const [actionMessage, setActionMessage] = React.useState<string | null>(null);
   const [actionError, setActionError] = React.useState<string | null>(null);
@@ -248,6 +250,8 @@ export function EntraConsole({
     needsReview: 0,
   });
   const [skippedTenants, setSkippedTenants] = React.useState<EntraSkippedTenant[]>([]);
+  // Bumped after a discovery so the mapping preview re-fetches the tenants it just found.
+  const [mappingRefreshKey, setMappingRefreshKey] = React.useState(0);
   const [remapTarget, setRemapTarget] = React.useState<EntraSkippedTenant | null>(null);
   const [remapBusy, setRemapBusy] = React.useState(false);
 
@@ -404,6 +408,35 @@ export function EntraConsole({
       await loadConsole();
     } finally {
       setSyncAllBusy(false);
+    }
+  }, [loadConsole, t]);
+
+  /**
+   * Discovery is not a setup-only step: an MSP that onboards a client after the
+   * wizard is finished had no way to find the new tenant, because the button
+   * only ever existed on the wizard the console replaces once setup completes.
+   */
+  const handleRunDiscovery = React.useCallback(async () => {
+    setDiscoveryBusy(true);
+    setActionError(null);
+    setActionMessage(null);
+    try {
+      const result = await discoverEntraManagedTenants();
+      if ('error' in result) {
+        setActionError(result.error || t('integrations.entra.settings.discovery.failed'));
+        return;
+      }
+
+      const discoveredCount = Number(result.data?.discoveredTenantCount || 0);
+      setActionMessage(
+        discoveredCount === 1
+          ? t('integrations.entra.settings.discovery.completedOne', { count: discoveredCount })
+          : t('integrations.entra.settings.discovery.completed', { count: discoveredCount })
+      );
+      setMappingRefreshKey((current) => current + 1);
+      await loadConsole();
+    } finally {
+      setDiscoveryBusy(false);
     }
   }, [loadConsole, t]);
 
@@ -1187,6 +1220,20 @@ export function EntraConsole({
         icon={Building2}
         title={t('integrations.entra.console.connection.mappingTitle')}
         description={t('integrations.entra.console.connection.mappingDescription')}
+        action={
+          <Button
+            id="entra-console-run-discovery"
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => void handleRunDiscovery()}
+            disabled={discoveryBusy}
+          >
+            {discoveryBusy
+              ? t('integrations.entra.settings.actions.runDiscoveryRunning')
+              : t('integrations.entra.settings.actions.runDiscovery')}
+          </Button>
+        }
       >
         <div className="mb-3 grid gap-2 text-sm text-muted-foreground sm:grid-cols-4">
           <p>
@@ -1215,6 +1262,7 @@ export function EntraConsole({
           </p>
         </div>
         <EntraTenantMappingTable
+          refreshKey={mappingRefreshKey}
           onSummaryChange={setMappingSummary}
           onSkippedTenantsChange={setSkippedTenants}
           onPersistedMappingChange={() => void loadConsole()}

--- a/package-lock.json
+++ b/package-lock.json
@@ -46729,7 +46729,7 @@
     },
     "packages/core": {
       "name": "@alga-psa/core",
-      "version": "1.5.1",
+      "version": "1.5.3",
       "dependencies": {
         "dotenv": "^16.4.5",
         "node-vault": "^0.10.2",
@@ -48445,7 +48445,11 @@
         "typescript": "^5.3.0"
       }
     },
-    "sdk": {},
+    "sdk": {
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "sdk/alga-cli": {
       "name": "@alga-psa/cli",
       "version": "0.2.0",
@@ -49449,7 +49453,7 @@
       }
     },
     "server": {
-      "version": "1.5.1",
+      "version": "1.5.3",
       "license": "ISC",
       "dependencies": {
         "@alga-psa/authorization": "*",


### PR DESCRIPTION
## Summary
Run Discovery for Entra-managed tenants previously lived only on the setup wizard. Once setup completed, the console replaced the wizard and there was no UI path to discover a client onboarded afterward short of patching the shipped build. This adds a Run Discovery action to the Connection tab's tenant-mapping section so discovery is available for the life of the integration, not just during initial setup.

## Changes
- **Entra console (`EntraConsole.tsx`)**: added a "Run Discovery" button to the tenant-mapping card header, wired to the existing `discoverEntraManagedTenants` action. Reports the discovered-tenant count through the console's message line (singular/plural copy), surfaces action errors inline, bumps a `mappingRefreshKey` so `EntraTenantMappingTable` re-fetches after a run, and reloads the console state on completion.
- **Tests**: added coverage in `entraConsoleOverview.test.tsx` for the discovery button's success path (message shown, mapping table re-fetch triggered) and failure path (server error surfaced, no success message rendered).
- **Lockfile**: synced `package-lock.json` with the 1.5.3 version bump already reflected in `packages/core`/`sdk` workspace metadata; no dependency added, removed, or re-resolved.

## Testing
- `npx vitest run src/__tests__/unit/entraConsoleOverview.test.tsx` (ee/server) — the two new discovery tests pass. Note: 12 of the 15 pre-existing tests in this file fail locally due to an unrelated environment issue (`window.localStorage.setItem is not a function` inside `DataTable`), which also affects unrelated suites (Stripe, Hudu, Tanium) in the same run — not caused by this change.
