### PR TITLE
ci: fix unit-test failures left on main by the usage-contracts merge

### DIFF
--- a/packages/billing/src/actions/invoiceGeneration.ts
+++ b/packages/billing/src/actions/invoiceGeneration.ts
@@ -3037,7 +3037,7 @@ export async function generateInvoiceForNormalizedSelectionInputs(params: {
   options?: IInvoiceGenerationRequestOptions;
   bridgeMetadata?: RecurringBridgeMetadata;
 }): Promise<InvoiceViewModel | null> {
-  return params.knex.transaction(async (trx) => {
+  return withTransaction(params.knex, async (trx: Knex.Transaction) => {
     await lockTenantBilling(trx, params.tenant);
     return generateInvoiceForLockedSelectionInputs({ ...params, knex: trx });
   });

--- a/packages/billing/tests/billing-dashboard/ContractLines.i18n.test.ts
+++ b/packages/billing/tests/billing-dashboard/ContractLines.i18n.test.ts
@@ -88,8 +88,6 @@ describe('ContractLines i18n wiring contract', () => {
       'contractLines.services.hourlyRate',
       'contractLines.services.unitRate',
       'contractLines.services.rateTaxAllocation',
-      'contractLines.services.unitOfMeasure',
-      'contractLines.services.unitPlaceholder',
       'contractLines.bucket.enableTracking',
       'contractLines.bucket.title',
       'contractLines.bucket.included',

--- a/packages/billing/tests/contractLineServiceUsageConfiguration.test.ts
+++ b/packages/billing/tests/contractLineServiceUsageConfiguration.test.ts
@@ -69,6 +69,7 @@ describe('ContractLineServiceConfigurationService usage configuration', () => {
     expect(mocks.usageCreate).toHaveBeenCalledWith({
       config_id: 'config-1',
       unit_of_measure: 'item',
+      measurement_mode: 'additive',
       enable_tiered_pricing: false,
       minimum_usage: 0,
       base_rate: 25000,

--- a/server/src/test/integration/billingInvoiceTiming.integration.test.ts
+++ b/server/src/test/integration/billingInvoiceTiming.integration.test.ts
@@ -1895,7 +1895,7 @@ it('T071: usage recurring charges bill usage records that fall inside a contract
   }
 }, HOOK_TIMEOUT);
 
-it('T072: usage recurring charges with no usage inside the service period produce no recurring invoice line while preserving due-window identity', async () => {
+it('T072: usage recurring charges with no usage inside the service period fail with the coded missing-usage error for that due window instead of writing an invoice', async () => {
   setupCommonMocks({ tenantId, userId: 'contract-usage-empty-user', permissionCheck: () => true });
 
   const { contextLike } = await createClientWithRecurringCycles({
@@ -1940,13 +1940,22 @@ it('T072: usage recurring charges with no usage inside the service period produc
     windowEnd: '2025-03-08T00:00:00Z',
   });
 
-  const invoice = await generateInvoiceForSelectionInput(selectorInput);
-  expect(invoice).toMatchObject({
-    billing_cycle_id: null,
-    subtotal: 0,
-    total: 0,
+  // Usage billing is record-driven: the only usage records fall outside the
+  // due window (2025-02-05 and 2025-03-11), so the window has nothing to bill
+  // and generation reports the coded missing-usage failure naming the window
+  // rather than finalizing a zero-dollar invoice.
+  const result = await generateInvoiceForSelectionInput(selectorInput);
+  expect(result).toMatchObject({
+    messageKey: 'msp/invoicing:manualInvoices.errors.USAGE_RECORDS_MISSING',
+    messageParams: expect.objectContaining({
+      periodStart: '2025-02-08',
+      periodEnd: '2025-03-07',
+      services: 'Contract Usage Empty Service',
+    }),
   });
-  expect(invoice?.invoice_charges ?? []).toHaveLength(0);
+
+  const invoices = await db('invoices').where({ tenant: tenantId, client_id: contextLike.clientId });
+  expect(invoices).toHaveLength(0);
 }, HOOK_TIMEOUT);
 
 it('T073: mixed recurring invoice generation can combine fixed, hourly, and usage content under one service-driven execution window when the commercial model requires it', async () => {

--- a/server/src/test/setup.ts
+++ b/server/src/test/setup.ts
@@ -233,11 +233,22 @@ global.ResizeObserver = class ResizeObserver {
 };
 
 // Mock UI reflection hooks
+// Keep the DOM contract the real hook provides: a component that passes an
+// `id` still renders `id` / `data-automation-id`, so tests can address it
+// with getElementById. Only the UI-reflection registration is stubbed out.
 vi.mock('@alga-psa/ui/ui-reflection/useAutomationIdAndRegister', () => ({
-  useAutomationIdAndRegister: () => ({
-    automationIdProps: {},
-    updateMetadata: vi.fn(),
-  }),
+  useAutomationIdAndRegister: (
+    component: { id?: string; type?: string } = {},
+    _actions?: unknown,
+    overrideId?: string,
+  ) => {
+    const id = overrideId || component.id;
+    return {
+      automationIdProps: id ? { id, 'data-automation-id': id } : {},
+      updateMetadata: vi.fn(),
+      updateActions: vi.fn(),
+    };
+  },
 }));
 
 vi.mock('@alga-psa/ui/ui-reflection/useRegisterUIComponent', () => ({

--- a/server/src/test/unit/billing/usageContractSemantics.ui.test.tsx
+++ b/server/src/test/unit/billing/usageContractSemantics.ui.test.tsx
@@ -28,6 +28,10 @@ const stableT = (key: string, options?: Record<string, unknown>) => {
   return template.replace(/\{\{(\w+)\}\}/g, (_match, name: string) =>
     String(options?.[name] ?? `{{${name}}}`));
 };
+// UsageTracking navigates back to the invoice preview via the app router,
+// which is not mounted under jsdom.
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }));
+
 vi.mock('@alga-psa/ui/lib/i18n/client', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   useTranslation: () => ({ t: stableT, i18n: { language: 'en' } }),

--- a/server/src/test/unit/contractReportActions.recurringServicePeriodBasis.test.ts
+++ b/server/src/test/unit/contractReportActions.recurringServicePeriodBasis.test.ts
@@ -80,7 +80,7 @@ function buildReportKnex(params: {
     if (table === 'contract_lines as cln') {
       return buildThenableQuery(contractLines);
     }
-    if (table === 'contract_line_service_configuration as clsc') {
+    if (table === 'contract_line_service_configuration as clsc' || table === 'contract_line_service_configuration') {
       return buildThenableQuery([]);
     }
     if (table === 'contract_line_unit_pricing_revisions as rev') {
@@ -167,7 +167,7 @@ describe('contractReportActions recurring service-period basis', () => {
       if (table === 'contract_lines as cln') {
         return buildThenableQuery(contractLines);
       }
-      if (table === 'contract_line_service_configuration as clsc') {
+      if (table === 'contract_line_service_configuration as clsc' || table === 'contract_line_service_configuration') {
         return buildThenableQuery([]);
       }
       if (table === 'contract_line_unit_pricing_revisions as rev') {

--- a/server/src/test/unit/docs/servicePeriodFirstBillingPlan.contract.test.ts
+++ b/server/src/test/unit/docs/servicePeriodFirstBillingPlan.contract.test.ts
@@ -120,6 +120,10 @@ const billingCycleAlignmentPostInventoryRefs = new Set([
   'server/src/test/integration/contractLineBucketsMigration.integration.test.ts',
   'shared/workflow/runtime/actions/__tests__/businessOperations.time.db.test.ts',
   'shared/workflow/runtime/actions/businessOperations/crmWorkerDal.ts',
+  // Explicit recurring-seat (pricing_basis unit) authoring in the custom
+  // contract line dialog and service form landed after the pass-0 snapshot.
+  'packages/billing/src/components/billing-dashboard/contracts/CreateCustomContractLineDialog.tsx',
+  'packages/billing/tests/ContractLineServiceForm.fixedPricingBasis.test.tsx',
 ]);
 
 // Files whose billing_cycle_alignment references were removed after the pass-0
@@ -256,6 +260,16 @@ const servicePeriodPostInventoryRefs = new Set([
   // snapshot; its baseline fixtures assert persisted service-period columns.
   'server/src/test/integration/billing/goldenOutput/baseline.json',
   'server/src/test/integration/billing/goldenOutput/goldenOutputBaseline.integration.test.ts',
+  // Usage period-total and recurring-seat semantics (explicit measurement
+  // mode, seat revisions, period-total identity, quick entry) read persisted
+  // service-period boundaries; they landed after the pass-0 snapshot.
+  'packages/billing/src/actions/contractLineUnitPricingActions.ts',
+  'packages/billing/src/components/billing-dashboard/UsagePeriodTotalQuickEntry.tsx',
+  'packages/billing/src/components/billing-dashboard/UsageTracking.tsx',
+  'packages/billing/src/lib/billing/seatRevisions.ts',
+  'packages/billing/src/lib/billing/usagePeriodTotalIdentity.ts',
+  'packages/billing/tests/automaticInvoices.duplicateIdentityDedupe.test.tsx',
+  'server/src/test/infrastructure/billing/invoices/contractQuantityUsageSemantics.test.ts',
 ]);
 
 // Files whose persisted service-period field references were removed after the


### PR DESCRIPTION
## What

Main has had a red **Unit Tests** workflow since #3337 merged (run 33983692658). Every PR branched from main since then (e.g. #3339, the Stripe webhook secret fix) inherits 34 failures in *Server unit suite + coverage* and a red `@alga-psa/billing:test` in *Nx affected unit tests* that have nothing to do with the branch.

## Fixes

**Source**
- `invoiceGeneration.ts`: the new tenant-billing lock wrapper called `params.knex.transaction` directly instead of the file's `withTransaction` helper. That bypassed nested-trx reuse / tenant context / after-commit hooks and threw `params.knex.transaction is not a function` in every generation unit test, whose leftover `mockResolvedValueOnce` queues then leaked into neighbouring preview tests.

**Test infrastructure**
- `server/src/test/setup.ts`: the `useAutomationIdAndRegister` stub returned empty `automationIdProps`, so every shared `Button` rendered without its `id` under the server suite. All `packages/billing` dialog tests addressing buttons by id failed there (and only there). The stub now keeps the id contract and only skips UI-reflection registration.

**Test updates for behaviour #3337 intentionally changed**
- usage configuration create persists `measurement_mode` (`'additive'` default)
- ContractLines no longer edits unit of measure inline (2 i18n contract keys dropped)
- contract monthly valuation reads `contract_line_service_configuration` unaliased (report test mock)
- UsageTracking uses the app router (mock `next/navigation`)
- service-period plan inventory: 9 new post-inventory refs

## Verification

- The 15 previously failing files (34 tests) pass under the server vitest config
- `nx run @alga-psa/billing:test`: 286 files / 1265 tests pass
- billing package `tsc --noEmit` clean