### PR TITLE
fix(seeds): ship closable ticket statuses on every board

### DIFF
--- a/server/seeds/dev/07_statuses.cjs
+++ b/server/seeds/dev/07_statuses.cjs
@@ -39,7 +39,8 @@ exports.seed = async function (knex) {
         {
             order_number: 5,
             name: 'Enchanted Closure',
-            status_type: 'ticket'
+            status_type: 'ticket',
+            is_closed: true
         }
     ];
 

--- a/server/seeds/dev/85_itil_priorities.cjs
+++ b/server/seeds/dev/85_itil_priorities.cjs
@@ -1,7 +1,8 @@
 /**
- * Development seed to create test ITIL board with priorities
+ * Development seed to create test ITIL board with statuses and priorities
  * This is for development/testing only - actual ITIL standards come from migrations
  */
+const { randomUUID } = require('crypto');
 const { getFirstTenantSeedContext } = require('./_tenant.cjs');
 
 exports.seed = async function(knex) {
@@ -25,7 +26,7 @@ exports.seed = async function(knex) {
   }
 
   // Create ITIL-enabled board for testing
-  const boardId = knex.raw('gen_random_uuid()');
+  const boardId = randomUUID();
   await db.table('boards').insert({
     board_id: boardId,
     tenant: tenantId,
@@ -52,6 +53,31 @@ exports.seed = async function(knex) {
   if (!createdByUser) {
     console.log('No user found for tenant, skipping ITIL priorities seed');
     return;
+  }
+
+  // Ticket statuses are per board. Copy the global catalog, as createBoard does,
+  // so the board can open and close tickets with the product's standard set.
+  const standardTicketStatuses = await knex('standard_statuses')
+    .where({ item_type: 'ticket' })
+    .orderBy('display_order', 'asc')
+    .orderBy('name', 'asc');
+
+  if (standardTicketStatuses.length === 0) {
+    console.warn('No standard ticket statuses found; ITIL Support board has no statuses');
+  } else {
+    await db.table('statuses').insert(
+      standardTicketStatuses.map((status) => ({
+        tenant: tenantId,
+        board_id: boardId,
+        name: status.name,
+        status_type: 'ticket',
+        order_number: status.display_order,
+        is_closed: Boolean(status.is_closed),
+        is_default: Boolean(status.is_default),
+        created_by: createdByUser.user_id
+      }))
+    );
+    console.log(`Created ${standardTicketStatuses.length} ticket statuses for ITIL Support board`);
   }
 
   // Copy ITIL priorities from standard_priorities to tenant's priorities table
@@ -84,4 +110,16 @@ exports.seed = async function(knex) {
   }
 
   console.log('Copied ITIL priorities to tenant for testing');
+
+  // Mirror createBoard: default the board to the ITIL "Medium" (level 3) priority.
+  const defaultPriority = await db.table('priorities')
+    .where({ item_type: 'ticket', is_from_itil_standard: true })
+    .orderByRaw('CASE WHEN itil_priority_level = 3 THEN 0 ELSE 1 END, order_number ASC, priority_name ASC')
+    .first('priority_id');
+
+  if (defaultPriority) {
+    await db.table('boards')
+      .where({ board_id: boardId })
+      .update({ default_priority_id: defaultPriority.priority_id });
+  }
 };


### PR DESCRIPTION
The demo seed created five ticket statuses per board with none marked is_closed, so a fresh install could never close a ticket. The ITIL Support board, created by a later seed, had no statuses at all.

- 07_statuses.cjs: mark "Enchanted Closure" as is_closed.
- 85_itil_priorities.cjs: generate the board id in JS, copy the global standard ticket status catalog onto the ITIL board the same way createBoard does, and set the board's default priority to the ITIL "Medium" (level 3) priority.

Verified on a freshly migrated and seeded database: every board has one default open status and at least one closed status.

"Off with its head!" cried the Queen, but no ticket could be sentenced, for Enchanted Closure had never learned to close. Now the Cheshire board grins with a proper Resolved and Closed, and even the ITIL Support board, once a Wonderland with no doors, has five ways out. 🎩🚪✨