### PR TITLE
Fix Level.io webhook authentication and group-rule matching (2352)

### DIFF
--- a/ee/server/src/__tests__/integration/levelioAlertGroupScoping.integration.test.ts
+++ b/ee/server/src/__tests__/integration/levelioAlertGroupScoping.integration.test.ts
@@ -1,0 +1,444 @@
+/**
+ * Level.io alert → group-scoped rule integration coverage.
+ *
+ * Reproduces the filed-ticket shape: an active rule scoped to a Level group id
+ * with keyword matching + createTicket + autoResolveTicket, a mapped Level
+ * device whose device mapping carries the sync-engine canonicalized realm id,
+ * and Level's real copied-automation payload (event/alert_id/device_id/
+ * hostname/name/severity/description — NO group_id).
+ *
+ * The events fed to processRmmAlertEvent below mirror exactly what the EE
+ * webhook handler produces after resolveLevelIoWebhookOrganization backfills
+ * externalOrganizationId from the device mapping's external_realm_id (the
+ * precedence chain is unit-tested in levelioWebhookOrganization.test.ts).
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { tenantDb } from '@alga-psa/db';
+import type { Knex } from 'knex';
+import { v4 as uuidv4 } from 'uuid';
+import { createTestDbConnection } from '@main-test-utils/dbConfig';
+import { processRmmAlertEvent, type NormalizedRmmAlertEvent } from '@alga-psa/shared/rmm/alerts';
+
+const HOOK_TIMEOUT = 180_000;
+
+let db: Knex;
+
+const tenantId = uuidv4();
+const userId = uuidv4();
+const clientA = uuidv4();
+const clientB = uuidv4();
+const boardId = uuidv4();
+const statusOpenId = uuidv4();
+const statusClosedId = uuidv4();
+const integrationId = uuidv4();
+const assetId = uuidv4();
+
+const GROUP_1 = 'level-group-1'; // mapped → clientA, has the active rule
+const GROUP_2 = 'level-group-2'; // mapped → clientB, no rule references it
+const DEVICE_1 = 'level-dev-1';
+const CONDITION = 'CPU';
+
+function tenantTable(table: string) {
+  return tenantDb(db, tenantId).table(table);
+}
+
+async function hasColumn(table: string, column: string): Promise<boolean> {
+  return db.schema.hasColumn(table, column);
+}
+
+/** Mirrors the normalized event the EE route builds from a Level payload. */
+function levelEvent(overrides: Partial<NormalizedRmmAlertEvent> = {}): NormalizedRmmAlertEvent {
+  return {
+    tenantId,
+    integrationId,
+    provider: 'levelio',
+    kind: 'triggered',
+    externalAlertId: `lvl-${uuidv4().slice(0, 8)}`,
+    externalDeviceId: DEVICE_1,
+    conditionIdentity: CONDITION,
+    activityType: 'levelio_webhook',
+    alertClass: 'CPU',
+    sourceType: 'levelio_webhook',
+    severity: 'major',
+    message: 'CPU: usage is above threshold',
+    deviceName: 'WS-01',
+    externalOrganizationId: GROUP_1,
+    occurredAt: new Date().toISOString(),
+    raw: {
+      event: 'alert.triggered',
+      alert_id: 'lv-disk-1',
+      device_id: DEVICE_1,
+      hostname: 'WS-01',
+      name: 'CPU',
+      severity: 'critical',
+      description: 'usage is above threshold',
+    },
+    ...overrides,
+  };
+}
+
+async function countTickets(): Promise<number> {
+  const row = await tenantTable('tickets').where({ tenant: tenantId }).count('ticket_id as n').first();
+  return Number(row?.n ?? 0);
+}
+
+beforeAll(async () => {
+  process.env.DB_PORT = process.env.DB_PORT || '5432';
+  process.env.APP_ENV = process.env.APP_ENV || 'test';
+  db = await createTestDbConnection();
+
+  await tenantTable('tenants').insert({
+    tenant: tenantId,
+    ...((await hasColumn('tenants', 'company_name'))
+      ? { company_name: 'LevelIO Group Scoping Test Tenant' }
+      : { client_name: 'LevelIO Group Scoping Test Tenant' }),
+    email: `levelio-group-${tenantId.slice(0, 8)}@example.com`,
+    created_at: db.fn.now(),
+    updated_at: db.fn.now(),
+  });
+
+  await tenantTable('users').insert({
+    tenant: tenantId,
+    user_id: userId,
+    username: `levelio-group-${tenantId.slice(0, 8)}`,
+    hashed_password: 'not-used',
+    email: `levelio-user-${tenantId.slice(0, 8)}@example.com`,
+    created_at: db.fn.now(),
+    updated_at: db.fn.now(),
+  });
+
+  await tenantTable('clients').insert([
+    {
+      tenant: tenantId,
+      client_id: clientA,
+      client_name: 'Acme Corp',
+      properties: JSON.stringify({}),
+      is_inactive: false,
+      created_at: db.fn.now(),
+      updated_at: db.fn.now(),
+    },
+    {
+      tenant: tenantId,
+      client_id: clientB,
+      client_name: 'Beta Inc',
+      properties: JSON.stringify({}),
+      is_inactive: false,
+      created_at: db.fn.now(),
+      updated_at: db.fn.now(),
+    },
+  ]);
+
+  await tenantTable('boards').insert({
+    tenant: tenantId,
+    board_id: boardId,
+    board_name: 'Alerts',
+    is_default: true,
+  });
+
+  const statusItemType = {
+    ...((await hasColumn('statuses', 'item_type')) ? { item_type: 'ticket' } : {}),
+    ...((await hasColumn('statuses', 'status_type')) ? { status_type: 'ticket' } : {}),
+  };
+  await tenantTable('statuses').insert([
+    {
+      tenant: tenantId,
+      status_id: statusOpenId,
+      name: 'Open',
+      ...statusItemType,
+      board_id: boardId,
+      is_closed: false,
+      is_default: true,
+      order_number: 10,
+      created_by: userId,
+    },
+    {
+      tenant: tenantId,
+      status_id: statusClosedId,
+      name: 'Closed',
+      ...statusItemType,
+      board_id: boardId,
+      is_closed: true,
+      is_default: false,
+      order_number: 20,
+      created_by: userId,
+    },
+  ]);
+
+  await tenantTable('rmm_integrations').insert({
+    tenant: tenantId,
+    integration_id: integrationId,
+    provider: 'levelio',
+    instance_url: 'https://api.level.io',
+    is_active: true,
+    connected_at: db.fn.now(),
+    settings: JSON.stringify({}),
+  });
+
+  await tenantTable('rmm_organization_mappings').insert([
+    {
+      tenant: tenantId,
+      mapping_id: uuidv4(),
+      integration_id: integrationId,
+      external_organization_id: GROUP_1,
+      external_organization_name: 'Acme Corp',
+      client_id: clientA,
+      default_contact_id: null,
+      auto_sync_assets: true,
+      auto_create_tickets: false,
+    },
+    {
+      tenant: tenantId,
+      mapping_id: uuidv4(),
+      integration_id: integrationId,
+      external_organization_id: GROUP_2,
+      external_organization_name: 'Beta Inc',
+      client_id: clientB,
+      default_contact_id: null,
+      auto_sync_assets: true,
+      auto_create_tickets: false,
+    },
+  ]);
+
+  await tenantTable('assets').insert({
+    tenant: tenantId,
+    asset_id: assetId,
+    asset_type: 'server',
+    name: 'WS-01',
+    asset_tag: 'levelio:level-dev-1',
+    serial_number: 'SN-L1',
+    status: 'active',
+    client_id: clientA,
+    rmm_provider: 'levelio',
+    rmm_device_id: DEVICE_1,
+    created_at: db.fn.now(),
+    updated_at: db.fn.now(),
+  });
+
+  // Mapped Level device: external_realm_id is the sync-engine canonicalized
+  // (deepest-mapped) group — the value the webhook handler uses to backfill
+  // externalOrganizationId for payloads without group_id.
+  await tenantTable('tenant_external_entity_mappings').insert({
+    tenant: tenantId,
+    id: uuidv4(),
+    integration_type: 'levelio',
+    alga_entity_type: 'asset',
+    alga_entity_id: assetId,
+    external_entity_id: DEVICE_1,
+    external_realm_id: GROUP_1,
+    sync_status: 'synced',
+    created_at: db.fn.now(),
+    updated_at: db.fn.now(),
+  });
+
+  // FTS shape: group + keyword scoped rule that creates and auto-resolves.
+  await tenantTable('rmm_alert_rules').insert({
+    tenant: tenantId,
+    rule_id: uuidv4(),
+    integration_id: integrationId,
+    name: 'Group-1 CPU alerts',
+    is_active: true,
+    priority_order: 0,
+    conditions: JSON.stringify({
+      keywords: ['cpu'],
+      organizationIds: [GROUP_1],
+    }),
+    actions: JSON.stringify({
+      createTicket: true,
+      boardId,
+      autoResolveTicket: true,
+    }),
+  });
+}, HOOK_TIMEOUT);
+
+afterAll(async () => {
+  if (!db) return;
+  for (const table of [
+    'comments',
+    'comment_threads',
+    'asset_associations',
+    'rmm_alerts',
+    'rmm_alert_rules',
+    'rmm_maintenance_windows',
+    'tickets',
+    'next_number',
+    'tenant_external_entity_mappings',
+    'rmm_organization_mappings',
+    'rmm_integrations',
+    'assets',
+    'statuses',
+    'boards',
+    'clients',
+    'users',
+    'tenants',
+  ]) {
+    await tenantTable(table)
+      .where({ tenant: tenantId })
+      .del()
+      .catch(() => undefined);
+  }
+  await db.destroy().catch(() => undefined);
+}, HOOK_TIMEOUT);
+
+describe('Level.io group-scoped alert rules (DB integration)', { shuffle: false }, () => {
+  let cpuTicketId: string;
+  let cpuAlertId: string;
+
+  it('creates exactly one ticket for a copied payload (no group_id) backed by the device realm group', async () => {
+    const before = await countTickets();
+
+    // Payload has NO group_id; the handler would have backfilled the org from
+    // the device mapping realm (GROUP_1). Keyword + org both match.
+    const result = await processRmmAlertEvent(
+      { knex: db },
+      levelEvent({ externalAlertId: 'lv-disk-1' })
+    );
+
+    expect(result.outcome).toBe('ticket_created');
+    expect(result.matchedRuleId).toBeDefined();
+    cpuTicketId = result.ticketId!;
+    cpuAlertId = result.alertId!;
+    expect(await countTickets()).toBe(before + 1);
+
+    const alert = await tenantTable('rmm_alerts')
+      .where({ tenant: tenantId, external_alert_id: 'lv-disk-1' })
+      .first();
+    expect(alert.status).toBe('active');
+    expect(alert.asset_id).toBe(assetId);
+    expect(alert.matched_rule_id).toBeDefined();
+    expect(alert.metadata).toMatchObject({
+      event: 'alert.triggered',
+      device_id: DEVICE_1,
+      name: 'CPU',
+    });
+    expect(alert.metadata.group_id).toBeUndefined();
+
+    const ticket = await tenantTable('tickets').where({ tenant: tenantId, ticket_id: cpuTicketId }).first();
+    expect(ticket.client_id).toBe(clientA); // correct tenant/client
+    expect(ticket.source).toBe('levelio');
+    expect(ticket.board_id).toBe(boardId);
+  });
+
+  it('a replayed delivery of the same alert_id is a no-op (no duplicate tickets)', async () => {
+    const before = await countTickets();
+    const result = await processRmmAlertEvent({ knex: db }, levelEvent({ externalAlertId: 'lv-disk-1' }));
+    expect(result.outcome).toBe('skipped');
+    expect(await countTickets()).toBe(before);
+
+    const rows = await tenantTable('rmm_alerts')
+      .where({ tenant: tenantId, external_alert_id: 'lv-disk-1' });
+    expect(rows).toHaveLength(1);
+  });
+
+  it('a repeat firing of the same (device, condition) appends to the open ticket', async () => {
+    const before = await countTickets();
+    const result = await processRmmAlertEvent({ knex: db }, levelEvent({ externalAlertId: 'lv-disk-2' }));
+    expect(result.outcome).toBe('occurrence_appended');
+    expect(result.ticketId).toBe(cpuTicketId);
+    expect(await countTickets()).toBe(before);
+
+    const original = await tenantTable('rmm_alerts').where({ tenant: tenantId, alert_id: cpuAlertId }).first();
+    expect(Number(original.occurrence_count)).toBe(2);
+  });
+
+  it('a group-scoped rule does NOT broaden: a mapped-but-unruled group stays unticketed', async () => {
+    const before = await countTickets();
+
+    // GROUP_2 is mapped to clientB but no rule references it; keyword matches.
+    // Group-scoped rules must not broaden — this records without a ticket.
+    const result = await processRmmAlertEvent(
+      { knex: db },
+      levelEvent({ externalAlertId: 'lv-other-org', externalOrganizationId: GROUP_2 })
+    );
+
+    expect(result.outcome).toBe('recorded_only');
+    expect(await countTickets()).toBe(before);
+
+    const alert = await tenantTable('rmm_alerts')
+      .where({ tenant: tenantId, external_alert_id: 'lv-other-org' })
+      .first();
+    expect(alert.ticket_id).toBeNull();
+    expect(alert.matched_rule_id).toBeNull();
+  });
+
+  it('keyword mismatch records without a ticket even for the matching group', async () => {
+    const before = await countTickets();
+    const result = await processRmmAlertEvent(
+      { knex: db },
+      levelEvent({
+        externalAlertId: 'lv-no-keyword',
+        externalDeviceId: 'level-dev-unknown-1',
+        externalOrganizationId: GROUP_1,
+        message: 'nothing relevant here',
+        raw: { event: 'alert.triggered', alert_id: 'lv-no-keyword', device_id: 'x', name: 'Other', severity: 'information' },
+      })
+    );
+    expect(result.outcome).toBe('recorded_only');
+    expect(await countTickets()).toBe(before);
+  });
+
+  it('unknown device + unresolved org records without a ticket (no broadening)', async () => {
+    const before = await countTickets();
+    const result = await processRmmAlertEvent(
+      { knex: db },
+      levelEvent({
+        externalAlertId: 'lv-unknown-device',
+        externalDeviceId: 'level-dev-ghost',
+        externalOrganizationId: null,
+      })
+    );
+    expect(result.outcome).toBe('recorded_only');
+    expect(await countTickets()).toBe(before);
+  });
+
+  it('an explicit group in the payload matches even without a mapped device (client from org mapping)', async () => {
+    const before = await countTickets();
+
+    // Copied payloads may later include group_id; precedence (a) must win and,
+    // with no asset, the org mapping supplies the client.
+    const result = await processRmmAlertEvent(
+      { knex: db },
+      levelEvent({
+        externalAlertId: 'lv-explicit-group',
+        externalDeviceId: 'level-dev-9',
+        conditionIdentity: 'MEMORY',
+        alertClass: 'MEMORY',
+        externalOrganizationId: GROUP_1,
+        raw: { group_id: GROUP_1 },
+      })
+    );
+
+    expect(result.outcome).toBe('ticket_created');
+    expect(await countTickets()).toBe(before + 1);
+
+    const ticket = await tenantTable('tickets').where({ tenant: tenantId, ticket_id: result.ticketId! }).first();
+    expect(ticket.client_id).toBe(clientA);
+  });
+
+  it('reset auto-resolves the untouched ticket and a later firing opens a new one', async () => {
+    const result = await processRmmAlertEvent(
+      { knex: db },
+      levelEvent({ externalAlertId: 'lv-disk-1', kind: 'reset' })
+    );
+    expect(result.outcome).toBe('resolved');
+
+    const alert = await tenantTable('rmm_alerts')
+      .where({ tenant: tenantId, alert_id: cpuAlertId })
+      .first();
+    expect(alert.status).toBe('auto_resolved');
+    expect(alert.resolved_at).not.toBeNull();
+
+    const ticket = await tenantTable('tickets').where({ tenant: tenantId, ticket_id: cpuTicketId }).first();
+    expect(ticket.status_id).toBe(statusClosedId);
+
+    // New firing of the same condition after close creates a fresh ticket.
+    const before = await countTickets();
+    const refire = await processRmmAlertEvent(
+      { knex: db },
+      levelEvent({ externalAlertId: 'lv-disk-3' })
+    );
+    expect(refire.outcome).toBe('ticket_created');
+    expect(refire.ticketId).not.toBe(cpuTicketId);
+    expect(await countTickets()).toBe(before + 1);
+  });
+});

--- a/ee/server/src/__tests__/unit/integrations/levelioWebhookOrganization.test.ts
+++ b/ee/server/src/__tests__/unit/integrations/levelioWebhookOrganization.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveLevelIoWebhookOrganization } from '../../../lib/integrations/levelio/webhookAlertOrganization';
+import type { LevelIoApiClient } from '../../../lib/integrations/levelio/levelApiClient';
+
+/**
+ * Knex stub that answers every tenant query from a per-table row bag. Mirrors
+ * the pattern used by the sync-engine unit tests: `tenantDb(...).table(...)`
+ * funnels through `conn(table).where(...)`, and this stub's builder treats
+ * every chained clause as a no-op before resolving rows.
+ */
+function createKnexStub(rowsByTable: Record<string, any[]>) {
+  const knex: any = (table: string) => {
+    const rows = rowsByTable[table] ?? [];
+    const builder: any = {
+      where: () => builder,
+      whereNotNull: () => builder,
+      andWhere: () => builder,
+      select: async () => rows,
+      first: async () => rows[0],
+    };
+    return builder;
+  };
+  return knex;
+}
+
+function stubClient(overrides: Partial<Record<'getDevice' | 'listGroups', any>> = {}) {
+  return {
+    getDevice: overrides.getDevice ?? vi.fn(async () => ({ id: 'dev-1', group_id: 'g-sub' })),
+    listGroups: overrides.listGroups ?? vi.fn(async () => [
+      { id: 'g-root', parent_id: null, name: 'Acme Corp' },
+      { id: 'g-mid', parent_id: 'g-root', name: 'Branch' },
+      { id: 'g-sub', parent_id: 'g-mid', name: 'Site' },
+    ]),
+  } as unknown as LevelIoApiClient;
+}
+
+const ARGS = { tenant: 'tenant-1', integrationId: 'int-1', deviceId: 'dev-1' };
+
+describe('resolveLevelIoWebhookOrganization', () => {
+  it('(a) prefers an explicit body.group_id and never touches the client or DB', async () => {
+    const knex = createKnexStub({});
+    const createClient = vi.fn(stubClient);
+    const result = await resolveLevelIoWebhookOrganization(
+      { knex, createClient },
+      { ...ARGS, explicitGroupId: 'g-explicit' }
+    );
+
+    expect(result).toBe('g-explicit');
+    expect(createClient).not.toHaveBeenCalled();
+  });
+
+  it('(b) falls back to the passed device mapping external_realm_id when no group_id', async () => {
+    const knex = createKnexStub({});
+    const createClient = vi.fn(stubClient);
+    const result = await resolveLevelIoWebhookOrganization(
+      { knex, deviceMapping: { external_realm_id: 'g-mapped' }, createClient },
+      ARGS
+    );
+
+    expect(result).toBe('g-mapped');
+    expect(createClient).not.toHaveBeenCalled();
+  });
+
+  it('(b) reads the canonicalized realm from the device mapping row when none is passed', async () => {
+    const knex = createKnexStub({
+      tenant_external_entity_mappings: [{ external_realm_id: 'g-mapped' }],
+    });
+    const createClient = vi.fn(stubClient);
+    const result = await resolveLevelIoWebhookOrganization({ knex, createClient }, ARGS);
+
+    expect(result).toBe('g-mapped');
+    expect(createClient).not.toHaveBeenCalled();
+  });
+
+  it('(c) resolves the deepest mapped ancestor via the Level hierarchy when no realm exists', async () => {
+    const knex = createKnexStub({
+      tenant_external_entity_mappings: [],
+      rmm_organization_mappings: [
+        { external_organization_id: 'g-root' },
+        { external_organization_id: 'g-mid' },
+      ],
+    });
+    const client = stubClient();
+    const createClient = vi.fn(async () => client);
+
+    const result = await resolveLevelIoWebhookOrganization({ knex, createClient }, ARGS);
+
+    // Device lives in g-sub; both g-root and g-mid are mapped, so the deepest
+    // (g-mid) wins — mirroring the sync engine's scoping.
+    expect(result).toBe('g-mid');
+    expect(client.getDevice).toHaveBeenCalledWith('dev-1');
+  });
+
+  it('(d) unknown device with no mapped group ancestors resolves to null', async () => {
+    const knex = createKnexStub({
+      tenant_external_entity_mappings: [],
+      rmm_organization_mappings: [{ external_organization_id: 'g-unrelated' }],
+    });
+    const client = stubClient({ getDevice: vi.fn(async () => ({ id: 'dev-x', group_id: 'g-other' })) });
+    const createClient = vi.fn(async () => client);
+
+    const result = await resolveLevelIoWebhookOrganization({ knex, createClient }, {
+      ...ARGS,
+      deviceId: 'dev-x',
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('(d) returns null when no mapping exists and no client factory is configured', async () => {
+    const knex = createKnexStub({ tenant_external_entity_mappings: [] });
+    const result = await resolveLevelIoWebhookOrganization({ knex }, ARGS);
+    expect(result).toBeNull();
+  });
+
+  it('(d) a failed client creation resolves to null instead of throwing', async () => {
+    const knex = createKnexStub({ tenant_external_entity_mappings: [] });
+    const createClient = vi.fn(async () => {
+      throw new Error('Level API key is not configured for this tenant.');
+    });
+    const result = await resolveLevelIoWebhookOrganization({ knex, createClient }, ARGS);
+    expect(result).toBeNull();
+  });
+
+  it('(d) a failed Level lookup (network/metadata) resolves to null instead of throwing', async () => {
+    const knex = createKnexStub({ tenant_external_entity_mappings: [] });
+    const client = stubClient({ getDevice: vi.fn(async () => {
+      throw new Error('Level API request failed with status 500');
+    }) });
+    const createClient = vi.fn(async () => client);
+    const result = await resolveLevelIoWebhookOrganization({ knex, createClient }, ARGS);
+    expect(result).toBeNull();
+  });
+});

--- a/ee/server/src/__tests__/unit/integrations/levelioWebhookRoute.test.ts
+++ b/ee/server/src/__tests__/unit/integrations/levelioWebhookRoute.test.ts
@@ -1,0 +1,234 @@
+/**
+ * EE Level.io webhook route tests (fully mocked, no DB).
+ *
+ * Locks the handler contract that middleware now lets through:
+ *   - tenant-scoped X-Alga-Webhook-Secret validation happens in-route, before
+ *     any processing, with zero side effects on rejection;
+ *   - the org backfill precedence is wired into the normalized event that the
+ *     shared RMM pipeline receives (explicit group_id → device mapping realm →
+ *     bounded Level hierarchy lookup → null).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => {
+  const dbRows: Record<string, any[]> = {};
+  const client: { getDevice?: any; listGroups?: any } = {};
+  const processRmmAlertEvent = vi.fn(async () => ({ outcome: 'ticket_created' as const }));
+  const publishEvent = vi.fn(async () => undefined);
+  const secrets = {
+    'tenant-a': 'secret-a',
+    'tenant-b': 'secret-b',
+  };
+  const getDeviceImpl = vi.fn(async () => ({ id: 'dev-1', hostname: 'WS-01', group_id: 'g-sub' }));
+  const listGroupsImpl = vi.fn(async () => [
+    { id: 'g-root', parent_id: null, name: 'Acme Corp' },
+    { id: 'g-sub', parent_id: 'g-root', name: 'Branch' },
+  ]);
+  return { dbRows, client, processRmmAlertEvent, publishEvent, secrets, getDeviceImpl, listGroupsImpl };
+});
+
+vi.mock('@alga-psa/db', () => ({
+  createTenantKnex: async () => ({ knex: {} }),
+  isTenantSuspended: async () => false,
+  tenantDb: (_knex: unknown, _tenant: string) => ({
+    table: (table: string) => {
+      const rows = h.dbRows[table] ?? [];
+      const builder: any = {
+        where: () => builder,
+        whereNotNull: () => builder,
+        andWhere: () => builder,
+        first: async () => rows[0],
+        select: async () => rows,
+      };
+      return builder;
+    },
+  }),
+}));
+
+vi.mock('@alga-psa/core/secrets', () => ({
+  getSecretProviderInstance: async () => ({
+    getTenantSecret: async (tenant: string) => h.secrets[tenant as keyof typeof h.secrets],
+  }),
+}));
+
+vi.mock('@alga-psa/event-bus/publishers', () => ({
+  publishEvent: h.publishEvent,
+}));
+
+vi.mock('@alga-psa/shared/rmm/alerts', () => ({
+  processRmmAlertEvent: h.processRmmAlertEvent,
+}));
+
+vi.mock('@alga-psa/integrations/lib/rmm/alerts/pipelineDeps', () => ({
+  buildRmmAlertPipelineDeps: () => ({}),
+}));
+
+vi.mock('@ee/lib/integrations/levelio/levelApiClient', () => ({
+  LEVELIO_WEBHOOK_SECRET_KEY: 'levelio_webhook_secret',
+  createLevelIoClient: async () => ({
+    getDevice: h.client.getDevice ?? h.getDeviceImpl,
+    listGroups: h.client.listGroups ?? h.listGroupsImpl,
+  }),
+}));
+
+vi.mock('@ee/lib/integrations/levelio/sync/transport', () => ({
+  levelIoTransportOverride: () => 'temporal',
+  startLevelIoDeviceSyncWorkflow: vi.fn(async () => null),
+}));
+
+vi.mock('@ee/lib/integrations/levelio/sync/syncEngine', () => ({
+  runLevelIoDeviceSync: vi.fn(async () => ({ externalDeviceId: 'dev-1', action: 'skipped' })),
+}));
+
+import { POST } from '../../../app/api/webhooks/levelio/route';
+
+const WEBHOOK_URL = 'http://localhost/api/webhooks/levelio';
+
+function payload(overrides: Record<string, unknown> = {}) {
+  return {
+    event: 'alert.triggered',
+    alert_id: 'al-1',
+    device_id: 'dev-1',
+    hostname: 'WS-01',
+    name: 'CPU',
+    severity: 'critical',
+    description: 'cpu usage above threshold',
+    ...overrides,
+  };
+}
+
+function request(tenant: string, secret: string | null, body: unknown): Request {
+  const headers: Record<string, string> = { 'content-type': 'application/json' };
+  if (secret !== null) headers['x-alga-webhook-secret'] = secret;
+  return new Request(`${WEBHOOK_URL}?tenant=${tenant}`, {
+    method: 'POST',
+    headers,
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+async function processCall() {
+  return h.processRmmAlertEvent.mock.calls[0]?.[1] as Record<string, unknown> | undefined;
+}
+
+beforeEach(() => {
+  h.dbRows['rmm_integrations'] = [{ integration_id: 'int-1' }];
+  h.dbRows['tenant_external_entity_mappings'] = [
+    { alga_entity_id: 'asset-1', external_realm_id: 'g-1' },
+  ];
+  h.dbRows['rmm_organization_mappings'] = [];
+  h.processRmmAlertEvent.mockClear();
+  h.publishEvent.mockClear();
+  h.getDeviceImpl.mockClear();
+  h.listGroupsImpl.mockClear();
+  h.client.getDevice = undefined;
+  h.client.listGroups = undefined;
+});
+
+afterEach(() => {
+  for (const key of Object.keys(h.dbRows)) delete h.dbRows[key];
+});
+
+describe('Level.io webhook route auth (tenant-scoped shared secret)', () => {
+  it('missing tenant → 400 Missing tenant with zero side effects', async () => {
+    const res = await POST(request('', 'secret-a', payload()));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'Missing tenant' });
+    expect(h.processRmmAlertEvent).not.toHaveBeenCalled();
+    expect(h.publishEvent).not.toHaveBeenCalled();
+  });
+
+  it('missing secret → 401 with zero side effects', async () => {
+    const res = await POST(request('tenant-a', null, payload()));
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'Unauthorized: missing webhook secret' });
+    expect(h.processRmmAlertEvent).not.toHaveBeenCalled();
+  });
+
+  it('wrong secret for the tenant → 401 invalid webhook secret', async () => {
+    const res = await POST(request('tenant-a', 'not-the-secret', payload()));
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'Unauthorized: invalid webhook secret' });
+    expect(h.processRmmAlertEvent).not.toHaveBeenCalled();
+  });
+
+  it('tenant-secret isolation: tenant A secret does not authorize tenant B', async () => {
+    const res = await POST(request('tenant-b', 'secret-a', payload()));
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'Unauthorized: invalid webhook secret' });
+    expect(h.processRmmAlertEvent).not.toHaveBeenCalled();
+  });
+
+  it('invalid JSON → 400 with zero side effects', async () => {
+    const res = await POST(request('tenant-a', 'secret-a', '{not json'));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'Invalid JSON body' });
+    expect(h.processRmmAlertEvent).not.toHaveBeenCalled();
+  });
+
+  it('missing device_id → 400 with zero side effects', async () => {
+    const res = await POST(request('tenant-a', 'secret-a', { ...payload(), device_id: '' }));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'device_id is required' });
+    expect(h.processRmmAlertEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe('Level.io webhook route org resolution wiring', () => {
+  it('backfills externalOrganizationId from the device mapping realm (no group_id in payload)', async () => {
+    const res = await POST(request('tenant-a', 'secret-a', payload()));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true, recorded: true, outcome: 'ticket_created' });
+
+    const normalized = await processCall();
+    expect(normalized).toMatchObject({
+      tenantId: 'tenant-a',
+      integrationId: 'int-1',
+      provider: 'levelio',
+      kind: 'triggered',
+      externalAlertId: 'al-1',
+      externalDeviceId: 'dev-1',
+      conditionIdentity: 'CPU',
+      severity: 'major', // Level 'critical' → normalized major
+      message: 'CPU: cpu usage above threshold',
+      deviceName: 'WS-01',
+      externalOrganizationId: 'g-1',
+    });
+    expect(h.publishEvent).toHaveBeenCalled();
+  });
+
+  it('an explicit body.group_id overrides the device mapping realm', async () => {
+    const res = await POST(
+      request('tenant-a', 'secret-a', payload({ group_id: 'g-2' }))
+    );
+    expect(res.status).toBe(200);
+    const normalized = await processCall();
+    expect((normalized as any).externalOrganizationId).toBe('g-2');
+  });
+
+  it('falls back to a bounded Level hierarchy lookup for an unmapped device', async () => {
+    h.dbRows['tenant_external_entity_mappings'] = [];
+    h.dbRows['rmm_organization_mappings'] = [{ external_organization_id: 'g-root' }];
+
+    const res = await POST(request('tenant-a', 'secret-a', payload()));
+    expect(res.status).toBe(200);
+    const normalized = await processCall();
+    expect((normalized as any).externalOrganizationId).toBe('g-root');
+    expect(h.getDeviceImpl).toHaveBeenCalledWith('dev-1');
+    expect(h.listGroupsImpl).toHaveBeenCalled();
+  });
+
+  it('a failed Level lookup leaves the org null and still records the alert', async () => {
+    h.dbRows['tenant_external_entity_mappings'] = [];
+    h.client.getDevice = vi.fn(async () => {
+      throw new Error('Level API request failed with status 500');
+    });
+
+    const res = await POST(request('tenant-a', 'secret-a', payload()));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true, recorded: true });
+    const normalized = await processCall();
+    expect((normalized as any).externalOrganizationId).toBeNull();
+  });
+});

--- a/ee/server/src/app/api/webhooks/levelio/route.ts
+++ b/ee/server/src/app/api/webhooks/levelio/route.ts
@@ -22,6 +22,7 @@ import {
   levelIoTransportOverride,
   startLevelIoDeviceSyncWorkflow,
 } from '../../../../lib/integrations/levelio/sync/transport';
+import { resolveLevelIoWebhookOrganization } from '../../../../lib/integrations/levelio/webhookAlertOrganization';
 
 export const runtime = 'nodejs';
 
@@ -94,7 +95,10 @@ export async function POST(req: Request) {
       return NextResponse.json({ ok: true, recorded: false, reason: 'integration_not_configured' }, { status: 200 });
     }
 
-    // Associate to asset when possible via external entity mapping.
+    // Associate to asset when possible via external entity mapping. The same
+    // row's external_realm_id holds the device's canonicalized (deepest-mapped)
+    // Level group from the sync engine; it is used below to backfill the org
+    // when the copied automation payload has no group_id.
     let assetId: string | undefined;
     const mapping = await db.table('tenant_external_entity_mappings')
       .where({
@@ -102,7 +106,7 @@ export async function POST(req: Request) {
         alga_entity_type: 'asset',
         external_entity_id: deviceId,
       })
-      .first(['alga_entity_id']);
+      .first(['alga_entity_id', 'external_realm_id']);
     assetId = mapping?.alga_entity_id;
 
     // Best-effort observability event.
@@ -124,6 +128,20 @@ export async function POST(req: Request) {
       // ignore
     }
 
+    // Resolve the event's organization for org-scoped rule matching before the
+    // shared pipeline evaluates rules: explicit group_id → device mapping
+    // external_realm_id (sync-engine canonicalized) → bounded Level hierarchy
+    // lookup → null (group-scoped rules then simply don't match).
+    const externalOrganizationId = await resolveLevelIoWebhookOrganization(
+      { knex, deviceMapping: mapping, createClient: () => createLevelIoClient(tenant) },
+      {
+        tenant,
+        integrationId: integration.integration_id,
+        deviceId,
+        explicitGroupId: body.group_id != null ? String(body.group_id) : null,
+      },
+    );
+
     // Alert handling (windows, rules, dedup, ticketing, lifecycle) lives in
     // the shared provider-agnostic pipeline.
     const normalized: NormalizedRmmAlertEvent = {
@@ -140,7 +158,7 @@ export async function POST(req: Request) {
       severity,
       message,
       deviceName: body.hostname ? String(body.hostname) : null,
-      externalOrganizationId: body.group_id != null ? String(body.group_id) : null,
+      externalOrganizationId,
       occurredAt: parseOccurredAt(body.alert_time ? String(body.alert_time) : ''),
       raw: body as Record<string, unknown>,
     };

--- a/ee/server/src/lib/integrations/levelio/webhookAlertOrganization.ts
+++ b/ee/server/src/lib/integrations/levelio/webhookAlertOrganization.ts
@@ -1,0 +1,145 @@
+/**
+ * Level.io webhook organization resolution.
+ *
+ * Level alert automations copied before this integration shipped do not include
+ * a `group_id` in their webhook payload (the generated template omits it and
+ * existing copies stay untouched). Org-scoped alert rules therefore could not
+ * match: the pipeline only saw `event.externalOrganizationId` derived from
+ * `body.group_id`.
+ *
+ * This resolver backfills the event's organization before rule evaluation using
+ * the approved precedence chain:
+ *
+ *   (a) explicit `body.group_id` when the payload carries one;
+ *   (b) the device mapping's `external_realm_id` in
+ *       `tenant_external_entity_mappings` — already canonicalized to the
+ *       deepest mapped Level group by the sync engine;
+ *   (c) a bounded Level API hierarchy lookup (device group + group parents vs.
+ *       the client-mapped groups the sync engine syncs) when no stored realm id
+ *       exists;
+ *   (d) otherwise `null` — group-scoped rules simply do not match (never
+ *       broadened).
+ *
+ * Tenant isolation is preserved: every read goes through the tenant-scoped
+ * facade, and the fallback only consults groups mapped for this integration.
+ * The API fallback is best-effort: any failure yields `null`.
+ */
+
+import type { Knex } from 'knex';
+import { tenantDb } from '@alga-psa/db';
+import type { LevelIoApiClient } from './levelApiClient';
+import { buildGroupParentMap, resolveDeepestMappedGroup } from './mappers/deviceMapper';
+
+const PROVIDER = 'levelio' as const;
+
+export interface LevelIoWebhookOrganizationDeps {
+  knex: Knex;
+  /**
+   * Creates a Level API client. Only invoked for the bounded hierarchy
+   * fallback (c); when absent the fallback is skipped and resolution stays
+   * `null`.
+   */
+  createClient?: () => Promise<LevelIoApiClient>;
+  /**
+   * The device mapping row already fetched by the caller (integration_type
+   * levelio, alga_entity_type asset, external_entity_id = device). When
+   * provided its `external_realm_id` is trusted for step (b) and the duplicate
+   * read is skipped.
+   */
+  deviceMapping?: { external_realm_id?: string | null } | null;
+}
+
+export interface ResolveLevelIoWebhookOrganizationArgs {
+  tenant: string;
+  integrationId: string;
+  deviceId: string;
+  /** Level copy of `body.group_id` when the automation included one. */
+  explicitGroupId?: string | null;
+}
+
+export async function resolveLevelIoWebhookOrganization(
+  deps: LevelIoWebhookOrganizationDeps,
+  args: ResolveLevelIoWebhookOrganizationArgs,
+): Promise<string | null> {
+  // (a) Explicit group id wins when the payload carries one. This is also the
+  // path for any future automation that includes {{group_id}}.
+  if (args.explicitGroupId) {
+    return String(args.explicitGroupId);
+  }
+
+  if (!args.deviceId) {
+    return null;
+  }
+
+  // (b) The sync engine canonicalizes each ingested device's scope to the
+  // deepest mapped Level group and stores it on the device mapping row. Trust
+  // it: it is DB-local, tenant-scoped, and needs no Level API call.
+  const realmId =
+    deps.deviceMapping?.external_realm_id ??
+    (await readDeviceRealmId(deps.knex, args.tenant, args.deviceId));
+  if (realmId) {
+    return String(realmId);
+  }
+
+  // (c) No stored realm (device never ingested, or ingested before any group
+  // was mapped): ask Level where the device sits and walk up to the deepest
+  // client-mapped ancestor — mirroring how the sync engine scopes devices.
+  if (!deps.createClient) {
+    return null;
+  }
+  try {
+    const client = await deps.createClient();
+    return await resolveFromLevelHierarchy(deps, client, args);
+  } catch {
+    // (d) Unavailable metadata or a failed lookup must not break alert
+    // processing: leave the organization unresolved so org-scoped rules do not
+    // broaden (they simply don't match) and the alert is recorded only.
+    return null;
+  }
+}
+
+async function readDeviceRealmId(
+  knex: Knex,
+  tenant: string,
+  deviceId: string,
+): Promise<string | null> {
+  const db = tenantDb(knex, tenant);
+  const mapping = await db.table('tenant_external_entity_mappings')
+    .where({
+      integration_type: PROVIDER,
+      alga_entity_type: 'asset',
+      external_entity_id: deviceId,
+    })
+    .first<{ external_realm_id?: string | null }>('external_realm_id');
+  return mapping?.external_realm_id ? String(mapping.external_realm_id) : null;
+}
+
+async function resolveFromLevelHierarchy(
+  deps: LevelIoWebhookOrganizationDeps,
+  client: LevelIoApiClient,
+  args: ResolveLevelIoWebhookOrganizationArgs,
+): Promise<string | null> {
+  const db = tenantDb(deps.knex, args.tenant);
+  const [device, groups, mappedRows] = await Promise.all([
+    client.getDevice(args.deviceId),
+    client.listGroups(),
+    db.table('rmm_organization_mappings')
+      .where({ integration_id: args.integrationId })
+      .whereNotNull('client_id')
+      .andWhere('auto_sync_assets', true)
+      .select<Array<{ external_organization_id: string }>>('external_organization_id'),
+  ]);
+
+  const mappedGroupIds = new Set(
+    mappedRows.map((row) => String(row.external_organization_id)),
+  );
+  if (mappedGroupIds.size === 0) {
+    return null;
+  }
+
+  return resolveDeepestMappedGroup(
+    device.group_id ?? null,
+    buildGroupParentMap(groups),
+    mappedGroupIds,
+  );
+}

--- a/server/src/middleware.ts
+++ b/server/src/middleware.ts
@@ -187,8 +187,26 @@ const apiKeySkipPaths = [
   '/api/internal/ext-services/', // Runner service read host API uses x-runner-auth token
 ];
 
+/**
+ * Routes exempted from the x-api-key check with exact, path-boundary matching
+ * only (never as a prefix). Joined alongside the apiKeySkipPaths entries above
+ * because they are exempt by the same rule — in-route authentication — but the
+ * prefix entries also exempt every deeper '/'-child, and Level.io has no deeper
+ * routes to exempt. Exempting exactly this single POST route keeps prefixed
+ * siblings like `/api/webhooks/levelioevil` and any future deeper route behind
+ * the API-key gate.
+ */
+const exactApiKeySkipPaths = [
+  // Level.io alert webhooks: single POST route that authenticates the tenant +
+  // X-Alga-Webhook-Secret in the route handler (no x-api-key). Same intent as
+  // the ninjaone/tacticalrmm entries, but Level has no sub-routes.
+  '/api/webhooks/levelio',
+  '/api/webhooks/levelio/',
+];
+
 export function shouldSkipApiKeyAuth(pathname: string): boolean {
   return pathname === '/api/ticket-comment-attachments/download' ||
+    exactApiKeySkipPaths.includes(pathname) ||
     apiKeySkipPaths.some((path) => pathname.startsWith(path)) ||
     (pathname.startsWith('/api/tickets/') && pathname.endsWith('/live-token')) ||
     (pathname.startsWith('/api/documents/') &&

--- a/server/src/test/unit/middleware.apiKeyAuth.test.ts
+++ b/server/src/test/unit/middleware.apiKeyAuth.test.ts
@@ -57,6 +57,27 @@ describe('shouldSkipApiKeyAuth', () => {
     expect(shouldSkipApiKeyAuth('/api/tickets/ticket-123/live-token')).toBe(true);
   });
 
+  it('allows the Level.io webhook route (X-Alga-Webhook-Secret authenticated in-route)', () => {
+    expect(shouldSkipApiKeyAuth('/api/webhooks/levelio')).toBe(true);
+    expect(shouldSkipApiKeyAuth('/api/webhooks/levelio/')).toBe(true);
+  });
+
+  it('exempts the Level.io route exactly, never a prefixed or deeper sibling', () => {
+    expect(shouldSkipApiKeyAuth('/api/webhooks/levelioevil')).toBe(false);
+    expect(shouldSkipApiKeyAuth('/api/webhooks/levelio-extra')).toBe(false);
+    expect(shouldSkipApiKeyAuth('/api/webhooks/levelio.more')).toBe(false);
+    expect(shouldSkipApiKeyAuth('/api/webhooks/levelio/malicious')).toBe(false);
+  });
+
+  it('keeps sibling RMM + payment webhook routes and unrelated APIs gated', () => {
+    expect(shouldSkipApiKeyAuth('/api/webhooks/ninjaone')).toBe(true);
+    expect(shouldSkipApiKeyAuth('/api/webhooks/tacticalrmm')).toBe(true);
+    expect(shouldSkipApiKeyAuth('/api/webhooks/ai-gateway')).toBe(true);
+    expect(shouldSkipApiKeyAuth('/api/webhooks/stripe/payments')).toBe(true);
+    expect(shouldSkipApiKeyAuth('/api/webhooks/other-provider')).toBe(false);
+    expect(shouldSkipApiKeyAuth('/api/instanceinfo')).toBe(false);
+  });
+
   it('still requires an API key for unrelated API routes', () => {
     expect(shouldSkipApiKeyAuth('/api/teams/package/upload')).toBe(false);
     expect(shouldSkipApiKeyAuth('/api/instanceinfo')).toBe(false);


### PR DESCRIPTION
## Summary

Fixes two root causes that prevented Level.io FTS webhook alerts from creating correctly-scoped tickets.

**Root cause A — webhook died in middleware auth.** `POST /api/webhooks/levelio` was rejected with `401 API key missing` in `server/src/middleware.ts` before the route's own tenant-scoped `X-Alga-Webhook-Secret` check could run. The fix adds a new `exactApiKeySkipPaths` list (alongside the existing NinjaOne/TacticalRMM handling) that exempts **only** the exact `/api/webhooks/levelio` path (plus its trailing-slash form) from api-key auth. Path-boundary matching means prefix siblings (e.g. `/api/webhooks/levelioevil`) and deeper paths stay api-key protected. In-handler `X-Alga-Webhook-Secret` validation is unchanged.

**Root cause B — copied automations omit `group_id`, so org-scoped rules never matched.** Copied Level.io automations carry no `group_id`, so group-scoped alert rules could never resolve an organization and thus never matched. A new `resolveLevelIoWebhookOrganization` (`ee/server/src/.../levelio/webhookAlertOrganization.ts`) is called in the EE handler before rule evaluation, with the approved precedence:

1. explicit `body.group_id`
2. device mapping `external_realm_id` (sync-engine canonicalized deepest-mapped group)
3. bounded Level.io API hierarchy lookup (deepest client-mapped ancestor)
4. `null` — group-scoped rules do **not** broaden

Tenant isolation is preserved at every step; shared RMM evaluator semantics are unchanged.

### Changed files
- `server/src/middleware.ts` — exact-path api-key exemption for the Level webhook
- `ee/server/src/app/api/webhooks/levelio/route.ts` — call the org resolver before rule evaluation
- `ee/server/src/.../levelio/webhookAlertOrganization.ts` — new organization resolver
- Tests: middleware skip-path unit cases, resolver precedence unit tests, fully-mocked route tests, and a DB integration test covering the FTS payload shape (one alert + one ticket on the correct client), redelivery no-op, occurrence append, no-broadening for non-matching group/keyword/org, and the auto-resolve reset lifecycle.

## Smoke-test results — PASS

Ran against the real worktree product at `localhost:3633` (commit `8afaa04dff`) using its real Next.js server, Postgres, Redis, UI, webhook route, RMM pipeline, and ticket UI.

Verified:
- Exact `/api/webhooks/levelio` and trailing-slash form bypass api-key auth and reach handler validation; sibling/deeper paths remain api-key protected.
- Missing/invalid webhook secrets, cross-tenant secret reuse, invalid JSON, and missing `device_id` reject without persisting alerts.
- Existing UI payload remains compatible without `group_id`.
- A mapped-device payload without `group_id` returned `ticket_created` and produced **TIC001095** for Emerald City with the expected rule/source. Redelivery returned `skipped` and retained one alert/ticket.
- Nested-group canonicalization created **TIC001097**.
- Explicit-group precedence created **TIC001099** for an unmapped device.
- Bounded hierarchy fallback created **TIC001096** after the stored realm was cleared; subsequent direct device sync restored the canonical realm.
- Wrong group, missing keyword, and unavailable Level metadata/API returned `recorded_only` with no matched rule or ticket.
- Alert reset auto-resolved **TIC001095** to a closed status; refiring created fresh ticket **TIC001098**.
- TacticalRMM and NinjaOne adjacent webhook validation still reached their handlers.
- Focused automated checks passed: 16 middleware tests and 18 Level resolver/route tests.

### Fidelity compromises
- Level.io itself was unavailable, so `tools/smoke-sim/levelio-api-sim.mjs` simulated only the external Level API for connection and hierarchy fallback.
- Temporal was unavailable, so the supported direct-sync transport (`LEVELIO_SYNC_TRANSPORT=direct`) was used.
- An existing authenticated dev session was reused.
- Browser console noise was limited to the unrelated unavailable Hocuspocus websocket.

A read-only production check confirmed the fix is **not** deployed: traffic remains 100% on green image `073b240f` and recent Level requests still return 401. No real FTS alert, customer secret, production persistence, deployment, or customer communication was exercised.

The Alga PSA MCP was not exposed in this agent context, so ticket `alga-2026-0002352` could not be updated; this was recorded as a workflow fact for follow-up. Existing uncommitted `package-lock.json` drift and the smoke simulator were preserved and not committed.

**Evidence directory:** `/tmp/alga-smoke-evidence/levelio-webhook-2352-20260908-200347`
