### PR TITLE
docs: reflect searchable accounting mapping pickers (2026-09-10)

### DIFF
--- a/docs/accounting-integration-overview.md
+++ b/docs/accounting-integration-overview.md
@@ -52,7 +52,7 @@ Key architecture artifacts come from:
   - Automatic enrichment of display names. The label of the selected option is also persisted as `metadata.externalDisplayName` and used as the fallback when a later catalog load no longer carries that external id (deactivated entity, different realm, pseudo codes).
   - Adapter/realm-aware CRUD.
   - Playwright overrides through `window.__ALGA_PLAYWRIGHT_ACCOUNTING__`.
-- `AccountingMappingDialog` provides add/edit UI, optional JSON metadata editing, manual entry fallback when catalog data is unavailable, and realm context readout.
+- `AccountingMappingDialog` provides add/edit UI with searchable, filterable pickers for both the Alga entity and the external target. Both pickers use `SearchableSelect` with `dropdownMode="overlay"`, so the dropdown portals into the dialog instead of being clipped by it — especially useful when a connected Xero organisation or QuickBooks realm carries hundreds of items or accounts. Optional JSON metadata editing, manual entry fallback when catalog data is unavailable, and realm context readout are also available.
 - `types.ts` defines configuration contracts: `AccountingMappingModule`, `AccountingMappingContext`, `AccountingMappingOverrides`, and metadata toggles.
 
 ### Module Configuration Pattern
@@ -130,8 +130,8 @@ Each adapter defines a factory that returns `AccountingMappingModule[]`. For CSV
 2. Select the adapter. The mapping tabs are rendered by `AccountingMappingManager`.
 3. For each tab:
    - Click **Add … Mapping**.
-   - Choose an Alga entity (client/service/tax code/payment term). Locked when editing an existing mapping.
-   - Choose the external entity from the catalog (OAuth adapters) or type the external identifier (CSV adapters).
+   - Choose an Alga entity (client/service/tax code/payment term). The picker is searchable — type to filter the list. Locked when editing an existing mapping.
+   - Choose the external entity. For OAuth adapters, the picker is catalog-backed and searchable — type to narrow a long list (particularly helpful when a Xero organisation or QuickBooks realm contains hundreds of items or accounts). For CSV adapters, type the external identifier directly.
    - Save; dialog displays validation errors from server actions.
 4. To edit or delete:
    - Use the row action menu.


### PR DESCRIPTION
## Source PR

- [#3354 Make accounting mapping pickers searchable](https://github.com/Nine-Minds/alga-psa/pull/3354) — merged 2026-09-09

## What changed (user-visible behavior)

In the accounting mapping dialog (`AccountingMappingDialog`), both the Alga entity picker and the external target picker (Xero Items/Accounts, QuickBooks items, etc.) were previously plain scroll-through dropdowns (`CustomSelect`). They now use `SearchableSelect` with `dropdownMode="overlay"`, meaning users can **type to filter** the list rather than scrolling through the full catalog. The dropdown portals into the dialog instead of being clipped by it. This is especially impactful for Xero organisations or QuickBooks realms with hundreds of items or accounts.

## Doc file edited

| File | Rationale |
|------|-----------|
| `docs/accounting-integration-overview.md` | Two sections updated: (1) the `AccountingMappingDialog` component description in **Generic React Components** now states that both pickers are searchable/filterable and explains the overlay portal behavior; (2) the **Managing Mappings** workflow step 3 now tells users they can type to narrow both the Alga entity list and the external catalog list, with a note that this is particularly helpful for large Xero/QuickBooks realms. |

## Needs human review

- **nm-store customer docs**: There is no Xero-specific setup/mapping guide in `packages/nm-store/src/site/content/docs/`. The existing `accounting-exports.md` and `how-accounting-works.md` do not describe picker UX at all, so no drift there. If a Xero setup guide is added in future, it should document the searchable pickers from the start.
- **Search index** (`/packages/nm-store/src/lib/developer-portal/search/`): No concepts or guide entries reference the accounting mapping dialog picker behavior; no update needed at this time.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012VN4icaRVxfvwfXgAVwifw

---
_Generated by [Claude Code](https://claude.ai/code/session_012VN4icaRVxfvwfXgAVwifw)_