### PR TITLE
Setup UI License Display

### DIFF
--- a/ee/appliance/host-service/manage-engine.mjs
+++ b/ee/appliance/host-service/manage-engine.mjs
@@ -69,8 +69,12 @@ export function decodeLicenseClaims(token) {
 }
 
 export function licenseStatusFromClaims(claims, editionFallback) {
+  // The token's tier is the license edition the portal displays; editionFallback
+  // is only the build/registry edition ('ee'/'ce'/essentials) and must not mask
+  // an active Pro license (remote-support gating reads this value).
+  const tokenEdition = claims && (claims.tier || claims.edition);
   const out = {
-    edition: editionFallback || (claims && (claims.edition || claims.tier)) || null,
+    edition: tokenEdition || editionFallback || null,
     expiresAt: null,
     perpetual: false,
     status: 'unknown'
@@ -102,27 +106,55 @@ function decodeSecretValue(value) {
   }
 }
 
-// Read edition + license expiry from the appliance-license-seed secret.
+// Read the live license_state row from the app, falling back to the
+// appliance-license-seed secret. The secret is only a last-activation snapshot,
+// so any live-read failure is recorded as `liveError` — the caller and the
+// operator must be able to tell "the app was unreachable" apart from "this
+// install has no license".
 export async function readLicenseStatus(deps) {
-  const { kube, namespace = 'msp', secretName = 'appliance-license-seed' } = deps;
-  const live = await kube.run('exec -i deploy/alga-core-sebastian -n msp -c sebastian -- node /app/server/scripts/appliance-license-status.mjs');
-  if (live?.ok) {
-    try {
-      const body = JSON.parse(live.stdout.trim());
-      if (body.ok && body.row) {
-        return { ...licenseStatusFromClaims(decodeLicenseClaims(body.row.license_token), body.row.edition_choice), source: 'live', lastCheckinAt: body.row.last_checkin_at };
+  const {
+    kube,
+    namespace = 'msp',
+    secretName = 'appliance-license-seed',
+    appDeployment = 'alga-core-sebastian',
+    appNamespace = 'msp'
+  } = deps;
+
+  let liveError = null;
+  try {
+    const live = await kube.run(`exec -i deploy/${appDeployment} -n ${appNamespace} -c sebastian -- node /app/server/scripts/appliance-license-status.mjs`);
+    if (!live?.ok) {
+      liveError = 'app_unreachable';
+    } else {
+      let body = null;
+      try { body = JSON.parse(String(live.stdout || '').trim()); } catch { liveError = 'invalid_response'; }
+      if (!liveError) {
+        if (body?.ok && body.row) {
+          return {
+            ...licenseStatusFromClaims(decodeLicenseClaims(body.row.license_token), body.row.edition_choice),
+            source: 'live',
+            liveError: null,
+            lastCheckinAt: body.row.last_checkin_at
+          };
+        }
+        liveError = body?.ok === false ? 'license_read_failed' : 'invalid_response';
       }
-    } catch { /* use seed fallback */ }
+    }
+  } catch {
+    liveError = 'app_unreachable';
   }
+
   const res = await kube.json(`get secret ${secretName} -n ${namespace}`);
   if (!res || !res.ok || !res.value || !res.value.data) {
-    return { edition: null, expiresAt: null, status: 'unknown', source: 'seed-fallback' };
+    return { edition: null, expiresAt: null, perpetual: false, status: 'unknown', source: 'seed-fallback', liveError: liveError || 'secret_unavailable' };
   }
   const data = res.value.data;
   const token = decodeSecretValue(data.LICENSE_TOKEN);
-  const edition = decodeSecretValue(data.EDITION_CHOICE) || null;
+  // INSTALL_EDITION (essentials|pro, from the install-code redeem) is the
+  // registry edition the portal shows; EDITION_CHOICE is only the build edition.
+  const edition = decodeSecretValue(data.INSTALL_EDITION) || decodeSecretValue(data.EDITION_CHOICE) || null;
   const claims = token ? decodeLicenseClaims(token) : null;
-  return { ...licenseStatusFromClaims(claims, edition), source: 'seed-fallback' };
+  return { ...licenseStatusFromClaims(claims, edition), source: 'seed-fallback', liveError };
 }
 
 function parseWorkflowResult(execResult) {
@@ -144,10 +176,10 @@ const REDEEM_ERRORS = {
   tenant_mismatch: 'This code belongs to a different account — reissue a code from your licensing portal.',
 };
 
-export async function redeemClaimCode({ claimCode, kube, namespace = 'msp', secretName = 'appliance-license-seed' }) {
+export async function redeemClaimCode({ claimCode, kube, namespace = 'msp', secretName = 'appliance-license-seed', appDeployment = 'alga-core-sebastian', appNamespace = 'msp' }) {
   const normalized = String(claimCode || '').trim().toUpperCase().replace(/[\s-]/g, '');
   if (!normalized) return { ok: false, status: 400, error: 'A claim code is required.' };
-  const executed = await kube.run('exec -i deploy/alga-core-sebastian -n msp -c sebastian -- node /app/server/scripts/appliance-redeem-claim-code.mjs', { stdin: JSON.stringify({ claimCode: normalized }) });
+  const executed = await kube.run(`exec -i deploy/${appDeployment} -n ${appNamespace} -c sebastian -- node /app/server/scripts/appliance-redeem-claim-code.mjs`, { stdin: JSON.stringify({ claimCode: normalized }) });
   const body = parseWorkflowResult(executed);
   if (!body.ok) return { ok: false, status: body.code === 'app_unavailable' ? 503 : 400, error: REDEEM_ERRORS[body.code] || body.error };
   const literals = licenseSeedFromRedeem(body.result);
@@ -416,7 +448,9 @@ export async function collectManageStatus(deps) {
     updateOwnerIsPidAlive = isPidAlive,
     updateOwnerMaxAgeMs = DEFAULT_UPDATE_OWNER_MAX_AGE_MS,
     licenseNamespace = 'msp',
-    licenseSecretName = 'appliance-license-seed'
+    licenseSecretName = 'appliance-license-seed',
+    licenseAppDeployment = 'alga-core-sebastian',
+    licenseAppNamespace = 'msp'
   } = deps;
 
   const selection = readJsonFile(releaseSelectionFile) || {};
@@ -475,11 +509,18 @@ export async function collectManageStatus(deps) {
     dnsServers: runtime.dnsServers ? String(runtime.dnsServers).split(',').map((s) => s.trim()).filter(Boolean) : []
   };
 
-  // License.
-  let license = { edition: null, expiresAt: null, perpetual: false, status: 'unknown' };
+  // License. readLicenseStatus records its own live-read diagnostic; the default
+  // here only applies if the read itself throws unexpectedly.
+  let license = { edition: null, expiresAt: null, perpetual: false, status: 'unknown', source: 'seed-fallback', liveError: 'status_unavailable' };
   try {
-    license = await readLicenseStatus({ kube, namespace: licenseNamespace, secretName: licenseSecretName });
-  } catch { /* best effort */ }
+    license = await readLicenseStatus({
+      kube,
+      namespace: licenseNamespace,
+      secretName: licenseSecretName,
+      appDeployment: licenseAppDeployment,
+      appNamespace: licenseAppNamespace
+    });
+  } catch { /* best effort — keep the diagnosable default above */ }
 
   // App-update status, reconciled against live reality. install-state persists the
   // *last* update attempt's outcome, which goes stale: a block that has since

--- a/ee/appliance/host-service/tests/manage-engine.test.mjs
+++ b/ee/appliance/host-service/tests/manage-engine.test.mjs
@@ -7,6 +7,7 @@ import {
   isWellFormedLicenseJws,
   decodeLicenseClaims,
   licenseStatusFromClaims,
+  readLicenseStatus,
   applyLicense,
   redeemClaimCode,
   applyAppUrl,
@@ -56,6 +57,111 @@ test('license JWS format check + claim decode + status', () => {
   assert.equal(perpetual.perpetual, true);
   assert.equal(perpetual.status, 'active');
   assert.equal(perpetual.expiresAt, null);
+});
+
+// --- License read: candidate reproductions --------------------------------
+//
+// The appliance Manage tab must mirror the portal, which derives the displayed
+// edition from the *license token's* `tier` claim, not from `edition_choice`
+// (the build edition, always 'ee' on an appliance). The claims actually minted
+// for appliance licenses carry `tier` + numeric `exp` (see
+// packages/licensing/src/lib/license-types.ts), so the token is authoritative.
+
+test('licenseStatusFromClaims treats the token tier as authoritative over the build edition', () => {
+  const future = Math.floor(Date.now() / 1000) + 3600;
+  const claims = decodeLicenseClaims(jwsWith({ tier: 'pro', exp: future }));
+  const status = licenseStatusFromClaims(claims, 'ee');
+  // Candidate 5: the 'ee' build edition must not mask the Pro license tier.
+  assert.equal(status.edition, 'pro');
+  assert.equal(status.status, 'active');
+  assert.equal(status.perpetual, false);
+});
+
+test('licenseStatusFromClaims reads the minted claim shape (tier + numeric exp)', () => {
+  // Candidate 4 (eliminated): real appliance tokens use `tier` and numeric
+  // `exp`, both of which the decoder already reads.
+  const future = Math.floor(Date.now() / 1000) + 3600;
+  const claims = decodeLicenseClaims(jwsWith({ iss: 'nineminds-license', sub: 's', cust: 'c', tier: 'pro', iat: 1, exp: future }));
+  const status = licenseStatusFromClaims(claims, null);
+  assert.equal(status.edition, 'pro');
+  assert.equal(status.status, 'active');
+  assert.ok(status.expiresAt);
+});
+
+test('readLicenseStatus reports the live token tier as the edition', async () => {
+  const future = Math.floor(Date.now() / 1000) + 3600;
+  const kube = fakeKube({
+    run: (args) => args.includes('appliance-license-status')
+      ? { ok: true, stdout: JSON.stringify({ ok: true, row: { edition_choice: 'ee', license_token: jwsWith({ tier: 'pro', exp: future }), last_checkin_at: '2026-08-01T00:00:00.000Z' } }) }
+      : { ok: true, stdout: '' }
+  });
+  const status = await readLicenseStatus({ kube });
+  assert.equal(status.source, 'live');
+  assert.equal(status.edition, 'pro');
+  assert.equal(status.status, 'active');
+  assert.equal(status.lastCheckinAt, '2026-08-01T00:00:00.000Z');
+});
+
+test('readLicenseStatus targets the configured app deployment/namespace for the live read', async () => {
+  // Candidate 1: the read path hardcoded deploy/alga-core-sebastian -n msp and
+  // ignored appDeployment/appNamespace, unlike applyLicense.
+  const future = Math.floor(Date.now() / 1000) + 3600;
+  const kube = fakeKube({
+    run: (args) => args.includes('appliance-license-status')
+      ? { ok: true, stdout: JSON.stringify({ ok: true, row: { edition_choice: 'ee', license_token: jwsWith({ tier: 'pro', exp: future }) } }) }
+      : { ok: true, stdout: '' }
+  });
+  await readLicenseStatus({ kube, appDeployment: 'custom-app', appNamespace: 'custom-ns' });
+  const exec = kube.calls.find((c) => c[0] === 'run' && c[1].includes('appliance-license-status'));
+  assert.ok(exec, 'expected a live status exec');
+  assert.match(exec[1], /deploy\/custom-app -n custom-ns/);
+});
+
+test('readLicenseStatus distinguishes a failed live read from an absent license', async () => {
+  // Candidate 2: every failure fell through to the seed fallback silently, so
+  // the operator could not tell "the app was unreachable" from "no license".
+  const kube = fakeKube({
+    run: (args) => args.includes('appliance-license-status')
+      ? { ok: false, stdout: '', stderr: 'error: unable to upgrade connection: container not found ("sebastian")' }
+      : { ok: true, stdout: '' },
+    json: () => ({ ok: true, value: { data: {} } })
+  });
+  const status = await readLicenseStatus({ kube });
+  assert.equal(status.status, 'unknown');
+  assert.equal(status.source, 'seed-fallback');
+  assert.ok(status.liveError, 'a failed live read must be distinguishable from no license');
+});
+
+test('readLicenseStatus seed fallback prefers the registry edition and the token tier', async () => {
+  // Candidate 3: the seed only ever carries activation-time data, and its
+  // INSTALL_EDITION (essentials|pro) is the registry edition the portal shows —
+  // EDITION_CHOICE ('ee') is the build edition and must not win.
+  const future = Math.floor(Date.now() / 1000) + 3600;
+  const kube = fakeKube({
+    run: (args) => args.includes('appliance-license-status') ? { ok: false, stdout: '', stderr: 'boom' } : { ok: true, stdout: '' },
+    json: () => ({ ok: true, value: { data: {
+      EDITION_CHOICE: Buffer.from('ee').toString('base64'),
+      INSTALL_EDITION: Buffer.from('pro').toString('base64'),
+      LICENSE_TOKEN: Buffer.from(jwsWith({ tier: 'pro', exp: future })).toString('base64')
+    } } })
+  });
+  const status = await readLicenseStatus({ kube });
+  assert.equal(status.source, 'seed-fallback');
+  assert.equal(status.edition, 'pro');
+  assert.equal(status.status, 'active');
+  assert.ok(status.liveError);
+});
+
+test('redeemClaimCode targets the configured app deployment/namespace', async () => {
+  // Candidate 1 (shared): redemption hardcoded the same deployment/namespace.
+  const result = { edition: 'pro', licenseToken: 'a.b.c', applianceId: 'appliance-1', applianceCredential: 'credential', checkInUrl: 'https://license.example/check-in' };
+  const kube = fakeKube({ run: (args) => args.includes('appliance-redeem-claim-code')
+    ? { ok: true, stdout: JSON.stringify({ ok: true, result }) }
+    : { ok: true, stdout: '' } });
+  await redeemClaimCode({ claimCode: 'ABCD', kube, appDeployment: 'custom-app', appNamespace: 'custom-ns' });
+  const exec = kube.calls.find((c) => c[0] === 'run' && c[1].includes('appliance-redeem-claim-code'));
+  assert.ok(exec, 'expected a redeem exec');
+  assert.match(exec[1], /deploy\/custom-app -n custom-ns/);
 });
 
 test('applyLicense rejects an invalid JWS without touching kubectl', async () => {
@@ -230,6 +336,36 @@ test('collectManageStatus reports upgradeAvailable on digest mismatch', async ()
   assert.equal(status.license.edition, 'pro');
   assert.equal(status.appUrl.url, 'http://10.0.0.5:3000');
   assert.equal(status.appUrl.host, '10.0.0.5');
+});
+
+test('collectManageStatus marks a failed live license read while still showing the seed edition', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'alga-manage-license-fallback-'));
+  const releaseSelectionFile = path.join(tmp, 'release-selection.json');
+  fs.writeFileSync(releaseSelectionFile, JSON.stringify({ selectedChannel: 'stable' }));
+  const future = Math.floor(Date.now() / 1000) + 3600;
+  const kube = fakeKube({
+    run: (args) => args.includes('appliance-license-status')
+      ? { ok: false, stdout: '', stderr: 'error: unable to upgrade connection' }
+      : { ok: true, stdout: '' },
+    json: (args) => args.includes('secret appliance-license-seed')
+      ? { ok: true, value: { data: {
+        EDITION_CHOICE: Buffer.from('ee').toString('base64'),
+        INSTALL_EDITION: Buffer.from('pro').toString('base64'),
+        LICENSE_TOKEN: Buffer.from(jwsWith({ tier: 'pro', exp: future })).toString('base64')
+      } } }
+      : { ok: true, value: {} }
+  });
+  const status = await collectManageStatus({
+    kube,
+    releaseSelectionFile,
+    installStateFile: path.join(tmp, 'install-state.json'),
+    cpUpgradeStatusFile: path.join(tmp, 'cp.json'),
+    resolveControlPlaneRef: async () => null
+  });
+  assert.equal(status.license.source, 'seed-fallback');
+  assert.equal(status.license.edition, 'pro');
+  assert.equal(status.license.status, 'active');
+  assert.ok(status.license.liveError, 'the failed live read must be surfaced to the UI');
 });
 
 // The detached update child (queueUpdateWorkflow) moves install-state through

--- a/ee/appliance/status-ui/app/manage/ManageView.tsx
+++ b/ee/appliance/status-ui/app/manage/ManageView.tsx
@@ -41,6 +41,8 @@ type ManageStatus = {
     perpetual: boolean;
     status: "active" | "expired" | "unknown";
     source?: "live" | "seed-fallback";
+    /** Set when the live read from the app failed; null on a successful read. */
+    liveError?: string | null;
     lastCheckinAt?: string | null;
   };
   appUrl: {
@@ -578,7 +580,13 @@ function LicenseTab({
         </div>
       </dl>
       {lic.source === "seed-fallback" ? (
-        <p className={styles.helpText}>As of last activation — live status unavailable.</p>
+        <p className={styles.helpText}>
+          {lic.liveError
+            ? "Live license status is unavailable right now — showing the last activation record. It refreshes automatically once the app is reachable."
+            : "As of last activation — live status unavailable."}
+        </p>
+      ) : lic.source === "live" && lic.status === "unknown" ? (
+        <p className={styles.helpText}>No license is active on this appliance.</p>
       ) : null}
 
       <div className={styles.manageSeparator} />


### PR DESCRIPTION
## Summary

Fixes the appliance Manage tab showing the wrong license edition. On an `ee` build with an active **Pro** license, the License tab rendered Edition `ee` (the build edition) instead of `pro`, and the Support tab gated remote support as `pro_required` — exactly ToddyDucati's report: "my license does not show on the :8080 appliance but it does in the portal."

**Scope correction:** this change lives entirely in the appliance — `ee/appliance/host-service/manage-engine.mjs` and `ee/appliance/status-ui/app/manage/ManageView.tsx` (the `:8080` appliance UI), not the PSA server on `:3836` named in the card. Testing `:3836` would have exercised nothing.

### Root cause

- `licenseStatusFromClaims()` put `edition_choice` (the build edition, always `ee` on an appliance) ahead of the license token's `tier`, so an active Pro license rendered edition `ee`. The token tier is now authoritative.
- `readLicenseStatus()` swallowed every live-exec failure with no log and no field, so "the app was unreachable" was indistinguishable from "no license" and the tab could show edition `—` / status `unknown` with no explanation.

### Changes

- `licenseStatusFromClaims()` prefers the token's `tier`/`edition` over the build-edition fallback.
- `readLicenseStatus()` records `liveError` (`app_unreachable | invalid_response | license_read_failed | secret_unavailable`) on a failed live read; the License tab shows a distinct, non-alarming "live status unavailable" line, while a successful read with no token reads "No license is active on this appliance."
- `readLicenseStatus` and `redeemClaimCode` accept `appDeployment`/`appNamespace` (matching `applyLicense`) instead of hardcoding `deploy/alga-core-sebastian -n msp`.
- Seed fallback prefers `INSTALL_EDITION` (the registry edition the portal shows) and the token, not `EDITION_CHOICE`.
- Reproductions added for each candidate cause; candidate 4 (minted claim shape) is eliminated by test — tokens carry `tier` + numeric `exp`, which the decoder already reads.

**Files:** `ee/appliance/host-service/manage-engine.mjs`, `ee/appliance/host-service/tests/manage-engine.test.mjs`, `ee/appliance/status-ui/app/manage/ManageView.tsx` (3 files, +206/−21).

## Smoke test

**Outcome: PASS.** Evidence directory: `/tmp/alga-smoke-evidence/setup-ui-license-display-20260910-012659`.

No appliance VM was booted (`alga-appliance-rec` exists but is shut off and would need a real k3s + real licensing service).

**Environment built:** ran the REAL appliance host-service (`ee/appliance/host-service/server.mjs`) on `:8088` (`:8080` is occupied by `alga-psa-local-test-imap-test-server-1`), serving the REAL built status-ui (`ee/appliance/status-ui/dist`, already containing the changed `ManageView`), with state files under `/tmp/alga-appliance-smoke/state`. Signed in through the real appliance auth flow (setup token → set password → session cookie).

**Fidelity:** real host-service, real status-ui, real Chrome (Playwright `channel=chrome`), and the live license read is NOT mocked — the kubectl shim shells out to the REAL product script `server/scripts/appliance-license-status.mjs`, which reads the REAL `license_state` row from the running dev Postgres (`alga-psa-local-test_postgres`, `127.0.0.1:5472`). License tokens are the repo's committed, properly-signed fixtures from `packages/licensing/src/lib/verify-license.test.ts` (`validToken` = pro/exp 2027-07-11, `expiredToken`).

**Simulators used (all level c, one file: `<evidenceDir>/harness/kubectl-simulator.mjs`):** a fake `kubectl` on PATH standing in for the k3s API surface only — (1) the `exec` transport into `deploy/alga-core-sebastian` (the script it runs is real), (2) the `appliance-license-seed` Secret get/patch, (3) the Temporal + central Nine Minds licensing service behind `appliance-redeem-claim-code.mjs` and `appliance-apply-license-key.mjs`, which are not runnable on this workstation. The redeem/apply sims perform the real activities' actual DB side effect (writing `license_state.license_token`) so the follow-up live read is genuine rather than faked.

**Flows and outcomes (all pass):**

1. **HEADLINE** — live read of an active Pro token on an `ee` build. Post-fix License tab: Edition `pro`, Status active, Expires July 11 2027. PRE-FIX BASELINE captured in the same UI with HEAD~1's `manage-engine.mjs` against identical data: Edition `ee`. This is exactly ToddyDucati's report.
2. **Downstream gating — Support tab.** Pre-fix: "Available with Pro." (`pro_required`). Post-fix: "Remote support is unavailable until the central support service is reachable" — the pro gate is passed. API confirms reason `pro_required` → `central_service_unavailable`.
3. **Live read fails, seed snapshot present:** Edition `pro` (from `INSTALL_EDITION`) + the new line "Live license status is unavailable right now — showing the last activation record…". Pre-fix API baseline for the same input: edition `ee`, no `liveError`, no explanation.
4. **Live read fails, no seed secret:** Edition `—`, Status unknown, plus the new explanatory line. Pre-fix: `{edition: null, status: unknown, source: seed-fallback}` with no diagnostic at all — the exact silent-failure the fix targets.
5. **Live read succeeds, no token on the install:** "No license is active on this appliance."
6. **Full air-gapped activation:** unlicensed appliance → paste the real signed Pro JWS → Confirm apply → "License applied." and the tab flips to pro/active/July 11 2027, verified by reading `license_token` back out of Postgres.
7. **Full claim-code activation:** "License activated: pro." and the tab flips to pro/active, DB write verified; the seed Secret written by redeem contains `INSTALL_EDITION=pro`, which the seed-fallback change then correctly consumes when the app is cut off.
8. **Invalid claim code** returns "Claim code not found" (HTTP 400) — the `redeemClaimCode` signature change did not break the path.
9. **Nearby regression check** — expired Pro token still renders Edition `pro`, Status `expired`, Expires July 11 2025, and correctly shows no help line.
10. `node --test ee/appliance/host-service/tests/*.test.mjs` = **195/195 pass**.

**Could not test:** a genuine k3s/Flux appliance with a genuine central licensing service; the user's actual live-read failure remains inferred, not observed. The C4 `/sign` licensing service and Temporal license workflows are external and were simulated.

**Noted, non-blocking:**
- `server.mjs` never passes `appDeployment`/`appNamespace` to `readLicenseStatus` (line 764), `applyLicense` (1441) or `redeemClaimCode` (1454), so the newly-added params only ever take their old hardcoded defaults — the parameterisation is currently inert plumbing with no env/config wired to it.
- When the live read fails AND no seed secret exists, the tab says "showing the last activation record" while Edition renders `—` and there is no record; `liveError` takes priority over `secret_unavailable`, so that case is never distinguished.
- With a live read that succeeds and no token, Edition shows the build edition `ee` alongside "No license is active" — coherent but slightly odd for an operator.

**Cleanup:** `license_state` restored byte-for-byte to its pre-test values (`edition_choice` ee, `license_token` NULL, `last_checkin_at` 2026-07-12T02:40:10.402+00); harness stopped; worktree clean apart from the pre-existing `package-lock.json` modification. Harness left in `/tmp` and copied into the evidence dir rather than committed.
