### PR TITLE
Default new records to the tenant's own country

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -350,6 +350,7 @@
       "dependencies": {
         "@alga-psa/authorization": "*",
         "@alga-psa/email": "*",
+        "@alga-psa/workflow-inference": "*",
         "@alga-psa/workflow-streams": "*",
         "@alga-psa/workflows": "*",
         "@huggingface/inference": "^3.3.3",
@@ -365,8 +366,7 @@
         "react-dom": "^19",
         "sharp": "^0.35.3",
         "tar-stream": "^3.1.7",
-        "uuid": "^11.0.5",
-        "@alga-psa/workflow-inference": "*"
+        "uuid": "^11.0.5"
       },
       "devDependencies": {
         "@playwright/test": "^1.40.0",
@@ -1319,6 +1319,10 @@
     },
     "node_modules/@alga-psa/validation": {
       "resolved": "packages/validation",
+      "link": true
+    },
+    "node_modules/@alga-psa/workflow-inference": {
+      "resolved": "packages/workflow-inference",
       "link": true
     },
     "node_modules/@alga-psa/workflow-streams": {
@@ -48309,7 +48313,7 @@
     },
     "packages/core": {
       "name": "@alga-psa/core",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "dependencies": {
         "dotenv": "^16.4.5",
         "node-vault": "^0.10.2",
@@ -48384,10 +48388,10 @@
       "dependencies": {
         "@alga-psa/authorization": "*",
         "@alga-psa/types": "*",
+        "@alga-psa/workflow-inference": "*",
         "google-auth-library": "^10.6.1",
         "jsonwebtoken": "^9.0.2",
-        "openai": "^4.104.0",
-        "@alga-psa/workflow-inference": "*"
+        "openai": "^4.104.0"
       }
     },
     "packages/ee-lib": {
@@ -48532,9 +48536,9 @@
       "version": "0.0.1",
       "dependencies": {
         "@alga-psa/emulator-host": "*",
+        "@js-temporal/polyfill": "^0.4.4",
         "express": "^5.1.0",
-        "zod": "^3.25.67",
-        "@js-temporal/polyfill": "^0.4.4"
+        "zod": "^3.25.67"
       },
       "devDependencies": {
         "@types/express": "^5.0.3",
@@ -50016,6 +50020,15 @@
         "typescript": "^5.7.3"
       }
     },
+    "packages/workflow-inference": {
+      "name": "@alga-psa/workflow-inference",
+      "version": "0.0.1",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "ajv-formats": "^2.1.1",
+        "openai": "^4.104.0"
+      }
+    },
     "packages/workflow-streams": {
       "name": "@alga-psa/workflow-streams",
       "version": "0.1.0",
@@ -51036,7 +51049,7 @@
       }
     },
     "server": {
-      "version": "1.5.3",
+      "version": "1.5.4",
       "license": "ISC",
       "dependencies": {
         "@alga-psa/authorization": "*",
@@ -52441,19 +52454,6 @@
       "dependencies": {
         "@nx/devkit": "^22.0.0",
         "tslib": "^2.6.0"
-      }
-    },
-    "node_modules/@alga-psa/workflow-inference": {
-      "resolved": "packages/workflow-inference",
-      "link": true
-    },
-    "packages/workflow-inference": {
-      "name": "@alga-psa/workflow-inference",
-      "version": "0.0.1",
-      "dependencies": {
-        "ajv": "^8.12.0",
-        "ajv-formats": "^2.1.1",
-        "openai": "^4.104.0"
       }
     }
   }

--- a/packages/clients/src/actions/clientActions.importCsv.test.ts
+++ b/packages/clients/src/actions/clientActions.importCsv.test.ts
@@ -144,13 +144,17 @@ const TABLE_COLUMNS: Record<string, Set<string>> = {
   ]),
   default_billing_settings: new Set(['tenant', 'default_currency_code']),
   countries: new Set(['code', 'name', 'is_active', 'created_at', 'updated_at']),
+  tenant_companies: new Set(['tenant', 'client_id', 'is_default', 'deleted_at', 'created_at', 'updated_at']),
 };
+
+type FakeTable = 'clients' | 'client_locations' | 'default_billing_settings' | 'countries' | 'tenant_companies';
 
 interface FakeState {
   clients: Record<string, any>[];
   client_locations: Record<string, any>[];
   default_billing_settings: Record<string, any>[];
   countries: Record<string, any>[];
+  tenant_companies: Record<string, any>[];
   updates: Array<{ table: string; data: Record<string, any> }>;
   failClientInsertNamed: string | null;
 }
@@ -180,15 +184,30 @@ function fakeConn(table: string) {
   if (!TABLE_COLUMNS[table]) {
     throw new Error(`Unexpected table ${table}`);
   }
-  const rows = () => state[table as 'clients' | 'client_locations' | 'default_billing_settings' | 'countries'];
+  const rows = () => state[table as FakeTable];
   const matching = (criteria: Record<string, any>) =>
-    rows().filter(row => Object.entries(criteria).every(([key, value]) => row[key] === value));
+    rows().filter(row => Object.entries(criteria).every(([key, value]) => (row[key] ?? null) === value));
 
   return {
     where(criteria: Record<string, any>) {
-      return {
+      const orderings: Array<{ column: string; direction: 'asc' | 'desc' }> = [];
+      // Every ordered column reached through this fake is a boolean flag.
+      const ordered = () => matching(criteria).sort((left, right) => {
+        for (const { column, direction } of orderings) {
+          const a = Number(Boolean(left[column]));
+          const b = Number(Boolean(right[column]));
+          if (a !== b) return direction === 'desc' ? b - a : a - b;
+        }
+        return 0;
+      });
+
+      const builder = {
+        orderBy(column: string, direction: 'asc' | 'desc' = 'asc') {
+          orderings.push({ column, direction });
+          return builder;
+        },
         first: async () => {
-          const match = matching(criteria)[0];
+          const match = ordered()[0];
           return match ? { ...match } : undefined;
         },
         select: async (...columns: string[]) => matching(criteria).map((row) =>
@@ -207,6 +226,8 @@ function fakeConn(table: string) {
           });
         },
       };
+
+      return builder;
     },
     insert(data: Record<string, any>) {
       assertRealColumns(table, data);
@@ -287,6 +308,7 @@ describe('importClientsFromCSV', () => {
         { code: 'CO', name: 'Colombia', is_active: true },
         { code: 'GB', name: 'United Kingdom', is_active: true },
       ],
+      tenant_companies: [],
       updates: [],
       failClientInsertNamed: null,
     };
@@ -379,6 +401,55 @@ describe('importClientsFromCSV', () => {
     expect(results[0].message).toContain('valid phone number');
     expect(state.clients).toHaveLength(0);
     expect(state.client_locations).toHaveLength(0);
+  });
+
+  it("gives a row with no country the tenant's own country instead of US", async () => {
+    state.tenant_companies = [
+      { tenant: 'tenant-1', client_id: 'msp-client', is_default: true, deleted_at: null },
+    ];
+    state.client_locations.push({
+      client_id: 'msp-client',
+      country_code: 'GB',
+      is_default: true,
+      is_billing_address: true,
+      is_active: true,
+    });
+
+    const results = await importClients([csvRow({
+      client_name: 'Bloomsbury Chambers',
+      country: '',
+      phone_number: '020 7946 0958',
+    })]);
+
+    expect(results[0]).toMatchObject({ success: true });
+    const imported = state.client_locations.find((location) => location.client_id === state.clients[0].client_id);
+    expect(imported).toMatchObject({
+      country_code: 'GB',
+      country_name: 'United Kingdom',
+      phone: '+442079460958',
+    });
+  });
+
+  it("keeps the US fallback when the tenant's own country is still the placeholder", async () => {
+    state.tenant_companies = [
+      { tenant: 'tenant-1', client_id: 'msp-client', is_default: true, deleted_at: null },
+    ];
+    state.client_locations.push({
+      client_id: 'msp-client',
+      country_code: 'XX',
+      is_default: true,
+      is_billing_address: true,
+      is_active: true,
+    });
+
+    const results = await importClients([csvRow({
+      client_name: 'Placeholder Tenant Co',
+      country: '',
+    })]);
+
+    expect(results[0]).toMatchObject({ success: true });
+    const imported = state.client_locations.find((location) => location.client_id === state.clients[0].client_id);
+    expect(imported).toMatchObject({ country_code: 'US', country_name: 'United States' });
   });
 
   it('rejects an unknown nonblank country instead of pairing it with US', async () => {

--- a/packages/clients/src/actions/clientActions.ts
+++ b/packages/clients/src/actions/clientActions.ts
@@ -44,6 +44,7 @@ import { applyClientListIndexedSearchFilter } from '../lib/listSearchSql';
 import { normalizeClientType } from '../lib/normalizeClientType';
 import { clientCoreFieldsSchema, normalizePhone, parseSubmittedFields } from '@alga-psa/validation';
 import { isStructuralFailure, type StructuralResult } from '../lib/structuralResult';
+import { resolveTenantDefaultCountry } from '../lib/tenantDefaultCountry';
 
 const CLIENT_PORTAL_MUTABLE_CLIENT_PROPERTIES = new Set([
   'website',
@@ -1675,12 +1676,19 @@ export const importClientsFromCSV = withAuth(async (
     countries.map((country) => [country.name.trim().toLowerCase(), country]),
   );
 
+  // A row that names no country adopts the tenant's own country, and only then US.
+  const tenantDefaultCountry = await resolveTenantDefaultCountry(db, tenant);
+  const fallbackCountry = (tenantDefaultCountry
+    ? countriesByCode.get(tenantDefaultCountry.code.toUpperCase())
+    : undefined)
+    ?? countriesByCode.get('US');
+
   const resolveRowCountry = (row: Record<string, any>): ImportCountry => {
     const rawCode = String(row.country_code ?? '').trim();
     const rawName = String(row.country ?? '').trim();
     const country = (rawCode ? countriesByCode.get(rawCode.toUpperCase()) : undefined)
       ?? (rawName ? countriesByName.get(rawName.toLowerCase()) : undefined)
-      ?? (!rawCode && !rawName ? countriesByCode.get('US') : undefined);
+      ?? (!rawCode && !rawName ? fallbackCountry : undefined);
 
     if (!country) {
       throw new Error(`Unknown country: ${rawCode || rawName}`);

--- a/packages/clients/src/actions/countryActions.test.ts
+++ b/packages/clients/src/actions/countryActions.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const createTenantKnexMock = vi.hoisted(() => vi.fn());
+const tenantDbMock = vi.hoisted(() => vi.fn((conn: any) => ({
+  table: (table: string) => conn(table),
+})));
+
+type ServerAction = (...args: unknown[]) => unknown;
+
+vi.mock('@alga-psa/auth', () => ({
+  withAuth: (fn: ServerAction) => (...args: unknown[]) =>
+    fn({ user_id: 'user-1', user_type: 'internal' }, { tenant: 'tenant-1' }, ...args),
+}));
+
+vi.mock('@alga-psa/db', () => ({
+  createTenantKnex: createTenantKnexMock,
+  tenantDb: tenantDbMock,
+}));
+
+interface FakeState {
+  tenant_companies: Record<string, any>[];
+  client_locations: Record<string, any>[];
+  countries: Record<string, any>[];
+}
+
+let state: FakeState;
+
+function fakeConn(table: keyof FakeState) {
+  if (!state[table]) {
+    throw new Error(`Unexpected table ${table}`);
+  }
+
+  return {
+    where(criteria: Record<string, any>) {
+      const matched = state[table].filter((row) =>
+        Object.entries(criteria).every(([column, value]) => (row[column] ?? null) === value)
+      );
+
+      const builder = {
+        // Every ordered column in this action is a boolean flag.
+        orderBy(column: string, direction: 'asc' | 'desc' = 'asc') {
+          matched.sort((left, right) => {
+            const a = Number(Boolean(left[column]));
+            const b = Number(Boolean(right[column]));
+            return direction === 'desc' ? b - a : a - b;
+          });
+          return builder;
+        },
+        first: async (...columns: string[]) => {
+          const row = matched[0];
+          if (!row) return undefined;
+          return columns.length === 0
+            ? { ...row }
+            : Object.fromEntries(columns.map((column) => [column, row[column]]));
+        },
+      };
+
+      return builder;
+    },
+  };
+}
+
+async function getTenantDefaultCountry() {
+  const { getTenantDefaultCountry: action } = await import('./countryActions');
+  return action() as Promise<{ code: string; name: string } | null>;
+}
+
+describe('getTenantDefaultCountry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state = {
+      tenant_companies: [{ client_id: 'msp-client', is_default: true, deleted_at: null }],
+      client_locations: [
+        {
+          client_id: 'msp-client',
+          country_code: 'GB',
+          is_default: true,
+          is_billing_address: true,
+          is_active: true,
+        },
+      ],
+      countries: [
+        { code: 'US', name: 'United States', is_active: true },
+        { code: 'GB', name: 'United Kingdom', is_active: true },
+      ],
+    };
+    createTenantKnexMock.mockResolvedValue({
+      knex: (table: keyof FakeState) => fakeConn(table),
+      tenant: 'tenant-1',
+    });
+  });
+
+  it('resolves the country on the MSP default client location against the reference table', async () => {
+    await expect(getTenantDefaultCountry()).resolves.toEqual({ code: 'GB', name: 'United Kingdom' });
+  });
+
+  it('prefers the default location over the tenant client other active locations', async () => {
+    state.client_locations.unshift({
+      client_id: 'msp-client',
+      country_code: 'US',
+      is_default: false,
+      is_billing_address: false,
+      is_active: true,
+    });
+
+    await expect(getTenantDefaultCountry()).resolves.toEqual({ code: 'GB', name: 'United Kingdom' });
+  });
+
+  it('normalizes a lowercase stored code', async () => {
+    state.client_locations[0].country_code = 'gb';
+
+    await expect(getTenantDefaultCountry()).resolves.toEqual({ code: 'GB', name: 'United Kingdom' });
+  });
+
+  it("returns null for the 'XX' placeholder rather than preselecting a country", async () => {
+    state.client_locations[0].country_code = 'XX';
+
+    await expect(getTenantDefaultCountry()).resolves.toBeNull();
+  });
+
+  it('returns null when the stored code is missing', async () => {
+    state.client_locations[0].country_code = null;
+
+    await expect(getTenantDefaultCountry()).resolves.toBeNull();
+  });
+
+  it('returns null when the stored code is not in the reference table', async () => {
+    state.client_locations[0].country_code = 'ZZ';
+
+    await expect(getTenantDefaultCountry()).resolves.toBeNull();
+  });
+
+  it('returns null when the tenant has no default client', async () => {
+    state.tenant_companies = [];
+
+    await expect(getTenantDefaultCountry()).resolves.toBeNull();
+  });
+
+  it('returns null when the tenant default client has no location', async () => {
+    state.client_locations = [];
+
+    await expect(getTenantDefaultCountry()).resolves.toBeNull();
+  });
+});

--- a/packages/clients/src/actions/countryActions.ts
+++ b/packages/clients/src/actions/countryActions.ts
@@ -2,6 +2,7 @@
 
 import { createTenantKnex, tenantDb } from '@alga-psa/db';
 import { withAuth } from '@alga-psa/auth';
+import { resolveTenantDefaultCountry } from '../lib/tenantDefaultCountry';
 
 export interface ICountry {
   code: string;
@@ -27,6 +28,25 @@ export const getAllCountries = withAuth(async (
     return countries;
   } catch (error) {
     console.error('Error fetching countries:', error);
+    throw error;
+  }
+});
+
+/**
+ * The tenant's own country, for preselecting country fields on new records.
+ * Null when the MSP's default client carries no usable country, so forms keep
+ * their existing default.
+ */
+export const getTenantDefaultCountry = withAuth(async (
+  _user,
+  { tenant }
+): Promise<ICountry | null> => {
+  const { knex } = await createTenantKnex();
+
+  try {
+    return await resolveTenantDefaultCountry(knex, tenant);
+  } catch (error) {
+    console.error('Error resolving tenant default country:', error);
     throw error;
   }
 });

--- a/packages/clients/src/components/clients/ClientLocations.tsx
+++ b/packages/clients/src/components/clients/ClientLocations.tsx
@@ -11,7 +11,7 @@ import {
   setDefaultClientLocation 
 } from '@alga-psa/clients/actions';
 import { getActiveTaxRegionsAsync } from '../../lib/billingHelpers';
-import { getAllCountries, ICountry } from '@alga-psa/clients/actions';
+import { getAllCountries, getTenantDefaultCountry, ICountry } from '@alga-psa/clients/actions';
 import { ITaxRegion } from '@alga-psa/types';
 import CountryPicker from '@alga-psa/ui/components/CountryPicker';
 import { Button } from '@alga-psa/ui/components/Button';
@@ -317,6 +317,7 @@ export default function ClientLocations({ clientId, isEditing }: ClientLocations
   const [isLoading, setIsLoading] = useState(false);
   const [taxRegions, setTaxRegions] = useState<Pick<ITaxRegion, 'region_code' | 'region_name'>[]>([]);
   const [countries, setCountries] = useState<ICountry[]>([]);
+  const [tenantDefaultCountry, setTenantDefaultCountry] = useState<ICountry | null>(null);
   const [isLoadingCountries, setIsLoadingCountries] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [locationToDelete, setLocationToDelete] = useState<IClientLocation | null>(null);
@@ -476,8 +477,13 @@ export default function ClientLocations({ clientId, isEditing }: ClientLocations
     if (isLoadingCountries || countries.length > 0) return;
     setIsLoadingCountries(true);
     try {
-      const countriesData = await getAllCountries();
+      // A missing tenant default must not empty the picker, so it fails soft.
+      const [countriesData, tenantCountry] = await Promise.all([
+        getAllCountries(),
+        getTenantDefaultCountry().catch(() => null),
+      ]);
       setCountries(countriesData);
+      setTenantDefaultCountry(tenantCountry);
     } catch (error) {
       console.error('Error loading countries:', error);
       toast({
@@ -520,6 +526,9 @@ export default function ClientLocations({ clientId, isEditing }: ClientLocations
     setEditingLocation(null);
     setFormData({
       ...initialFormData,
+      ...(tenantDefaultCountry
+        ? { country_code: tenantDefaultCountry.code, country_name: tenantDefaultCountry.name }
+        : {}),
       is_default: locations.length === 0 // First location should be default
     });
     setIsDialogOpen(true);

--- a/packages/clients/src/components/clients/QuickAddClient.tsx
+++ b/packages/clients/src/components/clients/QuickAddClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import type { ClientLifecycleStatus, ContactPhoneNumberInput, CreateContactInput, IClient, IClientLocation } from '@alga-psa/types';
 import { IContact } from '@alga-psa/types';
@@ -21,7 +21,7 @@ import { getUserAvatarUrlsBatchAction } from '@alga-psa/user-composition/actions
 import { getAllUsersBasicAsync } from '../../lib/usersHelpers';
 import { createClient } from '@alga-psa/clients/actions/clientActions';
 import { createClientLocation } from '@alga-psa/clients/actions/clientLocationActions';
-import { getAllCountries, ICountry } from '@alga-psa/clients/actions/countryActions';
+import { getAllCountries, getTenantDefaultCountry, ICountry } from '@alga-psa/clients/actions/countryActions';
 import { listContactPhoneTypeSuggestions, createClientContact } from '@alga-psa/clients/actions/contact-actions/contactActions';
 import CountryPicker from '@alga-psa/ui/components/CountryPicker';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
@@ -106,6 +106,11 @@ const QuickAddClient: React.FC<QuickAddClientProps> = ({
     account_manager_id: null
   };
 
+  // The tenant's own country, once resolved. Declared ahead of the initial form
+  // data because every reset seeds the country field from it.
+  const [tenantDefaultCountry, setTenantDefaultCountry] = useState<ICountry | null>(null);
+  const hasEditedCountryRef = useRef(false);
+
   const initialLocationData: CreateLocationData = {
     client_id: '',
     location_name: 'Main Office',
@@ -115,8 +120,8 @@ const QuickAddClient: React.FC<QuickAddClientProps> = ({
     city: '',
     state_province: '',
     postal_code: '',
-    country_code: 'US',
-    country_name: 'United States',
+    country_code: tenantDefaultCountry?.code ?? 'US',
+    country_name: tenantDefaultCountry?.name ?? 'United States',
     region_code: null,
     is_billing_address: true,
     is_shipping_address: true,
@@ -203,8 +208,21 @@ const QuickAddClient: React.FC<QuickAddClientProps> = ({
         if (isLoadingCountries || countries.length > 0) return;
         setIsLoadingCountries(true);
         try {
-          const countriesData = await getAllCountries();
+          // A missing tenant default must not empty the picker, so it fails soft.
+          const [countriesData, tenantCountry] = await Promise.all([
+            getAllCountries(),
+            getTenantDefaultCountry().catch(() => null),
+          ]);
           setCountries(countriesData);
+          if (tenantCountry) {
+            setTenantDefaultCountry(tenantCountry);
+            // An in-progress selection outranks the default that arrives after it.
+            setLocationData(prev => hasEditedCountryRef.current ? prev : {
+              ...prev,
+              country_code: tenantCountry.code,
+              country_name: tenantCountry.name,
+            });
+          }
         } catch (error: any) {
           handleError(error, t('quickAddClient.countriesLoadError', {
             defaultValue: 'Failed to load countries.',
@@ -233,6 +251,7 @@ const QuickAddClient: React.FC<QuickAddClientProps> = ({
       setFormData(initialFormData);
       setLocationData(initialLocationData);
       setContactData(initialContactData);
+      hasEditedCountryRef.current = false;
       setContactPhoneValidationErrors([]);
       setContactEmailValidationErrors([]);
       setIsSubmitting(false);
@@ -512,6 +531,7 @@ const QuickAddClient: React.FC<QuickAddClientProps> = ({
         setFormData(initialFormData);
         setLocationData(initialLocationData);
         setContactData(initialContactData);
+        hasEditedCountryRef.current = false;
         setContactPhoneValidationErrors([]);
         setContactEmailValidationErrors([]);
         setIsSubmitting(false);
@@ -623,6 +643,7 @@ const QuickAddClient: React.FC<QuickAddClientProps> = ({
   };
 
   const handleCountryChange = (countryCode: string, countryName: string) => {
+    hasEditedCountryRef.current = true;
     setLocationData(prev => ({
       ...prev,
       country_code: countryCode,

--- a/packages/clients/src/components/contacts/ContactDetailsEdit.tsx
+++ b/packages/clients/src/components/contacts/ContactDetailsEdit.tsx
@@ -6,7 +6,7 @@ import { Button } from '@alga-psa/ui/components/Button';
 import { Input } from '@alga-psa/ui/components/Input';
 import { TextArea } from '@alga-psa/ui/components/TextArea';
 import { Flex, Text, Heading } from '@radix-ui/themes';
-import { updateContact, listInboundTicketDestinationOptions, getAllCountries, type ICountry, listContactPhoneTypeSuggestions, getCustomPhoneTypeUsageCount, deleteOrphanedPhoneTypes } from '@alga-psa/clients/actions';
+import { updateContact, listInboundTicketDestinationOptions, getAllCountries, getTenantDefaultCountry, type ICountry, listContactPhoneTypeSuggestions, getCustomPhoneTypeUsageCount, deleteOrphanedPhoneTypes } from '@alga-psa/clients/actions';
 import { findTagsByEntityIds, isTagActionError } from '@alga-psa/tags/actions';
 import { ClientPicker } from '@alga-psa/ui/components/ClientPicker';
 import { TagManager } from '@alga-psa/tags/components';
@@ -79,6 +79,7 @@ const ContactDetailsEdit: React.FC<ContactDetailsEditProps> = ({
   const [inboundDestinationOptions, setInboundDestinationOptions] = useState<Array<{ value: string; label: string }>>([]);
   const [isInboundDestinationOptionsLoading, setIsInboundDestinationOptionsLoading] = useState(false);
   const [countries, setCountries] = useState<ICountry[]>([]);
+  const [tenantDefaultCountry, setTenantDefaultCountry] = useState<ICountry | null>(null);
   const [customPhoneTypeSuggestions, setCustomPhoneTypeSuggestions] = useState<string[]>([]);
   const [phoneValidationErrors, setPhoneValidationErrors] = useState<string[]>([]);
   const [emailValidationErrors, setEmailValidationErrors] = useState<string[]>([]);
@@ -145,18 +146,21 @@ const ContactDetailsEdit: React.FC<ContactDetailsEditProps> = ({
     let cancelled = false;
     (async () => {
       try {
-        const [countryRows, phoneTypeLabels] = await Promise.all([
+        const [countryRows, phoneTypeLabels, tenantCountry] = await Promise.all([
           getAllCountries(),
           listContactPhoneTypeSuggestions(),
+          getTenantDefaultCountry(),
         ]);
         if (cancelled) return;
         setCountries(countryRows);
         setCustomPhoneTypeSuggestions(phoneTypeLabels);
+        setTenantDefaultCountry(tenantCountry);
       } catch (err) {
         if (!cancelled) {
           console.error('Error loading phone metadata:', err);
           setCountries([]);
           setCustomPhoneTypeSuggestions([]);
+          setTenantDefaultCountry(null);
         }
       }
     })();
@@ -355,6 +359,7 @@ const ContactDetailsEdit: React.FC<ContactDetailsEditProps> = ({
                   value={contact.phone_numbers}
                   onChange={(rows) => handleInputChange('phone_numbers', rows)}
                   countries={countries}
+                  defaultCountryCode={tenantDefaultCountry?.code}
                   customTypeSuggestions={customPhoneTypeSuggestions}
                   errorMessages={phoneValidationErrors}
                   onValidationChange={setPhoneValidationErrors}

--- a/packages/clients/src/components/contacts/ContactPhoneNumbersEditor.tsx
+++ b/packages/clients/src/components/contacts/ContactPhoneNumbersEditor.tsx
@@ -304,6 +304,7 @@ interface ContactPhoneRowProps {
   index: number;
   row: EditablePhoneRow;
   customTypeSuggestions: string[];
+  defaultCountryCode?: string;
   disabled?: boolean;
   canMoveUp: boolean;
   canMoveDown: boolean;
@@ -322,6 +323,7 @@ const ContactPhoneRow: React.FC<ContactPhoneRowProps> = ({
   index,
   row,
   customTypeSuggestions,
+  defaultCountryCode,
   disabled = false,
   canMoveUp,
   canMoveDown,
@@ -338,6 +340,9 @@ const ContactPhoneRow: React.FC<ContactPhoneRowProps> = ({
   // Field messages live under common:clients.validation.*, not this page's namespace.
   const { t: tValidation } = useTranslation('common');
   const rowKey = row.contact_phone_number_id ?? row._localId ?? `${index}`;
+  // A stored international number keeps its own country, and the decision is taken
+  // once: flipping the formatter's country mid-entry reformats under the caret.
+  const [startedInternational] = useState(() => (row.phone_number ?? '').trim().startsWith('+'));
   // Plausibility only; the row still saves.
   const phoneWarnings = useMemo(
     () => translateFieldValidation(validatePhoneNumberField(row.phone_number ?? ''), tValidation).warnings,
@@ -479,6 +484,7 @@ const ContactPhoneRow: React.FC<ContactPhoneRowProps> = ({
               defaultValue: 'Extension',
             })}
             onBlur={onBlur}
+            countryCode={startedInternational ? undefined : defaultCountryCode}
             allowExtensions={true}
             disabled={disabled}
             className="w-full"
@@ -562,6 +568,8 @@ interface ContactPhoneNumbersEditorProps {
   onChange: (rows: ContactPhoneNumberInput[]) => void;
   countries: ICountry[];
   customTypeSuggestions?: string[];
+  /** Dial country for rows typed in national format; usually the tenant's own. */
+  defaultCountryCode?: string;
   disabled?: boolean;
   errorMessages?: string[];
   onValidationChange?: (errors: string[]) => void;
@@ -575,6 +583,7 @@ const ContactPhoneNumbersEditor: React.FC<ContactPhoneNumbersEditorProps> = ({
   value,
   onChange,
   customTypeSuggestions = [],
+  defaultCountryCode,
   disabled = false,
   errorMessages,
   onValidationChange,
@@ -809,6 +818,7 @@ const ContactPhoneNumbersEditor: React.FC<ContactPhoneNumbersEditorProps> = ({
               index={index}
               row={row}
               customTypeSuggestions={customTypeSuggestions}
+              defaultCountryCode={defaultCountryCode}
               disabled={disabled}
               canMoveUp={index > 0}
               canMoveDown={index < draftRows.length - 1}

--- a/packages/clients/src/components/contacts/QuickAddContact.tsx
+++ b/packages/clients/src/components/contacts/QuickAddContact.tsx
@@ -16,7 +16,7 @@ import { IContact } from '@alga-psa/types';
 import { Switch } from '@alga-psa/ui/components/Switch';
 import { Alert, AlertDescription } from '@alga-psa/ui/components/Alert';
 import { useToast } from '@alga-psa/ui';
-import { getAllCountries, ICountry } from '@alga-psa/clients/actions/countryActions';
+import { getAllCountries, getTenantDefaultCountry, ICountry } from '@alga-psa/clients/actions/countryActions';
 import {
   validateContactNameField,
   validateEmailAddressField,
@@ -117,6 +117,7 @@ const QuickAddContactContent: React.FC<QuickAddContactProps> = ({
   // Plausibility warnings. Rendered beneath the field; never gate the save.
   const [fieldWarnings, setFieldWarnings] = useState<Record<string, string[]>>({});
   const [countries, setCountries] = useState<ICountry[]>([]);
+  const [tenantDefaultCountry, setTenantDefaultCountry] = useState<ICountry | null>(null);
   const [pendingTags, setPendingTags] = useState<PendingTag[]>([]);
   const [isQuickAddClientOpen, setIsQuickAddClientOpen] = useState(false);
   const [localClients, setLocalClients] = useState<IClient[]>([]);
@@ -131,12 +132,14 @@ const QuickAddContactContent: React.FC<QuickAddContactProps> = ({
     if (isOpen) {
       const fetchFormMetadata = async () => {
         try {
-          const [countriesData, suggestionLabels] = await Promise.all([
+          const [countriesData, suggestionLabels, tenantCountry] = await Promise.all([
             countries.length > 0 ? Promise.resolve(countries) : getAllCountries(),
             listContactPhoneTypeSuggestions(),
+            getTenantDefaultCountry(),
           ]);
           setCountries(countriesData);
           setCustomPhoneTypeSuggestions(suggestionLabels);
+          setTenantDefaultCountry(tenantCountry);
         } catch (fetchError: any) {
           console.error('Error fetching contact form metadata:', fetchError);
         }
@@ -601,6 +604,7 @@ const QuickAddContactContent: React.FC<QuickAddContactProps> = ({
                   }
                 }}
                 countries={countries}
+                defaultCountryCode={tenantDefaultCountry?.code}
                 customTypeSuggestions={customPhoneTypeSuggestions}
                 allowEmpty={false}
                 errorMessages={hasAttemptedSubmit ? phoneValidationErrors : undefined}

--- a/packages/clients/src/lib/tenantDefaultCountry.ts
+++ b/packages/clients/src/lib/tenantDefaultCountry.ts
@@ -1,0 +1,48 @@
+import type { Knex } from 'knex';
+import { tenantDb } from '@alga-psa/db';
+import { COUNTRY_CODE_PLACEHOLDER } from '@alga-psa/core/formatters';
+
+export interface TenantDefaultCountry {
+  code: string;
+  name: string;
+}
+
+/**
+ * The MSP's own default client location, used as the tenant-wide country default
+ * for new records. Mirrors resolveTenantPhoneCountryCode (telephony) rather than
+ * importing it. A placeholder code ('XX') or one the reference table does not
+ * carry yields null, so callers keep their own fallback instead of preselecting
+ * a country the tenant never entered.
+ */
+export async function resolveTenantDefaultCountry(
+  conn: Knex | Knex.Transaction,
+  tenant: string
+): Promise<TenantDefaultCountry | null> {
+  const db = tenantDb(conn, tenant);
+
+  const tenantClient = await db.table('tenant_companies')
+    .where({ is_default: true, deleted_at: null })
+    .first('client_id');
+  if (!tenantClient?.client_id) {
+    return null;
+  }
+
+  const location = await db.table('client_locations')
+    .where({ client_id: tenantClient.client_id, is_active: true })
+    .orderBy('is_default', 'desc')
+    .orderBy('is_billing_address', 'desc')
+    .first('country_code');
+
+  const code = typeof location?.country_code === 'string'
+    ? location.country_code.trim().toUpperCase()
+    : '';
+  if (!code || code === COUNTRY_CODE_PLACEHOLDER) {
+    return null;
+  }
+
+  const country = await db.table('countries')
+    .where({ code, is_active: true })
+    .first('code', 'name');
+
+  return country ? { code: country.code, name: country.name } : null;
+}

--- a/packages/ui/src/components/CountryPicker.tsx
+++ b/packages/ui/src/components/CountryPicker.tsx
@@ -236,7 +236,7 @@ const CountryPicker = ({
       >
         <div className="flex items-center gap-2 flex-1">
           {currentCountry && (
-            <span className="text-sm font-mono bg-[rgb(var(--color-border-200))] px-1 rounded">
+            <span className="chip-neutral text-sm font-mono px-1 rounded">
               {currentCountry.code}
             </span>
           )}
@@ -297,7 +297,7 @@ const CountryPicker = ({
                     >
                       <span className="text-base">{getCountryFlag(country.code)}</span>
                       <span className="flex-1 truncate">{country.name}</span>
-                      <span className="text-xs font-mono bg-[rgb(var(--color-border-200))] px-1 rounded ml-2">
+                      <span className="chip-neutral text-xs font-mono px-1 rounded ml-2">
                         {country.code}
                       </span>
                     </div>

--- a/server/src/test/unit/QuickAddClient.ui-reflection.test.tsx
+++ b/server/src/test/unit/QuickAddClient.ui-reflection.test.tsx
@@ -62,6 +62,7 @@ vi.mock('@alga-psa/clients/actions/clientLocationActions', async (importOriginal
 vi.mock('@alga-psa/clients/actions/countryActions', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   getAllCountries: vi.fn().mockResolvedValue([]),
+  getTenantDefaultCountry: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock('@alga-psa/clients/actions/contact-actions/contactActions', async (importOriginal) => ({

--- a/server/src/test/unit/app/themeContract.test.ts
+++ b/server/src/test/unit/app/themeContract.test.ts
@@ -500,6 +500,19 @@ describe('picker surface contract', () => {
 
     expect(offenders, `receding/hardcoded surface(s):\n${offenders.join('\n')}`).toEqual([]);
   });
+
+  /**
+   * The country-code badges shipped filled with border-200 and no ink of their
+   * own — 1.09:1 in high-contrast dark, where that rung is a near-white
+   * hairline and the inherited ink is white. Layer 6 cannot see it: the element
+   * names no foreground token at all, so only the fill is measurable.
+   */
+  it('CountryPicker.tsx tints its country-code badges with a chip utility', () => {
+    const badges = read('CountryPicker.tsx').split('\n').filter((line) => line.includes('font-mono'));
+
+    expect(badges).toHaveLength(2);
+    badges.forEach((line) => expect(line.trim()).toContain('chip-neutral'));
+  });
 });
 
 /* ------------------------------------------------------------------------- *

--- a/server/src/test/unit/contacts/QuickAddClient.phoneNumbers.test.tsx
+++ b/server/src/test/unit/contacts/QuickAddClient.phoneNumbers.test.tsx
@@ -34,6 +34,7 @@ vi.mock('@alga-psa/clients/actions/clientLocationActions', () => ({
 
 vi.mock('@alga-psa/clients/actions/countryActions', () => ({
   getAllCountries: vi.fn().mockResolvedValue([{ code: 'US', name: 'United States', phone_code: '+1' }]),
+  getTenantDefaultCountry: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock('@alga-psa/clients/actions/contact-actions/contactActions', () => ({

--- a/server/src/test/unit/contacts/QuickAddContact.phoneNumbers.test.tsx
+++ b/server/src/test/unit/contacts/QuickAddContact.phoneNumbers.test.tsx
@@ -29,6 +29,7 @@ vi.mock('@alga-psa/clients/actions/contact-actions/contactActions', () => ({
 
 vi.mock('@alga-psa/clients/actions/countryActions', () => ({
   getAllCountries: vi.fn().mockResolvedValue([{ code: 'US', name: 'United States', phone_code: '+1' }]),
+  getTenantDefaultCountry: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock('@alga-psa/ui', () => ({


### PR DESCRIPTION
## Summary

Client, contact, and CSV-import forms previously hardcoded "United States" (or required manual selection) for country fields, which is a poor default for tenants based outside the US. This change resolves the MSP's own default client location as a tenant-wide default country and threads it through client/contact creation and editing flows, CSV import, and the phone number editor's implicit dial country. It also fixes a contrast bug in the country-code badge introduced along the way.

## Changes

**Tenant default country resolution**
- Add `resolveTenantDefaultCountry` (`packages/clients/src/lib/tenantDefaultCountry.ts`), which looks up the tenant's default client's active location (preferring the default/billing address), maps its `country_code` against the `countries` reference table, and returns `null` when the tenant has no usable country (placeholder code, no location, or code not in the reference table).
- Expose it via a new `getTenantDefaultCountry` server action in `countryActions.ts`.

**Client forms**
- `QuickAddClient`: seed the new-client location's country from the tenant default once resolved, without clobbering an in-progress user selection (tracked via a ref).
- `ClientLocations`: preselect the tenant default country when adding a new location, failing soft if the lookup errors so the country picker still populates.

**Contact forms**
- `ContactDetailsEdit` and `QuickAddContact`: fetch the tenant default country alongside existing metadata and pass it to `ContactPhoneNumbersEditor` as the implicit dial country.
- `ContactPhoneNumbersEditor`: accept a `defaultCountryCode` prop used for phone rows entered in national format; rows that already start in international format (`+...`) keep their own country and ignore the default.

**CSV import**
- `importClientsFromCSV`: when a row specifies no country/country_code, fall back to the resolved tenant default country before falling back to `US`.

**UI fix**
- `CountryPicker`: replace the hardcoded `bg-[rgb(var(--color-border-200))]` badge styling with the `chip-neutral` utility class, fixing unreadable (near-invisible) country-code badges in high-contrast dark theme.

## Testing

- `packages/clients/src/actions/countryActions.test.ts` (new): unit tests for `getTenantDefaultCountry` covering resolution against the default/billing location, placeholder/missing-country fallback to `null`, and reference-table mismatches.
- `packages/clients/src/actions/clientActions.importCsv.test.ts`: extended fake DB harness with `tenant_companies` and ordering support to cover CSV rows falling back to the tenant default country instead of `US`.
- `server/src/test/unit/app/themeContract.test.ts`: added a contract test asserting `CountryPicker.tsx`'s country-code badges use the `chip-neutral` utility.
- Updated existing snapshot/reflection tests (`QuickAddClient.ui-reflection.test.tsx`, `QuickAddClient.phoneNumbers.test.tsx`, `QuickAddContact.phoneNumbers.test.tsx`) for the new default-country wiring.
