### PR TITLE
chore(appliance): ignore the downloaded base ISO

### DIFF
--- a/ee/appliance/ubuntu-iso/base/.gitignore
+++ b/ee/appliance/ubuntu-iso/base/.gitignore
@@ -1,0 +1,3 @@
+/*
+!.gitkeep
+!.gitignore


### PR DESCRIPTION
## Summary

`ee/appliance/ubuntu-iso/base/` holds the upstream Ubuntu Server ISO that `build-ubuntu-appliance-iso.sh` consumes via `--base-iso`. The directory was untracked but **not ignored**, leaving a 3.2 GB download one `git add -A` away from being committed.

## Approach

Follows the convention already established by the sibling scratch directories `output/` and `work/` — a nested `.gitignore` that excludes everything but itself and `.gitkeep`, so the directory still exists on a fresh clone:

```
/*
!.gitkeep
!.gitignore
```

No change to the root `.gitignore`, and no change to the build scripts — `--base-iso` takes an explicit path, so the location stays conventional rather than hardcoded.

## Verification

```
$ git check-ignore -v ee/appliance/ubuntu-iso/base/ubuntu-24.04.4-live-server-amd64.iso
ee/appliance/ubuntu-iso/base/.gitignore:1:/*	ee/appliance/ubuntu-iso/base/ubuntu-24.04.4-live-server-amd64.iso
```

With a real 3.2 GB ISO present locally, it no longer appears in `git status`. Diff is two files, +3/−0.