### PR TITLE
docs: reflect Keycloak as first-class SSO provider (2026-09-11)

### DIFF
--- a/docs/getting-started/configuration_guide.md
+++ b/docs/getting-started/configuration_guide.md
@@ -249,7 +249,7 @@ The MSP dashboard surfaces a persistent onboarding drawer and quick-start cards 
 
 | Step | Server signal | Completion logic |
 | --- | --- | --- |
-| Identity & SSO | `server/src/lib/actions/onboarding-progress.ts` pulls provider state from `@ee/lib/auth/providerConfig` and counts linked accounts via `user_auth_accounts` in the admin DB. | Complete when at least one OAuth provider is configured **and** any MSP user has a linked Google/Microsoft identity. |
+| Identity & SSO | `server/src/lib/actions/onboarding-progress.ts` pulls provider state from `@ee/lib/auth/providerConfig` and counts linked accounts via `user_auth_accounts` in the admin DB. | Complete when at least one OAuth provider is configured **and** any MSP user has a linked Google, Microsoft, or Keycloak identity. Keycloak / OpenID Connect is available in all editions; Google and Microsoft are Enterprise Edition only. |
 | Client portal domain | `getPortalDomainStatusAction` (`server/src/lib/actions/tenant-actions/portalDomainActions.ts`). | Complete when the returned status is `active`; DNS/certificate failures set the step to `blocked` with the upstream status message. |
 | Data import | `listImportJobs` (`server/src/lib/actions/import-actions/importActions.ts`). | Complete after any import job reaches `completed`. Preview/processing jobs surface `in_progress`, while failed/cancelled jobs populate the blocker message. |
 | Calendar sync | `getCalendarProviders` (`server/src/lib/actions/calendarActions.ts`). | Complete when any provider is `active` and `connection_status === 'connected'`. Errors bubble up via `provider.error_message`. |


### PR DESCRIPTION
## Source PRs

- [#3361 feat(auth): make Keycloak a first-class SSO provider](https://github.com/Nine-Minds/alga-psa/pull/3361) — merged 2026-09-10

## Doc files edited

| File | Rationale |
|------|-----------|
| `docs/getting-started/configuration_guide.md` | The "Identity & SSO" row in the MSP Onboarding Checklist Signals table described the step as complete only when a user has a linked "Google/Microsoft" identity. Keycloak is now a first-class SSO provider available in all editions (including CE), so the completion condition and an edition note were added. |

## Needs human review

- **`docs/features/client-portal/client_portal_overview.md`**: Already updated by PR #3361 itself to list Keycloak under Authentication Providers. No further change needed here.
- **`docs/getting-started/setup_guide.md`**: Lists `google_oauth_client_id` / `google_oauth_client_secret` as Docker secrets but does not mention Keycloak. Tenant-level Keycloak config is done through the Settings UI (not Docker secrets), so this section may not need updating. However, PR #3361 also added app-wide `KEYCLOAK_*` environment variables to `.env.example` — please verify whether a short paragraph on the optional app-level Keycloak fallback belongs in the setup guide.
- **`docs/security/`**: No SSO configuration guide exists under `docs/security/`. A Keycloak setup walkthrough (covering realm creation, client registration, and redirect URI registration) may be worth adding, but there is no stale existing content to fix; deferred to human judgement.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvqvpbS9BjgGmDCb4ckMF2

---
_Generated by [Claude Code](https://claude.ai/code/session_01CvqvpbS9BjgGmDCb4ckMF2)_