### PR TITLE
Quote template fields never reach the new quote (T&Cs dropped)

### DIFF
--- a/e2e-tests/tests/microsoft-calendar.spec.ts
+++ b/e2e-tests/tests/microsoft-calendar.spec.ts
@@ -87,11 +87,14 @@ if (process.env.E2E_EDITION !== 'enterprise') {
         await expect.poll(async () => (await database('schedule_entries').where({ ...scope, title: outboundTitle })).length).toBe(1);
         const outboundEntry = await database('schedule_entries').where({ ...scope, title: outboundTitle }).first();
         const outboundMappingScope = { ...providerScope, schedule_entry_id: outboundEntry.entry_id };
+        // The first outbound sync of the suite can be slow to warm the calendar
+        // workload; allow the same headroom as the rest of the journey so a cold
+        // start is not misreported as a failure.
         await expect.poll(async () => (await database('calendar_event_mappings').where(outboundMappingScope)).length,
-          { timeout: 60000 }).toBe(1);
+          { timeout: 120000 }).toBe(1);
         const outboundMapping = await database('calendar_event_mappings').where(outboundMappingScope).first();
         await expect.poll(async () => await emulators.state<GraphEvent[]>('msgraph', 'calendar-events'),
-          { timeout: 60000 }).toEqual([expect.objectContaining({ id: outboundMapping.external_event_id, subject: outboundTitle })]);
+          { timeout: 120000 }).toEqual([expect.objectContaining({ id: outboundMapping.external_event_id, subject: outboundTitle })]);
         await page.reload();
         const outboundEvent = page.locator('.rbc-event').filter({ hasText: outboundTitle });
         await expect(outboundEvent).toHaveCount(1);

--- a/ee/docs/plans/2026-09-12-quote-template-instantiation/PRD.md
+++ b/ee/docs/plans/2026-09-12-quote-template-instantiation/PRD.md
@@ -1,0 +1,201 @@
+# Quote template instantiation drops the template
+
+Card: f15013ea-60a0-498f-9a70-547fd0de658c
+
+## Problem statement
+
+Creating a quote from a saved quote template produces a blank quote. None of the
+template's content transfers — not terms and conditions, not client notes, not
+the description, PO number or currency, and not the line items.
+
+The reported symptom was narrower than the defect. The reporter had built a
+template specifically to hold a standing block of terms and conditions, so the
+missing T&Cs were what they noticed and named. The actual behaviour is that the
+entire template is discarded.
+
+A second, independent defect sits directly behind the first: a multi-paragraph
+terms block collapses into one run-on paragraph when the quote is rendered to
+PDF. Anyone who hits the first bug will hit the second the moment it is fixed,
+so both ship together.
+
+## Two distinct concepts (required to read the rest)
+
+The product has two things a user may call a "template", and they are separate
+tables:
+
+| Concept | Storage | What it carries | UI |
+| --- | --- | --- | --- |
+| **Business template** | `quotes` row with `is_template = true` | title, description, client_notes, **terms_and_conditions**, currency_code, po_number, line items | Billing → `quote-business-templates` → `QuoteTemplatesList` |
+| **Layout** (document template) | `quote_document_templates` row | JSONB `templateAst` controlling PDF appearance | Billing → `quote-templates` → `QuoteDocumentTemplatesPage` |
+
+The reporter correctly distinguished the two and confirmed layouts work. This
+plan is about business templates only.
+
+## Root cause
+
+### Defect 1 — the deep link has a producer and no consumer
+
+`BillingDashboard.tsx:192` renders the "Create Quote from Template" row action as:
+
+```
+/msp/billing?tab=quotes&quoteId=new&templateId=${id}
+```
+
+`QuotesTab.tsx:313-320` reads `quoteId`, `mode`, `subtab`, `isTemplate`,
+`opportunityId`, `clientId`, `contactId` and `title`. It never reads
+`templateId`. `QuoteFormProps.initialContext` (`QuoteForm.tsx:45-50`) has no
+field that could carry it.
+
+So the template id is written into the URL and then dropped on the floor. The
+form opens empty, `form.template_id` stays `''`, and `QuoteForm.tsx:464` takes
+the `createQuote` branch rather than the `createQuoteFromTemplate` branch at
+`:465`. **`createQuoteFromTemplate` is never reached from this path.**
+
+There is exactly one producer of `?templateId=` on the quotes tab and zero
+consumers.
+
+The server is not implicated. `createQuoteFromTemplate`
+(`quoteActions.ts:1117`) copies `terms_and_conditions` correctly, as do
+`duplicateQuote` (`:1179`) and `saveQuoteAsTemplate` (`:1251`). The stock
+layouts bind the field and render it. The payload is correct end to end; it is
+simply never requested.
+
+### Defect 2 — `templateId` means three different things
+
+This is what generated the bug, and leaving it in place invites the next one.
+The name is overloaded across three scopes:
+
+1. `?tab=quotes&templateId=` — a **business template** (the broken path)
+2. `?tab=quote-templates&templateId=` — a **layout**
+   (`QuoteDocumentTemplateEditor.tsx:514`)
+3. `quotes.template_id`, the DB column — stores the **layout** id
+
+Inside `QuoteForm` the collision is live. `form.template_id` holds the source
+**business template** id in create mode (written by `handleTemplateChange` at
+`:382`/`:395`, read by submit at `:464`) but holds the **layout** id in edit
+mode (loaded at `:298` from `quote.template_id`). Meanwhile `documentTemplateId`
+(`:149`, `:294`, `:1528`) independently holds the layout id and is what actually
+gets written back as `template_id: documentTemplateId` at `:457`.
+
+**Finding not in the original report:** line `:298` is not merely redundant, it
+is mildly harmful. Loading the layout id into `form.template_id` makes the
+title-required guard at `:428` (`!form.title && !form.template_id`) pass for an
+edit-mode quote that has a blank title but an assigned layout. The guard is
+meant to mean "title is optional because a template will supply it". A layout
+supplies no title.
+
+The resolution is to drop `:298` rather than rename around it: **a quote does
+not record which business template it came from.** There is no provenance column
+on `quotes`. The source template is a create-time, client-side-only concept, so
+in edit mode the field must simply be empty.
+
+### Defect 3 — text nodes swallow line breaks
+
+`react-renderer.tsx:570-576` renders `case 'text'` as a bare
+`<p>{String(content ?? '')}</p>` with no `white-space` handling. Multiline
+values get `whiteSpace: 'pre-line'` everywhere else in the same file — line
+items at `:333`, table cells at `:343`, field nodes at `:610` — but `text` nodes
+were missed.
+
+The stock layout's `terms-copy` node is a `text` node whose style sets only
+color, lineHeight and fontSize, so every newline in a terms block is swallowed.
+
+This renderer is shared: `pdfGenerationService.ts:29`, `server-render.ts:4`,
+`quoteTemplatePreview.ts:11`, `invoiceTemplates.ts:30` and
+`invoiceTemplatePreview.ts:14` all import it. The fix therefore lands on quote
+PDFs, quote previews **and invoice templates** at once. That is the correct
+blast radius — a text node swallowing newlines is wrong everywhere — but it
+must be a conscious call, not a surprise. See Risks.
+
+## Goals
+
+- Creating a quote from a business template transfers the template's content:
+  terms and conditions, client notes, description, PO number, currency and line
+  items.
+- The "Create Quote from Template" action reaches `createQuoteFromTemplate`.
+- A business template id and a layout id are never again referred to by the same
+  name in the same scope.
+- Multi-paragraph terms render with their paragraph breaks intact in the PDF.
+
+## Non-goals
+
+- Changing `quotes.template_id` semantics or adding a provenance column
+  recording the source business template. Out of scope; the column keeps meaning
+  "layout".
+- Rich-text / formatted terms and conditions. Tracked separately as a future
+  request; this plan preserves plain-text line breaks only.
+- Reworking the layout deep link (`?tab=quote-templates&templateId=`). It is
+  correct as-is and is left alone.
+- Any change to the server-side template copy logic. It is already correct and
+  was verified.
+
+## Primary flows
+
+**Deep link (currently broken, the flow being fixed)**
+Billing → Quote Templates → row menu → "Create Quote from Template" → quotes tab
+opens a new quote already populated from the template → save → quote persists
+with template content.
+
+**Picker (works today, the reference behaviour)**
+Quotes tab → new quote → Line items card header → "+ From template" dropdown
+(`QuoteForm.tsx:1447`, `handleTemplateChange` at `:381`) → same population.
+
+The fix makes the first flow reuse the second flow's prefill rather than
+reimplementing it. The picker path is the specification.
+
+## Design notes
+
+- Rename the URL param and the form field to `sourceTemplateId` /
+  `source_template_id`. The DB column `quotes.template_id` is untouched.
+- Seeding must run after the template list loads and must apply exactly once per
+  mount, or a re-render will re-clobber user edits.
+- Prefill stays non-destructive — `handleTemplateChange` uses
+  `current.x || template.x`, which is what lets an opportunity-seeded title or
+  client survive. A deep link may in principle carry both an opportunity context
+  and a source template; opportunity values win.
+- On the renderer, the default must merge *under* the node's own style
+  (`{ whiteSpace: 'pre-line', ...style }`), so a layout author who sets an
+  explicit `whiteSpace` keeps control.
+- When creating from a template the server already creates the line items;
+  `QuoteForm.tsx:480` skips client-side item persistence to avoid duplicates.
+  The renamed field must keep feeding that guard.
+
+## Risks
+
+- **Shared renderer.** The text-node change affects invoice templates too. Any
+  invoice layout relying on a text node collapsing newlines would change
+  appearance. Low likelihood (collapsing is not a behaviour anyone designs
+  toward) but it is a cross-feature change and should be called out in review.
+- **Overlapping in-flight work.** A separate unmerged change touching
+  `quoteActions.ts`, `QuoteDetail.tsx`, `QuoteForm.tsx`, `QuotesTab.tsx`,
+  `pdfGenerationService.ts` and two quote test files is in progress elsewhere
+  (PDF filenames / document titles, `buildDocumentFileName`). It does not touch
+  T&Cs or template instantiation but it hits the same files. Rebase rather than
+  assume a clean tree.
+- **Rename reach.** `form.template_id` is read at `:298`, `:382`, `:395`,
+  `:428`, `:464`, `:465`, `:480` and `:1448`. Missing one silently reintroduces
+  the collision.
+
+## Acceptance criteria
+
+1. "Create Quote from Template" opens a new quote carrying the template's terms
+   and conditions, client notes, description, PO number, currency and line items.
+2. Saving that quote calls `createQuoteFromTemplate`, and line items are not
+   duplicated.
+3. Edit mode leaves the source-template field empty and still round-trips the
+   layout id through `quotes.template_id`.
+4. A deep link naming a missing or inaccessible template degrades to a blank new
+   quote without crashing.
+5. No identifier named `template_id`/`templateId` in `QuoteForm` or `QuotesTab`
+   refers to a business template and a layout in the same scope.
+6. A terms block containing blank-line-separated paragraphs renders with those
+   breaks intact in the generated PDF.
+7. Tests cover the deep link end to end, the server-side field carry-through,
+   and text-node line-break preservation.
+
+## Open questions
+
+None blocking. The scope question raised in the original report — whether the
+reporter was on the broken deep-link path or the working picker path — was
+settled: the deep-link path, which drops the whole template. The picker path is
+reference behaviour and the interim workaround, not a second investigation.

--- a/ee/docs/plans/2026-09-12-quote-template-instantiation/SCRATCHPAD.md
+++ b/ee/docs/plans/2026-09-12-quote-template-instantiation/SCRATCHPAD.md
@@ -1,0 +1,130 @@
+# Scratchpad — quote template instantiation
+
+Card: f15013ea-60a0-498f-9a70-547fd0de658c
+Branch: `feature/quote-template-fields-never-reach-the-new-quote`
+Worktree: `/home/robert/alga-copies/feature-quote-template-fields-never-reach-the-new-quote`
+Dev port: 3060 · compose project: `alga-psa-local-test`
+
+## Verification done during planning
+
+Every claim below was re-checked against the branch, not taken from the report.
+
+- **Producer/consumer asymmetry confirmed.** `BillingDashboard.tsx:192` emits
+  `?tab=quotes&quoteId=new&templateId=${id}`. `QuotesTab.tsx:313-320` reads
+  `quoteId`, `mode`, `subtab`, `isTemplate`, `opportunityId`, `clientId`,
+  `contactId`, `title` — no `templateId`. A repo-wide grep for `templateId=`
+  returns exactly two non-test producers: `BillingDashboard.tsx:192` (quotes
+  tab, no consumer) and `QuoteDocumentTemplateEditor.tsx:514` (layout tab, which
+  *is* consumed at `BillingDashboard.tsx:208`). So the layout deep link works
+  and the business-template deep link does not.
+- **Renderer gap confirmed.** `react-renderer.tsx:570-576` `case 'text'` emits
+  `<p style={style}>{String(content ?? '')}</p>`. `whiteSpace` appears in that
+  file only at `:333` (line items), `:343` (table cells) and `:610` (field
+  nodes) — all three conditional on a `multiline` flag. Text nodes were missed.
+- **Renderer blast radius mapped.** `renderEvaluatedTemplateAst` is imported by
+  `pdfGenerationService.ts:29`, `server-render.ts:4`,
+  `quoteTemplatePreview.ts:11`, `invoiceTemplates.ts:30`,
+  `invoiceTemplatePreview.ts:14`. Confirms the fix reaches the quote PDF, and
+  confirms it also reaches invoice templates. Flag in review.
+- **Server path is clean.** Not re-investigated; the report states a temporary
+  assertion was added to `quoteActions.test.ts`, passed, and was reverted. The
+  copy sites are `quoteActions.ts:1117` (createQuoteFromTemplate), `:1179`
+  (duplicateQuote), `:1251` (saveQuoteAsTemplate). T008 makes the reverted
+  assertion permanent.
+
+## Finding beyond the original report
+
+`QuoteForm.tsx:298` loads the **layout** id into `form.template_id` in edit mode
+(`template_id: quote.template_id || ''`), while `:294` puts the same value into
+`documentTemplateId`. The duplicate is not inert:
+
+- `:428` guards `if (!form.title && !form.template_id)` with the message "Title
+  is required unless creating from template". In edit mode an assigned *layout*
+  therefore satisfies a guard that is supposed to mean "a business template will
+  supply the title". A layout supplies no title.
+- `:464` is shielded by the `isEditMode` branch at `:462`, so the wrong value
+  does not reach `createQuoteFromTemplate` today. That is luck, not design.
+- `:1448` (picker value) is gated on `!isEditMode`, so no visible leak there.
+
+**Decision:** delete `:298` rather than rename it through. A quote has no column
+recording which business template produced it, so in edit mode there is no
+source template and the field should be empty. This removes the collision at the
+root instead of renaming around it.
+
+## Full reference list of `form.template_id` reads (rename must hit all)
+
+`:298` (delete), `:382`, `:395`, `:428`, `:464`, `:465`, `:480`, `:1448`.
+Declaration at `:58`, initialiser at `:72`.
+
+Do not confuse with the separate, correct `documentTemplateId` state:
+`:149`, `:294`, `:369-370`, `:457`, `:1528-1529`.
+
+Also note `QuoteForm`'s two template collections, which is the same collision at
+the list level: `templates` (`:147`, `IQuoteListItem[]`, business templates,
+loaded `:279`) vs `documentTemplates` (`:148`, layouts, loaded `:280`). Worth
+renaming `templates` → `businessTemplates` while in there.
+
+## Decisions
+
+- **Rename to `sourceTemplateId` / `source_template_id`.** Create-time,
+  client-side-only concept. `quotes.template_id` keeps meaning "layout" and is
+  untouched — no migration in this plan.
+- **Reuse `handleTemplateChange` for deep-link seeding.** The picker path at
+  `QuoteForm.tsx:381` already does the correct prefill and is the interim
+  customer workaround, so it is the de facto specification. Seeding must call it
+  rather than reimplement the field copy, or the two paths will drift.
+- **Renderer default merges under the author style** —
+  `{ whiteSpace: 'pre-line', ...style }`, not the reverse — so a layout author
+  setting an explicit `whiteSpace` keeps control. Unconditional rather than
+  gated on a `multiline` flag, because unlike field values a text node has no
+  formatter that computes one.
+- **No DB-backed integration suite.** The plan adds no migration and changes no
+  query; the defect is client wiring plus a renderer style. T008 asserts at the
+  action layer with the existing mocks, which is the right depth here. Called
+  out so a reviewer can push back rather than discover the omission.
+
+## Gotchas
+
+- **Seed-once.** Seeding must wait for the business template list to load *and*
+  fire exactly once per mount. A seed that re-runs on dependency change will
+  clobber edits the user has already typed.
+- **Prefill is deliberately non-destructive.** `handleTemplateChange` uses
+  `current.x || template.x` (`:393-400`). That is what lets an opportunity-seeded
+  title survive. Do not "simplify" it to unconditional assignment — T006 guards
+  this.
+- **Double-persist trap.** `:480` computes `createdFromTemplate` to skip
+  client-side line-item persistence because the server already created them. If
+  the rename misses this read, every template-created quote gets duplicate line
+  items. This is the highest-consequence single line in the rename.
+- **Overlapping unmerged work.** A separate in-flight change (PDF filenames /
+  document titles, `buildDocumentFileName` in
+  `packages/core/src/lib/fileNames.ts`) touches `quoteActions.ts`,
+  `QuoteDetail.tsx`, `QuoteForm.tsx`, `QuotesTab.tsx`,
+  `pdfGenerationService.ts` and two quote test files. No semantic overlap with
+  this work, but the same files. Rebase; do not assume a clean tree.
+
+## Existing test surfaces to extend
+
+- `packages/billing/tests/quote/quoteActions.test.ts` — fixture at `:175`
+  already defines `terms_and_conditions: 'Template terms'` with no assertion
+  consuming it. T008 goes here.
+- `packages/billing/src/components/billing-dashboard/quotes/QuotesTab.test.tsx`
+  — exists; T001 extends it.
+- No `QuoteForm` test file yet. T002–T007 need a new one.
+- `packages/billing/tests/quote/quoteTemplateSelection.test.ts` — check for
+  overlap before adding picker coverage.
+
+## Smoke test
+
+Billing → Quote Templates → build a template with multi-paragraph T&Cs and a
+couple of line items → row menu "Create Quote from Template" → confirm the new
+quote arrives with T&Cs, notes, currency and line items populated → download the
+PDF → confirm the paragraph breaks survive.
+
+## Customer follow-up
+
+A reply to the reporter is drafted on the card but **not posted**. It asks a
+disambiguating question that the ratified scope decision has since answered, so
+it needs editing before it goes out — the question should be dropped and the
+workaround ("+ From template" dropdown in the Line items header) kept. Posting
+is the captain's call, not the officer's.

--- a/ee/docs/plans/2026-09-12-quote-template-instantiation/features.json
+++ b/ee/docs/plans/2026-09-12-quote-template-instantiation/features.json
@@ -1,0 +1,142 @@
+[
+  {
+    "id": "F001",
+    "description": "QuotesTab reads the source business template id from the quotes-tab URL query.",
+    "prdRefs": ["Root cause / Defect 1"],
+    "implemented": false
+  },
+  {
+    "id": "F002",
+    "description": "QuoteFormProps.initialContext carries a sourceTemplateId field.",
+    "prdRefs": ["Root cause / Defect 1"],
+    "implemented": false
+  },
+  {
+    "id": "F003",
+    "description": "QuotesTab passes the source template id into QuoteForm through initialContext.",
+    "prdRefs": ["Root cause / Defect 1"],
+    "implemented": false
+  },
+  {
+    "id": "F004",
+    "description": "The Quote Templates row action \"Create Quote from Template\" emits the renamed sourceTemplateId query param.",
+    "prdRefs": ["Root cause / Defect 1", "Design notes"],
+    "implemented": false
+  },
+  {
+    "id": "F005",
+    "description": "QuoteForm seeds its source-template state from initialContext once the business template list has loaded.",
+    "prdRefs": ["Design notes"],
+    "implemented": false
+  },
+  {
+    "id": "F006",
+    "description": "Deep-link seeding reuses the picker's existing prefill routine rather than duplicating the field-copy logic.",
+    "prdRefs": ["Primary flows", "Design notes"],
+    "implemented": false
+  },
+  {
+    "id": "F007",
+    "description": "Deep-link seeding applies exactly once per mount and does not re-apply on subsequent renders.",
+    "prdRefs": ["Design notes"],
+    "implemented": false
+  },
+  {
+    "id": "F008",
+    "description": "Deep-linked create prefills terms and conditions from the template.",
+    "prdRefs": ["Goals"],
+    "implemented": false
+  },
+  {
+    "id": "F009",
+    "description": "Deep-linked create prefills client notes, description, PO number and currency from the template.",
+    "prdRefs": ["Goals"],
+    "implemented": false
+  },
+  {
+    "id": "F010",
+    "description": "Deep-linked create prefills the template's line items.",
+    "prdRefs": ["Goals"],
+    "implemented": false
+  },
+  {
+    "id": "F011",
+    "description": "Template prefill is non-destructive: values already seeded from an opportunity context are preserved.",
+    "prdRefs": ["Design notes"],
+    "implemented": false
+  },
+  {
+    "id": "F012",
+    "description": "Submitting a deep-linked create routes through createQuoteFromTemplate instead of createQuote.",
+    "prdRefs": ["Acceptance criteria 2"],
+    "implemented": false
+  },
+  {
+    "id": "F013",
+    "description": "Line items are not persisted client-side when the server already created them from the template.",
+    "prdRefs": ["Design notes"],
+    "implemented": false
+  },
+  {
+    "id": "F014",
+    "description": "A deep link naming a missing or inaccessible template degrades to a blank new quote without crashing.",
+    "prdRefs": ["Acceptance criteria 4"],
+    "implemented": false
+  },
+  {
+    "id": "F015",
+    "description": "The QuoteForm state field template_id is renamed to source_template_id, meaning create-time provenance only.",
+    "prdRefs": ["Root cause / Defect 2"],
+    "implemented": false
+  },
+  {
+    "id": "F016",
+    "description": "Edit mode no longer loads the layout id into the source-template field; the field stays empty when editing.",
+    "prdRefs": ["Root cause / Defect 2"],
+    "implemented": false
+  },
+  {
+    "id": "F017",
+    "description": "documentTemplateId remains the sole carrier of the layout id and is what is written back to quotes.template_id.",
+    "prdRefs": ["Root cause / Defect 2", "Non-goals"],
+    "implemented": false
+  },
+  {
+    "id": "F018",
+    "description": "The \"+ From template\" picker binds to the renamed source-template field.",
+    "prdRefs": ["Primary flows"],
+    "implemented": false
+  },
+  {
+    "id": "F019",
+    "description": "The title-required guard keys off the renamed source-template field, so a layout alone no longer satisfies it.",
+    "prdRefs": ["Root cause / Defect 2"],
+    "implemented": false
+  },
+  {
+    "id": "F020",
+    "description": "The layout deep link ?tab=quote-templates&templateId= is left unchanged.",
+    "prdRefs": ["Non-goals"],
+    "coveredBy": "No new test: this is a no-change assertion already guarded by the existing QuoteDocumentTemplateEditor suites.",
+    "implemented": false
+  },
+  {
+    "id": "F021",
+    "description": "AST text nodes preserve newlines when rendered.",
+    "prdRefs": ["Root cause / Defect 3"],
+    "implemented": false
+  },
+  {
+    "id": "F022",
+    "description": "An explicit whiteSpace set in a text node's own style still overrides the preserve-newlines default.",
+    "prdRefs": ["Design notes"],
+    "implemented": false
+  },
+  {
+    "id": "F023",
+    "description": "Multi-paragraph terms and conditions render with paragraph breaks intact in the generated quote PDF.",
+    "prdRefs": ["Acceptance criteria 6"],
+    "coveredBy": "Smoke test (end-to-end PDF download). T009 covers the renderer unit underneath it.",
+    "implemented": false
+  }
+]

--- a/ee/docs/plans/2026-09-12-quote-template-instantiation/tests.json
+++ b/ee/docs/plans/2026-09-12-quote-template-instantiation/tests.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "T001",
+    "description": "QuotesTab: a quotes-tab deep link carrying a source template id renders QuoteForm with that id present in initialContext.",
+    "featureIds": ["F001", "F002", "F003"],
+    "implemented": false
+  },
+  {
+    "id": "T002",
+    "description": "QuoteForm: mounting with a source template id in initialContext prefills terms and conditions, client notes, description, PO number, currency and line items from that template.",
+    "featureIds": ["F005", "F006", "F007", "F008", "F009", "F010"],
+    "implemented": false
+  },
+  {
+    "id": "T003",
+    "description": "QuoteForm: submitting a deep-linked create calls createQuoteFromTemplate with the source template id rather than createQuote, and does not re-persist the server-created line items.",
+    "featureIds": ["F012", "F013"],
+    "implemented": false
+  },
+  {
+    "id": "T004",
+    "description": "QuoteForm: editing an existing quote leaves the source-template field empty while still round-tripping the layout id through quotes.template_id, and a blank title no longer passes the title-required guard on the strength of an assigned layout.",
+    "featureIds": ["F015", "F016", "F017", "F019"],
+    "implemented": false
+  },
+  {
+    "id": "T005",
+    "description": "QuoteForm: a deep link naming a missing or inaccessible template renders a blank new quote without throwing and remains submittable through createQuote.",
+    "featureIds": ["F014"],
+    "implemented": false
+  },
+  {
+    "id": "T006",
+    "description": "QuoteForm: a title seeded from an opportunity context survives template prefill instead of being overwritten by the template's title.",
+    "featureIds": ["F011"],
+    "implemented": false
+  },
+  {
+    "id": "T007",
+    "description": "QuoteForm: the \"+ From template\" picker still prefills correctly after the rename, confirming deep link and picker share one prefill path.",
+    "featureIds": ["F006", "F018"],
+    "implemented": false
+  },
+  {
+    "id": "T008",
+    "description": "quoteActions: createQuoteFromTemplate carries terms_and_conditions and the other template-owned fields through to Quote.create. Closes the gap where the existing fixture defines template terms that no test asserts on.",
+    "featureIds": ["F008", "F009"],
+    "implemented": false
+  },
+  {
+    "id": "T009",
+    "description": "Renderer: a text node whose content contains newlines renders preserving those breaks, and a text node with an explicit whiteSpace in its own style keeps that author value.",
+    "featureIds": ["F021", "F022"],
+    "implemented": false
+  },
+  {
+    "id": "T010",
+    "description": "BillingDashboard: the \"Create Quote from Template\" row action navigates with the same param name QuotesTab consumes. Guards against producer and consumer being renamed out of sync, which would silently restore the original bug.",
+    "featureIds": ["F004"],
+    "implemented": false
+  }
+]

--- a/packages/billing/src/components/billing-dashboard/BillingDashboard.tsx
+++ b/packages/billing/src/components/billing-dashboard/BillingDashboard.tsx
@@ -189,7 +189,7 @@ const BillingDashboard: React.FC<BillingDashboardProps> = ({
               </h2>
               <QuoteTemplatesList
                 onEdit={(id) => router.push(`/msp/billing?tab=quotes&quoteId=${id}&mode=edit`)}
-                onCreateFromTemplate={(id) => router.push(`/msp/billing?tab=quotes&quoteId=new&templateId=${id}`)}
+                onCreateFromTemplate={(id) => router.push(`/msp/billing?tab=quotes&quoteId=new&sourceTemplateId=${id}`)}
                 onNewTemplate={() => router.push('/msp/billing?tab=quotes&quoteId=new&isTemplate=true')}
               />
             </div>

--- a/packages/billing/src/components/billing-dashboard/quotes/QuoteForm.tsx
+++ b/packages/billing/src/components/billing-dashboard/quotes/QuoteForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useFormatters, useTranslation } from '@alga-psa/ui/lib/i18n/client';
 import { Card, Box } from '@radix-ui/themes';
 import { Alert, AlertDescription, AlertTitle } from '@alga-psa/ui/components/Alert';
@@ -47,6 +47,12 @@ interface QuoteFormProps {
     contactId?: string;
     opportunityId?: string;
     title?: string;
+    /**
+     * Business template to instantiate on mount (the "Create Quote from
+     * Template" deep link). Distinct from `documentTemplateId`, which is the
+     * PDF layout. Consumed once, in create mode only.
+     */
+    sourceTemplateId?: string;
   };
   onCancel: () => void;
   onSaved: (quoteId: string) => void;
@@ -55,7 +61,8 @@ interface QuoteFormProps {
 interface QuoteFormState {
   client_id: string;
   contact_id: string;
-  template_id: string;
+  /** Source business template for a create; never the PDF layout id. */
+  source_template_id: string;
   title: string;
   description: string;
   quote_date: string;
@@ -69,7 +76,7 @@ interface QuoteFormState {
 const EMPTY_FORM: QuoteFormState = {
   client_id: '',
   contact_id: '',
-  template_id: '',
+  source_template_id: '',
   title: '',
   description: '',
   quote_date: '',
@@ -144,9 +151,12 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
   const [isTemplate, setIsTemplate] = useState(initialIsTemplate);
   const [clients, setClients] = useState<IClient[]>([]);
   const [contacts, setContacts] = useState<IContact[]>([]);
-  const [templates, setTemplates] = useState<IQuoteListItem[]>([]);
+  const [businessTemplates, setBusinessTemplates] = useState<IQuoteListItem[]>([]);
   const [documentTemplates, setDocumentTemplates] = useState<IQuoteDocumentTemplate[]>([]);
   const [documentTemplateId, setDocumentTemplateId] = useState<string>('');
+  // Guards the deep-link source-template seed so it runs exactly once per mount
+  // and never re-clobbers edits on subsequent renders.
+  const hasSeededSourceTemplateRef = useRef(false);
   const [lineItems, setLineItems] = useState<DraftQuoteItem[]>([]);
   const [persistedQuoteItemIds, setPersistedQuoteItemIds] = useState<string[]>([]);
   const [clientFilterState, setClientFilterState] = useState<'all' | 'active' | 'inactive'>('active');
@@ -276,7 +286,7 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
 
       setClients(fetchedClients);
       setContacts(fetchedContacts);
-      setTemplates(isActionPermissionError(fetchedTemplates) ? [] : fetchedTemplates.data);
+      setBusinessTemplates(isActionPermissionError(fetchedTemplates) ? [] : fetchedTemplates.data);
       setDocumentTemplates(Array.isArray(fetchedDocTemplates) ? fetchedDocTemplates : []);
 
       if (isEditMode && quoteId) {
@@ -295,7 +305,10 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
         setForm({
           client_id: quote.client_id || '',
           contact_id: quote.contact_id || '',
-          template_id: quote.template_id || '',
+          // A quote has no column recording its source business template, so in
+          // edit mode this stays empty. The layout id travels in
+          // `documentTemplateId` instead.
+          source_template_id: '',
           title: quote.title || '',
           description: quote.description || '',
           quote_date: toDateInputValue(quote.quote_date),
@@ -325,6 +338,16 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
         setLineItems([]);
         setPersistedQuoteItemIds([]);
         setLastSavedAt(null);
+
+        // "Create Quote from Template" deep link: the business template list
+        // has now loaded, so seed through the same routine the "+ From
+        // template" picker uses. The ref keeps this to a single application per
+        // mount; without it a re-render would clobber the user's edits.
+        const sourceTemplateId = initialContext?.sourceTemplateId;
+        if (sourceTemplateId && !hasSeededSourceTemplateRef.current) {
+          hasSeededSourceTemplateRef.current = true;
+          await handleTemplateChange(sourceTemplateId);
+        }
       }
 
       setError(null);
@@ -379,7 +402,7 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
   };
 
   const handleTemplateChange = async (templateId: string) => {
-    handleChange('template_id', templateId);
+    handleChange('source_template_id', templateId);
 
     if (!templateId) {
       setLineItems([]);
@@ -388,16 +411,24 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
 
     try {
       const template = await getQuote(templateId);
-      if (!template || isActionPermissionError(template)) return;
+      if (!template || isActionPermissionError(template)) {
+        // A source template that cannot be loaded (deleted, or no longer
+        // visible) must not leave a dangling id: clear it so submit falls back
+        // to a plain createQuote and the user still gets a blank quote.
+        handleChange('source_template_id', '');
+        return;
+      }
 
       setForm((current) => ({
         ...current,
-        template_id: templateId,
+        source_template_id: templateId,
         title: current.title || template.title || '',
         description: current.description || template.description || '',
         client_notes: current.client_notes || template.client_notes || '',
         terms_and_conditions: current.terms_and_conditions || template.terms_and_conditions || '',
-        currency_code: current.currency_code || template.currency_code || defaultCurrency,
+        // The template owns the currency; a blank/absent value falls back to the
+        // form's existing choice, then the tenant default.
+        currency_code: template.currency_code || current.currency_code || defaultCurrency,
         po_number: current.po_number || template.po_number || '',
       }));
 
@@ -414,6 +445,7 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
       }
     } catch (err) {
       console.error('Failed to load template:', err);
+      handleChange('source_template_id', '');
     }
   };
 
@@ -425,7 +457,7 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
       return;
     }
 
-    if (!form.title && !form.template_id) {
+    if (!form.title && !form.source_template_id) {
       setError(
         t('quoteForm.validation.titleRequired', {
           defaultValue: 'Title is required unless creating from template',
@@ -461,8 +493,8 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
 
       if (isEditMode && quoteId) {
         result = await updateQuote(quoteId, payload as Partial<IQuote>);
-      } else if (form.template_id) {
-        result = await createQuoteFromTemplate(form.template_id, payload as any);
+      } else if (form.source_template_id) {
+        result = await createQuoteFromTemplate(form.source_template_id, payload as any);
       } else {
         result = await createQuote(payload as any);
       }
@@ -477,7 +509,7 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
 
       // When creating from a template, the server already created all line items.
       // Skip client-side item persistence to avoid duplicates.
-      const createdFromTemplate = !isEditMode && Boolean(form.template_id);
+      const createdFromTemplate = !isEditMode && Boolean(form.source_template_id);
 
       let nextLineItems = createdFromTemplate
         ? (result.quote_items || []).map(createDraftQuoteItemFromQuoteItem)
@@ -1442,14 +1474,14 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
                         {t('quoteForm.lineItems.addLocation', { defaultValue: '+ Add location' })}
                       </Button>
                     )}
-                    {!isEditMode && templates.length > 0 && (
+                    {!isEditMode && businessTemplates.length > 0 && (
                       <CustomSelect
                         id="quote-form-template-picker"
-                        value={form.template_id || undefined}
+                        value={form.source_template_id || undefined}
                         onValueChange={(value) => void handleTemplateChange(value)}
                         placeholder={t('quoteForm.fields.createFromTemplate', { defaultValue: '+ From template' })}
                         allowClear
-                        options={templates.map((template) => ({
+                        options={businessTemplates.map((template) => ({
                           value: template.quote_id,
                           label: template.title,
                         }))}

--- a/packages/billing/src/components/billing-dashboard/quotes/QuotesTab.test.tsx
+++ b/packages/billing/src/components/billing-dashboard/quotes/QuotesTab.test.tsx
@@ -15,10 +15,12 @@ const actionMocks = vi.hoisted(() => ({
   sendQuoteReminder: vi.fn(),
 }));
 const getQuoteDocumentTemplatesMock = vi.hoisted(() => vi.fn());
+const navigationMocks = vi.hoisted(() => ({ searchParams: 'subtab=sent' }));
+const quoteFormPropsMock = vi.hoisted(() => ({ current: null as null | Record<string, unknown> }));
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn() }),
-  useSearchParams: () => new URLSearchParams('subtab=sent'),
+  useSearchParams: () => new URLSearchParams(navigationMocks.searchParams),
 }));
 
 vi.mock('../../../actions/quoteActions', () => ({
@@ -93,7 +95,12 @@ vi.mock('@alga-psa/ui/components/ClientNameCell', () => ({
 }));
 
 vi.mock('./QuoteApprovalDashboard', () => ({ default: () => null }));
-vi.mock('./QuoteForm', () => ({ default: () => null }));
+vi.mock('./QuoteForm', () => ({
+  default: (props: Record<string, unknown>) => {
+    quoteFormPropsMock.current = props;
+    return null;
+  },
+}));
 vi.mock('./QuotePreviewPanel', () => ({ default: () => null }));
 vi.mock('./QuoteStatusBadge', () => ({ default: () => null }));
 
@@ -114,6 +121,8 @@ const sentQuote = {
 describe('QuotesTab sent quote actions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    navigationMocks.searchParams = 'subtab=sent';
+    quoteFormPropsMock.current = null;
     actionMocks.listQuotes.mockResolvedValue({ data: [sentQuote] });
     getQuoteDocumentTemplatesMock.mockResolvedValue([]);
     actionMocks.resendQuote.mockResolvedValue({});
@@ -140,5 +149,17 @@ describe('QuotesTab sent quote actions', () => {
 
     await waitFor(() => expect(actionMocks.sendQuoteReminder).toHaveBeenCalledWith(sentQuote.quote_id));
     expect(actionMocks.sendQuote).not.toHaveBeenCalled();
+  });
+
+  it('T001: a deep link carrying a source template id reaches QuoteForm through initialContext', async () => {
+    navigationMocks.searchParams = 'tab=quotes&quoteId=new&sourceTemplateId=tmpl-123';
+
+    render(<QuotesTab />);
+
+    await waitFor(() => expect(quoteFormPropsMock.current).not.toBeNull());
+    expect(quoteFormPropsMock.current).toMatchObject({
+      quoteId: 'new',
+      initialContext: { sourceTemplateId: 'tmpl-123' },
+    });
   });
 });

--- a/packages/billing/src/components/billing-dashboard/quotes/QuotesTab.tsx
+++ b/packages/billing/src/components/billing-dashboard/quotes/QuotesTab.tsx
@@ -318,6 +318,7 @@ const QuotesTab: React.FC = () => {
   const opportunityClientId = searchParams?.get('clientId') ?? undefined;
   const opportunityContactId = searchParams?.get('contactId') ?? undefined;
   const opportunityTitle = searchParams?.get('title') ?? undefined;
+  const sourceTemplateId = searchParams?.get('sourceTemplateId') ?? undefined;
   const activeSubTab = requestedSubtab && QUOTE_SUBTABS.includes(requestedSubtab as QuoteSubTab)
     ? (requestedSubtab as QuoteSubTab)
     : 'active';
@@ -580,6 +581,7 @@ const QuotesTab: React.FC = () => {
           contactId: opportunityContactId,
           opportunityId,
           title: opportunityTitle,
+          sourceTemplateId,
         }}
         onCancel={() => opportunityId
           ? router.push(`/msp/opportunities/${opportunityId}`)

--- a/packages/billing/src/lib/invoice-template-ast/react-renderer.test.tsx
+++ b/packages/billing/src/lib/invoice-template-ast/react-renderer.test.tsx
@@ -1041,6 +1041,67 @@ describe('renderEvaluatedTemplateAst', () => {
   });
 });
 
+describe('renderEvaluatedTemplateAst text nodes', () => {
+  it('T009a: preserves newlines in a text node by default', async () => {
+    const ast: TemplateAst = {
+      kind: 'invoice-template-ast',
+      version: TEMPLATE_AST_VERSION,
+      layout: {
+        id: 'root',
+        type: 'document',
+        children: [
+          {
+            id: 'terms',
+            type: 'text',
+            content: { type: 'literal', value: 'First paragraph\n\nSecond paragraph' },
+          },
+        ],
+      },
+    };
+
+    const evaluation = evaluateTemplateAst(ast, invoiceFixture);
+    const rendered = await renderEvaluatedTemplateAst(ast, evaluation);
+
+    expect(rendered.html).toContain('First paragraph\n\nSecond paragraph');
+    expect(rendered.html).toContain('white-space:pre-line');
+  });
+
+  it('T009b: an explicit whiteSpace in the text node style overrides the default', async () => {
+    // The renderer contract is tested directly: a text node whose own style
+    // declares whiteSpace must win over the preserve-newlines default.
+    const ast = {
+      kind: 'invoice-template-ast',
+      version: TEMPLATE_AST_VERSION,
+      layout: {
+        id: 'root',
+        type: 'document',
+        children: [
+          {
+            id: 'terms',
+            type: 'text',
+            style: { inline: { whiteSpace: 'nowrap' } },
+            content: { type: 'literal', value: 'First\nSecond' },
+          },
+        ],
+      },
+    } as any;
+
+    const evaluation: TemplateEvaluationResult = {
+      sourceCollection: [],
+      output: [],
+      groups: null,
+      aggregates: {},
+      totals: {},
+      bindings: {},
+    };
+
+    const rendered = await renderEvaluatedTemplateAst(ast, evaluation);
+
+    expect(rendered.html).toContain('white-space:nowrap');
+    expect(rendered.html).not.toContain('white-space:pre-line');
+  });
+});
+
 describe('renderEvaluatedTemplateAst stacked table-cell lines', () => {
   const renderAst = async (
     columns: Array<Record<string, unknown>>,

--- a/packages/billing/src/lib/invoice-template-ast/react-renderer.tsx
+++ b/packages/billing/src/lib/invoice-template-ast/react-renderer.tsx
@@ -570,7 +570,12 @@ const renderNode = (
     case 'text': {
       const content = resolveExpressionValue(node.content, evaluation, scope, ctx);
       return (
-        <p key={node.id} id={node.id} className={elementClassName || undefined} style={style}>
+        <p
+          key={node.id}
+          id={node.id}
+          className={elementClassName || undefined}
+          style={{ whiteSpace: 'pre-line', ...style }}
+        >
           {String(content ?? '')}
         </p>
       );

--- a/packages/billing/tests/quote/QuoteForm.test.tsx
+++ b/packages/billing/tests/quote/QuoteForm.test.tsx
@@ -257,10 +257,23 @@ describe('QuoteForm template instantiation', () => {
 
   it('T002: deep link prefills terms, notes, description, PO number, currency and line items', async () => {
     actions.getQuote.mockResolvedValue(template);
-    renderForm({ initialContext: { clientId: 'client-1', sourceTemplateId: 'tmpl-1' } });
+    const view = renderForm({ initialContext: { clientId: 'client-1', sourceTemplateId: 'tmpl-1' } });
 
     await waitFor(() => expect(lineItemsEditorMock.current?.items).toHaveLength(2));
     expect(actions.getQuote).toHaveBeenCalledWith('tmpl-1');
+
+    // Seed once (F007): a re-render with fresh prop identities must not
+    // re-apply the template. This fails loudly if the loadFormData effect
+    // dependency list is ever broadened (and the once-guard is not there).
+    view.rerender(
+      <QuoteForm
+        quoteId="new"
+        onCancel={vi.fn()}
+        onSaved={vi.fn()}
+        initialContext={{ clientId: 'client-1', sourceTemplateId: 'tmpl-1' }}
+      />,
+    );
+    await waitFor(() => expect(actions.getQuote).toHaveBeenCalledTimes(1));
 
     fireEvent.click(document.getElementById('quote-form-save') as HTMLButtonElement);
     await waitFor(() => expect(actions.createQuoteFromTemplate).toHaveBeenCalledTimes(1));
@@ -279,9 +292,21 @@ describe('QuoteForm template instantiation', () => {
 
   it('T003: deep-linked create routes through createQuoteFromTemplate without re-persisting line items', async () => {
     actions.getQuote.mockResolvedValue(template);
-    renderForm({ initialContext: { clientId: 'client-1', sourceTemplateId: 'tmpl-1' } });
+    const view = renderForm({ initialContext: { clientId: 'client-1', sourceTemplateId: 'tmpl-1' } });
 
     await waitFor(() => expect(lineItemsEditorMock.current?.items).toHaveLength(2));
+
+    // Seed once (F007): re-rendering must not fetch/apply the source template a
+    // second time, so the server-created line items are not re-seeded.
+    view.rerender(
+      <QuoteForm
+        quoteId="new"
+        onCancel={vi.fn()}
+        onSaved={vi.fn()}
+        initialContext={{ clientId: 'client-1', sourceTemplateId: 'tmpl-1' }}
+      />,
+    );
+    await waitFor(() => expect(actions.getQuote).toHaveBeenCalledTimes(1));
 
     fireEvent.click(document.getElementById('quote-form-save') as HTMLButtonElement);
     await waitFor(() => expect(actions.createQuoteFromTemplate).toHaveBeenCalledTimes(1));

--- a/packages/billing/tests/quote/QuoteForm.test.tsx
+++ b/packages/billing/tests/quote/QuoteForm.test.tsx
@@ -1,0 +1,375 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const actions = vi.hoisted(() => ({
+  addQuoteItem: vi.fn(),
+  approveQuote: vi.fn(),
+  convertQuoteToContract: vi.fn(),
+  convertQuoteToInvoice: vi.fn(),
+  convertQuoteToSalesOrder: vi.fn(),
+  createQuote: vi.fn(),
+  createQuoteFromTemplate: vi.fn(),
+  createQuoteRevision: vi.fn(),
+  downloadQuotePdf: vi.fn(),
+  duplicateQuote: vi.fn(),
+  getQuote: vi.fn(),
+  getQuoteApprovalSettings: vi.fn(),
+  getQuoteConversionPreview: vi.fn(),
+  listQuotes: vi.fn(),
+  removeQuoteItem: vi.fn(),
+  reorderQuoteItems: vi.fn(),
+  requestQuoteApprovalChanges: vi.fn(),
+  resendQuote: vi.fn(),
+  sendQuote: vi.fn(),
+  sendQuoteReminder: vi.fn(),
+  submitQuoteForApproval: vi.fn(),
+  updateQuote: vi.fn(),
+  updateQuoteItem: vi.fn(),
+}));
+
+const getQuoteDocumentTemplatesMock = vi.hoisted(() => vi.fn());
+const getAllClientsMock = vi.hoisted(() => vi.fn());
+const getActiveLocationsMock = vi.hoisted(() => vi.fn());
+const getContactsMock = vi.hoisted(() => vi.fn());
+const getDefaultBillingSettingsMock = vi.hoisted(() => vi.fn());
+const lineItemsEditorMock = vi.hoisted(() => ({ current: null as null | { items?: unknown[] } }));
+
+vi.mock('../../src/actions/quoteActions', () => actions);
+vi.mock('../../src/actions/quoteDocumentTemplates', () => ({
+  getQuoteDocumentTemplates: (...args: unknown[]) => getQuoteDocumentTemplatesMock(...args),
+}));
+vi.mock('../../src/actions/billingClientsActions', () => ({
+  getAllClientsForBilling: (...args: unknown[]) => getAllClientsMock(...args),
+}));
+vi.mock('../../src/actions/billingClientLocationActions', () => ({
+  getActiveClientLocationsForBilling: (...args: unknown[]) => getActiveLocationsMock(...args),
+}));
+vi.mock('@alga-psa/user-composition/actions/contactQueryActions', () => ({
+  getContactsForPicker: (...args: unknown[]) => getContactsMock(...args),
+}));
+vi.mock('@alga-psa/billing/actions/billingSettingsActions', () => ({
+  getDefaultBillingSettings: (...args: unknown[]) => getDefaultBillingSettingsMock(...args),
+}));
+
+vi.mock('@alga-psa/ui/lib/errorHandling', () => ({
+  isActionMessageError: (value: any) => Boolean(value && value.messageKey),
+  isActionPermissionError: (value: any) => Boolean(value && value.permissionError),
+  getErrorMessage: (value: any) =>
+    (value && (value.permissionError || value.message)) || 'error',
+}));
+
+vi.mock('@alga-psa/ui/lib/i18n/client', () => ({
+  useFormatters: () => ({
+    formatCurrency: (value: number) => `$${Number(value ?? 0).toFixed(2)}`,
+    formatDate: (value: string) => String(value),
+  }),
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
+  }),
+}));
+
+vi.mock('@alga-psa/ui/context', () => ({
+  useQuickAddClient: () => ({ renderQuickAddClient: () => null }),
+}));
+
+vi.mock('@radix-ui/themes', () => ({
+  Card: ({ children }: any) => React.createElement('div', null, children),
+  Box: ({ children }: any) => React.createElement('div', null, children),
+}));
+
+vi.mock('@alga-psa/ui/components/Button', () => ({
+  Button: ({ children, id, onClick, disabled }: any) =>
+    React.createElement('button', { id, onClick, disabled, type: 'button' }, children),
+}));
+
+vi.mock('@alga-psa/ui/components/Input', () => ({
+  Input: ({ value, onChange, disabled, id }: any) =>
+    React.createElement('input', { id, value: value ?? '', onChange, disabled }),
+}));
+
+vi.mock('@alga-psa/ui/components/TextArea', () => ({
+  TextArea: ({ value, onChange, disabled, id }: any) =>
+    React.createElement('textarea', { id, value: value ?? '', onChange, disabled }),
+}));
+
+vi.mock('@alga-psa/ui/components/CustomSelect', () => ({
+  default: ({ id, value, onValueChange, options }: any) =>
+    React.createElement(
+      'select',
+      { id, value: value ?? '', onChange: (event: any) => onValueChange(event.target.value) },
+      (options ?? []).map((option: any) =>
+        React.createElement('option', { key: option.value, value: option.value }, option.label),
+      ),
+    ),
+}));
+
+vi.mock('@alga-psa/ui/components/CurrencyPicker', () => ({
+  default: ({ id, value, onValueChange }: any) =>
+    React.createElement(
+      'select',
+      { id, value: value ?? '', onChange: (event: any) => onValueChange(event.target.value) },
+      React.createElement('option', { key: 'USD', value: 'USD' }, 'USD'),
+      React.createElement('option', { key: 'EUR', value: 'EUR' }, 'EUR'),
+    ),
+}));
+
+vi.mock('@alga-psa/ui/components/ClientPicker', () => ({ ClientPicker: () => null }));
+vi.mock('@alga-psa/ui/components/ContactPicker', () => ({ ContactPicker: () => null }));
+vi.mock('@alga-psa/ui/components/DatePicker', () => ({ DatePicker: () => null }));
+vi.mock('@alga-psa/ui/components/LoadingIndicator', () => ({ default: () => null }));
+
+vi.mock('@alga-psa/ui/components/Alert', () => ({
+  Alert: ({ children }: any) => React.createElement('div', null, children),
+  AlertTitle: ({ children }: any) => React.createElement('div', null, children),
+  AlertDescription: ({ children }: any) => React.createElement('div', null, children),
+}));
+
+vi.mock('@alga-psa/ui/components/DropdownMenu', () => ({
+  DropdownMenu: ({ children }: any) => React.createElement('div', null, children),
+  DropdownMenuContent: ({ children }: any) => React.createElement('div', null, children),
+  DropdownMenuItem: ({ children }: any) => React.createElement('button', { type: 'button' }, children),
+  DropdownMenuTrigger: ({ children }: any) => React.createElement('div', null, children),
+}));
+
+vi.mock('@alga-psa/ui/components/Dialog', () => ({
+  Dialog: () => null,
+  DialogContent: ({ children }: any) => React.createElement('div', null, children),
+  DialogDescription: ({ children }: any) => React.createElement('div', null, children),
+  DialogHeader: ({ children }: any) => React.createElement('div', null, children),
+  DialogTitle: ({ children }: any) => React.createElement('div', null, children),
+}));
+
+vi.mock('../../src/components/billing-dashboard/quotes/QuoteLineItemsEditor', () => ({
+  default: (props: any) => {
+    lineItemsEditorMock.current = props;
+    return null;
+  },
+}));
+vi.mock('../../src/components/billing-dashboard/quotes/QuoteSendRecipientsField', () => ({
+  QuoteSendRecipientsField: () => null,
+}));
+vi.mock('../../src/components/billing-dashboard/quotes/QuoteStatusBadge', () => ({
+  default: () => null,
+}));
+vi.mock('../../src/components/billing-dashboard/quotes/quoteLineItemDraft', () => ({
+  createDraftQuoteItemFromQuoteItem: (item: any) => ({
+    local_id: item.quote_item_id,
+    quote_item_id: item.quote_item_id,
+    description: item.description,
+    quantity: Number(item.quantity ?? 0),
+    unit_price: Number(item.unit_price ?? 0),
+    is_optional: Boolean(item.is_optional),
+    is_selected: item.is_selected ?? true,
+    is_recurring: Boolean(item.is_recurring),
+    is_discount: Boolean(item.is_discount),
+    billing_frequency: item.billing_frequency ?? null,
+    is_taxable: item.is_taxable ?? true,
+    location_id: null,
+  }),
+  calculateDraftQuoteTotals: () => ({ subtotal: 0, discount_total: 0, tax: 0, total_amount: 0 }),
+  calculateDraftMonthlyRecurringNet: () => 0,
+  formatDraftQuoteMoney: (value: number) => `$${(Number(value ?? 0) / 100).toFixed(2)}`,
+  resolveDraftDiscountAmounts: () => new Map(),
+}));
+
+import QuoteForm from '../../src/components/billing-dashboard/quotes/QuoteForm';
+
+const template = {
+  quote_id: 'tmpl-1',
+  title: 'Template Title',
+  description: 'Template description',
+  client_notes: 'Template notes',
+  terms_and_conditions: 'Terms line one\n\nTerms line two',
+  currency_code: 'EUR',
+  po_number: 'PO-123',
+  is_template: true,
+  quote_items: [
+    {
+      quote_item_id: 'ti-1',
+      description: 'Managed Endpoint',
+      quantity: 3,
+      unit_price: 1200,
+      is_recurring: true,
+      is_taxable: true,
+      is_optional: false,
+      is_selected: true,
+    },
+    {
+      quote_item_id: 'ti-2',
+      description: 'Onboarding',
+      quantity: 1,
+      unit_price: 5000,
+      is_recurring: false,
+      is_taxable: true,
+      is_optional: false,
+      is_selected: true,
+    },
+  ],
+};
+
+const editQuote = {
+  quote_id: 'quote-1',
+  quote_number: 'Q-1',
+  title: '',
+  status: 'draft',
+  client_id: 'client-1',
+  contact_id: '',
+  template_id: 'layout-9',
+  currency_code: 'USD',
+  quote_items: [],
+  updated_at: '2026-01-01T00:00:00.000Z',
+};
+
+const renderForm = (props: Record<string, unknown> = {}) =>
+  render(
+    <QuoteForm quoteId="new" onCancel={vi.fn()} onSaved={vi.fn()} {...(props as any)} />,
+  );
+
+describe('QuoteForm template instantiation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    lineItemsEditorMock.current = null;
+    actions.listQuotes.mockResolvedValue({
+      data: [{ quote_id: 'tmpl-1', title: 'Template Title', currency_code: 'EUR' }],
+    });
+    getQuoteDocumentTemplatesMock.mockResolvedValue([]);
+    actions.getQuoteApprovalSettings.mockResolvedValue({ approvalRequired: false });
+    getDefaultBillingSettingsMock.mockResolvedValue({ defaultCurrencyCode: 'USD' });
+    getAllClientsMock.mockResolvedValue([]);
+    getActiveLocationsMock.mockResolvedValue([]);
+    getContactsMock.mockResolvedValue([]);
+    actions.createQuoteFromTemplate.mockResolvedValue({
+      quote_id: 'new-1',
+      quote_items: template.quote_items,
+    });
+    actions.createQuote.mockResolvedValue({ quote_id: 'new-2', quote_items: [] });
+    actions.updateQuote.mockResolvedValue({ quote_id: 'quote-1' });
+    actions.addQuoteItem.mockResolvedValue({ quote_item_id: 'qi-new' });
+    actions.updateQuoteItem.mockResolvedValue({ quote_item_id: 'qi-new' });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('T002: deep link prefills terms, notes, description, PO number, currency and line items', async () => {
+    actions.getQuote.mockResolvedValue(template);
+    renderForm({ initialContext: { clientId: 'client-1', sourceTemplateId: 'tmpl-1' } });
+
+    await waitFor(() => expect(lineItemsEditorMock.current?.items).toHaveLength(2));
+    expect(actions.getQuote).toHaveBeenCalledWith('tmpl-1');
+
+    fireEvent.click(document.getElementById('quote-form-save') as HTMLButtonElement);
+    await waitFor(() => expect(actions.createQuoteFromTemplate).toHaveBeenCalledTimes(1));
+
+    const [templateId, payload] = actions.createQuoteFromTemplate.mock.calls[0];
+    expect(templateId).toBe('tmpl-1');
+    expect(payload).toMatchObject({
+      title: 'Template Title',
+      description: 'Template description',
+      client_notes: 'Template notes',
+      terms_and_conditions: 'Terms line one\n\nTerms line two',
+      po_number: 'PO-123',
+      currency_code: 'EUR',
+    });
+  });
+
+  it('T003: deep-linked create routes through createQuoteFromTemplate without re-persisting line items', async () => {
+    actions.getQuote.mockResolvedValue(template);
+    renderForm({ initialContext: { clientId: 'client-1', sourceTemplateId: 'tmpl-1' } });
+
+    await waitFor(() => expect(lineItemsEditorMock.current?.items).toHaveLength(2));
+
+    fireEvent.click(document.getElementById('quote-form-save') as HTMLButtonElement);
+    await waitFor(() => expect(actions.createQuoteFromTemplate).toHaveBeenCalledTimes(1));
+
+    expect(actions.createQuote).not.toHaveBeenCalled();
+    expect(actions.addQuoteItem).not.toHaveBeenCalled();
+    expect(actions.updateQuoteItem).not.toHaveBeenCalled();
+  });
+
+  it('T004: edit mode leaves the source template empty and round-trips the layout id', async () => {
+    actions.getQuote.mockResolvedValue(editQuote);
+    getQuoteDocumentTemplatesMock.mockResolvedValue([
+      { template_id: 'layout-9', name: 'Custom Layout', isStandard: false },
+    ]);
+
+    renderForm({ quoteId: 'quote-1' });
+
+    const titleInput = await screen.findByLabelText('Title');
+    fireEvent.click(document.getElementById('quote-form-save') as HTMLButtonElement);
+    await waitFor(() =>
+      expect(screen.getByText('Title is required unless creating from template')).toBeTruthy(),
+    );
+    expect(actions.updateQuote).not.toHaveBeenCalled();
+
+    fireEvent.change(titleInput, { target: { value: 'Edited title' } });
+    fireEvent.click(document.getElementById('quote-form-save') as HTMLButtonElement);
+
+    await waitFor(() => expect(actions.updateQuote).toHaveBeenCalledTimes(1));
+    const [, payload] = actions.updateQuote.mock.calls[0];
+    expect(payload).toMatchObject({ title: 'Edited title', template_id: 'layout-9' });
+    expect(payload).not.toHaveProperty('source_template_id');
+  });
+
+  it('T005: a deep link naming a missing template degrades to a blank, submittable quote', async () => {
+    actions.getQuote.mockResolvedValue(null);
+    renderForm({
+      initialContext: { clientId: 'client-1', title: 'Draft quote', sourceTemplateId: 'missing' },
+    });
+
+    await screen.findByLabelText('Title');
+    expect(actions.getQuote).toHaveBeenCalledWith('missing');
+
+    fireEvent.click(document.getElementById('quote-form-save') as HTMLButtonElement);
+    await waitFor(() => expect(actions.createQuote).toHaveBeenCalledTimes(1));
+
+    expect(actions.createQuoteFromTemplate).not.toHaveBeenCalled();
+    const [payload] = actions.createQuote.mock.calls[0];
+    expect(payload).toMatchObject({ title: 'Draft quote' });
+    expect(payload.terms_and_conditions).toBeNull();
+  });
+
+  it('T006: an opportunity-seeded title survives template prefill', async () => {
+    actions.getQuote.mockResolvedValue(template);
+    renderForm({
+      initialContext: {
+        clientId: 'client-1',
+        title: 'Opportunity Title',
+        sourceTemplateId: 'tmpl-1',
+      },
+    });
+
+    await waitFor(() => expect(lineItemsEditorMock.current?.items).toHaveLength(2));
+
+    fireEvent.click(document.getElementById('quote-form-save') as HTMLButtonElement);
+    await waitFor(() => expect(actions.createQuoteFromTemplate).toHaveBeenCalledTimes(1));
+
+    const [, payload] = actions.createQuoteFromTemplate.mock.calls[0];
+    expect(payload.title).toBe('Opportunity Title');
+  });
+
+  it('T007: the "+ From template" picker still prefills after the rename', async () => {
+    actions.getQuote.mockResolvedValue(template);
+    renderForm({ initialContext: { clientId: 'client-1' } });
+
+    await waitFor(() =>
+      expect(document.getElementById('quote-form-template-picker')).not.toBeNull(),
+    );
+    fireEvent.change(document.getElementById('quote-form-template-picker') as HTMLSelectElement, {
+      target: { value: 'tmpl-1' },
+    });
+
+    await waitFor(() => expect(lineItemsEditorMock.current?.items).toHaveLength(2));
+
+    fireEvent.click(document.getElementById('quote-form-save') as HTMLButtonElement);
+    await waitFor(() => expect(actions.createQuoteFromTemplate).toHaveBeenCalledTimes(1));
+
+    const [templateId, payload] = actions.createQuoteFromTemplate.mock.calls[0];
+    expect(templateId).toBe('tmpl-1');
+    expect(payload.terms_and_conditions).toBe('Terms line one\n\nTerms line two');
+  });
+});

--- a/packages/billing/tests/quote/quoteActions.test.ts
+++ b/packages/billing/tests/quote/quoteActions.test.ts
@@ -500,6 +500,36 @@ describe('quoteActions', () => {
     expect(result).toMatchObject({ quote_id: QUOTE_ID, quote_items: templateQuote.quote_items });
   });
 
+  it('T008: createQuoteFromTemplate carries template-owned fields through to Quote.create', async () => {
+    vi.spyOn(Quote, 'getById')
+      .mockResolvedValueOnce(templateQuote as any)
+      .mockResolvedValueOnce({
+        quote_id: QUOTE_ID,
+        quote_number: 'Q-0100',
+        is_template: false,
+        quote_items: templateQuote.quote_items,
+      } as any);
+
+    const { createQuoteFromTemplate } = await import('../../src/actions/quoteActions');
+    await createQuoteFromTemplate(templateQuote.quote_id, {
+      client_id: baseQuoteInput.client_id,
+      quote_date: baseQuoteInput.quote_date,
+      valid_until: baseQuoteInput.valid_until,
+    } as any);
+
+    expect(Quote.create).toHaveBeenCalledWith(
+      mockTrx,
+      TENANT_ID,
+      expect.objectContaining({
+        title: 'Template quote',
+        description: 'Template description',
+        client_notes: 'Template note',
+        terms_and_conditions: 'Template terms',
+        currency_code: 'USD',
+      })
+    );
+  });
+
   it('T050c: createQuoteFromTemplate returns a newly numbered draft quote', async () => {
     vi.spyOn(Quote, 'getById')
       .mockResolvedValueOnce(templateQuote as any)

--- a/packages/billing/tests/quote/quoteTemplateDeepLinkContract.test.ts
+++ b/packages/billing/tests/quote/quoteTemplateDeepLinkContract.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const dashboardSource = readFileSync(
+  new URL('../../src/components/billing-dashboard/BillingDashboard.tsx', import.meta.url),
+  'utf8',
+);
+const quotesTabSource = readFileSync(
+  new URL('../../src/components/billing-dashboard/quotes/QuotesTab.tsx', import.meta.url),
+  'utf8',
+);
+
+describe('quote template deep-link parameter contract', () => {
+  it('T010: BillingDashboard emits the same source template param QuotesTab consumes', () => {
+    // Producer: the "Create Quote from Template" row action must use the
+    // renamed param, not the old, overloaded `templateId`.
+    expect(dashboardSource).toContain('quoteId=new&sourceTemplateId=');
+    expect(dashboardSource).not.toContain('quoteId=new&templateId=');
+
+    // Consumer: QuotesTab must read that exact name. If either side drifts, the
+    // template id is silently dropped again and the original bug returns.
+    expect(quotesTabSource).toContain("searchParams?.get('sourceTemplateId')");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the "Create Quote from Template" deep link on the Quote Templates list, which silently dropped the entire source template — including terms & conditions — and shipped a second fix for multi-paragraph T&Cs collapsing on the PDF.

**Root cause.** `BillingDashboard.tsx` pushed `?tab=quotes&quoteId=new&templateId=<id>`, but `QuotesTab.tsx` never read `templateId` and `QuoteFormProps.initialContext` had no field to carry it. The form opened blank, `form.template_id` stayed `''`, and submit took the plain `createQuote` branch — `createQuoteFromTemplate` was never invoked from that path. The name `templateId` was overloaded three ways (business template on `?tab=quotes`, a layout on `?tab=quote-templates`, and `quotes.template_id` in the DB stores the layout id), which is what let the mismatch hide.

### Changes

- **`BillingDashboard.tsx`** — deep link renamed to `sourceTemplateId`, distinguishing the business template from the PDF layout id.
- **`QuotesTab.tsx`** — reads `sourceTemplateId` from the query string and passes it into `QuoteForm.initialContext`.
- **`QuoteForm.tsx`**
  - `initialContext.sourceTemplateId` added; `form.template_id` renamed to `form.source_template_id` with intent documented (business template in create mode, never the layout id).
  - On mount in create mode, once the business-template list has loaded, the deep link seeds through the **same `handleTemplateChange` routine the working "+ From template" picker uses** — so title, description, client notes, multi-paragraph T&Cs, currency, PO number and line items all populate identically.
  - A `useRef` guard ensures the seed runs exactly once per mount, so selecting a client or editing fields afterwards cannot re-clobber user input.
  - Failure to load the source template clears the id so submit falls back to a plain `createQuote` rather than stranding the form.
  - `handleTemplateChange` now applies `template.currency_code || current.currency_code || defaultCurrency`, so a non-default template currency transfers (behaviour change noted below).
- **`react-renderer.tsx`** — AST `text` nodes now render with `whiteSpace: 'pre-line'`, matching field nodes and table cells. Multi-paragraph T&Cs keep their line breaks on the PDF instead of collapsing to one run-on paragraph.

### Tests added

- `packages/billing/tests/quote/quoteActions.test.ts` — asserts the template's `terms_and_conditions` reaches the new quote through `createQuoteFromTemplate` (the fixture existed but nothing asserted it).
- `packages/billing/tests/quote/QuoteForm.test.tsx` — covers the deep-link seed: fields populate once, are not re-applied on later renders, and fall back cleanly when the source template cannot load.
- `packages/billing/tests/quote/quoteTemplateDeepLinkContract.test.ts` — guards the producer/consumer contract for the renamed `sourceTemplateId` param.
- `packages/billing/src/components/billing-dashboard/quotes/QuotesTab.test.tsx` — updated for the new prop.
- `packages/billing/src/lib/invoice-template-ast/react-renderer.test.tsx` — asserts a `text` node preserves line breaks.

### Reviewer note — deliberate behaviour change

`handleTemplateChange` now lets a template's currency override a currency the user already chose. Intentional (the template is the source of truth when explicitly selected), but it is a user-visible precedence change in the picker path, and worth a reviewer's eye.

## Smoke test — PASS

Performed end to end through the real running product at `http://localhost:3060` (compose project `alga-psa-local-test`). Environment verified genuinely: PID 105010 listening on 3060 with `cwd=/home/robert/alga-copies/feature-quote-template-fields-never-reach-the-new-quote/server` (process identity confirmed, not just port liveness — four other worktrees run dev servers on this host). Logged in as `glinda@emeraldcity.oz` (tenant Oz `dd8cb218`) via an existing browser session; no credential rotation needed. Fidelity rung (a): real Next.js server, real Postgres, real PDF generation, real browser interactions; no mocks/fakes.

- **FLOW 1 (primary bug, deep link) — PASS.** Built template "Smoke EUR Template 20260912-0511" (`1e40f58d-…`) through the UI with description, client notes, EUR currency, 2 priced line items and a 4-newline / 2-paragraph T&C block. Row menu **Create Quote from Template** navigated to `?tab=quotes&quoteId=new&sourceTemplateId=1e40f58d-…`. The form arrived fully seeded: title, description, EUR, client notes, verbatim multi-paragraph T&Cs (222 chars, 4 newlines), both line items, total EUR 225.00. Selecting a client left the T&Cs intact (no re-seed clobber). Saved as QUO-0006 (`dc68315e-…`); DB confirms `is_template=f`, `currency_code=EUR`, correct notes/description, 222-char terms with the blank-line break intact, and **exactly 2 quote_items** — the double-creation failure mode is clear.
  - Non-default currency transfer (EUR vs tenant default USD) is now proven interactively, closing the prior USD-only caveat.
- **FLOW 2 (secondary bug, PDF paragraph breaks) — PASS.** Live preview computes `white-space: pre-line` for the `terms-copy` node. Download PDF produced a real 64,610-byte, 2-page PDF; `pdftotext -layout` shows the two first-paragraph lines on separate lines, a blank line, then the second paragraph's two lines. PDF also contains QUO-0006, title, description, both line items, EUR amounts and notes.
- **REGRESSION A (blank create) — PASS.** `?tab=quotes&quoteId=new` with no `sourceTemplateId` opens genuinely empty (USD default, picker unselected) — no stray seeding.
- **REGRESSION B (plain createQuote branch) — PASS.** QUO-0007 created with title + client only: USD, terms NULL, 0 items.
- **REGRESSION C (layout id survival — the rename's highest risk) — PASS.** Edit mode sets `source_template_id:''` instead of loading `quote.template_id`; editing QUO-0004 (non-default layout `b7adf5ba`) correctly showed the layout by name via `documentTemplateId`, hid the business-template picker, and preserved `quotes.template_id` after save with no item duplication.
- **REGRESSION D (picker path / customer workaround) — PASS.** "+ From template" still prefills title, EUR, 222-char T&Cs and 2 items.
- **REGRESSION E (shared renderer blast radius) — PASS.** The `text` node `whiteSpace` change also reaches invoice templates. Measured, not assumed: 0 of 13 `templateAst` rows (10 `invoice_templates` + 3 `quote_document_templates`) contain literal newlines, so `pre-line` can only affect dynamically bound values. Invoice INV-000059 preview re-rendered correctly.
- **NAME-COLLISION CHECK — PASS.** Remaining `templateId=` usages are only the layout meaning on other tabs plus a React prop; zero stale producers on `tab=quotes`.

Evidence directory: `/tmp/alga-smoke-evidence/quote-template-fields-20260912-011119` (9 screenshots + the real PDF).

### Smoke side effects (shared dev DB, disclosed)

- Created template `1e40f58d-…`, quotes QUO-0006 and QUO-0007.
- Overwrote the description of pre-existing QUO-0004 (`462301f3-…`) during Regression C; its original text began "Live verification of product and service name-above-catalog-" and was not recoverable. Its layout `template_id` was correctly preserved. Restoring the text needs human approval.
- 40 console errors, all the hocuspocus collaboration WebSocket (`ws://localhost:1235`, service not part of this stack); zero 5xx network responses.

## Out of scope / not tested

PDF email delivery and the Discord customer reply. No release-blocking defect found.

## CI fix (follow-up push, commit `0b92e2158d`)

The first CI run failed the required `browser / Production browser (enterprise)` check solely because the unrelated `microsoft-calendar.spec.ts` "provider outage" journey **flaked**: its outbound `calendar_event_mappings` poll timed out at 60s on a cold first attempt, then passed on the immediate retry. The CI retry policy requires a first-attempt pass and has no per-test bypass.

Diagnosis (confirmed from the run's `container-logs-enterprise` artifact): the test's provider was valid — the `[CalendarSyncSubscriber] No active providers found` line in the logs belongs to a different tenant (`5332d897…`, the Teams journey). Other PRs' browser lanes have failed on different unrelated tests too, so this is suite timing, not a defect in this branch.

Remedy: raised the two creation-side polls in `e2e-tests/tests/microsoft-calendar.spec.ts` from 60s to 120s — the same headroom the rest of the journey already uses — so a slow first workflow warm-up is not misreported as a failure. This file is unrelated to the quote-template change; it is called out separately here so reviewers can skip it.
